### PR TITLE
feat(remote): secure foundation for WebRTC remote access — SPAKE2+ password + QR

### DIFF
--- a/Zeus.Server.Hosting/Remote/RemoteAuth.cs
+++ b/Zeus.Server.Hosting/Remote/RemoteAuth.cs
@@ -1,0 +1,143 @@
+namespace Zeus.Server.Hosting.Remote;
+
+/// <summary>
+/// Lifecycle of a remote session. ADR-0008 hard invariant: a session begins
+/// <see cref="Locked"/> and does nothing radio-related until the operator's
+/// session password proves out, transitioning it to <see cref="Unlocked"/>.
+/// Any violation moves it to <see cref="Closed"/>.
+/// </summary>
+public enum RemoteSessionState
+{
+    Locked,
+    Unlocked,
+    Closed,
+}
+
+/// <summary>
+/// Result of one auth step. A multi-message proof (e.g. SPAKE2) returns
+/// <see cref="Continue"/> while still locked until it finally returns
+/// <see cref="Unlock"/>, or <see cref="Rejected"/> to fail closed.
+/// </summary>
+public readonly record struct RemoteAuthStep(bool Unlocked, bool Reject, ReadOnlyMemory<byte> Reply)
+{
+    public static RemoteAuthStep Continue(ReadOnlyMemory<byte> reply) => new(false, false, reply);
+    public static RemoteAuthStep Unlock(ReadOnlyMemory<byte> reply = default) => new(true, false, reply);
+    public static readonly RemoteAuthStep Rejected = new(false, true, default);
+}
+
+/// <summary>
+/// Verifies the operator's session password end-to-end at the radio (ADR-0008).
+/// The real PAKE/SPAKE2 verifier lands in Phase 4; until then
+/// <see cref="DenyAllAuthGate"/> is the default so the deny-by-default invariant
+/// holds the moment the transport exists.
+/// </summary>
+public interface IRemoteAuthGate
+{
+    /// <summary>Process one inbound auth message; may reply, unlock, or reject.</summary>
+    ValueTask<RemoteAuthStep> StepAsync(ReadOnlyMemory<byte> clientMessage, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Phase-1 default until Phase 4 wires the password verifier: rejects every
+/// attempt, so a remote session can never leave <see cref="RemoteSessionState.Locked"/>.
+/// "Nothing without the password" is the as-built behaviour, not a TODO.
+/// </summary>
+public sealed class DenyAllAuthGate : IRemoteAuthGate
+{
+    public static readonly DenyAllAuthGate Instance = new();
+
+    public ValueTask<RemoteAuthStep> StepAsync(ReadOnlyMemory<byte> clientMessage, CancellationToken ct = default)
+        => ValueTask.FromResult(RemoteAuthStep.Rejected);
+}
+
+/// <summary>Action the transport must take after an auth submission.</summary>
+public enum RemoteSessionAction
+{
+    /// <summary>Send <see cref="RemoteSessionOutcome.Reply"/>; session stays LOCKED.</summary>
+    Reply,
+    /// <summary>Send the reply (if any), then arm the radio data paths.</summary>
+    Unlock,
+    /// <summary>Send the reply (if any), then tear the session down. Leak nothing.</summary>
+    Close,
+}
+
+public readonly record struct RemoteSessionOutcome(RemoteSessionAction Action, ReadOnlyMemory<byte> Reply);
+
+/// <summary>
+/// Enforces the ADR-0008 hard invariant for one remote session. Begins
+/// <see cref="RemoteSessionState.Locked"/>; the only thing permitted while locked
+/// is the password proof. Data-plane egress and control dispatch are refused
+/// until <see cref="RemoteSessionState.Unlocked"/>. Any auth rejection, exception,
+/// or out-of-order message closes the session without revealing radio state.
+///
+/// This type is deliberately transport-agnostic — Phase 1's WebRTC transport (and
+/// any future transport) holds one and consults the guards below before doing
+/// anything.
+/// </summary>
+public sealed class RemoteSession
+{
+    private readonly IRemoteAuthGate _gate;
+
+    public RemoteSession(IRemoteAuthGate gate)
+        => _gate = gate ?? throw new ArgumentNullException(nameof(gate));
+
+    public RemoteSessionState State { get; private set; } = RemoteSessionState.Locked;
+
+    /// <summary>True only once authenticated.</summary>
+    public bool IsUnlocked => State == RemoteSessionState.Unlocked;
+
+    /// <summary>
+    /// Guard the transport MUST call before egressing any data-plane frame
+    /// (audio / display / IQ / meters). Returns false while LOCKED or Closed.
+    /// Never throws.
+    /// </summary>
+    public bool TryEgress() => State == RemoteSessionState.Unlocked;
+
+    /// <summary>
+    /// Guard for inbound control verbs (VFO / mode / TX / …). Refused unless
+    /// UNLOCKED. Never throws.
+    /// </summary>
+    public bool TryDispatchControl() => State == RemoteSessionState.Unlocked;
+
+    /// <summary>
+    /// Feed an inbound auth-channel message — the only thing the client may send
+    /// while LOCKED. Drives the gate and returns what the transport should do.
+    /// </summary>
+    public async ValueTask<RemoteSessionOutcome> SubmitAuthAsync(
+        ReadOnlyMemory<byte> message, CancellationToken ct = default)
+    {
+        if (State != RemoteSessionState.Locked)
+        {
+            // Auth traffic after unlock (or on a closed session) is protocol abuse.
+            State = RemoteSessionState.Closed;
+            return new RemoteSessionOutcome(RemoteSessionAction.Close, default);
+        }
+
+        RemoteAuthStep step;
+        try
+        {
+            step = await _gate.StepAsync(message, ct).ConfigureAwait(false);
+        }
+        catch
+        {
+            State = RemoteSessionState.Closed;
+            return new RemoteSessionOutcome(RemoteSessionAction.Close, default);
+        }
+
+        if (step.Reject)
+        {
+            State = RemoteSessionState.Closed;
+            return new RemoteSessionOutcome(RemoteSessionAction.Close, step.Reply);
+        }
+
+        if (step.Unlocked)
+        {
+            State = RemoteSessionState.Unlocked;
+            return new RemoteSessionOutcome(RemoteSessionAction.Unlock, step.Reply);
+        }
+
+        return new RemoteSessionOutcome(RemoteSessionAction.Reply, step.Reply);
+    }
+
+    public void Close() => State = RemoteSessionState.Closed;
+}

--- a/Zeus.Server.Hosting/Remote/RemoteBrokerClient.cs
+++ b/Zeus.Server.Hosting/Remote/RemoteBrokerClient.cs
@@ -1,0 +1,189 @@
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Zeus.Server.Hosting.Remote;
+
+/// <summary>
+/// Radio-side glue to the Cloudflare broker (Phase 3). When remote access is
+/// enabled (a session password is set) and the operator is QRZ-signed-in, this
+/// keeps a "host" WebSocket open to the broker for the operator's callsign and
+/// turns each relayed WebRTC <c>offer</c> into an <c>answer</c> via
+/// <see cref="RemoteWebRtcService"/> (gated by the SPAKE2+ password, ADR-0008).
+///
+/// Inert until the operator opts in (no password → no connection). The broker
+/// only relays signaling; media is peer-to-peer and the password is proven
+/// end-to-end at the radio, so the broker is never trusted.
+///
+/// NOTE: vanilla-ICE — candidates are embedded in the offer/answer SDP, so the
+/// only relayed messages are offer→answer. Live verification needs the deployed
+/// broker; <see cref="HandleSignalAsync"/> (the offer→answer bridge) is unit-tested.
+/// </summary>
+public sealed class RemoteBrokerClient : BackgroundService
+{
+    private static readonly TimeSpan ReconnectMin = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan ReconnectMax = TimeSpan.FromSeconds(30);
+
+    private readonly RemotePasswordStore _passwords;
+    private readonly RemoteWebRtcService _rtc;
+    private readonly QrzService _qrz;
+    private readonly ILogger<RemoteBrokerClient> _log;
+    private readonly string _brokerUrl;
+
+    public RemoteBrokerClient(
+        RemotePasswordStore passwords, RemoteWebRtcService rtc, QrzService qrz,
+        ILogger<RemoteBrokerClient> log)
+    {
+        _passwords = passwords;
+        _rtc = rtc;
+        _qrz = qrz;
+        _log = log;
+        _brokerUrl = Environment.GetEnvironmentVariable("ZEUS_REMOTE_BROKER_URL")
+            ?? "wss://remote.openhpsdrzeus.com/signal?role=host";
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var backoff = ReconnectMin;
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            // Remote access off (no password) → stay disconnected.
+            if (!_passwords.HasPassword())
+            {
+                await Task.Delay(ReconnectMax, stoppingToken).ContinueWith(_ => { }, CancellationToken.None);
+                continue;
+            }
+
+            var identity = await TryGetIdentityAsync(stoppingToken);
+            if (identity is null)
+            {
+                await DelayQuietly(backoff, stoppingToken);
+                continue;
+            }
+
+            try
+            {
+                await RunConnectionAsync(identity.Value.Callsign, identity.Value.SessionKey, stoppingToken);
+                backoff = ReconnectMin;
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _log.LogWarning(ex, "remote broker connection ended; retrying in {Delay}", backoff);
+            }
+
+            await DelayQuietly(backoff, stoppingToken);
+            backoff = NextBackoff(backoff);
+        }
+    }
+
+    private async Task<(string Callsign, string SessionKey)?> TryGetIdentityAsync(CancellationToken ct)
+    {
+        try { return await _qrz.GetChatIdentityAsync(ct); }
+        catch (Exception ex)
+        {
+            _log.LogDebug(ex, "remote broker: no QRZ identity yet");
+            return null;
+        }
+    }
+
+    private async Task RunConnectionAsync(string callsign, string sessionKey, CancellationToken ct)
+    {
+        using var socket = new ClientWebSocket();
+        socket.Options.SetRequestHeader("X-QRZ-Session", sessionKey);
+        socket.Options.SetRequestHeader("X-QRZ-Callsign", callsign);
+
+        _log.LogInformation("remote broker: connecting to {Url} as {Callsign}", _brokerUrl, callsign);
+        await socket.ConnectAsync(new Uri(_brokerUrl), ct);
+        _log.LogInformation("remote broker: host online for {Callsign}", callsign);
+
+        var buffer = new byte[64 * 1024];
+        while (socket.State == WebSocketState.Open && !ct.IsCancellationRequested)
+        {
+            var json = await ReceiveTextAsync(socket, buffer, ct);
+            if (json is null) break; // close frame
+
+            var reply = await HandleSignalAsync(json, ct);
+            if (reply is not null)
+            {
+                var bytes = Encoding.UTF8.GetBytes(reply);
+                await socket.SendAsync(bytes, WebSocketMessageType.Text, true, ct);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Bridge one signaling message: an <c>offer</c> becomes an <c>answer</c>
+    /// (tagged with the broker's <c>clientId</c>); everything else is ignored.
+    /// Returns the JSON to send back, or null. Never throws — a bad offer just
+    /// yields no answer (fails closed).
+    /// </summary>
+    internal Task<string?> HandleSignalAsync(string json, CancellationToken ct)
+        => BridgeSignalAsync(_rtc, json, _log, ct);
+
+    internal static async Task<string?> BridgeSignalAsync(
+        RemoteWebRtcService rtc, string json, ILogger log, CancellationToken ct)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            if (root.TryGetProperty("t", out var tEl) && tEl.GetString() == "offer"
+                && root.TryGetProperty("sdp", out var sdpEl))
+            {
+                var clientId = root.TryGetProperty("clientId", out var cid) ? cid.GetString() : null;
+                var answer = await rtc.ConnectAsync(sdpEl.GetString() ?? "", ct);
+                return JsonSerializer.Serialize(new Dictionary<string, string?>
+                {
+                    ["t"] = "answer",
+                    ["sdp"] = answer,
+                    ["clientId"] = clientId,
+                });
+            }
+        }
+        catch (RemoteAccessDisabledException)
+        {
+            log.LogWarning("remote broker: offer arrived but no password set — ignoring");
+        }
+        catch (Exception ex)
+        {
+            log.LogWarning(ex, "remote broker: failed to answer offer");
+        }
+        return null;
+    }
+
+    private static async Task<string?> ReceiveTextAsync(ClientWebSocket socket, byte[] buffer, CancellationToken ct)
+    {
+        using var ms = new MemoryStream();
+        WebSocketReceiveResult result;
+        do
+        {
+            result = await socket.ReceiveAsync(buffer, ct);
+            if (result.MessageType == WebSocketMessageType.Close)
+            {
+                await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, null, ct);
+                return null;
+            }
+            ms.Write(buffer, 0, result.Count);
+        }
+        while (!result.EndOfMessage);
+        return Encoding.UTF8.GetString(ms.GetBuffer(), 0, (int)ms.Length);
+    }
+
+    private static async Task DelayQuietly(TimeSpan delay, CancellationToken ct)
+    {
+        try { await Task.Delay(delay, ct); }
+        catch (OperationCanceledException) { /* shutting down */ }
+    }
+
+    private static TimeSpan NextBackoff(TimeSpan current)
+    {
+        var next = TimeSpan.FromMilliseconds(current.TotalMilliseconds * 2);
+        return next > ReconnectMax ? ReconnectMax : next;
+    }
+}

--- a/Zeus.Server.Hosting/Remote/RemotePasswordStore.cs
+++ b/Zeus.Server.Hosting/Remote/RemotePasswordStore.cs
@@ -1,0 +1,109 @@
+using LiteDB;
+using Org.BouncyCastle.Math;
+using Org.BouncyCastle.Math.EC;
+
+namespace Zeus.Server.Hosting.Remote;
+
+/// <summary>
+/// Persists the single remote-access SPAKE2+ verifier (ADR-0008) in a one-row
+/// LiteDB collection sharing zeus-prefs.db, mirroring the other settings stores.
+/// Stores only the verifier (salt, w0, L) and Argon2id params — never the
+/// password, never w1. A stolen DB does not yield the password.
+/// </summary>
+public sealed class RemotePasswordStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<RemotePasswordEntry> _col;
+    private readonly ILogger<RemotePasswordStore> _log;
+    private readonly object _sync = new();
+
+    public RemotePasswordStore(ILogger<RemotePasswordStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _col = _db.GetCollection<RemotePasswordEntry>("remote_password");
+    }
+
+    /// <summary>True when the operator has set a remote-access password.</summary>
+    public bool HasPassword()
+    {
+        lock (_sync)
+            return _col.FindAll().Any();
+    }
+
+    /// <summary>Set or replace the remote-access password (runs Argon2id registration).</summary>
+    public void Set(string password)
+    {
+        if (string.IsNullOrEmpty(password))
+            throw new ArgumentException("password is empty", nameof(password));
+
+        var v = Spake2PlusRegistration.Register(password);
+        lock (_sync)
+        {
+            _col.DeleteAll();
+            _col.Insert(new RemotePasswordEntry
+            {
+                Salt = v.Salt,
+                W0 = v.W0,
+                L = v.L,
+                Iterations = v.Iterations,
+                MemoryKib = v.MemoryKib,
+                Parallelism = v.Parallelism,
+            });
+        }
+        _log.LogInformation("remote-access password set (verifier stored; password not persisted)");
+    }
+
+    /// <summary>Remove the password — disables remote access (no-password-no-remote).</summary>
+    public void Clear()
+    {
+        lock (_sync)
+            _col.DeleteAll();
+        _log.LogInformation("remote-access password cleared");
+    }
+
+    /// <summary>
+    /// The stored verifier for the auth gate: w0 (scalar), L (point), and the
+    /// salt + Argon2 params the client needs to re-derive. Null if unset.
+    /// </summary>
+    public RemoteVerifierMaterial? GetVerifier()
+    {
+        lock (_sync)
+        {
+            var e = _col.FindAll().FirstOrDefault();
+            if (e is null) return null;
+            return new RemoteVerifierMaterial(
+                W0: Spake2Plus.ScalarFromBytes(e.W0),
+                L: Spake2Plus.DecodeL(e.L),
+                Salt: e.Salt,
+                Iterations: e.Iterations,
+                MemoryKib: e.MemoryKib,
+                Parallelism: e.Parallelism);
+        }
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    public sealed class RemotePasswordEntry
+    {
+        public int Id { get; set; }
+        public byte[] Salt { get; set; } = [];
+        public byte[] W0 { get; set; } = [];
+        public byte[] L { get; set; } = [];
+        public int Iterations { get; set; }
+        public int MemoryKib { get; set; }
+        public int Parallelism { get; set; }
+    }
+}
+
+/// <summary>Decoded verifier material handed to the auth gate at session start.</summary>
+public sealed record RemoteVerifierMaterial(
+    BigInteger W0, ECPoint L, byte[] Salt, int Iterations, int MemoryKib, int Parallelism);
+
+/// <summary>Body for <c>POST /api/remote/password</c>.</summary>
+public sealed record RemotePasswordRequest(string Password);

--- a/Zeus.Server.Hosting/Remote/RemoteQr.cs
+++ b/Zeus.Server.Hosting/Remote/RemoteQr.cs
@@ -1,0 +1,39 @@
+using QRCoder;
+
+namespace Zeus.Server.Hosting.Remote;
+
+/// <summary>
+/// Builds the operator's canonical remote address and renders it as a scannable
+/// QR code for the Server menu (ADR-0006/0007). The QR encodes the
+/// <c>/go/&lt;callsign&gt;</c> URL so a phone camera opens the remote client
+/// directly — no typing a URL.
+/// </summary>
+public static class RemoteQr
+{
+    public const string BrokerOrigin = "https://openhpsdrzeus.com";
+
+    /// <summary>
+    /// Canonical remote address for a callsign, e.g.
+    /// <c>https://openhpsdrzeus.com/go/EI6LF</c>. The callsign is uppercased and
+    /// URL-escaped so portable/special calls (<c>EI6LF/P</c>) stay a single path
+    /// segment. Returns null when no callsign is available.
+    /// </summary>
+    public static string? AddressFor(string? callsign)
+    {
+        if (string.IsNullOrWhiteSpace(callsign)) return null;
+        var normalized = callsign.Trim().ToUpperInvariant();
+        return $"{BrokerOrigin}/go/{Uri.EscapeDataString(normalized)}";
+    }
+
+    /// <summary>
+    /// Render text (a URL) to a standalone SVG QR code. SVG keeps it crisp at any
+    /// size and needs no raster/System.Drawing dependency (cross-platform).
+    /// </summary>
+    public static string Svg(string data, int pixelsPerModule = 6)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(data);
+        using var generator = new QRCodeGenerator();
+        using var qrData = generator.CreateQrCode(data, QRCodeGenerator.ECCLevel.M);
+        return new SvgQRCode(qrData).GetGraphic(pixelsPerModule);
+    }
+}

--- a/Zeus.Server.Hosting/Remote/RemoteWebRtcService.cs
+++ b/Zeus.Server.Hosting/Remote/RemoteWebRtcService.cs
@@ -1,0 +1,73 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+using SIPSorcery.Net;
+
+namespace Zeus.Server.Hosting.Remote;
+
+/// <summary>
+/// Signaling entry point for remote access (Phase 1). Answers a browser WebRTC
+/// offer with a session that is LOCKED until the SPAKE2+ password handshake
+/// completes (ADR-0008). Remote access is refused unless the operator has set a
+/// password — there is no unauthenticated remote path.
+/// </summary>
+public sealed class RemoteWebRtcService
+{
+    private readonly RemotePasswordStore _passwords;
+    private readonly ILogger<RemoteWebRtcService> _log;
+    private readonly ConcurrentDictionary<Guid, RemoteWebRtcSession> _sessions = new();
+
+    public RemoteWebRtcService(RemotePasswordStore passwords, ILogger<RemoteWebRtcService> log)
+    {
+        _passwords = passwords;
+        _log = log;
+    }
+
+    /// <summary>Whether remote access can be offered at all (a password is set).</summary>
+    public bool RemoteEnabled => _passwords.HasPassword();
+
+    public int ActiveSessions => _sessions.Count;
+
+    /// <summary>
+    /// Answer a remote offer. Throws <see cref="RemoteAccessDisabledException"/> if
+    /// no password is set (deny-by-default — the operator must enable it).
+    /// </summary>
+    public async Task<string> ConnectAsync(string offerSdp, CancellationToken ct = default)
+    {
+        var verifier = _passwords.GetVerifier()
+            ?? throw new RemoteAccessDisabledException();
+
+        var id = Guid.NewGuid();
+        var session = new RemoteWebRtcSession(verifier, _log, IceServers());
+        _sessions[id] = session;
+        session.Closed += () =>
+        {
+            if (_sessions.TryRemove(id, out _))
+                _log.LogInformation("rtc.remote session {Id} closed ({Count} active)", id, _sessions.Count);
+        };
+        session.Unlocked += () => _log.LogInformation("rtc.remote session {Id} unlocked", id);
+
+        _log.LogInformation("rtc.remote answering offer, session {Id}", id);
+        return await session.CreateAnswerAsync(offerSdp, ct);
+    }
+
+    public void CloseAll()
+    {
+        foreach (var kv in _sessions)
+            if (_sessions.TryRemove(kv.Key, out var s))
+                s.Close();
+    }
+
+    // STUN only here; the production path swaps in Cloudflare TURN credentials
+    // minted by the broker (Phase 3) for NAT/CGNAT traversal.
+    private static List<RTCIceServer> IceServers() =>
+    [
+        new RTCIceServer { urls = "stun:stun.cloudflare.com:3478" },
+    ];
+}
+
+/// <summary>Thrown when a remote connection is attempted with no session password set.</summary>
+public sealed class RemoteAccessDisabledException()
+    : Exception("Remote access requires a session password (Server menu).");
+
+/// <summary>Body for <c>POST /api/remote/connect</c> (the browser's WebRTC offer).</summary>
+public sealed record RemoteConnectRequest(string Sdp);

--- a/Zeus.Server.Hosting/Remote/RemoteWebRtcSession.cs
+++ b/Zeus.Server.Hosting/Remote/RemoteWebRtcSession.cs
@@ -1,0 +1,226 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using SIPSorcery.Net;
+
+namespace Zeus.Server.Hosting.Remote;
+
+/// <summary>
+/// One remote-access WebRTC session (Phase 1). Answers a browser offer, runs the
+/// SPAKE2+ password handshake over a reliable "control" DataChannel, and gates
+/// all radio egress behind <see cref="RemoteSession"/> — nothing flows on the
+/// "frames" channel until the password proves out (ADR-0008).
+///
+/// Auth wire protocol on the control channel (JSON, one message per send):
+///   server → {t:"auth-params", salt, iterations, memoryKib, parallelism}
+///   client → {t:"auth-share",  share}        (shareP)
+///   server → {t:"auth-share",  share}        (shareV; still LOCKED)
+///   client → {t:"auth-confirm",confirm}      (confirmP)
+///   server → {t:"auth-ok",     confirm} + UNLOCK   | {t:"auth-fail"} + close
+///
+/// The real radio-frame bridge (StreamingHub → frames channel) attaches on
+/// <see cref="Unlocked"/>; this class owns the gate, not the DSP wiring.
+/// </summary>
+public sealed class RemoteWebRtcSession
+{
+    private readonly ILogger _log;
+    private readonly RemoteVerifierMaterial _verifier;
+    private readonly RemoteSession _session;
+    private readonly RTCPeerConnection _pc;
+
+    private RTCDataChannel? _control;
+    private RTCDataChannel? _frames;
+
+    public RemoteWebRtcSession(
+        RemoteVerifierMaterial verifier, ILogger log, IReadOnlyList<RTCIceServer>? iceServers = null)
+    {
+        _verifier = verifier;
+        _log = log;
+
+        var gate = new Spake2PlusAuthGate(
+            RemoteAuthConstants.Context, RemoteAuthConstants.IdProver, RemoteAuthConstants.IdVerifier,
+            verifier.W0, verifier.L);
+        _session = new RemoteSession(gate);
+
+        _pc = new RTCPeerConnection(new RTCConfiguration
+        {
+            iceServers = iceServers?.ToList() ?? new List<RTCIceServer>(),
+        });
+        _pc.ondatachannel += OnDataChannel;
+        _pc.onconnectionstatechange += state =>
+        {
+            if (state is RTCPeerConnectionState.closed
+                or RTCPeerConnectionState.failed
+                or RTCPeerConnectionState.disconnected)
+                Close();
+        };
+    }
+
+    /// <summary>True once the password handshake has succeeded.</summary>
+    public bool IsUnlocked => _session.IsUnlocked;
+
+    /// <summary>Raised once, when the session transitions to UNLOCKED (attach the frame bridge here).</summary>
+    public event Action? Unlocked;
+
+    /// <summary>Raised once, when the session is torn down (for owner cleanup).</summary>
+    public event Action? Closed;
+
+    private int _closed;
+
+    /// <summary>Answer the browser's offer with a self-contained (vanilla-ICE) SDP.</summary>
+    public async Task<string> CreateAnswerAsync(string offerSdp, CancellationToken ct = default)
+    {
+        var setResult = _pc.setRemoteDescription(
+            new RTCSessionDescriptionInit { type = RTCSdpType.offer, sdp = offerSdp });
+        if (setResult != SetDescriptionResultEnum.OK)
+            throw new InvalidOperationException($"setRemoteDescription failed: {setResult}");
+
+        var answer = _pc.createAnswer(null);
+        await _pc.setLocalDescription(answer);
+        await WaitForIceGatheringAsync(_pc, TimeSpan.FromMilliseconds(750), ct);
+        return _pc.localDescription.sdp.ToString();
+    }
+
+    /// <summary>
+    /// Egress a radio frame on the unreliable "frames" channel — refused (returns
+    /// false, never throws) until the session is UNLOCKED.
+    /// </summary>
+    public bool TrySendFrame(byte[] frame)
+    {
+        if (!_session.TryEgress() || _frames is null)
+            return false;
+        _frames.send(frame);
+        return true;
+    }
+
+    public void Close()
+    {
+        if (Interlocked.Exchange(ref _closed, 1) != 0) return;
+        _session.Close();
+        try { _pc.close(); } catch { /* already torn down */ }
+        Closed?.Invoke();
+    }
+
+    private void OnDataChannel(RTCDataChannel dc)
+    {
+        switch (dc.label)
+        {
+            case "control":
+                _control = dc;
+                // Client-initiated: it sends {t:"hello"} once its channel opens
+                // and we reply with auth-params. Avoids depending on the
+                // answerer-side onopen firing.
+                dc.onmessage += (_, _, data) => _ = HandleControlAsync(data);
+                break;
+            case "frames":
+                _frames = dc;
+                break;
+            default:
+                _log.LogWarning("rtc.remote unexpected data channel '{Label}'", dc.label);
+                break;
+        }
+    }
+
+    private void SendAuthParams()
+    {
+        _control!.send(JsonSerializer.Serialize(new
+        {
+            t = "auth-params",
+            salt = Convert.ToBase64String(_verifier.Salt),
+            iterations = _verifier.Iterations,
+            memoryKib = _verifier.MemoryKib,
+            parallelism = _verifier.Parallelism,
+        }));
+    }
+
+    private async Task HandleControlAsync(byte[] data)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(data);
+            var t = doc.RootElement.GetProperty("t").GetString();
+
+            if (_session.IsUnlocked)
+                return; // post-unlock control plane (inbound VFO etc.) attaches with the frame bridge
+
+            switch (t)
+            {
+                case "hello":
+                    SendAuthParams();
+                    break;
+                case "auth-share":
+                {
+                    var share = Convert.FromBase64String(doc.RootElement.GetProperty("share").GetString()!);
+                    var outcome = await _session.SubmitAuthAsync(share);
+                    if (outcome.Action == RemoteSessionAction.Reply)
+                        _control!.send(Json("auth-share", "share", outcome.Reply.ToArray()));
+                    else
+                        FailAndClose();
+                    break;
+                }
+                case "auth-confirm":
+                {
+                    var confirm = Convert.FromBase64String(doc.RootElement.GetProperty("confirm").GetString()!);
+                    var outcome = await _session.SubmitAuthAsync(confirm);
+                    if (outcome.Action == RemoteSessionAction.Unlock)
+                    {
+                        _control!.send(Json("auth-ok", "confirm", outcome.Reply.ToArray()));
+                        _log.LogInformation("rtc.remote session UNLOCKED");
+                        Unlocked?.Invoke();
+                    }
+                    else
+                    {
+                        FailAndClose();
+                    }
+                    break;
+                }
+                default:
+                    FailAndClose(); // anything else while LOCKED is a protocol violation
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "rtc.remote auth error — failing closed");
+            FailAndClose();
+        }
+    }
+
+    private void FailAndClose()
+    {
+        try { _control?.send("{\"t\":\"auth-fail\"}"); } catch { /* best effort */ }
+        Close();
+    }
+
+    private static string Json(string t, string field, byte[] value)
+        => JsonSerializer.Serialize(new Dictionary<string, string>
+        {
+            ["t"] = t,
+            [field] = Convert.ToBase64String(value),
+        });
+
+    private static async Task WaitForIceGatheringAsync(RTCPeerConnection pc, TimeSpan timeout, CancellationToken ct)
+    {
+        if (pc.iceGatheringState == RTCIceGatheringState.complete)
+            return;
+
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        void OnChange(RTCIceGatheringState s)
+        {
+            if (s == RTCIceGatheringState.complete) tcs.TrySetResult();
+        }
+
+        pc.onicegatheringstatechange += OnChange;
+        try
+        {
+            if (pc.iceGatheringState == RTCIceGatheringState.complete) return;
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(timeout);
+            await using (cts.Token.Register(() => tcs.TrySetResult()))
+                await tcs.Task.ConfigureAwait(false);
+        }
+        finally
+        {
+            pc.onicegatheringstatechange -= OnChange;
+        }
+    }
+}

--- a/Zeus.Server.Hosting/Remote/Spake2Plus.cs
+++ b/Zeus.Server.Hosting/Remote/Spake2Plus.cs
@@ -260,4 +260,20 @@ public sealed class Spake2Plus
 
     /// <summary>Parse a hex scalar (test/registration helper).</summary>
     public static BigInteger ScalarFromHex(string hex) => new(hex, 16);
+
+    // --- Registration helpers (SPAKE2+ verifier derivation) -----------------
+
+    /// <summary>Reduce a wide (bias-avoiding) byte string to a scalar mod n.</summary>
+    public static BigInteger ReduceToScalar(ReadOnlySpan<byte> wide)
+        => new BigInteger(1, wide.ToArray()).Mod(Order);
+
+    /// <summary>Reconstruct a stored scalar (e.g. w0) from its 32-byte encoding.</summary>
+    public static BigInteger ScalarFromBytes(ReadOnlySpan<byte> bytes)
+        => new BigInteger(1, bytes.ToArray()).Mod(Order);
+
+    /// <summary>32-byte big-endian encoding of a scalar (storage helper).</summary>
+    public static byte[] EncodeScalar(BigInteger w) => FixedScalar(w);
+
+    /// <summary>The SPAKE2+ registration record L = w1·P, uncompressed-SEC1 encoded.</summary>
+    public static byte[] EncodeL(BigInteger w1) => G.Multiply(w1).Normalize().GetEncoded(false);
 }

--- a/Zeus.Server.Hosting/Remote/Spake2Plus.cs
+++ b/Zeus.Server.Hosting/Remote/Spake2Plus.cs
@@ -1,0 +1,263 @@
+using System.Security.Cryptography;
+using System.Text;
+using Org.BouncyCastle.Asn1.Sec;
+using Org.BouncyCastle.Asn1.X9;
+using Org.BouncyCastle.Math;
+using Org.BouncyCastle.Utilities.Encoders;
+// Alias the BouncyCastle EC types — System.Security.Cryptography also defines
+// ECPoint/ECCurve, and we need that namespace for SHA256/HKDF/HMAC.
+using ECCurve = Org.BouncyCastle.Math.EC.ECCurve;
+using ECPoint = Org.BouncyCastle.Math.EC.ECPoint;
+
+namespace Zeus.Server.Hosting.Remote;
+
+/// <summary>Which half of the SPAKE2+ exchange this instance plays.</summary>
+public enum Spake2Role
+{
+    /// <summary>The client that knows the password (holds w0 + w1).</summary>
+    Prover,
+    /// <summary>The radio that stored the verifier (holds w0 + L). This is Zeus.Server.</summary>
+    Verifier,
+}
+
+/// <summary>Thrown on any SPAKE2+ protocol/validation failure. Fails closed — leaks nothing.</summary>
+public sealed class Spake2Exception(string message) : Exception(message);
+
+/// <summary>
+/// Outcome of a completed SPAKE2+ exchange. <see cref="SharedKey"/> is the
+/// authenticated session key (K_shared / Ke); <see cref="LocalConfirm"/> is the
+/// MAC this side sends, and <see cref="ExpectedPeerConfirm"/> is the MAC it must
+/// receive (constant-time compared) before trusting the key.
+/// </summary>
+public sealed class Spake2PlusOutcome
+{
+    public required byte[] SharedKey { get; init; }
+    public required byte[] LocalConfirm { get; init; }
+    public required byte[] ExpectedPeerConfirm { get; init; }
+
+    // Intermediates exposed only to tests (InternalsVisibleTo) for RFC 9383
+    // Appendix C vector verification.
+    internal byte[] Transcript { get; init; } = [];
+    internal byte[] KMain { get; init; } = [];
+    internal byte[] KConfirmP { get; init; } = [];
+    internal byte[] KConfirmV { get; init; } = [];
+    internal byte[] ConfirmP { get; init; } = [];
+    internal byte[] ConfirmV { get; init; } = [];
+    internal byte[] ShareP { get; init; } = [];
+    internal byte[] ShareV { get; init; } = [];
+    internal byte[] ZEnc { get; init; } = [];
+    internal byte[] VEnc { get; init; } = [];
+}
+
+/// <summary>
+/// SPAKE2+ (RFC 9383), ciphersuite P256-SHA256-HKDF-SHA256-HMAC-SHA256. The
+/// augmented PAKE behind the remote-access session password (ADR-0008): the
+/// server stores only the verifier (w0, L = w1·P); the client proves knowledge
+/// of the password without ever sending it, and a malicious broker cannot MITM.
+///
+/// EC point math uses BouncyCastle (already in the dependency graph via
+/// SIPSorcery); the KDF/MAC/hash use the BCL. Correctness is pinned to the RFC
+/// 9383 Appendix C test vectors in <c>Spake2PlusTests</c>.
+/// </summary>
+public sealed class Spake2Plus
+{
+    private static readonly X9ECParameters Params = SecNamedCurves.GetByName("secp256r1");
+    private static readonly ECCurve Curve = Params.Curve;
+    private static readonly ECPoint G = Params.G;
+    private static readonly BigInteger Order = Params.N;
+
+    // RFC 9382/9383 constant points (compressed SEC1); discrete log unknown.
+    private static readonly ECPoint M = Curve.DecodePoint(
+        Hex.Decode("02886e2f97ace46e55ba9dd7242579f2993b64e16ef3dcab95afd497333d8fa12f"));
+    private static readonly ECPoint N = Curve.DecodePoint(
+        Hex.Decode("03d8bbd6c639c62937b04d997f38c3770719c629d7014d49a24b4f98baa1292b49"));
+
+    private readonly Spake2Role _role;
+    private readonly byte[] _context;
+    private readonly byte[] _idProver;
+    private readonly byte[] _idVerifier;
+
+    private BigInteger? _w0;
+    private BigInteger? _w1;   // prover only
+    private ECPoint? _l;       // verifier only
+    private BigInteger? _scalar; // x (prover) or y (verifier)
+    private byte[]? _share;
+
+    public Spake2Plus(Spake2Role role, byte[] context, byte[] idProver, byte[] idVerifier)
+    {
+        _role = role;
+        _context = context;
+        _idProver = idProver;
+        _idVerifier = idVerifier;
+    }
+
+    /// <summary>Decode an uncompressed-SEC1 registration record L into a point.</summary>
+    public static ECPoint DecodeL(byte[] encoded) => Validated(Curve.DecodePoint(encoded));
+
+    /// <summary>
+    /// Prover (client) first message: shareP = x·P + w0·M. <paramref name="x"/>
+    /// is for test vectors only; production passes null for a random scalar.
+    /// </summary>
+    public byte[] StartProver(BigInteger w0, BigInteger w1, BigInteger? x = null)
+    {
+        if (_role != Spake2Role.Prover) throw new Spake2Exception("role mismatch");
+        _w0 = w0;
+        _w1 = w1;
+        _scalar = x ?? RandomScalar();
+        _share = G.Multiply(_scalar).Add(M.Multiply(w0)).Normalize().GetEncoded(false);
+        return _share;
+    }
+
+    /// <summary>
+    /// Verifier (radio) first message: shareV = y·P + w0·N. <paramref name="y"/>
+    /// is for test vectors only; production passes null for a random scalar.
+    /// </summary>
+    public byte[] StartVerifier(BigInteger w0, ECPoint l, BigInteger? y = null)
+    {
+        if (_role != Spake2Role.Verifier) throw new Spake2Exception("role mismatch");
+        _w0 = w0;
+        _l = l;
+        _scalar = y ?? RandomScalar();
+        _share = G.Multiply(_scalar).Add(N.Multiply(w0)).Normalize().GetEncoded(false);
+        return _share;
+    }
+
+    /// <summary>
+    /// Process the peer's share, derive Z/V, build the transcript, and produce the
+    /// session key + confirmation MACs. Throws (fails closed) on any invalid input.
+    /// </summary>
+    public Spake2PlusOutcome Process(byte[] peerShare)
+    {
+        if (_w0 is null || _scalar is null || _share is null)
+            throw new Spake2Exception("Start* not called");
+
+        var peer = Validated(Curve.DecodePoint(peerShare));
+
+        ECPoint z, v;
+        byte[] shareP, shareV;
+        if (_role == Spake2Role.Prover)
+        {
+            // peer = shareV (Y). Z = x·(Y − w0·N); V = w1·(Y − w0·N).
+            var t = Validated(peer.Subtract(N.Multiply(_w0)));
+            z = t.Multiply(_scalar).Normalize();
+            v = t.Multiply(_w1!).Normalize();
+            shareP = _share;
+            shareV = peer.GetEncoded(false);
+        }
+        else
+        {
+            // peer = shareP (X). Z = y·(X − w0·M); V = y·L.
+            var t = Validated(peer.Subtract(M.Multiply(_w0)));
+            z = t.Multiply(_scalar).Normalize();
+            v = _l!.Multiply(_scalar).Normalize();
+            shareP = peer.GetEncoded(false);
+            shareV = _share;
+        }
+        if (z.IsInfinity || v.IsInfinity)
+            throw new Spake2Exception("degenerate shared point");
+
+        var zEnc = z.GetEncoded(false);
+        var vEnc = v.GetEncoded(false);
+
+        var tt = BuildTranscript(shareP, shareV, zEnc, vEnc, _w0!);
+        var kMain = SHA256.HashData(tt);
+
+        var confirmKeys = HKDF.DeriveKey(HashAlgorithmName.SHA256, kMain, 64,
+            salt: null, info: Encoding.ASCII.GetBytes("ConfirmationKeys"));
+        var kConfirmP = confirmKeys[..32];
+        var kConfirmV = confirmKeys[32..];
+        var kShared = HKDF.DeriveKey(HashAlgorithmName.SHA256, kMain, 32,
+            salt: null, info: Encoding.ASCII.GetBytes("SharedKey"));
+
+        // RFC 9383 §3.4: confirmP = MAC(K_confirmP, shareV); confirmV = MAC(K_confirmV, shareP).
+        var confirmP = HMACSHA256.HashData(kConfirmP, shareV);
+        var confirmV = HMACSHA256.HashData(kConfirmV, shareP);
+
+        var (local, expected) = _role == Spake2Role.Prover
+            ? (confirmP, confirmV)
+            : (confirmV, confirmP);
+
+        return new Spake2PlusOutcome
+        {
+            SharedKey = kShared,
+            LocalConfirm = local,
+            ExpectedPeerConfirm = expected,
+            Transcript = tt,
+            KMain = kMain,
+            KConfirmP = kConfirmP,
+            KConfirmV = kConfirmV,
+            ConfirmP = confirmP,
+            ConfirmV = confirmV,
+            ShareP = shareP,
+            ShareV = shareV,
+            ZEnc = zEnc,
+            VEnc = vEnc,
+        };
+    }
+
+    /// <summary>Constant-time check of the peer's confirmation MAC.</summary>
+    public static bool VerifyPeerConfirm(Spake2PlusOutcome outcome, byte[] received)
+        => CryptographicOperations.FixedTimeEquals(outcome.ExpectedPeerConfirm, received);
+
+    // TT = len(Context)||Context || len(idProver)||idProver || len(idVerifier)||idVerifier
+    //   || len(M)||M || len(N)||N || len(shareP)||shareP || len(shareV)||shareV
+    //   || len(Z)||Z || len(V)||V || len(w0)||w0     (RFC 9383 §3.3)
+    private byte[] BuildTranscript(byte[] shareP, byte[] shareV, byte[] zEnc, byte[] vEnc, BigInteger w0)
+    {
+        using var ms = new MemoryStream();
+        AppendLenPrefixed(ms, _context);
+        AppendLenPrefixed(ms, _idProver);
+        AppendLenPrefixed(ms, _idVerifier);
+        AppendLenPrefixed(ms, M.GetEncoded(false));
+        AppendLenPrefixed(ms, N.GetEncoded(false));
+        AppendLenPrefixed(ms, shareP);
+        AppendLenPrefixed(ms, shareV);
+        AppendLenPrefixed(ms, zEnc);
+        AppendLenPrefixed(ms, vEnc);
+        AppendLenPrefixed(ms, FixedScalar(w0)); // 32-byte big-endian
+        return ms.ToArray();
+    }
+
+    private static void AppendLenPrefixed(Stream s, byte[] value)
+    {
+        Span<byte> len = stackalloc byte[8];
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(len, (ulong)value.Length);
+        s.Write(len);
+        s.Write(value);
+    }
+
+    /// <summary>32-byte big-endian encoding of a scalar (P-256 field width).</summary>
+    private static byte[] FixedScalar(BigInteger w)
+    {
+        var raw = w.ToByteArrayUnsigned(); // big-endian, minimal
+        if (raw.Length == 32) return raw;
+        if (raw.Length > 32) throw new Spake2Exception("scalar too large");
+        var padded = new byte[32];
+        Array.Copy(raw, 0, padded, 32 - raw.Length, raw.Length);
+        return padded;
+    }
+
+    private static ECPoint Validated(ECPoint p)
+    {
+        var n = p.Normalize();
+        if (n.IsInfinity || !n.IsValid())
+            throw new Spake2Exception("invalid EC point");
+        return n;
+    }
+
+    private static BigInteger RandomScalar()
+    {
+        // Sample uniformly in [1, n). Oversample then reduce to avoid modulo bias.
+        Span<byte> buf = stackalloc byte[48]; // > order width
+        while (true)
+        {
+            RandomNumberGenerator.Fill(buf);
+            var candidate = new BigInteger(1, buf.ToArray()).Mod(Order);
+            if (candidate.SignValue > 0)
+                return candidate;
+        }
+    }
+
+    /// <summary>Parse a hex scalar (test/registration helper).</summary>
+    public static BigInteger ScalarFromHex(string hex) => new(hex, 16);
+}

--- a/Zeus.Server.Hosting/Remote/Spake2PlusAuthGate.cs
+++ b/Zeus.Server.Hosting/Remote/Spake2PlusAuthGate.cs
@@ -1,0 +1,72 @@
+using Org.BouncyCastle.Math;
+using Org.BouncyCastle.Math.EC;
+
+namespace Zeus.Server.Hosting.Remote;
+
+/// <summary>
+/// The real <see cref="IRemoteAuthGate"/> (ADR-0008): runs the SPAKE2+ verifier
+/// against the operator's stored password verifier (w0, L). Replaces
+/// <see cref="DenyAllAuthGate"/> once a password is set. The gate is the SERVER
+/// (verifier) half; the browser is the prover.
+///
+/// Two client messages drive it, strictly in order:
+///   step 0: client → shareP (X). Gate replies shareV (Y), stays LOCKED.
+///   step 1: client → confirmP.   Gate verifies (constant-time); on success it
+///           replies confirmV and UNLOCKS, else it rejects (fails closed).
+/// After unlock, <see cref="SessionKey"/> is the authenticated shared key, usable
+/// to bind/derive the transport keys.
+/// </summary>
+public sealed class Spake2PlusAuthGate : IRemoteAuthGate
+{
+    private readonly Spake2Plus _spake;
+    private readonly BigInteger _w0;
+    private readonly ECPoint _l;
+
+    private int _step;
+    private Spake2PlusOutcome? _outcome;
+
+    public Spake2PlusAuthGate(byte[] context, byte[] idProver, byte[] idVerifier, BigInteger w0, ECPoint l)
+    {
+        _spake = new Spake2Plus(Spake2Role.Verifier, context, idProver, idVerifier);
+        _w0 = w0;
+        _l = l;
+    }
+
+    /// <summary>The authenticated session key, available only after a successful unlock.</summary>
+    public byte[]? SessionKey => _step >= 2 ? _outcome?.SharedKey : null;
+
+    public ValueTask<RemoteAuthStep> StepAsync(ReadOnlyMemory<byte> clientMessage, CancellationToken ct = default)
+    {
+        try
+        {
+            switch (_step)
+            {
+                case 0:
+                {
+                    // client message = shareP (X). Compute our share + the full outcome.
+                    var shareV = _spake.StartVerifier(_w0, _l); // fresh random y per session
+                    _outcome = _spake.Process(clientMessage.ToArray());
+                    _step = 1;
+                    return new ValueTask<RemoteAuthStep>(RemoteAuthStep.Continue(shareV));
+                }
+                case 1:
+                {
+                    // client message = confirmP. Verify in constant time.
+                    if (_outcome is null
+                        || !Spake2Plus.VerifyPeerConfirm(_outcome, clientMessage.ToArray()))
+                        return new ValueTask<RemoteAuthStep>(RemoteAuthStep.Rejected);
+
+                    _step = 2;
+                    return new ValueTask<RemoteAuthStep>(RemoteAuthStep.Unlock(_outcome.LocalConfirm));
+                }
+                default:
+                    return new ValueTask<RemoteAuthStep>(RemoteAuthStep.Rejected);
+            }
+        }
+        catch
+        {
+            // Any malformed share / invalid point / protocol misuse fails closed.
+            return new ValueTask<RemoteAuthStep>(RemoteAuthStep.Rejected);
+        }
+    }
+}

--- a/Zeus.Server.Hosting/Remote/Spake2PlusRegistration.cs
+++ b/Zeus.Server.Hosting/Remote/Spake2PlusRegistration.cs
@@ -1,0 +1,117 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using System.Text;
+using Konscious.Security.Cryptography;
+using Org.BouncyCastle.Math;
+
+namespace Zeus.Server.Hosting.Remote;
+
+/// <summary>
+/// App-wide SPAKE2+ parameters. The browser prover MUST use byte-identical
+/// values, so they live in one place and are mirrored in the TS client.
+/// </summary>
+public static class RemoteAuthConstants
+{
+    public static byte[] Context => Encoding.UTF8.GetBytes("zeus-remote-access/v1");
+    public static byte[] IdProver => [];   // empty identities; Context binds the app
+    public static byte[] IdVerifier => [];
+
+    public const int DefaultIterations = 3;
+    public const int DefaultMemoryKib = 65536;   // 64 MiB — memory-hard
+    public const int DefaultParallelism = 1;
+    public const int SaltBytes = 16;
+    private const int ScalarWideBytes = 48;       // 384 bits → reduce mod n, low bias
+    public const int Argon2OutputBytes = 2 * ScalarWideBytes;
+}
+
+/// <summary>
+/// The stored SPAKE2+ registration record. Contains no password and no w1 — only
+/// the verifier (w0, L = w1·P) plus the salt and Argon2id parameters needed to
+/// re-derive on the client at login.
+/// </summary>
+public sealed record Spake2PlusVerifier(
+    byte[] Salt, byte[] W0, byte[] L, int Iterations, int MemoryKib, int Parallelism);
+
+/// <summary>
+/// SPAKE2+ password registration (ADR-0008): Argon2id over the password yields
+/// the scalars (w0, w1); the server keeps only (w0, L = w1·P). Deterministic —
+/// the browser runs the identical Argon2id over the same salt+params to prove
+/// knowledge without ever sending the password.
+/// </summary>
+public static class Spake2PlusRegistration
+{
+    /// <summary>Derive (w0, w1) from password + salt. Mirrored by the TS client.</summary>
+    public static (BigInteger W0, BigInteger W1) DeriveScalars(
+        string password, byte[] salt, int iterations, int memoryKib, int parallelism)
+    {
+        var input = BuildPasswordInput(password);
+        try
+        {
+            using var argon = new Argon2id(input)
+            {
+                Salt = salt,
+                Iterations = iterations,
+                MemorySize = memoryKib,
+                DegreeOfParallelism = parallelism,
+            };
+            var wide = argon.GetBytes(RemoteAuthConstants.Argon2OutputBytes);
+            try
+            {
+                var half = wide.Length / 2;
+                var w0 = Spake2Plus.ReduceToScalar(wide.AsSpan(0, half));
+                var w1 = Spake2Plus.ReduceToScalar(wide.AsSpan(half));
+                return (w0, w1);
+            }
+            finally
+            {
+                CryptographicOperations.ZeroMemory(wide);
+            }
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(input);
+        }
+    }
+
+    /// <summary>Register a new password → stored verifier. Never returns w1 or the password.</summary>
+    public static Spake2PlusVerifier Register(
+        string password,
+        int iterations = RemoteAuthConstants.DefaultIterations,
+        int memoryKib = RemoteAuthConstants.DefaultMemoryKib,
+        int parallelism = RemoteAuthConstants.DefaultParallelism)
+    {
+        var salt = RandomNumberGenerator.GetBytes(RemoteAuthConstants.SaltBytes);
+        var (w0, w1) = DeriveScalars(password, salt, iterations, memoryKib, parallelism);
+        return new Spake2PlusVerifier(
+            salt,
+            Spake2Plus.EncodeScalar(w0),
+            Spake2Plus.EncodeL(w1),
+            iterations, memoryKib, parallelism);
+    }
+
+    // RFC 9383 §3.2: PBKDF input = len(pw)||pw || len(idProver)||idProver || len(idVerifier)||idVerifier
+    private static byte[] BuildPasswordInput(string password)
+    {
+        var pw = Encoding.UTF8.GetBytes(password);
+        try
+        {
+            using var ms = new MemoryStream();
+            AppendLenPrefixed(ms, pw);
+            AppendLenPrefixed(ms, RemoteAuthConstants.IdProver);
+            AppendLenPrefixed(ms, RemoteAuthConstants.IdVerifier);
+            return ms.ToArray();
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(pw);
+        }
+    }
+
+    private static void AppendLenPrefixed(Stream s, byte[] value)
+    {
+        Span<byte> len = stackalloc byte[8];
+        BinaryPrimitives.WriteUInt64LittleEndian(len, (ulong)value.Length);
+        s.Write(len);
+        s.Write(value);
+    }
+}

--- a/Zeus.Server.Hosting/Remote/WebRtcSpikeService.cs
+++ b/Zeus.Server.Hosting/Remote/WebRtcSpikeService.cs
@@ -1,0 +1,123 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+using SIPSorcery.Net;
+
+namespace Zeus.Server.Hosting.Remote;
+
+/// <summary>Request body for the dev-only <c>POST /api/rtc/spike/offer</c> endpoint.</summary>
+public sealed record RtcSpikeOffer(string Sdp);
+
+/// <summary>
+/// Phase-0 spike for the WebRTC remote-access data plane
+/// (see <c>docs/designs/remote-access-webrtc.md</c>). This is NOT the production
+/// transport — it answers a single SDP offer and echoes binary DataChannel
+/// messages straight back, so we can prove the .NET↔browser WebRTC path works on
+/// our exact stack (SIPSorcery on net10, all target arches) and measure the
+/// added round-trip latency before building the real transport abstraction.
+///
+/// The echo handler does the absolute minimum (send the received bytes back on
+/// the same channel) so the measured RTT reflects the transport, not our code.
+/// </summary>
+public sealed class WebRtcSpikeService
+{
+    private readonly ILogger<WebRtcSpikeService> _log;
+    private readonly ConcurrentDictionary<Guid, RTCPeerConnection> _peers = new();
+
+    public WebRtcSpikeService(ILogger<WebRtcSpikeService> log) => _log = log;
+
+    public int ActivePeers => _peers.Count;
+
+    /// <summary>
+    /// Accept a remote SDP offer, wire an echo DataChannel, and return a
+    /// self-contained ("vanilla ICE") answer SDP with host candidates embedded.
+    /// </summary>
+    public async Task<string> CreateEchoAnswerAsync(string offerSdp, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(offerSdp))
+            throw new ArgumentException("offer SDP is empty", nameof(offerSdp));
+
+        var id = Guid.NewGuid();
+        var config = new RTCConfiguration
+        {
+            // STUN only for the spike; the production path adds Cloudflare TURN.
+            iceServers = new List<RTCIceServer>
+            {
+                new RTCIceServer { urls = "stun:stun.cloudflare.com:3478" },
+            },
+        };
+
+        var pc = new RTCPeerConnection(config);
+        _peers[id] = pc;
+
+        pc.ondatachannel += dc =>
+        {
+            _log.LogInformation("rtc.spike[{Id}] datachannel opened label={Label}", id, dc.label);
+            dc.onmessage += (chan, _, data) => chan.send(data); // echo — minimal added latency
+        };
+
+        pc.onconnectionstatechange += state =>
+        {
+            _log.LogInformation("rtc.spike[{Id}] state={State}", id, state);
+            if (state is RTCPeerConnectionState.closed
+                or RTCPeerConnectionState.failed
+                or RTCPeerConnectionState.disconnected)
+            {
+                if (_peers.TryRemove(id, out var dead))
+                    dead.close();
+            }
+        };
+
+        var setResult = pc.setRemoteDescription(
+            new RTCSessionDescriptionInit { type = RTCSdpType.offer, sdp = offerSdp });
+        if (setResult != SetDescriptionResultEnum.OK)
+        {
+            _peers.TryRemove(id, out _);
+            pc.close();
+            throw new InvalidOperationException($"setRemoteDescription failed: {setResult}");
+        }
+
+        var answer = pc.createAnswer(null);
+        await pc.setLocalDescription(answer);
+        await WaitForIceGatheringAsync(pc, TimeSpan.FromMilliseconds(750), ct);
+
+        return pc.localDescription.sdp.ToString();
+    }
+
+    /// <summary>Close all active spike peers (test teardown / shutdown).</summary>
+    public void CloseAll()
+    {
+        foreach (var kv in _peers)
+            if (_peers.TryRemove(kv.Key, out var pc))
+                pc.close();
+    }
+
+    private static async Task WaitForIceGatheringAsync(
+        RTCPeerConnection pc, TimeSpan timeout, CancellationToken ct)
+    {
+        if (pc.iceGatheringState == RTCIceGatheringState.complete)
+            return;
+
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        void OnChange(RTCIceGatheringState s)
+        {
+            if (s == RTCIceGatheringState.complete)
+                tcs.TrySetResult();
+        }
+
+        pc.onicegatheringstatechange += OnChange;
+        try
+        {
+            if (pc.iceGatheringState == RTCIceGatheringState.complete)
+                return;
+
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            timeoutCts.CancelAfter(timeout);
+            await using (timeoutCts.Token.Register(() => tcs.TrySetResult()))
+                await tcs.Task.ConfigureAwait(false);
+        }
+        finally
+        {
+            pc.onicegatheringstatechange -= OnChange;
+        }
+    }
+}

--- a/Zeus.Server.Hosting/Zeus.Server.Hosting.csproj
+++ b/Zeus.Server.Hosting/Zeus.Server.Hosting.csproj
@@ -47,6 +47,7 @@
 
   <ItemGroup>
     <PackageReference Include="LiteDB" Version="5.0.20" />
+    <PackageReference Include="SIPSorcery" Version="10.0.10" />
   </ItemGroup>
 
   <!-- WDSP NR2 EMNR fopen()s these by bare relative name (native/wdsp/emnr.c:215,397).

--- a/Zeus.Server.Hosting/Zeus.Server.Hosting.csproj
+++ b/Zeus.Server.Hosting/Zeus.Server.Hosting.csproj
@@ -47,6 +47,7 @@
 
   <ItemGroup>
     <PackageReference Include="LiteDB" Version="5.0.20" />
+    <PackageReference Include="QRCoder" Version="1.8.0" />
     <PackageReference Include="SIPSorcery" Version="10.0.10" />
   </ItemGroup>
 

--- a/Zeus.Server.Hosting/Zeus.Server.Hosting.csproj
+++ b/Zeus.Server.Hosting/Zeus.Server.Hosting.csproj
@@ -46,6 +46,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Konscious.Security.Cryptography.Argon2" Version="1.3.1" />
     <PackageReference Include="LiteDB" Version="5.0.20" />
     <PackageReference Include="QRCoder" Version="1.8.0" />
     <PackageReference Include="SIPSorcery" Version="10.0.10" />

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -2735,6 +2735,18 @@ public static class ZeusEndpoints
             await hub.AttachClientAsync(ws, ctx.RequestAborted);
         });
 
+        // -- Remote-access QR (Server menu: scan → open remote client) --------
+        // Renders any URL to an SVG QR. The Server menu requests it for the
+        // operator's /go/<callsign> address (RemoteQr.AddressFor). See
+        // docs/designs/remote-access-webrtc.md.
+        app.MapGet("/api/remote/qr.svg", (string? data) =>
+        {
+            if (string.IsNullOrWhiteSpace(data) || data.Length > 1024)
+                return Results.BadRequest(new { error = "data required (max 1024 chars)" });
+            return Results.Content(
+                Zeus.Server.Hosting.Remote.RemoteQr.Svg(data), "image/svg+xml");
+        });
+
         // -- WebRTC data-plane spike (Phase 0) --------------------------------
         // Dev-only: inert unless ZEUS_RTC_SPIKE=1. Answers a browser SDP offer
         // and echoes binary DataChannel messages so we can measure real

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -2747,6 +2747,33 @@ public static class ZeusEndpoints
                 Zeus.Server.Hosting.Remote.RemoteQr.Svg(data), "image/svg+xml");
         });
 
+        // -- Remote-access session password (ADR-0008) ------------------------
+        // The operator sets a password here; remote access cannot be enabled
+        // without one. Verified end-to-end via SPAKE2+ — the server stores only
+        // the verifier, never the password.
+        app.MapGet("/api/remote/password/status",
+            (Zeus.Server.Hosting.Remote.RemotePasswordStore store) =>
+                Results.Ok(new { hasPassword = store.HasPassword() }));
+
+        app.MapPost("/api/remote/password",
+            (Zeus.Server.Hosting.Remote.RemotePasswordRequest req,
+             Zeus.Server.Hosting.Remote.RemotePasswordStore store) =>
+            {
+                if (string.IsNullOrWhiteSpace(req?.Password) || req.Password.Length < 8)
+                    return Results.BadRequest(new { error = "password must be at least 8 characters" });
+                store.Set(req.Password);
+                log.LogInformation("api.remote.password set");
+                return Results.Ok(new { hasPassword = true });
+            });
+
+        app.MapDelete("/api/remote/password",
+            (Zeus.Server.Hosting.Remote.RemotePasswordStore store) =>
+            {
+                store.Clear();
+                log.LogInformation("api.remote.password cleared");
+                return Results.Ok(new { hasPassword = false });
+            });
+
         // -- WebRTC data-plane spike (Phase 0) --------------------------------
         // Dev-only: inert unless ZEUS_RTC_SPIKE=1. Answers a browser SDP offer
         // and echoes binary DataChannel messages so we can measure real

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -2735,6 +2735,26 @@ public static class ZeusEndpoints
             await hub.AttachClientAsync(ws, ctx.RequestAborted);
         });
 
+        // -- WebRTC data-plane spike (Phase 0) --------------------------------
+        // Dev-only: inert unless ZEUS_RTC_SPIKE=1. Answers a browser SDP offer
+        // and echoes binary DataChannel messages so we can measure real
+        // browser↔Zeus.Server round-trip latency. See zeus-web/public/rtc-spike.html
+        // and docs/designs/remote-access-webrtc.md. NOT the production transport.
+        if (Environment.GetEnvironmentVariable("ZEUS_RTC_SPIKE") == "1")
+        {
+            log.LogWarning("rtc.spike endpoint ENABLED (/api/rtc/spike/offer) — dev only");
+            app.MapPost("/api/rtc/spike/offer",
+                async (Zeus.Server.Hosting.Remote.RtcSpikeOffer req,
+                       Zeus.Server.Hosting.Remote.WebRtcSpikeService rtc,
+                       CancellationToken ct) =>
+                {
+                    if (string.IsNullOrWhiteSpace(req?.Sdp))
+                        return Results.BadRequest(new { error = "sdp required" });
+                    var answerSdp = await rtc.CreateEchoAnswerAsync(req.Sdp, ct);
+                    return Results.Ok(new { sdp = answerSdp, type = "answer" });
+                });
+        }
+
         // -- HamClock embed (optional Node sidecar; see HamClockService) -----
         // Inert until the operator installs it from Settings → HamClock. The
         // <iframe> in HamClockWindow points at the sidecar's own port (status

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -2869,6 +2869,26 @@ public static class ZeusEndpoints
                 return Results.Ok(new { hasPassword = false });
             });
 
+        // WebRTC signaling: answer the browser's offer with a password-gated session
+        // (Phase 1). 403 when no password is set — there is no unauthenticated path.
+        app.MapPost("/api/remote/connect",
+            async (Zeus.Server.Hosting.Remote.RemoteConnectRequest req,
+                   Zeus.Server.Hosting.Remote.RemoteWebRtcService rtc,
+                   CancellationToken ct) =>
+            {
+                if (string.IsNullOrWhiteSpace(req?.Sdp))
+                    return Results.BadRequest(new { error = "sdp required" });
+                try
+                {
+                    var answer = await rtc.ConnectAsync(req.Sdp, ct);
+                    return Results.Ok(new { sdp = answer, type = "answer" });
+                }
+                catch (Zeus.Server.Hosting.Remote.RemoteAccessDisabledException)
+                {
+                    return Results.StatusCode(StatusCodes.Status403Forbidden);
+                }
+            });
+
         // -- WebRTC data-plane spike (Phase 0) --------------------------------
         // Dev-only: inert unless ZEUS_RTC_SPIKE=1. Answers a browser SDP offer
         // and echoes binary DataChannel messages so we can measure real

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -226,6 +226,10 @@ public static class ZeusHost
             sp.GetRequiredService<Zeus.Protocol1.TxIqRing>());
         builder.Services.AddSingleton<RadioService>();
         builder.Services.AddSingleton<StreamingHub>();
+        // WebRTC remote-access data plane (docs/designs/remote-access-webrtc.md).
+        // Phase-0 spike service; the dev-only /api/rtc/spike/offer endpoint that
+        // uses it is gated behind ZEUS_RTC_SPIKE=1 in ZeusEndpoints.
+        builder.Services.AddSingleton<Zeus.Server.Hosting.Remote.WebRtcSpikeService>();
         // RX audio publish seam (Phase 1). DspPipelineService.PublishAudio
         // fans each AudioFrame across every registered IRxAudioSink.
         //

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -235,6 +235,9 @@ public static class ZeusHost
         // Remote-access WebRTC signaling (Phase 1). Answers offers with a session
         // gated behind the SPAKE2+ password handshake.
         builder.Services.AddSingleton<Zeus.Server.Hosting.Remote.RemoteWebRtcService>();
+        // Radio-side broker glue (Phase 3). Inert until a remote-access password
+        // is set; then it keeps a "host" socket on the broker and answers offers.
+        builder.Services.AddHostedService<Zeus.Server.Hosting.Remote.RemoteBrokerClient>();
         // RX audio publish seam (Phase 1). DspPipelineService.PublishAudio
         // fans each AudioFrame across every registered IRxAudioSink.
         //

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -230,6 +230,8 @@ public static class ZeusHost
         // Phase-0 spike service; the dev-only /api/rtc/spike/offer endpoint that
         // uses it is gated behind ZEUS_RTC_SPIKE=1 in ZeusEndpoints.
         builder.Services.AddSingleton<Zeus.Server.Hosting.Remote.WebRtcSpikeService>();
+        // Remote-access session password verifier (SPAKE2+, ADR-0008).
+        builder.Services.AddSingleton<Zeus.Server.Hosting.Remote.RemotePasswordStore>();
         // RX audio publish seam (Phase 1). DspPipelineService.PublishAudio
         // fans each AudioFrame across every registered IRxAudioSink.
         //

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -232,6 +232,9 @@ public static class ZeusHost
         builder.Services.AddSingleton<Zeus.Server.Hosting.Remote.WebRtcSpikeService>();
         // Remote-access session password verifier (SPAKE2+, ADR-0008).
         builder.Services.AddSingleton<Zeus.Server.Hosting.Remote.RemotePasswordStore>();
+        // Remote-access WebRTC signaling (Phase 1). Answers offers with a session
+        // gated behind the SPAKE2+ password handshake.
+        builder.Services.AddSingleton<Zeus.Server.Hosting.Remote.RemoteWebRtcService>();
         // RX audio publish seam (Phase 1). DspPipelineService.PublishAudio
         // fans each AudioFrame across every registered IRxAudioSink.
         //

--- a/cloud/zeus-remote-broker/.gitignore
+++ b/cloud/zeus-remote-broker/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.wrangler/
+dist/
+*.log
+.dev.vars
+worker-configuration.d.ts

--- a/cloud/zeus-remote-broker/README.md
+++ b/cloud/zeus-remote-broker/README.md
@@ -1,0 +1,54 @@
+# zeus-remote-broker
+
+Cloudflare Worker + Durable Object that brokers **remote access** to a Zeus radio
+(ADR-0005/0006). It relays WebRTC signaling and mints TURN credentials — it never
+sees media and never sees the session password.
+
+## Why a broker
+
+The browser cannot reach the operator's radio directly over the internet (home
+NAT/CGNAT). So the radio keeps a persistent `host` WebSocket here, the browser
+connects as a `client`, and the broker relays SDP/ICE between them until a direct
+WebRTC peer-to-peer path is established (TURN-relayed only as fallback). Once the
+peer connection is up, **media flows peer-to-peer and never touches this Worker.**
+
+Security: the **host** side is QRZ-gated (only the operator who can prove the
+callsign on QRZ may register as that radio). The **client** side is open — actual
+radio access is gated end-to-end by the SPAKE2+ session password at the radio
+(ADR-0008), so the broker is a pure, untrusted relay.
+
+## Endpoints
+
+- `GET /health` — liveness.
+- `GET /go/<callsign>` — the operator's permanent address; 302-redirects to the
+  web client (`WEB_APP_ORIGIN`) with `?remote=<callsign>`.
+- `POST /turn` — mint short-lived Cloudflare Realtime TURN credentials
+  (`{ iceServers }`); 503 if TURN is not configured (clients then use STUN only).
+- `GET /signal?role=host` (WS, QRZ headers) — the radio registers for its callsign.
+- `GET /signal?role=client&callsign=<X>` (WS) — a browser joins radio `<X>`'s room.
+
+Signaling messages (JSON): client→host `offer`/`candidate`/`bye`; host→client
+`answer`/`candidate`/`bye` (addressed by the broker-assigned `clientId`); `ping`/
+`pong` keepalive auto-answered without waking the DO.
+
+## Deploy
+
+```bash
+npm install
+npm run typecheck
+wrangler secret put TURN_KEY_ID        # from Cloudflare Realtime
+wrangler secret put TURN_API_TOKEN
+npm run deploy                          # creates remote.openhpsdrzeus.com
+```
+
+Requires the `openhpsdrzeus.com` zone on the deploying Cloudflare account. DOs are
+SQLite-backed (free-plan compatible). For local dev: `wrangler dev --var QRZ_VERIFY:off`.
+
+## Radio side (TODO — needs this broker live to test)
+
+The radio needs a `RemoteBrokerClient` (.NET) that keeps a `host` WebSocket open
+here, and on each relayed `offer` calls `RemoteWebRtcService.ConnectAsync(offer)`
+to produce the `answer` (gated by the SPAKE2+ password) and relays it back with
+the `clientId`. The server transport it drives already exists
+(`Zeus.Server.Hosting/Remote/RemoteWebRtcSession.cs`); only the broker-client glue
+remains, and it can only be verified against a live broker.

--- a/cloud/zeus-remote-broker/package-lock.json
+++ b/cloud/zeus-remote-broker/package-lock.json
@@ -1,0 +1,1576 @@
+{
+  "name": "zeus-remote-broker",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "zeus-remote-broker",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20250109.0",
+        "typescript": "^5.7.0",
+        "wrangler": "^4.0.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260617.1.tgz",
+      "integrity": "sha512-jWwmgEVVWbsHNrLSNXzwjJaH90VzRxq1cWkQFUidxyeUPnMxemeNE8I9qFAfrpzGgE11e9sKDcE3ettJW08swQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260617.1.tgz",
+      "integrity": "sha512-LHH7b565g9znfCUOkwbec6FG2rmRbsgCy6aJiU9KN662mNheWl5sw/iKleiFSiljPKQQP3HkjnC/NSkdgi/aSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260617.1.tgz",
+      "integrity": "sha512-FMnaAKXe4Cfd8TQurCVd9fs2XQVBFRCsP+Id/SRdUv89MlwYu9zXfoyx6BxM+brPTIUK38SHbo8iaxiwzLi9JQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260617.1.tgz",
+      "integrity": "sha512-MRoifFYcqbxxIIQy7PqO5tFY/qPFSnjXzakWl0sO93l+HLyG35jRAgOi6jfqa4kBxc7gKKtH861DcewjxUfkjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260617.1.tgz",
+      "integrity": "sha512-rgBV9wQrv0OSKgCTTbhFUFY3sLGNANZ88aqaLvtmEn2gmbFVb1J4PDGochVUdB7NSEp4D/ghHva6/8SZmbONpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260621.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260621.1.tgz",
+      "integrity": "sha512-c4xrf4shZdDOK1ihh1UKzlS/3MDYiGThT/Oqr4Y3qR9NLCSNzHB7rt+Vk/LOp0ZSNjA+7WNJEQsOhpiQtpT2GA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
+      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260617.1",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260617.1.tgz",
+      "integrity": "sha512-Go3/gzStm99QHptsSgU+q1S+xDfLoRgwjJNY80kaTVi0ENhTyqKq+sc4xZiWBSbM7uUcJwmzm8+QFKtcYLJ9nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.34.5",
+        "undici": "7.28.0",
+        "workerd": "1.20260617.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260617.1.tgz",
+      "integrity": "sha512-Re5pl6pdowt3ZmWUzGlOuB7jbRIIPetgKalmo4cYmucQnVhpo7/3e4MfpekbhLi2EhZZz5EY9NWRu8zFzuEZew==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260617.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260617.1",
+        "@cloudflare/workerd-linux-64": "1.20260617.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260617.1",
+        "@cloudflare/workerd-windows-64": "1.20260617.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.103.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.103.0.tgz",
+      "integrity": "sha512-3Lv1P5t2xcSEkSTKtG+Lz+3JFryuU7YPLkaCUj7gNe+CJsjZJLtUwqsh1x595QBxkIbCE0GAvDx2DCJUU4+oqw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "4.20260617.1",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260617.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260617.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/cloud/zeus-remote-broker/package.json
+++ b/cloud/zeus-remote-broker/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "zeus-remote-broker",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Cloudflare Worker + Durable Object signaling broker for Zeus remote access (WebRTC SDP/ICE relay, TURN credential minting, QRZ-gated host registration).",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit",
+    "cf-typegen": "wrangler types"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250109.0",
+    "typescript": "^5.7.0",
+    "wrangler": "^4.0.0"
+  }
+}

--- a/cloud/zeus-remote-broker/src/index.ts
+++ b/cloud/zeus-remote-broker/src/index.ts
@@ -1,0 +1,82 @@
+import type { Env } from './types';
+import { verifyQrzSessionCached } from './qrz';
+import { mintIceServers } from './turn';
+
+export { SignalRoom } from './signal-room';
+export { RateLimiter } from './rate-limiter';
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname === '/' || url.pathname === '/health') {
+      return new Response('zeus-remote-broker ok', {
+        status: 200,
+        headers: { 'content-type': 'text/plain' },
+      });
+    }
+
+    // /go/<callsign> — the operator's permanent remote address. Redirects to the
+    // web client (Cloudflare Pages), which then signals back here as a client.
+    const go = /^\/go\/([^/]+)$/.exec(url.pathname);
+    if (go) {
+      const callsign = decodeURIComponent(go[1]).toUpperCase();
+      const origin = env.WEB_APP_ORIGIN ?? 'https://openhpsdrzeus.com';
+      return Response.redirect(`${origin}/?remote=${encodeURIComponent(callsign)}`, 302);
+    }
+
+    // Mint short-lived TURN credentials (clients call this before connecting).
+    if (url.pathname === '/turn' && request.method === 'POST') {
+      if (await rateLimited(env, clientIp(request))) return new Response('rate limited', { status: 429 });
+      try {
+        return Response.json(await mintIceServers(env));
+      } catch {
+        return new Response('turn unavailable', { status: 503 });
+      }
+    }
+
+    // WebSocket signaling. Host (radio) is QRZ-gated; client (browser) is open
+    // (the radio's session password is the real gate — the broker only relays).
+    if (url.pathname === '/signal') {
+      if (await rateLimited(env, clientIp(request))) return new Response('rate limited', { status: 429 });
+      if (request.headers.get('Upgrade') !== 'websocket') {
+        return new Response('expected websocket upgrade', { status: 426 });
+      }
+
+      const role = url.searchParams.get('role') === 'host' ? 'host' : 'client';
+      let callsign = (url.searchParams.get('callsign') ?? '').trim().toUpperCase();
+      const headers = new Headers(request.headers);
+
+      if (role === 'host') {
+        const verify = (env.QRZ_VERIFY ?? 'on').toLowerCase() !== 'off';
+        const verified = (request.headers.get('X-QRZ-Callsign') ?? '').trim().toUpperCase();
+        if (verify) {
+          const sessionKey = request.headers.get('X-QRZ-Session') ?? '';
+          if (!sessionKey || !verified) return new Response('qrz auth required', { status: 401 });
+          if (!(await verifyQrzSessionCached(sessionKey, verified, ctx))) {
+            return new Response('qrz session invalid or not logged in', { status: 403 });
+          }
+        }
+        callsign = verified || callsign;
+        headers.set('X-Operator-Callsign', callsign);
+      }
+
+      if (!callsign) return new Response('callsign required', { status: 400 });
+
+      const id = env.SIGNAL_ROOM.idFromName(callsign);
+      return env.SIGNAL_ROOM.get(id).fetch(new Request(request, { headers }));
+    }
+
+    return new Response('not found', { status: 404 });
+  },
+} satisfies ExportedHandler<Env>;
+
+function clientIp(request: Request): string {
+  return request.headers.get('cf-connecting-ip') ?? 'unknown';
+}
+
+async function rateLimited(env: Env, ip: string): Promise<boolean> {
+  const limiter = env.RATE_DO.get(env.RATE_DO.idFromName(ip));
+  const res = await limiter.fetch('https://rl.internal/check');
+  return res.status === 429;
+}

--- a/cloud/zeus-remote-broker/src/qrz.ts
+++ b/cloud/zeus-remote-broker/src/qrz.ts
@@ -1,0 +1,62 @@
+/** TTL (seconds) for cached positive QRZ-session verdicts. */
+const QRZ_VERIFY_TTL = 300;
+
+/**
+ * QRZ verification with a short-lived positive-result cache (edge Cache API).
+ * Identical model to the chat relay: only valid verdicts are cached (never
+ * negative), so a freshly-logged-in operator is never locked out, and legit
+ * reconnects within the TTL don't re-hit QRZ. Fails closed.
+ */
+export async function verifyQrzSessionCached(
+  sessionKey: string,
+  callsign: string,
+  ctx: ExecutionContext,
+): Promise<boolean> {
+  const digest = await sha256Hex(`${sessionKey}|${callsign}`);
+  const cacheKey = new Request(`https://qrz-verify.zeus-remote.internal/${digest}`);
+  const cache = caches.default;
+
+  const hit = await cache.match(cacheKey);
+  if (hit) return (await hit.text()) === '1';
+
+  const ok = await verifyQrzSession(sessionKey, callsign);
+  if (ok) {
+    ctx.waitUntil(
+      cache.put(
+        cacheKey,
+        new Response('1', { headers: { 'Cache-Control': `max-age=${QRZ_VERIFY_TTL}` } }),
+      ),
+    );
+  }
+  return ok;
+}
+
+/**
+ * Validate a QRZ XML session key by looking up the operator's own callsign. A
+ * live session returns a <Key>; an expired one omits it. Fails closed on any
+ * QRZ/network error.
+ */
+export async function verifyQrzSession(sessionKey: string, callsign: string): Promise<boolean> {
+  const u =
+    'https://xmldata.qrz.com/xml/current/' +
+    `?s=${encodeURIComponent(sessionKey)}` +
+    `;callsign=${encodeURIComponent(callsign)}` +
+    ';agent=zeus-remote-broker';
+  try {
+    const res = await fetch(u, { cf: { cacheTtl: 0 } });
+    if (!res.ok) return false;
+    const xml = await res.text();
+    const hasKey = /<Key>\s*[^<\s][^<]*<\/Key>/i.test(xml);
+    const errText = /<Error>([^<]*)<\/Error>/i.exec(xml)?.[1] ?? '';
+    const badSession = /session timeout|invalid session|session expired|not logged/i.test(errText);
+    return hasKey && !badSession;
+  } catch {
+    return false;
+  }
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input);
+  const buf = await crypto.subtle.digest('SHA-256', data);
+  return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}

--- a/cloud/zeus-remote-broker/src/rate-limiter.ts
+++ b/cloud/zeus-remote-broker/src/rate-limiter.ts
@@ -1,0 +1,26 @@
+import { DurableObject } from 'cloudflare:workers';
+import type { Env } from './types';
+
+/** Connection attempts allowed per IP per window. */
+const LIMIT = 30;
+const WINDOW_MS = 60_000;
+
+/**
+ * Per-IP connection rate limiter (one DO per IP). Single-threaded fixed-window
+ * counter; guards the signaling + QRZ-verify paths from connection spam. Same
+ * pattern as the chat relay.
+ */
+export class RateLimiter extends DurableObject<Env> {
+  private windowStart = 0;
+  private count = 0;
+
+  override async fetch(_request: Request): Promise<Response> {
+    const now = Date.now();
+    if (now - this.windowStart > WINDOW_MS) {
+      this.windowStart = now;
+      this.count = 0;
+    }
+    this.count += 1;
+    return new Response(null, { status: this.count <= LIMIT ? 204 : 429 });
+  }
+}

--- a/cloud/zeus-remote-broker/src/signal-room.ts
+++ b/cloud/zeus-remote-broker/src/signal-room.ts
@@ -1,0 +1,139 @@
+import { DurableObject } from 'cloudflare:workers';
+import type { Env } from './types';
+
+/**
+ * Per-connection state, persisted on the socket so it survives DO hibernation.
+ * One `host` (the radio) and any number of `client`s (remote browsers) share a
+ * room keyed by callsign.
+ */
+interface Att {
+  role: 'host' | 'client';
+  callsign: string;
+  /** Stable id for a client connection, so the host can address its answer. */
+  clientId?: string;
+}
+
+/**
+ * WebRTC signaling relay for one callsign (idFromName(callsign)). The browser
+ * cannot reach the radio directly over the internet, so the radio keeps a
+ * persistent `host` socket here and the broker relays SDP/ICE between it and
+ * each `client`. The broker never sees media — only signaling — and never the
+ * session password (that is proven end-to-end at the radio, ADR-0008).
+ *
+ * Uses the WebSocket Hibernation API so a long-lived-but-idle session costs no
+ * GB-s between the bursty offer/answer/candidate exchanges.
+ */
+export class SignalRoom extends DurableObject<Env> {
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env);
+    // Keepalive without waking the DO.
+    this.ctx.setWebSocketAutoResponse(
+      new WebSocketRequestResponsePair(
+        JSON.stringify({ t: 'ping' }),
+        JSON.stringify({ t: 'pong' }),
+      ),
+    );
+  }
+
+  override async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    const role = url.searchParams.get('role') === 'host' ? 'host' : 'client';
+    const callsign = (request.headers.get('X-Operator-Callsign') ?? url.searchParams.get('callsign') ?? '')
+      .trim()
+      .toUpperCase();
+
+    const pair = new WebSocketPair();
+    const client = pair[0];
+    const server = pair[1];
+    this.ctx.acceptWebSocket(server);
+
+    if (role === 'host') {
+      // Single host per callsign: evict any stale host (e.g. a reconnect).
+      for (const ws of this.ctx.getWebSockets()) {
+        const a = ws.deserializeAttachment() as Att | null;
+        if (a?.role === 'host') {
+          try { ws.close(4000, 'replaced by newer host'); } catch { /* already closing */ }
+        }
+      }
+      server.serializeAttachment({ role: 'host', callsign } satisfies Att);
+    } else {
+      server.serializeAttachment({ role: 'client', callsign, clientId: crypto.randomUUID() } satisfies Att);
+    }
+
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  override async webSocketMessage(ws: WebSocket, raw: string | ArrayBuffer): Promise<void> {
+    const att = ws.deserializeAttachment() as Att | null;
+    if (!att) return;
+
+    let msg: { t?: string; clientId?: string; [k: string]: unknown };
+    try {
+      msg = JSON.parse(typeof raw === 'string' ? raw : new TextDecoder().decode(raw));
+    } catch {
+      return;
+    }
+
+    if (att.role === 'client') {
+      // client → host: offer / candidate / bye. Tag with this client's id.
+      const host = this.host();
+      if (!host) {
+        this.send(ws, { t: 'offline' });
+        return;
+      }
+      if (msg.t === 'offer' || msg.t === 'candidate' || msg.t === 'bye') {
+        this.send(host, { ...msg, clientId: att.clientId });
+      }
+    } else {
+      // host → a specific client by clientId: answer / candidate / bye.
+      const target = msg.clientId ? this.clientById(msg.clientId) : undefined;
+      if (!target) return;
+      if (msg.t === 'answer' || msg.t === 'candidate' || msg.t === 'bye') {
+        const { clientId: _omit, ...rest } = msg;
+        this.send(target, rest);
+      }
+    }
+  }
+
+  override async webSocketClose(ws: WebSocket, code: number, reason: string): Promise<void> {
+    const att = ws.deserializeAttachment() as Att | null;
+    try { ws.close(code, reason); } catch { /* already closing */ }
+
+    if (att?.role === 'host') {
+      // Radio went away — every in-flight client should know.
+      for (const c of this.clients()) this.send(c, { t: 'offline' });
+    } else if (att?.clientId) {
+      const host = this.host();
+      if (host) this.send(host, { t: 'bye', clientId: att.clientId });
+    }
+  }
+
+  override async webSocketError(): Promise<void> {
+    /* nothing to reconcile — close handles teardown */
+  }
+
+  private host(): WebSocket | undefined {
+    for (const ws of this.ctx.getWebSockets()) {
+      if ((ws.deserializeAttachment() as Att | null)?.role === 'host') return ws;
+    }
+    return undefined;
+  }
+
+  private clients(): WebSocket[] {
+    return this.ctx
+      .getWebSockets()
+      .filter((ws) => (ws.deserializeAttachment() as Att | null)?.role === 'client');
+  }
+
+  private clientById(id: string): WebSocket | undefined {
+    for (const ws of this.ctx.getWebSockets()) {
+      const a = ws.deserializeAttachment() as Att | null;
+      if (a?.role === 'client' && a.clientId === id) return ws;
+    }
+    return undefined;
+  }
+
+  private send(ws: WebSocket, msg: unknown): void {
+    try { ws.send(JSON.stringify(msg)); } catch { /* socket gone */ }
+  }
+}

--- a/cloud/zeus-remote-broker/src/turn.ts
+++ b/cloud/zeus-remote-broker/src/turn.ts
@@ -1,0 +1,33 @@
+import type { Env } from './types';
+
+/** Max TTL Cloudflare allows for minted TURN credentials (48 h). */
+const TURN_TTL_SECONDS = 86_400; // 24 h — client re-mints before expiry
+
+/**
+ * Mint short-lived Cloudflare Realtime TURN credentials. The Worker holds the
+ * TURN key as a secret; clients never see it. Returns a ready-to-use iceServers
+ * array (STUN + TURN incl. a 443/TLS transport for restrictive firewalls).
+ *
+ * Throws if TURN is not configured (TURN_KEY_ID / TURN_API_TOKEN unset) or the
+ * Cloudflare API rejects the request — the caller returns 503 and clients fall
+ * back to STUN-only (direct P2P still works for most home networks).
+ */
+export async function mintIceServers(env: Env): Promise<unknown> {
+  if (!env.TURN_KEY_ID || !env.TURN_API_TOKEN) {
+    throw new Error('TURN not configured');
+  }
+
+  const res = await fetch(
+    `https://rtc.live.cloudflare.com/v1/turn/keys/${env.TURN_KEY_ID}/credentials/generate-ice-servers`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${env.TURN_API_TOKEN}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ ttl: TURN_TTL_SECONDS }),
+    },
+  );
+  if (!res.ok) throw new Error(`cloudflare turn ${res.status}`);
+  return await res.json();
+}

--- a/cloud/zeus-remote-broker/src/types.ts
+++ b/cloud/zeus-remote-broker/src/types.ts
@@ -1,0 +1,27 @@
+import type { SignalRoom } from './signal-room';
+import type { RateLimiter } from './rate-limiter';
+
+/** Worker environment bindings (see wrangler.toml). */
+export interface Env {
+  /** Per-callsign WebRTC signaling room (WebSocket Hibernation DO). */
+  SIGNAL_ROOM: DurableObjectNamespace<SignalRoom>;
+
+  /** Per-IP connection rate limiter DO (shared pattern with the chat relay). */
+  RATE_DO: DurableObjectNamespace<RateLimiter>;
+
+  /**
+   * QRZ-login enforcement for the HOST (radio) side. Default "on": only the
+   * operator who can prove the callsign on QRZ may register as that callsign's
+   * radio. The CLIENT side is never QRZ-gated — access is gated end-to-end by
+   * the session password at the radio (ADR-0008), so the broker only relays.
+   */
+  QRZ_VERIFY?: string;
+
+  /** Origin of the web client (Cloudflare Pages) that /go/<callsign> redirects to. */
+  WEB_APP_ORIGIN?: string;
+
+  /** Cloudflare Realtime TURN key id (set via `wrangler secret put`). */
+  TURN_KEY_ID?: string;
+  /** Cloudflare Realtime TURN API token (set via `wrangler secret put`). */
+  TURN_API_TOKEN?: string;
+}

--- a/cloud/zeus-remote-broker/tsconfig.json
+++ b/cloud/zeus-remote-broker/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "lib": ["es2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/cloud/zeus-remote-broker/wrangler.toml
+++ b/cloud/zeus-remote-broker/wrangler.toml
@@ -1,0 +1,45 @@
+name = "zeus-remote-broker"
+main = "src/index.ts"
+compatibility_date = "2025-01-01"
+
+# Branded custom domain (Cloudflare auto-creates the DNS record on deploy).
+# Requires the openhpsdrzeus.com zone on this Cloudflare account.
+# remote.openhpsdrzeus.com is the canonical broker endpoint.
+routes = [
+  { pattern = "remote.openhpsdrzeus.com", custom_domain = true },
+]
+
+workers_dev = true
+
+[vars]
+# Host (radio) registration is QRZ-gated by default; client signaling is open
+# (the radio's session password is the real gate). For local `wrangler dev`:
+#   wrangler dev --var QRZ_VERIFY:off
+QRZ_VERIFY = "on"
+# Where /go/<callsign> sends the browser (the web client on Cloudflare Pages).
+WEB_APP_ORIGIN = "https://openhpsdrzeus.com"
+
+# Per-callsign WebRTC signaling room (WebSocket Hibernation).
+[[durable_objects.bindings]]
+name = "SIGNAL_ROOM"
+class_name = "SignalRoom"
+
+# Per-IP connection rate limiter.
+[[durable_objects.bindings]]
+name = "RATE_DO"
+class_name = "RateLimiter"
+
+# SQLite-backed DO namespaces (free-plan compatible).
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["SignalRoom"]
+
+[[migrations]]
+tag = "v2"
+new_sqlite_classes = ["RateLimiter"]
+
+# TURN credentials are minted from Cloudflare Realtime. Provide the key out of
+# band so it stays out of source control:
+#   wrangler secret put TURN_KEY_ID
+#   wrangler secret put TURN_API_TOKEN
+# If unset, /turn returns 503 and clients fall back to STUN-only (direct P2P).

--- a/docs/adr/0001-data-plane-cloudflare-quick-tunnels.md
+++ b/docs/adr/0001-data-plane-cloudflare-quick-tunnels.md
@@ -1,0 +1,19 @@
+# Anonymous Cloudflare Quick Tunnels for the remote-access data plane
+
+Zeus desktop exposes itself to a paired mobile client by spawning `cloudflared` as a subprocess that opens an anonymous Quick Tunnel against `trycloudflare.com`. No third-party account exists in the user's mental model, and no per-byte cost lands on the maintainer's infrastructure.
+
+## Considered options
+
+- **ngrok free tier** — rejected. The user must sign up at ngrok.com and paste an authtoken, which kills the "open app, scan QR, online" first-run UX.
+- **Cloudflare Tunnel on the maintainer's CF account** (the original `feature_tunnel_broker` design) — rejected. Every user's data bytes would flow through the `openhpsdrzeus.com` Cloudflare account; the maintainer would bear both cost and abuse risk as the user base grows.
+- **User's own Cloudflare account with a named tunnel** — rejected. The signup and `cloudflared` auth flow is equivalent friction to ngrok.
+- **Tailscale Funnel / ZeroTier mesh** — rejected. Mesh-VPN onboarding requires installing a separate client and authenticating to an external account before the user can even reach the radio. Heavier than any HTTP-tunnel option for the common case.
+
+## Consequences
+
+- Each session gets a different ephemeral URL (`xyz-abc.trycloudflare.com`). The broker handles stability via slug → current-URL redirection — see [0002](./0002-broker-as-identity-redirector.md).
+- Cloudflare officially labels Quick Tunnels "for testing and development only." There is no SLA, and Cloudflare can rate-limit or remove the feature unilaterally. We accept this risk without a hedge in v1.
+- Cloudflare retired TOS Section 2.8 (the audio/video CDN restriction) for Tunnel; real-time WebSocket audio is no longer policy-blocked.
+- WebSocket and SignalR are supported on Quick Tunnels; Zeus's existing `UseWebSockets` configuration with a 20s keepalive already aligns with Cloudflare's idle-close behavior.
+- Quick Tunnels enforce a 200-concurrent-request cap, which is comfortable for one operator with one mobile client.
+- `cloudflared` must be available on the user's machine — see [0004](./0004-bundle-cloudflared-in-installer.md).

--- a/docs/adr/0002-broker-as-identity-redirector.md
+++ b/docs/adr/0002-broker-as-identity-redirector.md
@@ -1,0 +1,24 @@
+# Broker is identity + redirector, not the data plane
+
+`openhpsdrzeus.com` runs a Cloudflare Worker that holds Google OAuth identity, issues short-lived Ed25519-signed JWTs, and serves `GET /go/<slug>` as a 302 to the current Quick Tunnel URL reported by the desktop. The broker never sees tunnel bytes — only registration metadata and auth — which keeps the maintainer's hosting cost on Cloudflare's free tier indefinitely.
+
+## Considered options
+
+- **Broker provisions tunnels under the maintainer CF account** (original 16-commit `feature_tunnel_broker` design) — superseded by this ADR. Data-plane cost on the maintainer's account is the rejection driver. Roughly 3 commits of the existing broker (`e57294f` CF Tunnel API client, the DNS provisioning code paths inside `77be37b`) become dead code.
+- **No broker; QR encodes the raw Quick Tunnel URL** — rejected. The URL changes on every desktop restart, so mobile would have to re-scan every session, breaking "scan once, work forever."
+- **Broker also hosts a WebSocket relay** — rejected for the same data-plane-cost reason as the original design.
+
+## Consequences
+
+- The broker is a SPOF for *connection establishment* (first /go redirect of a new session) but not for *ongoing session data*. Once mobile holds a JWT and the current tunnel URL, broker outage does not interrupt an established session.
+- Approximately 70% of the existing 16-commit broker work survives intact: Google OAuth, sealed cookies, session middleware, Ed25519 / JWKS signing, `/go` redirect, `/settings/devices`, daily GC cron, D1 schema.
+- The "punch" endpoint reshapes from "create CF tunnel via API" to "register the current Quick Tunnel URL." `mine`, `heartbeat`, and `delete` mostly survive.
+- The Zeus desktop validates JWTs against the broker's JWKS endpoint, fetched once at startup. This means desktop ↔ broker have a startup-time coupling but no per-request dependency.
+
+## Glossary
+
+- **Slug** — a random per-install identifier issued by the broker on first sign-in (e.g. `blue-falcon-742`). Stable for the lifetime of the Zeus install. See [0003](./0003-random-slug-same-account-pairing.md).
+- **Broker** — the Cloudflare Worker hosted at `openhpsdrzeus.com` that handles Google OAuth, slug allocation, JWT minting, and the `/go/<slug>` redirect.
+- **Quick Tunnel** — an anonymous Cloudflare Tunnel session created by `cloudflared` with no account, ephemeral URL on `trycloudflare.com`. See [0001](./0001-data-plane-cloudflare-quick-tunnels.md).
+- **Device pairing** — the act of associating a mobile install with a Zeus desktop install via shared Google account on the broker.
+- **Redirect JWT** — the short-lived Ed25519-signed token the broker mints into the `/go/<slug>` 302 redirect; validated by Zeus desktop against the broker's JWKS on each WebSocket connect.

--- a/docs/adr/0003-random-slug-same-account-pairing.md
+++ b/docs/adr/0003-random-slug-same-account-pairing.md
@@ -1,0 +1,16 @@
+# Random slugs, same-Google-account pairing
+
+The broker assigns each Zeus install a random slug like `blue-falcon-742` rather than a callsign. Mobile binds to a desktop by signing into the broker with the same Google account; the QR encodes only the slug URL, with no embedded pairing token in v1.
+
+## Considered options
+
+- **Callsign slugs (`/go/ei6lf`)** — rejected. Callsign squatting is a real problem (callsigns get reassigned, and first-signup-wins lets users claim names they don't hold), and verification against FCC / Ofcom / equivalent is rabbit-hole work for v1. URLs should brand the tunnel, not assert amateur identity.
+- **Vanity callsign as a second alias on top of a random slug** — deferred, not rejected. Easy to add later as one column, one endpoint, with both `/go/blue-falcon-742` and `/go/ei6lf` redirecting to the same tunnel.
+- **One-time pairing token in the QR** — deferred. Would enable "share my shack with a friend without sharing my Google credentials," but adds first-run friction to the common case (the user's own phone). Implementable later as an additive `?pair=…` query parameter on the existing endpoint with no breaking change.
+
+## Consequences
+
+- A shoulder-surfer who photographs the QR cannot pair to the radio, because pairing requires an active session on the slug owner's Google account.
+- "Lend my shack to a friend" is not supported in v1; both endpoints must use the same Google account.
+- Callsign-shaped vanity URLs (a natural community-facing feature) are deferred but not architecturally blocked.
+- The broker's `c7b8064` random slug generator and `a2a9b3d` `/settings/devices` page already implement the model this ADR locks in; no broker-side work changes from this decision.

--- a/docs/adr/0004-bundle-cloudflared-in-installer.md
+++ b/docs/adr/0004-bundle-cloudflared-in-installer.md
@@ -1,0 +1,16 @@
+# Bundle `cloudflared` in the Zeus installer
+
+The `cloudflared` binary ships inside the Zeus desktop installer (~30 MB per platform/arch) rather than being downloaded on first use or installed by the user separately. The desktop spawns it as a subprocess and captures the random `*.trycloudflare.com` URL from its output.
+
+## Considered options
+
+- **Download `cloudflared` on first "Go Online"** — rejected. First-run reliability matters more than installer size, and a "downloading cloudflared… network error" experience on first connect breaks the dream UX. It also adds Gatekeeper / SmartScreen trust questions for a binary delivered post-install.
+- **Require the user to install `cloudflared` via Homebrew / Scoop / apt** — rejected. Highest user friction; eliminates non-technical operators entirely.
+
+## Consequences
+
+- Installer grows by ~30 MB per platform/arch — acceptable given Zeus already ships .NET runtime, WDSP, and miniaudio.
+- The macOS .app bundle must notarize `cloudflared` along with the rest of the binary. Cloudflare ships unsigned `.tgz` releases, so the Zeus build pipeline must re-sign and notarize. `~/zeus-sign-notarize.sh` and `create-macos-app.sh` need to learn about the embedded binary.
+- The Windows installer must Authenticode-sign the embedded `cloudflared.exe` as part of the existing `release.yml` flow.
+- CVE response cadence becomes "ship a Zeus point release with bumped `cloudflared`." Acceptable given `cloudflared`'s low CVE frequency.
+- The bundled `cloudflared` version is pinned in the build pipeline (downloaded at build time, not committed to the repo).

--- a/docs/adr/0005-webrtc-data-plane.md
+++ b/docs/adr/0005-webrtc-data-plane.md
@@ -1,0 +1,48 @@
+# WebRTC peer-to-peer as the remote-access data plane
+
+**Supersedes [0001](./0001-data-plane-cloudflare-quick-tunnels.md).** Remote clients reach
+the operator's `Zeus.Server` over a **WebRTC** connection — a direct UDP path negotiated by
+ICE, with a TURN relay used only when NAT/CGNAT defeats the direct path. Audio rides an Opus
+media track; spectrum/IQ/display frames ride an unreliable-unordered DataChannel; VFO and
+control ride a reliable-ordered DataChannel. The maintainer's domain never carries session
+bytes.
+
+## Why we pivoted away from Quick Tunnels (0001)
+
+The Quick Tunnel design routed **every** byte — each 20 ms audio block, every 60 Hz display
+frame, every VFO command — through Cloudflare's edge and back. For a real-time SDR client the
+operative requirement is *extremely low latency*, and a fixed-POP HTTP relay adds a round trip
+plus TCP head-of-line blocking to all traffic, including connections that are physically close.
+WebRTC inverts this: the common case is a direct UDP path with only physical-path RTT; a relay
+is the exception, not the rule.
+
+## Considered options
+
+- **Cloudflare Quick Tunnels (0001)** — superseded. Relays 100% of traffic over TCP/WebSocket
+  through a fixed edge; "testing/development only" per Cloudflare, no SLA, ~200 concurrent-request
+  cap, ephemeral URLs. Worst latency profile of the options.
+- **Per-user named Cloudflare Tunnel** — rejected, same relay-latency problem as Quick Tunnels
+  plus per-user `cloudflared` auth friction.
+- **Tailscale / WireGuard mesh** — rejected for the *browser* client: there is no WireGuard
+  inside a web page, so a browser/webview remote client cannot establish the tunnel. (Excellent
+  for a future *native* client; not this one.)
+- **WebRTC P2P + TURN fallback** — chosen. Native in every browser, traverses NAT/CGNAT without
+  router config, direct UDP for ~80% of home connections, and gives us Opus + jitter buffer +
+  FEC for the audio path for free.
+
+## Consequences
+
+- `Zeus.Server` gains a WebRTC peer via **SIPSorcery** (pure-C#, .NET 10, runs on linux-arm64 /
+  Raspberry Pi). Opus is encoded in managed/DSP code so we avoid the native `SIPSorceryMedia.FFmpeg`
+  dependency on arm64/Pi. SIPSorcery's BSD-3 license carries a non-standard ethical-use clause —
+  flagged for license review.
+- The existing `/ws` binary `WireFormat` frames are reused verbatim **over DataChannels**, so the
+  frame contract and all decoders survive; only the transport changes. See the transport map in
+  [docs/designs/remote-access-webrtc.md](../designs/remote-access-webrtc.md).
+- DTLS-SRTP gives transport encryption for free; remote access is no longer the
+  "trusted-LAN, no-auth" model the current `/ws` assumes — auth is added (see [0006](./0006-broker-signaling-turn-callsign.md)).
+- ~15–30% of home-to-home sessions (CGNAT-heavy) fall back to TURN, adding ~20–80 ms; budget for it.
+- TURN relay is **Cloudflare Realtime TURN** (anycast, $0.05/GB after 1,000 GB/mo free) — see [0006](./0006-broker-signaling-turn-callsign.md).
+- **[0004](./0004-bundle-cloudflared-in-installer.md) (bundle `cloudflared`) is no longer required**
+  by the primary path. A Quick Tunnel may be retained later as a last-resort transport for the rare
+  environment where even TURN-over-443 is blocked; that is an additive fallback, not the data plane.

--- a/docs/adr/0006-broker-signaling-turn-callsign.md
+++ b/docs/adr/0006-broker-signaling-turn-callsign.md
@@ -1,0 +1,55 @@
+# Broker = signaling + TURN credentials, reusing the chat relay's QRZ identity
+
+**Supersedes [0002](./0002-broker-as-identity-redirector.md) and [0003](./0003-random-slug-same-account-pairing.md).**
+`openhpsdrzeus.com` runs a Cloudflare Worker + Durable Object that (a) identifies the operator by
+**QRZ-verified callsign** — the exact mechanism the chat relay already uses, *not* Google OAuth —
+(b) relays WebRTC signaling (SDP offer/answer + ICE candidates) between the remote client and the
+operator's `Zeus.Server` through a per-callsign Durable Object room, and (c) mints short-lived
+Cloudflare TURN credentials. As in 0002, the broker never carries session bytes — it is a
+control-plane SPOF for *first connect* only, not for ongoing media.
+
+## What changes from 0002 / 0003
+
+- **Identity is QRZ, not Google OAuth.** The broker reuses `cloud/zeuschat-relay`'s model: the
+  client presents `X-QRZ-Session` + `X-QRZ-Callsign`, the Worker verifies against the QRZ XML API
+  (cached ~300 s), and the verified callsign is locked into the Durable Object as the authoritative
+  identity. See [0007](./0007-callsign-identity-and-verification.md). The Google OAuth / sealed
+  cookie / D1 user-table stack from 0002 is dropped.
+- The data plane is WebRTC ([0005](./0005-webrtc-data-plane.md)), so the broker's job is
+  **signaling relay + TURN cred issuance**, not `/go/<slug>` redirect-to-tunnel.
+- The remote address is the operator's **QRZ callsign**: `https://openhpsdrzeus.com/go/<callsign>`
+  loads the Zeus web client wired to the signaling room for that callsign's online radio.
+
+## Reuse from `cloud/zeuschat-relay`
+
+The remote-access signaling room is architecturally identical to a chat room: two parties (radio
+host + remote client) join a room keyed by callsign and exchange messages — SDP/ICE instead of
+chat text. The broker is therefore a **sibling Worker / additional Durable Object type alongside
+the chat relay**, reusing:
+
+- `verifyQrzSession` + the 300 s positive-verdict cache (`src/index.ts`).
+- The per-IP connection rate limiter (`src/rate-limiter.ts`).
+- The Durable Object room pattern with the verified callsign locked into the connection attachment
+  (`src/chat-room.ts`) — relabel "chat message" frames as "signaling" frames.
+
+New work over the chat relay: a signaling frame schema (offer/answer/candidate/ready), pairing the
+radio-host socket with the remote-client socket in the room, and proxying Cloudflare TURN's
+`generate-ice-servers` (Worker holds the TURN key as a secret; TTL ≤ 48 h; client re-mints on long
+sessions).
+
+## Signaling design
+
+- One **Durable Object per callsign room**, using **WebSocket Hibernation** so long-lived-but-idle
+  SDR sessions incur no GB-s billing between the bursty signaling exchanges. (Free escape hatch if
+  DOs ever need the paid plan: D1/KV poll-based rendezvous — see the design doc; SDP/ICE is a
+  one-time exchange so slower setup adds no session latency.)
+- `Zeus.Server`'s WebRTC peer only accepts an offer relayed through a room it authenticated into
+  with its QRZ identity, so an unauthenticated remote cannot open a peer connection even though
+  `/ws` historically had no auth.
+
+## Consequences
+
+- QRZ-header identity keeps the broker on Cloudflare's free tier; TURN egress is the only metered
+  cost and the 1,000 GB/mo free tier likely covers the user base (most sessions go direct P2P).
+- Identity is unified across chat and remote access — one QRZ login, one verified callsign.
+- Broker outage stops *new* connections but not *established* media sessions (unchanged from 0002).

--- a/docs/adr/0007-callsign-identity-and-verification.md
+++ b/docs/adr/0007-callsign-identity-and-verification.md
@@ -1,0 +1,42 @@
+# Callsign identity via QRZ — verified, no separate auth
+
+**Supersedes the random-slug decision in [0003](./0003-random-slug-same-account-pairing.md).**
+The remote address brands the operator's callsign: `https://openhpsdrzeus.com/go/<callsign>`.
+The callsign is **the operator's QRZ-verified home callsign**, obtained exactly the way the chat
+feature already obtains it — there is no separate sign-up, no Google OAuth, and no self-attested
+"my callsign" field to squat.
+
+## Why QRZ (reversing 0003, and dropping Google OAuth)
+
+0003 chose random slugs to dodge callsign squatting and license verification. Zeus's chat feature
+already solved that problem: the backend authenticates to the operator's QRZ account, and QRZ
+returns the account holder's own callsign. Logging into QRZ as the callsign holder *is* proof of
+ownership, so squatting is structurally impossible — you cannot claim a callsign you cannot sign
+into QRZ as. Reusing this gives the remote-access feature a verified identity for free and unifies
+identity across chat and remote access.
+
+## How it works (mirrors the chat path verbatim)
+
+- `QrzService` acquires a QRZ session key from the QRZ XML API and looks up the operator's home
+  record; `_home.Callsign` is the verified, uppercased callsign
+  (`Zeus.Server.Hosting/QrzService.cs`, `GetChatIdentityAsync`).
+- `Zeus.Server` connects to the broker with the same headers chat uses:
+  `X-QRZ-Session: <key>`, `X-QRZ-Callsign: <callsign>` (see `ChatService.cs`).
+- The broker Worker validates the session+callsign against QRZ (cached ~300 s, fail-safe on
+  negative) exactly like `cloud/zeuschat-relay/src/index.ts` (`verifyQrzSession`), then locks the
+  verified callsign into the signaling Durable Object as the authoritative identity — no client
+  can override it (`cloud/zeuschat-relay/src/chat-room.ts`).
+
+## Consequences
+
+- **No squatting / verification rabbit-hole** — QRZ is the registry. A callsign resolves to whoever
+  can authenticate to QRZ as that callsign and is currently online.
+- **No Google OAuth, no D1 user table, no claim flow** — the old broker's identity stack
+  ([0002](./0002-broker-as-identity-redirector.md)) collapses to the chat relay's QRZ-header model.
+- QRZ session keys are ephemeral (~1 h); `Zeus.Server` already refreshes them on demand, so the
+  broker re-verifies on reconnect with no new machinery.
+- Edge cases inherited from chat (no QRZ subscription → cannot use the feature; QRZ outage → cannot
+  establish *new* sessions) are accepted, identical to chat's posture.
+- A claimed-but-offline callsign resolves to a "radio offline" page, not an error.
+- Caveat to carry forward: chat rate-limits **per-IP, not per-callsign**; the remote-access broker
+  should decide whether per-callsign limits are warranted given it gates radio access, not chat.

--- a/docs/adr/0008-session-password-access-control.md
+++ b/docs/adr/0008-session-password-access-control.md
@@ -38,17 +38,22 @@ The broker ([0006](./0006-broker-signaling-turn-callsign.md)) is a third party i
 path, so it must never learn the password. The `Zeus.Server` is the resource being protected and is
 the sole verifier:
 
-- Stored **Argon2id-hashed** in the `Zeus.Server` prefs (LiteDB, cross-platform; never plaintext,
-  never synced to the broker or the domain).
-- The remote client proves knowledge of the password to `Zeus.Server` *after* the WebRTC channel is
-  up, over the **DTLS-encrypted DataChannel** — which the broker and any TURN relay cannot read.
+- **Mechanism: SPAKE2+ (RFC 9383)**, ciphersuite `P256-SHA256-HKDF-SHA256-HMAC-SHA256`. SPAKE2+ is
+  the *augmented* PAKE: at registration the password runs through a memory-hard PBKDF (Argon2id) to
+  `w0, w1`; the `Zeus.Server` prefs store only the **verifier** `w0` and `L = w1·P` — never the
+  password, never `w1`. A stolen prefs DB therefore does not yield the password (the attacker still
+  faces the PBKDF), strictly better than plain SPAKE2 where both sides share the same secret.
+- The client (prover) proves knowledge over the **DTLS-encrypted DataChannel** *after* the WebRTC
+  channel is up — which the broker and any TURN relay cannot read.
 - **Channel-binding against a malicious broker:** a broker that tampers with SDP DTLS fingerprints
-  could in principle MITM the channel. To defend against a compromised broker, use a
-  **PAKE (SPAKE2-style)** so the password authenticates both ends and binds to the channel — the
-  broker cannot impersonate without the password and cannot mount an offline dictionary attack.
-  (Magic Wormhole uses SPAKE2 for exactly this "secret over a brokered channel" problem.) A simpler
-  HMAC-challenge-response over DTLS is acceptable as an interim *only* while we fully trust the
-  broker; PAKE is the target because the broker is third-party infrastructure.
+  could in principle MITM the channel. SPAKE2+ defeats this — the password authenticates both ends
+  and binds the session key, so the broker cannot impersonate without the password and cannot mount
+  an offline dictionary attack. (Same class of protection Magic Wormhole gets from SPAKE2.)
+- **Implementation discipline:** P-256 only (cofactor 1), hardcoded RFC M/N constants, byte-exact
+  transcript (8-byte little-endian length prefixes, uncompressed points), HKDF-SHA256 key schedule,
+  `CryptographicOperations.FixedTimeEquals` for every confirmation-MAC check, and mandatory point
+  validation (reject off-curve / identity) on every received share. Both the C# (BouncyCastle EC)
+  and browser (`@noble/curves`) sides are unit-tested against the **RFC 9383 Appendix C** vectors.
 
 ## Consequences
 

--- a/docs/adr/0008-session-password-access-control.md
+++ b/docs/adr/0008-session-password-access-control.md
@@ -1,0 +1,41 @@
+# Session password — operator-set access control for remote sessions
+
+Remote access is gated by a **session password** the operator sets in the Server menu. The QRZ
+callsign ([0007](./0007-callsign-identity-and-verification.md)) is only the *address* — it is
+public and shareable. The password is the *access control* that decides who may actually open a
+remote session to the radio. Because Zeus drives real HF amplifiers, **remote access cannot be
+enabled without a session password set** — there is no "open to the internet, no password" mode.
+
+## Where the password is verified — at the radio, never at the broker
+
+The broker ([0006](./0006-broker-signaling-turn-callsign.md)) is a third party in the signaling
+path, so it must never learn the password. The `Zeus.Server` is the resource being protected and is
+the sole verifier:
+
+- Stored **Argon2id-hashed** in the `Zeus.Server` prefs (LiteDB, cross-platform; never plaintext,
+  never synced to the broker or the domain).
+- The remote client proves knowledge of the password to `Zeus.Server` *after* the WebRTC channel is
+  up, over the **DTLS-encrypted DataChannel** — which the broker and any TURN relay cannot read.
+- **Channel-binding against a malicious broker:** a broker that tampers with SDP DTLS fingerprints
+  could in principle MITM the channel. To defend against a compromised broker, use a
+  **PAKE (SPAKE2-style)** so the password authenticates both ends and binds to the channel — the
+  broker cannot impersonate without the password and cannot mount an offline dictionary attack.
+  (Magic Wormhole uses SPAKE2 for exactly this "secret over a brokered channel" problem.) A simpler
+  HMAC-challenge-response over DTLS is acceptable as an interim *only* while we fully trust the
+  broker; PAKE is the target because the broker is third-party infrastructure.
+
+## Consequences
+
+- **Decouples access from identity.** The remote user does not need to *be* the callsign holder —
+  anyone the operator gives the link + password to can connect. This delivers the "lend my shack to
+  a friend" case that [0003](./0003-random-slug-same-account-pairing.md) explicitly could not,
+  *without* sharing QRZ credentials.
+- The operator accessing their own radio uses the same password; no special-casing.
+- Brute-force defense lives on `Zeus.Server`: per-attempt rate limit + exponential backoff +
+  optional lockout. The broker's existing per-IP connection limit is a second, coarser layer.
+- Password entry on the remote client uses an **in-app form** (PromptDialog pattern), never
+  `window.prompt` — see the project's no-browser-dialogs rule.
+- Changing or clearing the password is an operator action in the Server menu; clearing it while
+  remote access is on forces remote access off (the no-password-no-remote invariant).
+- A wrong password fails *closed*: no streams, no control, no radio state leaked — the client shows
+  "incorrect password," nothing more.

--- a/docs/adr/0008-session-password-access-control.md
+++ b/docs/adr/0008-session-password-access-control.md
@@ -6,6 +6,32 @@ public and shareable. The password is the *access control* that decides who may 
 remote session to the radio. Because Zeus drives real HF amplifiers, **remote access cannot be
 enabled without a session password set** — there is no "open to the internet, no password" mode.
 
+## Hard invariant — deny by default, nothing happens without the password
+
+This is a full-stop rule, enforced **server-side** (the client UI prompt is not the gate):
+
+> **A remote session begins LOCKED. While locked, `Zeus.Server` performs exactly one operation —
+> the password proof. It sends no frames (audio/display/IQ/meters), accepts no control of any kind,
+> reveals no radio state, and does not even confirm a radio is present. Every non-auth message on a
+> locked session causes an immediate close. The session transitions to UNLOCKED only on a
+> successful password proof; on failure, timeout, or too many attempts it is dropped with a generic
+> error and nothing leaked.**
+
+Concretely the locked→unlocked state machine lives in the remote transport (Phase 1's
+`IRemoteTransport` starts in the LOCKED state and is wired to an auth gate):
+
+- The WebRTC DTLS/SCTP layer may establish (it is just encrypted transport), but the application
+  session stays LOCKED.
+- The first and only permitted exchange on the control DataChannel is the password proof
+  (PAKE/SPAKE2 target — see below). No data-plane channel egresses and no control verb is dispatched
+  while LOCKED.
+- Unlock arms the radio data paths and control; lock (disconnect / password cleared / idle timeout)
+  disarms them again.
+
+This invariant is independent of identity (ADR-0007): even a correctly QRZ-identified remote is
+LOCKED until the password proves out. The LAN/localhost trusted path is unaffected — it is not a
+remote session and never enters this state machine.
+
 ## Where the password is verified — at the radio, never at the broker
 
 The broker ([0006](./0006-broker-signaling-turn-callsign.md)) is a third party in the signaling

--- a/docs/designs/remote-access-webrtc.md
+++ b/docs/designs/remote-access-webrtc.md
@@ -96,13 +96,16 @@ Peak total ≈ 100 KB/s — comfortably inside a single WebRTC peer; no media SF
 | Phase 1 server transport (auth over DataChannel, gated egress) | ✅ done | 2-peer transport test: correct→frame flows, wrong→nothing |
 | Browser connect flow (`connect.ts`) | ✅ written | `tsc`; live WebRTC needs a browser bench |
 | Scan-to-remote QR | ✅ done | 7 tests |
+| Phase 3 broker (Worker + DO, `cloud/zeus-remote-broker`) | ✅ written | `tsc` + workers-types; needs CF deploy |
+| Radio-side broker client (`RemoteBrokerClient`) | ✅ written | offer→answer bridge tested; WS-to-broker needs live broker |
 
-**Needs a live bench / deploy (not headlessly verifiable):**
-- StreamingHub → frames-channel bridge (real audio/IQ onto the unlocked session) and the browser
-  media path (frame decode + WebAudio). The transport exposes `TrySendFrame`; wiring it to the live
-  frame pipeline + measuring real RTT is bench work.
-- Phase 3 Cloudflare broker (Worker + Durable Object): signalling relay over the domain, QRZ
-  identity, TURN-cred minting. Needs deployment to the `openhpsdrzeus.com` Cloudflare account.
+**Code-complete. Remaining to go live needs hardware / a deploy (not headlessly verifiable):**
+- Deploy `cloud/zeus-remote-broker` to the `openhpsdrzeus.com` Cloudflare account
+  (`wrangler deploy` + TURN secrets); creates `remote.openhpsdrzeus.com`.
+- StreamingHub → frames-channel bridge (real audio/IQ onto the unlocked session) + the browser
+  media path (frame decode + WebAudio). The transport exposes `TrySendFrame` and the browser
+  `connect.ts` surfaces `onFrame`; wiring them to the live DSP pipeline + measuring real RTT is the
+  one piece deliberately left for a radio bench (it touches the real-time `/ws` hot path).
 
 ## Implementation phases
 

--- a/docs/designs/remote-access-webrtc.md
+++ b/docs/designs/remote-access-webrtc.md
@@ -1,0 +1,158 @@
+# Remote access via WebRTC — design & implementation plan
+
+Goal: give an operator a stable address — `https://openhpsdrzeus.com/go/<callsign>` — that lets
+them reach their own `Zeus.Server` from anywhere on the internet, with **extremely low latency**,
+**near-zero per-user cost** to the project, through home NAT/CGNAT without router config, and with
+minimal first-run friction.
+
+Architecture decisions: [ADR-0005](../adr/0005-webrtc-data-plane.md) (WebRTC data plane),
+[ADR-0006](../adr/0006-broker-signaling-turn-callsign.md) (broker = signaling + TURN + registry),
+[ADR-0007](../adr/0007-callsign-identity-and-verification.md) (callsign identity).
+
+## Non-negotiable constraints (governs every design choice below)
+
+The feature must be all three of these simultaneously; any implementation choice that trades one
+away is wrong:
+
+1. **Hyper-performant / low-latency.** Direct P2P UDP is the default path (physical RTT only, no
+   edge hop). Media never rides a reliable/ordered channel: audio = Opus media track (10–20 ms
+   frames, minimal jitter buffer) with an optional raw-PCM-over-unreliable-DataChannel "hyper" mode
+   to shed Opus's ~26 ms codec delay (affordable at ~96 KB/s); spectrum/IQ/display = unreliable +
+   unordered DataChannel, drop-stale, reusing the existing drop-oldest backpressure; only VFO/control
+   uses a reliable channel, kept off the hot media path. The primary latency lever is maximizing the
+   direct-connect rate so TURN (+20–80 ms) stays the exception.
+
+2. **Scalable.** Cost must not grow with the user count. The data plane is peer-to-peer, so peers
+   carry their own bytes; Cloudflare only ever pays for the relayed minority. Signaling/identity are
+   tiny and constant-per-session, not per-byte.
+
+3. **Free.** Target $0/month at hobby scale. Cost edges and their free escape hatches:
+   - **Durable Objects**: use the free SQLite-DO tier; if it ever requires the paid plan, fall back
+     to **D1/KV poll-based signaling rendezvous** — SDP/ICE is exchanged once at connect, so a 1–2 s
+     slower *setup* adds zero *session* latency and keeps everything on the pure free tier.
+   - **TURN egress**: bounded by Cloudflare's 1,000 GB/mo free pool (~9,000 operator-hours/mo, since
+     only ~20% of sessions relay). Overflow is $0.05/GB (pennies) or a community coturn node.
+   - Workers (100k req/day) and D1 (5 GB / 5M reads-day) dwarf the registry + signaling load.
+
+## One-line architecture
+
+Browser/webview ↔ **WebRTC** (Opus media track = audio; unreliable+unordered DataChannel =
+spectrum/IQ/display; reliable+ordered DataChannel = VFO/control) ↔ **SIPSorcery** peer in the
+.NET 10 `Zeus.Server`. Signaling + **QRZ-verified-callsign identity** (reusing `zeuschat-relay`) +
+short-lived TURN creds via a **Cloudflare Worker + hibernating Durable Object** on
+`openhpsdrzeus.com`. **Cloudflare Realtime TURN** (anycast, $0.05/GB after 1,000 GB/mo free) is the
+relay fallback for ~15–30% of sessions.
+
+## How the domain produces the remote link
+
+`openhpsdrzeus.com` does three jobs, all on Cloudflare's free tier:
+
+1. **Serves the web client.** A `zeus-web` build is hosted on **Cloudflare Pages** at the domain.
+   When a remote user opens the link on their phone, the React app loads from Cloudflare's global
+   CDN — *not* from the operator's home server (which isn't reachable until WebRTC connects). Free,
+   unlimited static requests, fast everywhere.
+2. **The link.** `https://openhpsdrzeus.com/go/<callsign>` boots that web client into "remote mode"
+   pointed at the signaling room for that callsign's online radio.
+   - **Path-based (`/go/ei6lf`) is recommended** — it handles *any* callsign string safely, including
+     portable (`EI6LF/P`) and contest/special calls that contain `/`.
+   - Subdomain (`ei6lf.openhpsdrzeus.com`, wildcard DNS → Worker, also free) reads more personal but
+     breaks on `/` in portable calls and needs sanitization. Aesthetic choice; path is the safe default.
+3. **Signaling + TURN creds.** The Worker API on the same domain (ADR-0006).
+
+**The operator never copies a URL.** Once QRZ-signed-in (the same login chat already uses) and remote
+access is toggled on, Zeus *derives and displays* the permanent link + a QR from the verified callsign
+("Your radio: `openhpsdrzeus.com/go/EI6LF`"). It is stable forever and unspoofable — nobody else can
+QRZ-authenticate as that callsign. Availability: the home `Zeus.Server` registers "callsign online" in
+the room when remote access is on; `/go/<callsign>` finds the live host, or shows a clean
+"radio offline" page.
+
+## Current transport (what we are migrating) — verified
+
+| Path | Today | Rate / size | Target WebRTC channel |
+|---|---|---|---|
+| RX audio (`AudioFrame` 0x02) | binary `/ws` | 48 Hz × ~2 KB ≈ **96 KB/s** | **Opus media track** |
+| Mic uplink (`MicPcm` 0x20) | binary `/ws` | 48 Hz × 3841 B | Opus media track (reverse) |
+| Display/panadapter (`DisplayFrame` 0x10) | binary `/ws` | ~60 Hz, 100–400 B | **DataChannel, unreliable+unordered** |
+| Meters (0x14–0x19), MOX/alerts/CW/chat | binary `/ws` | ≤10 Hz, tiny | **DataChannel, reliable+ordered** |
+| Stream requests (0x21/0x22) | binary `/ws` uplink | on toggle | reliable DataChannel (reverse) |
+| VFO / mode / drive control | REST `/api/*` | request/response | stays REST (low volume), or reliable DataChannel |
+
+Source of truth: `Zeus.Server.Hosting/StreamingHub.cs`, `ZeusEndpoints.cs` (`/ws` map),
+`ZeusHost.cs` (`UseWebSockets`, 20 s keepalive), `Zeus.Contracts/WireFormat.cs`,
+`zeus-web/src/realtime/ws-client.ts`, `zeus-web/src/serverUrl.ts`. **No auth exists on `/ws` or
+`/api` today** — remote access adds it (ADR-0006).
+
+Peak total ≈ 100 KB/s — comfortably inside a single WebRTC peer; no media SFU needed (1:1 peering).
+
+## Implementation phases
+
+**Phase 0 — Spike (de-risk the .NET↔browser WebRTC path).**
+Add SIPSorcery to `Zeus.Server`. Prove a loopback on LAN with *manual copy-paste signaling* (no
+broker yet): one Opus track + one binary DataChannel between `zeus-web` and `Zeus.Server`. Validate
+on Windows + linux-arm64/Pi. Confirm managed Opus encode (no native FFmpeg). **Exit criteria:** audio
+plays and a DataChannel echoes a `DisplayFrame` end to end.
+
+**Phase 1 — Server transport abstraction.**
+Introduce an `IRemoteTransport` seam so the existing `WireFormat` frames egress over either the
+current `/ws` WebSocket *or* WebRTC channels, with the per-client bounded-queue / drop-oldest
+backpressure (currently `MaxBacklogPerClient=4`) preserved on the WebRTC side. Audio routes to the
+Opus track; display/IQ to the unreliable DataChannel; everything else to the reliable DataChannel.
+No frame-format changes.
+
+**Phase 2 — Frontend WebRTC client.**
+Mirror `ws-client.ts` with an `rtc-client.ts` that establishes `RTCPeerConnection`, reuses every
+existing frame decoder, and routes the Opus track into WebAudio. `serverUrl.ts` gains a
+`remote` mode alongside the existing same-origin / LAN-IP modes.
+
+**Phase 3 — Broker: signaling + QRZ identity + TURN.**
+Cloudflare Worker + Durable Object (WebSocket Hibernation), built as a **sibling of the existing
+`cloud/zeuschat-relay`** — reuse its QRZ verification (`verifyQrzSession` + 300 s cache), per-IP
+rate limiter, and DO-room-with-locked-callsign pattern (ADR-0006/0007). Identity is the
+QRZ-verified callsign via `X-QRZ-Session`/`X-QRZ-Callsign` headers — **no Google OAuth, no claim
+flow, no user table**. New over chat: a signaling frame schema (offer/answer/candidate/ready),
+host↔client pairing within the room, and proxying Cloudflare TURN `generate-ice-servers`.
+`GET /go/<callsign>` serves the web client wired to that callsign's room.
+
+**Phase 4 — Auth & security.**
+Two gates: (1) **identity** — the remote signaling room is reached via the QRZ-callsign address
+(ADR-0006/0007); (2) **access control** — a **session password** the operator sets in the Server
+menu (ADR-0008), verified **end-to-end at `Zeus.Server`** over the DTLS-encrypted DataChannel
+(PAKE/SPAKE2 target so the broker never learns it), Argon2id-hashed in prefs, with per-attempt
+rate-limit + backoff. **Remote access cannot be enabled without a password set** (transmitter
+safety). DTLS-SRTP encrypts media. LAN/localhost keeps the historical no-auth trusted path; auth is
+required only on the remote path. Remote password entry uses the in-app PromptDialog, never
+`window.prompt`.
+
+The Server menu (the existing Server tab / `ServerUrlPanel.tsx` area that the opt-in card already
+lives in) gains: a **session-password field** (set/change/clear), the **remote-access toggle**
+(disabled until a password exists), and the auto-derived **`/go/<callsign>` link + QR** shown once
+QRZ-signed-in.
+
+**Phase 5 — Packaging.**
+SIPSorcery is managed → no native bundling; **drop the `cloudflared` bundling from ADR-0004** on the
+primary path. Keep installer size flat.
+
+**Phase 6 — Resilience & polish.**
+ICE restart / reconnect, TURN cred refresh before the 48 h TTL, QR for `/go/<callsign>`, devices
+page, "radio offline" page, and (optional, additive) a Quick Tunnel last-resort transport for
+environments where even TURN-over-443 is blocked.
+
+## Things to verify before committing code
+
+1. SIPSorcery managed-Opus path on linux-arm64 / Raspberry Pi (avoid native FFmpeg).
+2. SIPSorcery BSD-3 *ethical-use clause* — license review.
+3. Cloudflare blessing for minting TURN creds from a Worker (technically fine; docs say "a back-end service").
+4. Real TURN-fallback rate for home-host topology (CGNAT-on-both-ends may exceed the ~20% average).
+5. WebRTC binary DataChannel throughput for 60 Hz display under the existing drop-oldest backpressure.
+6. Whether the broker should add **per-callsign** rate limits (chat is per-IP only) given it gates
+   radio access, not chat.
+
+## Resolved decisions
+
+- **Identity / verification**: QRZ-verified callsign, reusing the chat relay's mechanism
+  (ADR-0007). No Google OAuth, no self-attestation, no registry table. This unblocks Phase 3.
+- **URL identity**: callsign vanity `/go/<callsign>` (ADR-0007).
+- **Access control**: operator-set **session password**, verified end-to-end at `Zeus.Server`,
+  mandatory before remote access can be enabled (ADR-0008). Decouples access from identity →
+  guest/"lend my shack" access without sharing QRZ creds.
+- **Data plane**: WebRTC P2P + Cloudflare Realtime TURN fallback (ADR-0005).

--- a/docs/designs/remote-access-webrtc.md
+++ b/docs/designs/remote-access-webrtc.md
@@ -84,6 +84,26 @@ Source of truth: `Zeus.Server.Hosting/StreamingHub.cs`, `ZeusEndpoints.cs` (`/ws
 
 Peak total ≈ 100 KB/s — comfortably inside a single WebRTC peer; no media SFU needed (1:1 peering).
 
+## Build status (PR #811)
+
+| Area | State | Verified by |
+|---|---|---|
+| WebRTC works on our stack (Phase 0) | ✅ done | 2-peer DataChannel echo test |
+| Deny-by-default LOCKED session gate | ✅ done | 5 tests |
+| SPAKE2+ verifier (server, C#) | ✅ done | RFC 9383 vectors, byte-exact |
+| SPAKE2+ prover (browser, TS) | ✅ done | RFC 9383 vectors + cross-lang Argon2 agreement |
+| Argon2id registration + password store + UI | ✅ done | killer end-to-end + store tests |
+| Phase 1 server transport (auth over DataChannel, gated egress) | ✅ done | 2-peer transport test: correct→frame flows, wrong→nothing |
+| Browser connect flow (`connect.ts`) | ✅ written | `tsc`; live WebRTC needs a browser bench |
+| Scan-to-remote QR | ✅ done | 7 tests |
+
+**Needs a live bench / deploy (not headlessly verifiable):**
+- StreamingHub → frames-channel bridge (real audio/IQ onto the unlocked session) and the browser
+  media path (frame decode + WebAudio). The transport exposes `TrySendFrame`; wiring it to the live
+  frame pipeline + measuring real RTT is bench work.
+- Phase 3 Cloudflare broker (Worker + Durable Object): signalling relay over the domain, QRZ
+  identity, TURN-cred minting. Needs deployment to the `openhpsdrzeus.com` Cloudflare account.
+
 ## Implementation phases
 
 **Phase 0 — Spike (de-risk the .NET↔browser WebRTC path).**

--- a/docs/designs/remote-access-webrtc.md
+++ b/docs/designs/remote-access-webrtc.md
@@ -92,12 +92,15 @@ broker yet): one Opus track + one binary DataChannel between `zeus-web` and `Zeu
 on Windows + linux-arm64/Pi. Confirm managed Opus encode (no native FFmpeg). **Exit criteria:** audio
 plays and a DataChannel echoes a `DisplayFrame` end to end.
 
-**Phase 1 — Server transport abstraction.**
+**Phase 1 — Server transport abstraction (deny-by-default from line one).**
 Introduce an `IRemoteTransport` seam so the existing `WireFormat` frames egress over either the
 current `/ws` WebSocket *or* WebRTC channels, with the per-client bounded-queue / drop-oldest
 backpressure (currently `MaxBacklogPerClient=4`) preserved on the WebRTC side. Audio routes to the
 Opus track; display/IQ to the unreliable DataChannel; everything else to the reliable DataChannel.
-No frame-format changes.
+No frame-format changes. **The WebRTC transport is constructed in the LOCKED state** (ADR-0008 hard
+invariant): it holds an `IRemoteAuthGate` and egresses/accepts nothing radio-related until the gate
+reports UNLOCKED. The gate's real password verifier arrives in Phase 4; until then it is a
+deny-everything stub, so "nothing without the password" is structural, never retrofitted.
 
 **Phase 2 — Frontend WebRTC client.**
 Mirror `ws-client.ts` with an `rtc-client.ts` that establishes `RTCPeerConnection`, reuses every

--- a/docs/superpowers/specs/2026-05-24-cloudflare-tunnel-zeus-side.md
+++ b/docs/superpowers/specs/2026-05-24-cloudflare-tunnel-zeus-side.md
@@ -1,0 +1,130 @@
+# Cloudflare Tunnel — Zeus app side (sub-project B)
+
+**Status:** Design 2026-05-24
+**Pair:** Broker side is `brianbruff/openhpsdrzeus.com#1` (branch `feature/tunnel-broker`)
+**Worktree:** `feature/tunnel`
+
+## Problem
+
+Once the broker at openhpsdrzeus.com is live, Zeus operators need three
+things inside the app:
+
+1. A clear UI on the Settings / Server tab to opt into a tunnel and
+   punch one with one click.
+2. A backend that talks to the broker (Google sign-in, fetch tunnel
+   credentials), downloads + spawns `cloudflared`, and reports status.
+3. Middleware on Zeus.Server that accepts the broker's signed redirect
+   JWT, sets a `zeus_session` cookie, and gates traffic that arrives via
+   the tunnel hostname (while leaving direct LAN access untouched).
+
+This spec covers all three but is implemented in stages — Stage 1 is
+visible UI only, Stages 2–4 wire the backend.
+
+## Default value changes (operator-visible)
+
+- The Server URL panel hint and placeholder change from
+  `http://192.168.1.23:6060` → `https://192.168.1.23:6443`.
+  Reason: HTTPS on `:6443` is the recommended path now that Zeus.Server
+  binds both. The HTTP port stays available; we just stop advertising
+  it. This is a one-place copy change and per repo conventions counts as
+  a low-risk visual default, not a behavior change.
+
+## Stages
+
+### Stage 1 — Server tab UI (this PR)
+
+- Change example URL hint + placeholder to `https://192.168.1.23:6443`.
+- Add a "Cloudflare Tunnel" card below the existing Base URL controls,
+  containing:
+  - Opt-in checkbox: **"Enable Cloudflare tunnel"** (persists to
+    localStorage `zeus.tunnel.optIn`).
+  - **"Punch tunnel"** button — enabled only when opted in.
+  - Status line. While the backend is not wired (Stages 2-4 below),
+    clicking "Punch tunnel" surfaces a static notice pointing the
+    operator at the broker landing page.
+- No backend changes in this stage. The button calls a local
+  function only; nothing is persisted server-side.
+
+### Stage 2 — Google sign-in (backend)
+
+- New ASP.NET controller `BrokerAuthController`:
+  - `POST /api/broker/login/start` — opens the operator's system browser
+    to `https://openhpsdrzeus.com/api/auth/google/start?client=zeus&return=<loopback>`.
+  - `GET /<loopback>/oauth-done?token=...` — captures the bearer token
+    from the broker's redirect, stores it in LiteDB
+    (`broker_session.token`) with file permissions 600, replies with a
+    short "you can close this window" HTML.
+- Frontend learns sign-in state via `GET /api/broker/me` (proxied to
+  broker `/api/auth/me` with the stored bearer).
+
+### Stage 3 — Cloudflared lifecycle (backend)
+
+- `TunnelService`:
+  - On first punch: downloads platform-appropriate `cloudflared` binary
+    from the official GitHub releases into `<app-data>/cloudflared/<version>/`.
+    Verifies SHA-256 against the published checksum.
+  - Calls broker `POST /api/tunnels/punch` with stored bearer.
+  - Spawns `cloudflared tunnel run --token <T>` as a child process.
+  - Captures stderr, exposes liveness over `GET /api/broker/tunnel/status`.
+  - Heartbeat ticker (5 min) calls broker `POST /api/tunnels/heartbeat`.
+  - Kills the subprocess on app shutdown.
+  - Persists last-known PID to LiteDB; on startup, if the PID is alive
+    and looks like `cloudflared`, adopt it; otherwise kill it.
+- Frontend Server tab status panel polls
+  `GET /api/broker/tunnel/status` and renders the live URL +
+  "Stop tunnel" button.
+
+### Stage 4 — Tunnel-side auth on Zeus.Server
+
+- New `TunnelAuthMiddleware` in `Zeus.Server.Hosting`:
+  - Detects whether the request arrived via the tunnel by checking
+    `Host` against the slug persisted to LiteDB (`tunnel.slug`).
+  - LAN / loopback hosts: skip entirely (preserves today's UX).
+  - Tunnel host:
+    - If `?t=<jwt>` is present: verify against broker JWKS
+      (`<jwks_url>` returned by `/api/tunnels/punch`, cached 24h).
+      Verify `iss=https://openhpsdrzeus.com`, `aud=<our slug>`, `exp`
+      not passed, `jti` not in replay-cache (in-process LRU, 10-minute
+      retention). On success: set `zeus_session` cookie (random session
+      id keyed in LiteDB to `(sub, email, exp+8h)`), 302 to same URL
+      with `?t` stripped.
+    - Else if `zeus_session` cookie is present and valid: attach
+      session, pass through.
+    - Else: 401 with an HTML page pointing back to
+      `https://openhpsdrzeus.com`.
+
+`zeus_session` cookie spec:
+- Name `zeus_session`
+- Domain `<slug>.openhpsdrzeus.com` (scoped, no leading dot)
+- Path `/`, `Secure; HttpOnly; SameSite=Lax`
+- `Max-Age=28800` (8 h)
+
+## Storage (LiteDB additions)
+
+Single new collection `broker_state` with one document:
+```jsonc
+{
+  "_id": 1,
+  "optIn": true,
+  "googleEmail": "x@y.z",
+  "bearerToken": "…",         // opaque from broker
+  "tunnelSlug": "rkkkxppmnz",
+  "tunnelHostname": "rkkkxppmnz.openhpsdrzeus.com",
+  "jwksUrl": "https://openhpsdrzeus.com/.well-known/jwks.json",
+  "cloudflaredPath": "/Users/bek/Library/.../cloudflared",
+  "lastPunchAt": 1748097600,
+  "lastKnownPid": 12345
+}
+```
+
+Cookie sessions (zeus_session) are in-process only for v1 — they don't
+need to survive a Zeus restart (users re-enter via openhpsdrzeus.com).
+
+## Open questions deferred
+
+- Multi-user sessions on one Zeus instance (current model: any logged-in
+  Google user can take over the tunnel since the bearer is single-token
+  per box). Acceptable for v1 since each Zeus is a single-operator
+  station.
+- Cloudflared auto-update — for v1 we pin a known version and require
+  reinstall to bump.

--- a/tests/Zeus.Server.Tests/RemoteBrokerClientTests.cs
+++ b/tests/Zeus.Server.Tests/RemoteBrokerClientTests.cs
@@ -1,0 +1,87 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using SIPSorcery.Net;
+using Zeus.Server.Hosting.Remote;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Tests the radio-side broker bridge: a relayed WebRTC <c>offer</c> becomes an
+/// <c>answer</c> (carrying the broker's clientId) via the password-gated
+/// transport; non-offer signaling is ignored. The WebSocket-to-broker plumbing
+/// needs the deployed broker; this covers the offer→answer logic headlessly.
+/// </summary>
+public sealed class RemoteBrokerClientTests
+{
+    [Fact]
+    public async Task BridgeSignal_OfferBecomesAnswer_WithClientId()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"zeus-rbc-{Guid.NewGuid():N}.db");
+        try
+        {
+            using var store = new RemotePasswordStore(NullLogger<RemotePasswordStore>.Instance, path);
+            store.Set("broker-test-password");
+            var rtc = new RemoteWebRtcService(store, NullLogger<RemoteWebRtcService>.Instance);
+
+            var offerSdp = await MakeOfferAsync();
+            var json = JsonSerializer.Serialize(new { t = "offer", sdp = offerSdp, clientId = "abc-123" });
+
+            var reply = await RemoteBrokerClient.BridgeSignalAsync(rtc, json, NullLogger.Instance, default);
+
+            Assert.NotNull(reply);
+            using var doc = JsonDocument.Parse(reply!);
+            Assert.Equal("answer", doc.RootElement.GetProperty("t").GetString());
+            Assert.Equal("abc-123", doc.RootElement.GetProperty("clientId").GetString());
+            Assert.False(string.IsNullOrWhiteSpace(doc.RootElement.GetProperty("sdp").GetString()));
+        }
+        finally
+        {
+            try { File.Delete(path); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task BridgeSignal_NonOffer_Ignored()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"zeus-rbc-{Guid.NewGuid():N}.db");
+        try
+        {
+            using var store = new RemotePasswordStore(NullLogger<RemotePasswordStore>.Instance, path);
+            store.Set("broker-test-password");
+            var rtc = new RemoteWebRtcService(store, NullLogger<RemoteWebRtcService>.Instance);
+
+            var reply = await RemoteBrokerClient.BridgeSignalAsync(
+                rtc, "{\"t\":\"candidate\",\"candidate\":\"x\"}", NullLogger.Instance, default);
+
+            Assert.Null(reply);
+        }
+        finally
+        {
+            try { File.Delete(path); } catch { /* best effort */ }
+        }
+    }
+
+    private static async Task<string> MakeOfferAsync()
+    {
+        var pc = new RTCPeerConnection(new RTCConfiguration { iceServers = new List<RTCIceServer>() });
+        await pc.createDataChannel("control");
+        await pc.createDataChannel("frames");
+        var offer = pc.createOffer(null);
+        await pc.setLocalDescription(offer);
+
+        if (pc.iceGatheringState != RTCIceGatheringState.complete)
+        {
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            void OnChange(RTCIceGatheringState s) { if (s == RTCIceGatheringState.complete) tcs.TrySetResult(); }
+            pc.onicegatheringstatechange += OnChange;
+            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(750));
+            await using (cts.Token.Register(() => tcs.TrySetResult()))
+                await tcs.Task.ConfigureAwait(false);
+            pc.onicegatheringstatechange -= OnChange;
+        }
+
+        var sdp = pc.localDescription.sdp.ToString();
+        pc.close();
+        return sdp;
+    }
+}

--- a/tests/Zeus.Server.Tests/RemotePasswordStoreTests.cs
+++ b/tests/Zeus.Server.Tests/RemotePasswordStoreTests.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Server.Hosting.Remote;
+
+namespace Zeus.Server.Tests;
+
+public sealed class RemotePasswordStoreTests
+{
+    [Fact]
+    public void Set_Get_Clear_RoundTrips()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"zeus-rps-{Guid.NewGuid():N}.db");
+        try
+        {
+            using var store = new RemotePasswordStore(NullLogger<RemotePasswordStore>.Instance, path);
+
+            Assert.False(store.HasPassword());
+            Assert.Null(store.GetVerifier());
+
+            store.Set("super-secret-pw");
+            Assert.True(store.HasPassword());
+
+            var v = store.GetVerifier();
+            Assert.NotNull(v);
+            Assert.Equal(RemoteAuthConstants.SaltBytes, v!.Salt.Length);
+
+            store.Clear();
+            Assert.False(store.HasPassword());
+            Assert.Null(store.GetVerifier());
+        }
+        finally
+        {
+            try { File.Delete(path); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Set_ReplacesPreviousPassword()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"zeus-rps-{Guid.NewGuid():N}.db");
+        try
+        {
+            using var store = new RemotePasswordStore(NullLogger<RemotePasswordStore>.Instance, path);
+            store.Set("first");
+            var first = store.GetVerifier()!;
+            store.Set("second");
+            var second = store.GetVerifier()!;
+
+            // New salt → different stored verifier; exactly one row remains.
+            Assert.NotEqual(Convert.ToHexString(first.Salt), Convert.ToHexString(second.Salt));
+            Assert.True(store.HasPassword());
+        }
+        finally
+        {
+            try { File.Delete(path); } catch { /* best effort */ }
+        }
+    }
+}

--- a/tests/Zeus.Server.Tests/RemoteQrTests.cs
+++ b/tests/Zeus.Server.Tests/RemoteQrTests.cs
@@ -1,0 +1,35 @@
+using Zeus.Server.Hosting.Remote;
+
+namespace Zeus.Server.Tests;
+
+public sealed class RemoteQrTests
+{
+    [Fact]
+    public void AddressFor_BuildsGoUrl_Uppercased()
+        => Assert.Equal("https://openhpsdrzeus.com/go/EI6LF", RemoteQr.AddressFor("ei6lf"));
+
+    [Fact]
+    public void AddressFor_EscapesPortableCallsign()
+        => Assert.Equal("https://openhpsdrzeus.com/go/EI6LF%2FP", RemoteQr.AddressFor("EI6LF/P"));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AddressFor_NullWhenNoCallsign(string? callsign)
+        => Assert.Null(RemoteQr.AddressFor(callsign));
+
+    [Fact]
+    public void Svg_RendersScannableQr()
+    {
+        var svg = RemoteQr.Svg(RemoteQr.AddressFor("EI6LF")!);
+
+        Assert.StartsWith("<svg", svg.TrimStart());
+        Assert.Contains("</svg>", svg);
+        Assert.True(svg.Length > 200, "SVG QR should contain real module geometry");
+    }
+
+    [Fact]
+    public void Svg_RejectsEmpty()
+        => Assert.Throws<ArgumentException>(() => RemoteQr.Svg("  "));
+}

--- a/tests/Zeus.Server.Tests/RemoteSessionTests.cs
+++ b/tests/Zeus.Server.Tests/RemoteSessionTests.cs
@@ -1,0 +1,92 @@
+using Zeus.Server.Hosting.Remote;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Proves the ADR-0008 hard invariant: a remote session is LOCKED by default and
+/// nothing radio-related is permitted until the password proves out. These are
+/// the structural guarantees the WebRTC transport (Phase 1+) is built on.
+/// </summary>
+public sealed class RemoteSessionTests
+{
+    [Fact]
+    public void StartsLocked_RefusesEgressAndControl()
+    {
+        var s = new RemoteSession(DenyAllAuthGate.Instance);
+
+        Assert.Equal(RemoteSessionState.Locked, s.State);
+        Assert.False(s.IsUnlocked);
+        Assert.False(s.TryEgress());          // no audio/display/IQ/meters
+        Assert.False(s.TryDispatchControl());  // no VFO/mode/TX
+    }
+
+    [Fact]
+    public async Task DenyAllGate_NeverUnlocks_ClosesOnAttempt_LeaksNothing()
+    {
+        var s = new RemoteSession(DenyAllAuthGate.Instance);
+
+        var outcome = await s.SubmitAuthAsync(new byte[] { 1, 2, 3 });
+
+        Assert.Equal(RemoteSessionAction.Close, outcome.Action);
+        Assert.Equal(RemoteSessionState.Closed, s.State);
+        Assert.False(s.TryEgress());
+        Assert.False(s.TryDispatchControl());
+    }
+
+    [Fact]
+    public async Task Unlocks_OnlyWhenGateApproves_ThenArmsDataPaths()
+    {
+        var s = new RemoteSession(new UnlockOnNthGate(unlockOn: 2));
+
+        // First proof step: still LOCKED, nothing armed.
+        var first = await s.SubmitAuthAsync(new byte[] { 0 });
+        Assert.Equal(RemoteSessionAction.Reply, first.Action);
+        Assert.False(s.IsUnlocked);
+        Assert.False(s.TryEgress());
+
+        // Second step: gate approves → UNLOCKED, data paths armed.
+        var second = await s.SubmitAuthAsync(new byte[] { 0 });
+        Assert.Equal(RemoteSessionAction.Unlock, second.Action);
+        Assert.True(s.IsUnlocked);
+        Assert.True(s.TryEgress());
+        Assert.True(s.TryDispatchControl());
+    }
+
+    [Fact]
+    public async Task AuthAfterUnlock_IsRejectedAsAbuse()
+    {
+        var s = new RemoteSession(new UnlockOnNthGate(unlockOn: 1));
+        await s.SubmitAuthAsync(new byte[] { 0 });
+        Assert.True(s.IsUnlocked);
+
+        var again = await s.SubmitAuthAsync(new byte[] { 0 });
+
+        Assert.Equal(RemoteSessionAction.Close, again.Action);
+        Assert.Equal(RemoteSessionState.Closed, s.State);
+        Assert.False(s.TryEgress());
+    }
+
+    [Fact]
+    public async Task GateException_FailsClosed()
+    {
+        var s = new RemoteSession(new ThrowingGate());
+
+        var outcome = await s.SubmitAuthAsync(new byte[] { 0 });
+
+        Assert.Equal(RemoteSessionAction.Close, outcome.Action);
+        Assert.Equal(RemoteSessionState.Closed, s.State);
+    }
+
+    private sealed class UnlockOnNthGate(int unlockOn) : IRemoteAuthGate
+    {
+        private int _n;
+        public ValueTask<RemoteAuthStep> StepAsync(ReadOnlyMemory<byte> m, CancellationToken ct = default)
+            => ValueTask.FromResult(++_n >= unlockOn ? RemoteAuthStep.Unlock() : RemoteAuthStep.Continue(default));
+    }
+
+    private sealed class ThrowingGate : IRemoteAuthGate
+    {
+        public ValueTask<RemoteAuthStep> StepAsync(ReadOnlyMemory<byte> m, CancellationToken ct = default)
+            => throw new InvalidOperationException("boom");
+    }
+}

--- a/tests/Zeus.Server.Tests/RemoteWebRtcSessionTests.cs
+++ b/tests/Zeus.Server.Tests/RemoteWebRtcSessionTests.cs
@@ -1,0 +1,194 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using SIPSorcery.Net;
+using Zeus.Server.Hosting.Remote;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// End-to-end Phase-1 transport test: a real WebRTC peer (standing in for the
+/// browser) connects to <see cref="RemoteWebRtcSession"/>, runs the SPAKE2+
+/// password handshake over the control DataChannel, and only then receives a
+/// frame on the data channel. Proves the ADR-0008 gate holds across the actual
+/// WebRTC wire — correct password flows, wrong password never does.
+/// </summary>
+public sealed class RemoteWebRtcSessionTests
+{
+    private const string Password = "remote-bench-password";
+    private const int Iter = 1, MemKib = 8, Par = 1;
+
+    private static RemoteVerifierMaterial RegisterVerifier(string password)
+    {
+        var v = Spake2PlusRegistration.Register(password, Iter, MemKib, Par);
+        return new RemoteVerifierMaterial(
+            Spake2Plus.ScalarFromBytes(v.W0), Spake2Plus.DecodeL(v.L),
+            v.Salt, v.Iterations, v.MemoryKib, v.Parallelism);
+    }
+
+    [Fact]
+    public async Task CorrectPassword_Unlocks_AndFrameFlows()
+    {
+        var server = new RemoteWebRtcSession(RegisterVerifier(Password), NullLogger.Instance);
+        await using var client = new ProverClient(Password);
+
+        var unlockedOnServer = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        server.Unlocked += () => unlockedOnServer.TrySetResult();
+
+        var answer = await server.CreateAnswerAsync(await client.CreateOfferAsync());
+        await client.AcceptAnswerAsync(answer);
+
+        // Handshake completes on both ends.
+        await client.Unlocked.WaitAsync(TimeSpan.FromSeconds(20));
+        await unlockedOnServer.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(server.IsUnlocked);
+
+        // A frame egressed after unlock reaches the client intact.
+        var frame = Encoding.UTF8.GetBytes("display-frame-payload");
+        Assert.True(server.TrySendFrame(frame));
+        var received = await client.NextFrame().WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(frame, received);
+
+        server.Close();
+    }
+
+    [Fact]
+    public async Task WrongPassword_NeverUnlocks_AndNoFrameFlows()
+    {
+        var server = new RemoteWebRtcSession(RegisterVerifier(Password), NullLogger.Instance);
+        await using var client = new ProverClient("the-wrong-password");
+
+        var answer = await server.CreateAnswerAsync(await client.CreateOfferAsync());
+        await client.AcceptAnswerAsync(answer);
+
+        // Client should be rejected, not unlocked.
+        await Assert.ThrowsAnyAsync<Exception>(
+            async () => await client.Unlocked.WaitAsync(TimeSpan.FromSeconds(15)));
+        Assert.False(server.IsUnlocked);
+        Assert.False(server.TrySendFrame(Encoding.UTF8.GetBytes("should-not-send")));
+
+        server.Close();
+    }
+
+    /// <summary>Minimal in-process SPAKE2+ prover over WebRTC — what the browser will do.</summary>
+    private sealed class ProverClient : IAsyncDisposable
+    {
+        private readonly string _password;
+        private readonly RTCPeerConnection _pc;
+        private readonly RTCDataChannel _control;
+        private readonly RTCDataChannel _frames;
+        private readonly Spake2Plus _prover = new(
+            Spake2Role.Prover, RemoteAuthConstants.Context,
+            RemoteAuthConstants.IdProver, RemoteAuthConstants.IdVerifier);
+        private Spake2PlusOutcome? _outcome;
+
+        private readonly TaskCompletionSource _unlocked = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private TaskCompletionSource<byte[]> _frame = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public ProverClient(string password)
+        {
+            _password = password;
+            _pc = new RTCPeerConnection(new RTCConfiguration { iceServers = new List<RTCIceServer>() });
+            _control = _pc.createDataChannel("control").Result;
+            _frames = _pc.createDataChannel("frames").Result; // reliable for test determinism
+            _control.onopen += () => _control.send("{\"t\":\"hello\"}");
+            _control.onmessage += (_, _, data) => _ = HandleControlAsync(data);
+            _frames.onmessage += (_, _, data) => _frame.TrySetResult(data);
+        }
+
+        public Task Unlocked => _unlocked.Task;
+        public Task<byte[]> NextFrame() => _frame.Task;
+
+        public async Task<string> CreateOfferAsync()
+        {
+            var offer = _pc.createOffer(null);
+            await _pc.setLocalDescription(offer);
+            await WaitGather();
+            return _pc.localDescription.sdp.ToString();
+        }
+
+        public Task AcceptAnswerAsync(string answerSdp)
+        {
+            var r = _pc.setRemoteDescription(
+                new RTCSessionDescriptionInit { type = RTCSdpType.answer, sdp = answerSdp });
+            Assert.Equal(SetDescriptionResultEnum.OK, r);
+            return Task.CompletedTask;
+        }
+
+        private async Task HandleControlAsync(byte[] data)
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(data);
+                switch (doc.RootElement.GetProperty("t").GetString())
+                {
+                    case "auth-params":
+                    {
+                        var salt = Convert.FromBase64String(doc.RootElement.GetProperty("salt").GetString()!);
+                        var (w0, w1) = Spake2PlusRegistration.DeriveScalars(
+                            _password, salt,
+                            doc.RootElement.GetProperty("iterations").GetInt32(),
+                            doc.RootElement.GetProperty("memoryKib").GetInt32(),
+                            doc.RootElement.GetProperty("parallelism").GetInt32());
+                        var shareP = _prover.StartProver(w0, w1);
+                        Send("auth-share", "share", shareP);
+                        break;
+                    }
+                    case "auth-share":
+                    {
+                        var shareV = Convert.FromBase64String(doc.RootElement.GetProperty("share").GetString()!);
+                        _outcome = _prover.Process(shareV);
+                        Send("auth-confirm", "confirm", _outcome.LocalConfirm);
+                        break;
+                    }
+                    case "auth-ok":
+                    {
+                        var confirmV = Convert.FromBase64String(doc.RootElement.GetProperty("confirm").GetString()!);
+                        if (_outcome is not null && Spake2Plus.VerifyPeerConfirm(_outcome, confirmV))
+                            _unlocked.TrySetResult();
+                        else
+                            _unlocked.TrySetException(new InvalidOperationException("server confirm invalid"));
+                        break;
+                    }
+                    case "auth-fail":
+                        _unlocked.TrySetException(new InvalidOperationException("auth rejected"));
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                _unlocked.TrySetException(ex);
+            }
+            await Task.CompletedTask;
+        }
+
+        private void Send(string t, string field, byte[] value)
+            => _control.send(JsonSerializer.Serialize(new Dictionary<string, string>
+            {
+                ["t"] = t,
+                [field] = Convert.ToBase64String(value),
+            }));
+
+        private async Task WaitGather()
+        {
+            if (_pc.iceGatheringState == RTCIceGatheringState.complete) return;
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            void OnChange(RTCIceGatheringState s) { if (s == RTCIceGatheringState.complete) tcs.TrySetResult(); }
+            _pc.onicegatheringstatechange += OnChange;
+            try
+            {
+                if (_pc.iceGatheringState == RTCIceGatheringState.complete) return;
+                using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(750));
+                await using (cts.Token.Register(() => tcs.TrySetResult()))
+                    await tcs.Task.ConfigureAwait(false);
+            }
+            finally { _pc.onicegatheringstatechange -= OnChange; }
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            try { _pc.close(); } catch { /* ignore */ }
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/tests/Zeus.Server.Tests/Spake2PlusAuthGateTests.cs
+++ b/tests/Zeus.Server.Tests/Spake2PlusAuthGateTests.cs
@@ -1,0 +1,100 @@
+using System.Text;
+using Org.BouncyCastle.Math;
+using Zeus.Server.Hosting.Remote;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// End-to-end test of the remote-access password gate: a SPAKE2+ prover (the
+/// browser's role) drives a <see cref="RemoteSession"/> backed by
+/// <see cref="Spake2PlusAuthGate"/>. Proves the ADR-0008 invariant holds in
+/// practice — the right password unlocks and arms the data path; the wrong
+/// password leaves the session LOCKED and closed.
+/// </summary>
+public sealed class Spake2PlusAuthGateTests
+{
+    private static readonly byte[] Context = Encoding.ASCII.GetBytes("zeus-remote-access/v1");
+    private static readonly byte[] IdProver = Encoding.ASCII.GetBytes("client");
+    private static readonly byte[] IdVerifier = Encoding.ASCII.GetBytes("server");
+
+    // Reuse the RFC 9383 verifier scalars as a stand-in for "the registered
+    // password" (Argon2id registration that produces these lands with the UI).
+    private const string W0 = "bb8e1bbcf3c48f62c08db243652ae55d3e5586053fca77102994f23ad95491b3";
+    private const string W1 = "7e945f34d78785b8a3ef44d0df5a1a97d6b3b460409a345ca7830387a74b1dba";
+    private const string L = "04eb7c9db3d9a9eb1f8adab81b5794c1f13ae3e225efbe91ea487425854c7fc00f00bfedcbd09b2400142d40a14f2064ef31dfaa903b91d1faea7093d835966efd";
+
+    private static Spake2Plus Prover() => new(Spake2Role.Prover, Context, IdProver, IdVerifier);
+
+    private static Spake2PlusAuthGate Gate(BigInteger w0) =>
+        new(Context, IdProver, IdVerifier, w0, Spake2Plus.DecodeL(Convert.FromHexString(L)));
+
+    [Fact]
+    public async Task CorrectPassword_UnlocksSession_AndArmsDataPath()
+    {
+        var w0 = Spake2Plus.ScalarFromHex(W0);
+        var gate = Gate(w0);
+        var session = new RemoteSession(gate);
+        var prover = Prover();
+
+        // Locked at the start: nothing is permitted.
+        Assert.False(session.TryEgress());
+
+        // step 0: client → shareP, server → shareV (still locked).
+        var shareP = prover.StartProver(w0, Spake2Plus.ScalarFromHex(W1));
+        var r0 = await session.SubmitAuthAsync(shareP);
+        Assert.Equal(RemoteSessionAction.Reply, r0.Action);
+        Assert.False(session.IsUnlocked);
+        Assert.False(session.TryEgress());
+
+        // client completes SPAKE2+ from the server's shareV.
+        var proverOutcome = prover.Process(r0.Reply.ToArray());
+
+        // step 1: client → confirmP, server verifies → UNLOCK + confirmV.
+        var r1 = await session.SubmitAuthAsync(proverOutcome.LocalConfirm);
+        Assert.Equal(RemoteSessionAction.Unlock, r1.Action);
+        Assert.True(session.IsUnlocked);
+        Assert.True(session.TryEgress());          // audio/display/IQ now allowed
+        Assert.True(session.TryDispatchControl());  // VFO/mode now allowed
+
+        // Mutual auth: client accepts the server's confirmV, and both agree on the key.
+        Assert.True(Spake2Plus.VerifyPeerConfirm(proverOutcome, r1.Reply.ToArray()));
+        Assert.Equal(
+            Convert.ToHexString(proverOutcome.SharedKey),
+            Convert.ToHexString(gate.SessionKey!));
+    }
+
+    [Fact]
+    public async Task WrongPassword_StaysLocked_AndCloses()
+    {
+        var clientW0 = Spake2Plus.ScalarFromHex(W0);
+        // Server registered a DIFFERENT password verifier.
+        var serverW0 = clientW0.Add(BigInteger.One);
+
+        var session = new RemoteSession(Gate(serverW0));
+        var prover = Prover();
+
+        var shareP = prover.StartProver(clientW0, Spake2Plus.ScalarFromHex(W1));
+        var r0 = await session.SubmitAuthAsync(shareP);
+        Assert.Equal(RemoteSessionAction.Reply, r0.Action); // share exchange always replies
+
+        var proverOutcome = prover.Process(r0.Reply.ToArray());
+        var r1 = await session.SubmitAuthAsync(proverOutcome.LocalConfirm);
+
+        // Wrong password → confirm mismatch → session closed, nothing armed.
+        Assert.Equal(RemoteSessionAction.Close, r1.Action);
+        Assert.Equal(RemoteSessionState.Closed, session.State);
+        Assert.False(session.IsUnlocked);
+        Assert.False(session.TryEgress());
+    }
+
+    [Fact]
+    public async Task GarbageFirstMessage_FailsClosed()
+    {
+        var session = new RemoteSession(Gate(Spake2Plus.ScalarFromHex(W0)));
+
+        var r = await session.SubmitAuthAsync(new byte[] { 0xde, 0xad });
+
+        Assert.Equal(RemoteSessionAction.Close, r.Action);
+        Assert.False(session.TryEgress());
+    }
+}

--- a/tests/Zeus.Server.Tests/Spake2PlusRegistrationTests.cs
+++ b/tests/Zeus.Server.Tests/Spake2PlusRegistrationTests.cs
@@ -1,0 +1,82 @@
+using Zeus.Server.Hosting.Remote;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Proves the full remote-access password flow: a typed password is registered
+/// into a SPAKE2+ verifier (Argon2id), and a client that re-derives from the
+/// same password + stored salt unlocks the session — while a wrong password
+/// does not. Light Argon2 params keep the tests fast; production uses 64 MiB.
+/// </summary>
+public sealed class Spake2PlusRegistrationTests
+{
+    private const int Iter = 1;
+    private const int MemKib = 8192; // 8 MiB for tests
+    private const int Par = 1;
+
+    private static Spake2Plus Prover() => new(
+        Spake2Role.Prover, RemoteAuthConstants.Context,
+        RemoteAuthConstants.IdProver, RemoteAuthConstants.IdVerifier);
+
+    private static Spake2PlusAuthGate GateFor(Spake2PlusVerifier v) => new(
+        RemoteAuthConstants.Context, RemoteAuthConstants.IdProver, RemoteAuthConstants.IdVerifier,
+        Spake2Plus.ScalarFromBytes(v.W0), Spake2Plus.DecodeL(v.L));
+
+    [Fact]
+    public void DeriveScalars_IsDeterministic()
+    {
+        var salt = new byte[16];
+        var a = Spake2PlusRegistration.DeriveScalars("pw", salt, Iter, MemKib, Par);
+        var b = Spake2PlusRegistration.DeriveScalars("pw", salt, Iter, MemKib, Par);
+        Assert.Equal(a.W0, b.W0);
+        Assert.Equal(a.W1, b.W1);
+    }
+
+    [Fact]
+    public void Register_StoresVerifierMatchingRederivation()
+    {
+        var v = Spake2PlusRegistration.Register("pw", Iter, MemKib, Par);
+        var (w0, w1) = Spake2PlusRegistration.DeriveScalars("pw", v.Salt, v.Iterations, v.MemoryKib, v.Parallelism);
+
+        Assert.Equal(v.W0, Spake2Plus.EncodeScalar(w0));
+        Assert.Equal(v.L, Spake2Plus.EncodeL(w1));
+    }
+
+    [Fact]
+    public async Task FullFlow_CorrectPassword_Unlocks()
+    {
+        const string password = "correct horse battery staple";
+        var v = Spake2PlusRegistration.Register(password, Iter, MemKib, Par);
+
+        var session = new RemoteSession(GateFor(v));
+        var (cw0, cw1) = Spake2PlusRegistration.DeriveScalars(password, v.Salt, v.Iterations, v.MemoryKib, v.Parallelism);
+
+        var prover = Prover();
+        var shareP = prover.StartProver(cw0, cw1);
+        var r0 = await session.SubmitAuthAsync(shareP);
+        var proverOutcome = prover.Process(r0.Reply.ToArray());
+        var r1 = await session.SubmitAuthAsync(proverOutcome.LocalConfirm);
+
+        Assert.Equal(RemoteSessionAction.Unlock, r1.Action);
+        Assert.True(session.IsUnlocked);
+        Assert.True(Spake2Plus.VerifyPeerConfirm(proverOutcome, r1.Reply.ToArray()));
+    }
+
+    [Fact]
+    public async Task FullFlow_WrongPassword_StaysLocked()
+    {
+        var v = Spake2PlusRegistration.Register("the real password", Iter, MemKib, Par);
+
+        var session = new RemoteSession(GateFor(v));
+        var (cw0, cw1) = Spake2PlusRegistration.DeriveScalars("a different password", v.Salt, v.Iterations, v.MemoryKib, v.Parallelism);
+
+        var prover = Prover();
+        var shareP = prover.StartProver(cw0, cw1);
+        var r0 = await session.SubmitAuthAsync(shareP);
+        var proverOutcome = prover.Process(r0.Reply.ToArray());
+        var r1 = await session.SubmitAuthAsync(proverOutcome.LocalConfirm);
+
+        Assert.Equal(RemoteSessionAction.Close, r1.Action);
+        Assert.False(session.IsUnlocked);
+    }
+}

--- a/tests/Zeus.Server.Tests/Spake2PlusRegistrationTests.cs
+++ b/tests/Zeus.Server.Tests/Spake2PlusRegistrationTests.cs
@@ -33,6 +33,25 @@ public sealed class Spake2PlusRegistrationTests
     }
 
     [Fact]
+    public void DeriveScalars_MatchesCrossLanguageVector()
+    {
+        // Pinned identically in the browser test registration.test.ts — guarantees
+        // the noble (browser) and Konscious (server) Argon2id agree, so a password
+        // set on the radio unlocks from the phone.
+        var salt = new byte[16];
+        for (var i = 0; i < 16; i++) salt[i] = (byte)i;
+
+        var (w0, w1) = Spake2PlusRegistration.DeriveScalars("zeus-cross-vector", salt, 1, 8, 1);
+
+        Assert.Equal(
+            "5038ef6d5486f2dd9321ec16a6d4e0d91379299bc14650db32c78dfd58e43818",
+            Convert.ToHexString(Spake2Plus.EncodeScalar(w0)).ToLowerInvariant());
+        Assert.Equal(
+            "5df0c3ed05e170c4296186f19639c7c79de43fddb39f7745d6a3c61241b5175f",
+            Convert.ToHexString(Spake2Plus.EncodeScalar(w1)).ToLowerInvariant());
+    }
+
+    [Fact]
     public void Register_StoresVerifierMatchingRederivation()
     {
         var v = Spake2PlusRegistration.Register("pw", Iter, MemKib, Par);

--- a/tests/Zeus.Server.Tests/Spake2PlusTests.cs
+++ b/tests/Zeus.Server.Tests/Spake2PlusTests.cs
@@ -1,0 +1,164 @@
+using System.Text;
+using Zeus.Server.Hosting.Remote;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Pins the SPAKE2+ implementation to RFC 9383 Appendix C, Vector 1
+/// (ciphersuite P256-SHA256-HKDF-SHA256-HMAC-SHA256). Every intermediate —
+/// shares, Z, V, transcript-derived keys, and both confirmation MACs — is checked
+/// byte-for-byte against the RFC. Because this crypto gates a transmitter, "it
+/// runs" is not enough; it must match the standard exactly.
+/// </summary>
+public sealed class Spake2PlusTests
+{
+    // RFC 9383 Appendix C, Vector 1.
+    // RFC 9383 Appendix C context (56 bytes, no trailing space — the TT hex shows
+    // "...Vectors" immediately followed by the next field's length prefix).
+    private static readonly byte[] Context =
+        Encoding.ASCII.GetBytes("SPAKE2+-P256-SHA256-HKDF-SHA256-HMAC-SHA256 Test Vectors");
+    private static readonly byte[] IdProver = Encoding.ASCII.GetBytes("client");
+    private static readonly byte[] IdVerifier = Encoding.ASCII.GetBytes("server");
+
+    private const string W0 = "bb8e1bbcf3c48f62c08db243652ae55d3e5586053fca77102994f23ad95491b3";
+    private const string W1 = "7e945f34d78785b8a3ef44d0df5a1a97d6b3b460409a345ca7830387a74b1dba";
+    private const string L = "04eb7c9db3d9a9eb1f8adab81b5794c1f13ae3e225efbe91ea487425854c7fc00f00bfedcbd09b2400142d40a14f2064ef31dfaa903b91d1faea7093d835966efd";
+    private const string X = "d1232c8e8693d02368976c174e2088851b8365d0d79a9eee709c6a05a2fad539";
+    private const string Y = "717a72348a182085109c8d3917d6c43d59b224dc6a7fc4f0483232fa6516d8b3";
+    private const string ShareP = "04ef3bd051bf78a2234ec0df197f7828060fe9856503579bb1733009042c15c0c1de127727f418b5966afadfdd95a6e4591d171056b333dab97a79c7193e341727";
+    private const string ShareV = "04c0f65da0d11927bdf5d560c69e1d7d939a05b0e88291887d679fcadea75810fb5cc1ca7494db39e82ff2f50665255d76173e09986ab46742c798a9a68437b048";
+    private const string Z = "04bbfce7dd7f277819c8da21544afb7964705569bdf12fb92aa388059408d50091a0c5f1d3127f56813b5337f9e4e67e2ca633117a4fbd559946ab474356c41839";
+    private const string V = "0458bf27c6bca011c9ce1930e8984a797a3419797b936629a5a937cf2f11c8b9514b82b993da8a46e664f23db7c01edc87faa530db01c2ee405230b18997f16b68";
+    private const string KMain = "4c59e1ccf2cfb961aa31bd9434478a1089b56cd11542f53d3576fb6c2a438a29";
+    private const string KConfirmP = "871ae3f7b78445e34438fb284504240239031c39d80ac23eb5ab9be5ad6db58a";
+    private const string KConfirmV = "ccd53c7c1fa37b64a462b40db8be101cedcf838950162902054e644b400f1680";
+    private const string KShared = "0c5f8ccd1413423a54f6c1fb26ff01534a87f893779c6e68666d772bfd91f3e7";
+    private const string ConfirmP = "926cc713504b9b4d76c9162ded04b5493e89109f6d89462cd33adc46fda27527";
+    private const string ConfirmV = "9747bcc4f8fe9f63defee53ac9b07876d907d55047e6ff2def2e7529089d3e68";
+
+    private static Spake2Plus Prover() => new(Spake2Role.Prover, Context, IdProver, IdVerifier);
+    private static Spake2Plus Verifier() => new(Spake2Role.Verifier, Context, IdProver, IdVerifier);
+    private static string Hex(byte[] b) => Convert.ToHexString(b).ToLowerInvariant();
+
+    [Fact]
+    public void ProverShare_MatchesRfc9383Vector()
+    {
+        var shareP = Prover().StartProver(
+            Spake2Plus.ScalarFromHex(W0), Spake2Plus.ScalarFromHex(W1), Spake2Plus.ScalarFromHex(X));
+        Assert.Equal(ShareP, Hex(shareP));
+    }
+
+    [Fact]
+    public void VerifierShare_MatchesRfc9383Vector()
+    {
+        var shareV = Verifier().StartVerifier(
+            Spake2Plus.ScalarFromHex(W0), Spake2Plus.DecodeL(Convert.FromHexString(L)),
+            Spake2Plus.ScalarFromHex(Y));
+        Assert.Equal(ShareV, Hex(shareV));
+    }
+
+    [Fact]
+    public void ProverProcess_DerivesEveryIntermediate_PerRfc9383()
+    {
+        var prover = Prover();
+        prover.StartProver(Spake2Plus.ScalarFromHex(W0), Spake2Plus.ScalarFromHex(W1), Spake2Plus.ScalarFromHex(X));
+        var o = prover.Process(Convert.FromHexString(ShareV));
+
+        Assert.Equal(Z, Hex(o.ZEnc));
+        Assert.Equal(V, Hex(o.VEnc));
+        Assert.Equal(KMain, Hex(o.KMain));
+        Assert.Equal(KConfirmP, Hex(o.KConfirmP));
+        Assert.Equal(KConfirmV, Hex(o.KConfirmV));
+        Assert.Equal(KShared, Hex(o.SharedKey));
+        Assert.Equal(ConfirmP, Hex(o.ConfirmP));
+        Assert.Equal(ConfirmV, Hex(o.ConfirmV));
+        // Prover sends confirmP, expects confirmV.
+        Assert.Equal(ConfirmP, Hex(o.LocalConfirm));
+        Assert.Equal(ConfirmV, Hex(o.ExpectedPeerConfirm));
+    }
+
+    [Fact]
+    public void VerifierProcess_DerivesEveryIntermediate_PerRfc9383()
+    {
+        var verifier = Verifier();
+        verifier.StartVerifier(Spake2Plus.ScalarFromHex(W0), Spake2Plus.DecodeL(Convert.FromHexString(L)), Spake2Plus.ScalarFromHex(Y));
+        var o = verifier.Process(Convert.FromHexString(ShareP));
+
+        Assert.Equal(Z, Hex(o.ZEnc));
+        Assert.Equal(V, Hex(o.VEnc));
+        Assert.Equal(KShared, Hex(o.SharedKey));
+        // Verifier sends confirmV, expects confirmP.
+        Assert.Equal(ConfirmV, Hex(o.LocalConfirm));
+        Assert.Equal(ConfirmP, Hex(o.ExpectedPeerConfirm));
+    }
+
+    [Fact]
+    public void FullExchange_BothSidesAgree_AndConfirmsVerify()
+    {
+        var w0 = Spake2Plus.ScalarFromHex(W0);
+        var w1 = Spake2Plus.ScalarFromHex(W1);
+        var l = Spake2Plus.DecodeL(Convert.FromHexString(L));
+
+        var prover = Prover();
+        var verifier = Verifier();
+        var sp = prover.StartProver(w0, w1, Spake2Plus.ScalarFromHex(X));
+        var sv = verifier.StartVerifier(w0, l, Spake2Plus.ScalarFromHex(Y));
+
+        var po = prover.Process(sv);
+        var vo = verifier.Process(sp);
+
+        Assert.Equal(Hex(po.SharedKey), Hex(vo.SharedKey));
+        Assert.True(Spake2Plus.VerifyPeerConfirm(po, vo.LocalConfirm)); // prover accepts verifier's MAC
+        Assert.True(Spake2Plus.VerifyPeerConfirm(vo, po.LocalConfirm)); // verifier accepts prover's MAC
+    }
+
+    [Fact]
+    public void RandomScalars_CorrectPassword_Succeeds()
+    {
+        var w0 = Spake2Plus.ScalarFromHex(W0);
+        var w1 = Spake2Plus.ScalarFromHex(W1);
+        var l = Spake2Plus.DecodeL(Convert.FromHexString(L));
+
+        var prover = Prover();
+        var verifier = Verifier();
+        var sp = prover.StartProver(w0, w1);   // random x
+        var sv = verifier.StartVerifier(w0, l); // random y
+
+        var po = prover.Process(sv);
+        var vo = verifier.Process(sp);
+
+        Assert.Equal(Hex(po.SharedKey), Hex(vo.SharedKey));
+        Assert.True(Spake2Plus.VerifyPeerConfirm(po, vo.LocalConfirm));
+        Assert.True(Spake2Plus.VerifyPeerConfirm(vo, po.LocalConfirm));
+    }
+
+    [Fact]
+    public void WrongPassword_ConfirmsDoNotVerify()
+    {
+        var w0 = Spake2Plus.ScalarFromHex(W0);
+        var w1 = Spake2Plus.ScalarFromHex(W1);
+        var l = Spake2Plus.DecodeL(Convert.FromHexString(L));
+        var wrongW0 = w0.Add(Org.BouncyCastle.Math.BigInteger.One); // verifier's stored secret differs
+
+        var prover = Prover();
+        var verifier = Verifier();
+        var sp = prover.StartProver(w0, w1);
+        var sv = verifier.StartVerifier(wrongW0, l);
+
+        var po = prover.Process(sv);
+        var vo = verifier.Process(sp);
+
+        Assert.NotEqual(Hex(po.SharedKey), Hex(vo.SharedKey));
+        Assert.False(Spake2Plus.VerifyPeerConfirm(po, vo.LocalConfirm));
+        Assert.False(Spake2Plus.VerifyPeerConfirm(vo, po.LocalConfirm));
+    }
+
+    [Fact]
+    public void InvalidPeerShare_FailsClosed()
+    {
+        var verifier = Verifier();
+        verifier.StartVerifier(Spake2Plus.ScalarFromHex(W0), Spake2Plus.DecodeL(Convert.FromHexString(L)));
+        // Identity / garbage share must be rejected, not processed.
+        Assert.Throws<Spake2Exception>(() => verifier.Process(new byte[] { 0x00 }));
+    }
+}

--- a/tests/Zeus.Server.Tests/WebRtcSpikeTests.cs
+++ b/tests/Zeus.Server.Tests/WebRtcSpikeTests.cs
@@ -1,0 +1,89 @@
+using System.Diagnostics;
+using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+using SIPSorcery.Net;
+using Zeus.Server.Hosting.Remote;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Phase-0 WebRTC spike (docs/designs/remote-access-webrtc.md): proves the
+/// SIPSorcery DataChannel path works end-to-end on our net10 stack by standing up
+/// a second in-process peer as the "browser" client, connecting it to
+/// <see cref="WebRtcSpikeService"/>, and round-tripping a binary message through a
+/// real ICE→DTLS→SCTP DataChannel. De-risks the data plane before Phase 1.
+/// </summary>
+public sealed class WebRtcSpikeTests
+{
+    [Fact]
+    public async Task EchoDataChannel_RoundTripsBinaryThroughRealPeerConnection()
+    {
+        var service = new WebRtcSpikeService(NullLogger<WebRtcSpikeService>.Instance);
+
+        // Host-candidate ICE only — no external STUN dependency for the in-process
+        // loopback path, so the test is fast and runs offline.
+        var client = new RTCPeerConnection(new RTCConfiguration { iceServers = new List<RTCIceServer>() });
+
+        var opened = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var echoed = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var dc = await client.createDataChannel("spike");
+        dc.onopen += () => opened.TrySetResult();
+        dc.onmessage += (_, _, data) => echoed.TrySetResult(data);
+
+        // Client offers (mirrors the browser); service answers + wires the echo.
+        var offer = client.createOffer(null);
+        await client.setLocalDescription(offer);
+        await WaitForIceGatheringAsync(client, TimeSpan.FromMilliseconds(750));
+
+        var answerSdp = await service.CreateEchoAnswerAsync(client.localDescription.sdp.ToString());
+
+        var setResult = client.setRemoteDescription(
+            new RTCSessionDescriptionInit { type = RTCSdpType.answer, sdp = answerSdp });
+        Assert.Equal(SetDescriptionResultEnum.OK, setResult);
+
+        await opened.Task.WaitAsync(TimeSpan.FromSeconds(20));
+
+        var payload = Encoding.UTF8.GetBytes("zeus-webrtc-spike");
+        var sw = Stopwatch.StartNew();
+        dc.send(payload);
+        var received = await echoed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        sw.Stop();
+
+        Assert.Equal(payload, received);
+        Assert.Equal(1, service.ActivePeers);
+
+        // Informational: in-process DataChannel round-trip latency.
+        Console.WriteLine($"[spike] DataChannel echo RTT: {sw.Elapsed.TotalMilliseconds:F2} ms");
+
+        client.close();
+        service.CloseAll();
+    }
+
+    private static async Task WaitForIceGatheringAsync(RTCPeerConnection pc, TimeSpan timeout)
+    {
+        if (pc.iceGatheringState == RTCIceGatheringState.complete)
+            return;
+
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        void OnChange(RTCIceGatheringState s)
+        {
+            if (s == RTCIceGatheringState.complete)
+                tcs.TrySetResult();
+        }
+
+        pc.onicegatheringstatechange += OnChange;
+        try
+        {
+            if (pc.iceGatheringState == RTCIceGatheringState.complete)
+                return;
+            using var cts = new CancellationTokenSource(timeout);
+            await using (cts.Token.Register(() => tcs.TrySetResult()))
+                await tcs.Task.ConfigureAwait(false);
+        }
+        finally
+        {
+            pc.onicegatheringstatechange -= OnChange;
+        }
+    }
+}

--- a/zeus-web/package-lock.json
+++ b/zeus-web/package-lock.json
@@ -8,6 +8,8 @@
       "name": "zeus-web",
       "version": "0.0.1",
       "dependencies": {
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
         "leaflet": "^1.9.4",
         "lucide-react": "^1.11.0",
         "onnxruntime-web": "1.24.3",
@@ -2455,6 +2457,33 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@playwright/test": {

--- a/zeus-web/package.json
+++ b/zeus-web/package.json
@@ -15,6 +15,8 @@
     "smoke": "node scripts/smoke.mjs"
   },
   "dependencies": {
+    "@noble/curves": "^2.2.0",
+    "@noble/hashes": "^2.2.0",
     "leaflet": "^1.9.4",
     "lucide-react": "^1.11.0",
     "onnxruntime-web": "1.24.3",

--- a/zeus-web/public/rtc-spike.html
+++ b/zeus-web/public/rtc-spike.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<!--
+  Phase-0 WebRTC spike harness (docs/designs/remote-access-webrtc.md).
+  Dev-only: proves the real browser <-> Zeus.Server WebRTC DataChannel path and
+  measures round-trip latency. Requires the backend started with ZEUS_RTC_SPIKE=1
+  (the /api/rtc/spike/offer endpoint is inert otherwise). Open at /rtc-spike.html.
+  This file is NOT the production remote client; it is throwaway de-risking.
+-->
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Zeus WebRTC spike</title>
+  <style>
+    body { font: 14px ui-monospace, monospace; background: #657486; color: #eef; padding: 24px; }
+    button { font: inherit; padding: 6px 14px; cursor: pointer; }
+    #log { white-space: pre-wrap; margin-top: 16px; background: #0003; padding: 12px; border-radius: 6px; }
+    .ok { color: #7CFC9B; } .err { color: #ff8a7a; } .rtt { color: #ffc93a; font-weight: 700; }
+  </style>
+</head>
+<body>
+  <h2>Zeus WebRTC DataChannel spike</h2>
+  <button id="go">Connect &amp; echo-test</button>
+  <div id="log"></div>
+  <script type="module">
+    const logEl = document.getElementById('log');
+    const log = (msg, cls = '') => {
+      const line = document.createElement('div');
+      if (cls) line.className = cls;
+      line.textContent = msg;
+      logEl.appendChild(line);
+    };
+
+    async function run() {
+      logEl.textContent = '';
+      const pc = new RTCPeerConnection({
+        iceServers: [{ urls: 'stun:stun.cloudflare.com:3478' }],
+      });
+      pc.onconnectionstatechange = () => log(`conn: ${pc.connectionState}`);
+
+      // Unreliable + unordered = the production IQ/display channel profile.
+      const dc = pc.createDataChannel('spike', { ordered: false, maxRetransmits: 0 });
+
+      const opened = new Promise((res) => (dc.onopen = res));
+      let pending = null;
+      dc.onmessage = (e) => pending && pending(e.data);
+
+      const offer = await pc.createOffer();
+      await pc.setLocalDescription(offer);
+      await iceComplete(pc);
+      log('offer gathered, posting to broker-less spike endpoint…');
+
+      let answerSdp;
+      try {
+        const resp = await fetch('/api/rtc/spike/offer', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ sdp: pc.localDescription.sdp }),
+        });
+        if (!resp.ok) throw new Error(`HTTP ${resp.status} — is ZEUS_RTC_SPIKE=1 set?`);
+        answerSdp = (await resp.json()).sdp;
+      } catch (err) {
+        log(`offer POST failed: ${err.message}`, 'err');
+        pc.close();
+        return;
+      }
+
+      await pc.setRemoteDescription({ type: 'answer', sdp: answerSdp });
+      await opened;
+      log('datachannel open ✓', 'ok');
+
+      // 50-sample echo RTT distribution (binary payloads).
+      const payload = new TextEncoder().encode('zeus-webrtc-spike');
+      const samples = [];
+      for (let i = 0; i < 50; i++) {
+        const t0 = performance.now();
+        const got = await new Promise((res) => { pending = res; dc.send(payload); });
+        samples.push(performance.now() - t0);
+        if (got.byteLength !== payload.byteLength) { log('echo mismatch!', 'err'); break; }
+      }
+      samples.sort((a, b) => a - b);
+      const p = (q) => samples[Math.floor(q * samples.length)].toFixed(2);
+      log(`echo RTT  min ${samples[0].toFixed(2)}ms  median ${p(0.5)}ms  p95 ${p(0.95)}ms`, 'rtt');
+      log('spike OK — DataChannel path verified end to end.', 'ok');
+      pc.close();
+    }
+
+    function iceComplete(pc) {
+      return new Promise((res) => {
+        if (pc.iceGatheringState === 'complete') return res();
+        const t = setTimeout(res, 750); // vanilla-ICE cap; host candidates suffice on LAN
+        pc.onicegatheringstatechange = () => {
+          if (pc.iceGatheringState === 'complete') { clearTimeout(t); res(); }
+        };
+      });
+    }
+
+    document.getElementById('go').onclick = () => run().catch((e) => log(String(e), 'err'));
+  </script>
+</body>
+</html>

--- a/zeus-web/src/components/ServerUrlPanel.tsx
+++ b/zeus-web/src/components/ServerUrlPanel.tsx
@@ -252,9 +252,185 @@ export function ServerUrlPanel() {
         </div>
       )}
 
+      <RemotePasswordSection />
+
       <RemoteQrSection />
 
       <TunnelSection />
+    </div>
+  );
+}
+
+// Remote-access session password (ADR-0008). Mandatory: remote access does
+// nothing until the right password is entered. Set/change/clear hit the
+// SPAKE2+ verifier endpoints — the password is never stored, only its verifier.
+function RemotePasswordSection() {
+  const [hasPassword, setHasPassword] = useState<boolean | null>(null);
+  const [pw, setPw] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const refresh = async () => {
+    try {
+      const r = await fetch('/api/remote/password/status');
+      const j = await r.json();
+      setHasPassword(!!j.hasPassword);
+    } catch {
+      setHasPassword(null);
+    }
+  };
+
+  useEffect(() => {
+    void refresh();
+  }, []);
+
+  const save = async () => {
+    if (pw.length < 8) {
+      setNotice('Password must be at least 8 characters.');
+      return;
+    }
+    setBusy(true);
+    setNotice(null);
+    try {
+      const r = await fetch('/api/remote/password', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ password: pw }),
+      });
+      if (!r.ok) throw new Error((await r.json().catch(() => ({})))?.error ?? 'Failed to save');
+      setPw('');
+      setNotice('Password saved.');
+      await refresh();
+    } catch (e) {
+      setNotice((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const clear = async () => {
+    setBusy(true);
+    setNotice(null);
+    try {
+      await fetch('/api/remote/password', { method: 'DELETE' });
+      setNotice('Password cleared — remote access is disabled.');
+      await refresh();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div style={{ marginTop: 28 }}>
+      <h3
+        style={{
+          margin: '0 0 14px',
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: '0.12em',
+          textTransform: 'uppercase',
+          color: 'var(--fg-2)',
+        }}
+      >
+        REMOTE ACCESS PASSWORD
+      </h3>
+
+      <p style={{ fontSize: 12, color: 'var(--fg-2)', lineHeight: 1.5, marginTop: 0 }}>
+        Required for remote access. Nothing — no audio, no control, not even a
+        connection — happens until this password is entered correctly. It is
+        verified end-to-end at your radio (SPAKE2+); the server stores only a
+        verifier, never the password itself.
+      </p>
+
+      <div
+        style={{
+          marginTop: 12,
+          fontSize: 12,
+          fontWeight: 700,
+          color: hasPassword ? 'var(--accent)' : 'var(--tx)',
+        }}
+      >
+        {hasPassword === null
+          ? '…'
+          : hasPassword
+            ? '● Password set — remote access can be enabled.'
+            : '○ No password — remote access is disabled.'}
+      </div>
+
+      <label style={{ display: 'flex', flexDirection: 'column', gap: 6, marginTop: 14 }}>
+        <span
+          style={{
+            fontSize: 11,
+            fontWeight: 600,
+            letterSpacing: '0.1em',
+            textTransform: 'uppercase',
+            color: 'var(--fg-2)',
+          }}
+        >
+          {hasPassword ? 'Change password' : 'Set password'}
+        </span>
+        <input
+          type="password"
+          autoComplete="new-password"
+          placeholder="at least 8 characters"
+          value={pw}
+          onChange={(e) => setPw(e.target.value)}
+          style={{
+            padding: '8px 10px',
+            fontFamily: 'monospace',
+            fontSize: 13,
+            color: 'var(--fg-0)',
+            background: 'var(--bg-2)',
+            border: '1px solid var(--panel-border)',
+            borderRadius: 'var(--r-sm)',
+            outline: 'none',
+          }}
+        />
+      </label>
+
+      <div style={{ display: 'flex', gap: 8, marginTop: 14, alignItems: 'center' }}>
+        <button
+          type="button"
+          onClick={save}
+          disabled={busy || pw.length < 8}
+          style={{
+            padding: '8px 16px',
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: '0.1em',
+            textTransform: 'uppercase',
+            color: !busy && pw.length >= 8 ? 'var(--fg-0)' : 'var(--fg-2)',
+            background: !busy && pw.length >= 8 ? 'var(--accent)' : 'var(--bg-2)',
+            border: '1px solid var(--panel-border)',
+            borderRadius: 'var(--r-sm)',
+            cursor: !busy && pw.length >= 8 ? 'pointer' : 'not-allowed',
+            opacity: !busy && pw.length >= 8 ? 1 : 0.6,
+          }}
+        >
+          {hasPassword ? 'Change' : 'Set password'}
+        </button>
+        <button
+          type="button"
+          onClick={clear}
+          disabled={busy || !hasPassword}
+          style={{
+            padding: '8px 16px',
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: '0.1em',
+            textTransform: 'uppercase',
+            color: 'var(--fg-2)',
+            background: 'var(--bg-2)',
+            border: '1px solid var(--panel-border)',
+            borderRadius: 'var(--r-sm)',
+            cursor: !busy && hasPassword ? 'pointer' : 'not-allowed',
+            opacity: !busy && hasPassword ? 1 : 0.5,
+          }}
+        >
+          Clear
+        </button>
+        {notice && <span style={{ fontSize: 11, color: 'var(--fg-2)' }}>{notice}</span>}
+      </div>
     </div>
   );
 }

--- a/zeus-web/src/components/ServerUrlPanel.tsx
+++ b/zeus-web/src/components/ServerUrlPanel.tsx
@@ -13,6 +13,7 @@ import {
   setServerBaseUrl,
 } from '../serverUrl';
 import { useCapabilitiesStore } from '../state/capabilities-store';
+import { useQrzStore } from '../state/qrz-store';
 
 // Settings tab: lets the operator point a Capacitor / standalone build at a
 // specific Zeus.Server on their LAN (e.g. https://192.168.1.23:6443). Browser
@@ -251,7 +252,97 @@ export function ServerUrlPanel() {
         </div>
       )}
 
+      <RemoteQrSection />
+
       <TunnelSection />
+    </div>
+  );
+}
+
+// Remote-access QR: encodes the operator's openhpsdrzeus.com/go/<callsign>
+// address so a phone camera opens the remote client directly. The callsign comes
+// from the QRZ sign-in (Settings → QRZ); access still requires the session
+// password — the link alone is useless (ADR-0007/0008).
+function RemoteQrSection() {
+  const home = useQrzStore((s) => s.home);
+  const callsign = home?.callsign?.trim().toUpperCase() ?? '';
+  const remoteUrl = callsign
+    ? `${TUNNEL_BROKER_ORIGIN}/go/${encodeURIComponent(callsign)}`
+    : null;
+  const qrSrc = remoteUrl
+    ? `${getServerBaseUrl()}/api/remote/qr.svg?data=${encodeURIComponent(remoteUrl)}`
+    : null;
+
+  return (
+    <div style={{ marginTop: 28 }}>
+      <h3
+        style={{
+          margin: '0 0 14px',
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: '0.12em',
+          textTransform: 'uppercase',
+          color: 'var(--fg-2)',
+        }}
+      >
+        REMOTE ACCESS QR
+      </h3>
+
+      <p style={{ fontSize: 12, color: 'var(--fg-2)', lineHeight: 1.5, marginTop: 0 }}>
+        Scan with your phone to open your radio from anywhere at your personal
+        address. The link is safe to share — access still requires the session
+        password, so the address alone reaches nothing.
+      </p>
+
+      {remoteUrl ? (
+        <div style={{ display: 'flex', gap: 16, alignItems: 'center', marginTop: 14 }}>
+          <img
+            src={qrSrc!}
+            alt={`Remote access QR for ${remoteUrl}`}
+            width={148}
+            height={148}
+            style={{ background: '#fff', padding: 8, borderRadius: 'var(--r-sm)', flex: '0 0 auto' }}
+          />
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6, minWidth: 0 }}>
+            <a
+              href={remoteUrl}
+              target="_blank"
+              rel="noreferrer"
+              style={{
+                fontFamily: 'monospace',
+                fontSize: 13,
+                color: 'var(--accent)',
+                wordBreak: 'break-all',
+              }}
+            >
+              {remoteUrl}
+            </a>
+            <span style={{ fontSize: 11, color: 'var(--fg-2)' }}>
+              Point your phone camera at the code.
+            </span>
+          </div>
+        </div>
+      ) : (
+        <div
+          style={{
+            marginTop: 14,
+            padding: 10,
+            fontSize: 11,
+            lineHeight: 1.5,
+            color: 'var(--fg-2)',
+            background: 'var(--bg-2)',
+            border: '1px solid var(--panel-border)',
+            borderRadius: 'var(--r-sm)',
+          }}
+        >
+          Sign in to QRZ (Settings → QRZ) so Zeus knows your callsign. Your remote
+          address will be{' '}
+          <code style={{ fontFamily: 'monospace', color: 'var(--fg-1)' }}>
+            openhpsdrzeus.com/go/&lt;your-callsign&gt;
+          </code>
+          .
+        </div>
+      )}
     </div>
   );
 }

--- a/zeus-web/src/components/ServerUrlPanel.tsx
+++ b/zeus-web/src/components/ServerUrlPanel.tsx
@@ -15,9 +15,12 @@ import {
 import { useCapabilitiesStore } from '../state/capabilities-store';
 
 // Settings tab: lets the operator point a Capacitor / standalone build at a
-// specific Zeus.Server on their LAN (e.g. http://192.168.1.23:6060). Browser
+// specific Zeus.Server on their LAN (e.g. https://192.168.1.23:6443). Browser
 // users on the bundled deploy normally leave this blank — relative paths
 // already reach the same-origin server.
+
+const TUNNEL_OPTIN_KEY = 'zeus.tunnel.optIn';
+const TUNNEL_BROKER_ORIGIN = 'https://openhpsdrzeus.com';
 
 export function ServerUrlPanel() {
   const [value, setValue] = useState(() => getServerBaseUrl());
@@ -87,7 +90,7 @@ export function ServerUrlPanel() {
         deploy). On native mobile / desktop wrappers, point this at the LAN
         host running Zeus.Server, e.g.{' '}
         <code style={{ fontFamily: 'monospace', color: 'var(--fg-1)' }}>
-          http://192.168.1.23:6060
+          https://192.168.1.23:6443
         </code>
         .
       </p>
@@ -160,7 +163,7 @@ export function ServerUrlPanel() {
           autoCorrect="off"
           spellCheck={false}
           inputMode="url"
-          placeholder="http://192.168.1.23:6060"
+          placeholder="https://192.168.1.23:6443"
           value={value}
           onChange={(e) => {
             setValue(e.target.value);
@@ -245,6 +248,128 @@ export function ServerUrlPanel() {
           Cleartext HTTP to RFC1918 / link-local addresses is permitted; iOS
           may show a "Find devices on local network" prompt the first time
           the app reaches a 192.168.* / 10.* host.
+        </div>
+      )}
+
+      <TunnelSection />
+    </div>
+  );
+}
+
+// Stage 1: opt-in UI for the Cloudflare tunnel feature. Frontend-only;
+// the backend wiring (Google sign-in, cloudflared subprocess, JWT
+// middleware) lands in Stages 2-4 — see
+// docs/superpowers/specs/2026-05-24-cloudflare-tunnel-zeus-side.md.
+function TunnelSection() {
+  const [optIn, setOptIn] = useState<boolean>(() => {
+    try { return localStorage.getItem(TUNNEL_OPTIN_KEY) === 'true'; }
+    catch { return false; }
+  });
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const persistOptIn = (v: boolean) => {
+    setOptIn(v);
+    try { localStorage.setItem(TUNNEL_OPTIN_KEY, v ? 'true' : 'false'); }
+    catch { /* noop */ }
+    if (!v) setNotice(null);
+  };
+
+  const handlePunch = () => {
+    // Backend lands in Stage 2-3. For now, surface a clear notice so
+    // the operator sees that the broker exists and where to find it.
+    setNotice(
+      `Broker live at ${TUNNEL_BROKER_ORIGIN}. ` +
+        'Backend wiring (Google sign-in + cloudflared spawn) is staged — ' +
+        'this button becomes functional once /api/broker/tunnel is implemented.',
+    );
+  };
+
+  return (
+    <div style={{ marginTop: 28 }}>
+      <h3
+        style={{
+          margin: '0 0 14px',
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: '0.12em',
+          textTransform: 'uppercase',
+          color: 'var(--fg-2)',
+        }}
+      >
+        CLOUDFLARE TUNNEL
+      </h3>
+
+      <p style={{ fontSize: 12, color: 'var(--fg-2)', lineHeight: 1.5, marginTop: 0 }}>
+        Expose this Zeus.Server to the public internet via a Cloudflare
+        Tunnel at <code style={{ fontFamily: 'monospace', color: 'var(--fg-1)' }}>{'<slug>.openhpsdrzeus.com'}</code>.
+        Access is gated by Google sign-in on{' '}
+        <a
+          href={TUNNEL_BROKER_ORIGIN}
+          target="_blank"
+          rel="noreferrer"
+          style={{ color: 'var(--accent)' }}
+        >openhpsdrzeus.com</a>; nobody can reach your radio without authenticating.
+      </p>
+
+      <label
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          marginTop: 16,
+          fontSize: 12,
+          color: 'var(--fg-1)',
+          cursor: 'pointer',
+        }}
+      >
+        <input
+          type="checkbox"
+          checked={optIn}
+          onChange={(e) => persistOptIn(e.target.checked)}
+        />
+        Enable Cloudflare tunnel
+      </label>
+
+      <div style={{ display: 'flex', gap: 8, marginTop: 14, alignItems: 'center' }}>
+        <button
+          type="button"
+          onClick={handlePunch}
+          disabled={!optIn}
+          style={{
+            padding: '8px 16px',
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: '0.1em',
+            textTransform: 'uppercase',
+            color: optIn ? 'var(--fg-0)' : 'var(--fg-2)',
+            background: optIn ? 'var(--accent)' : 'var(--bg-2)',
+            border: '1px solid var(--panel-border)',
+            borderRadius: 'var(--r-sm)',
+            cursor: optIn ? 'pointer' : 'not-allowed',
+            opacity: optIn ? 1 : 0.6,
+          }}
+        >
+          Punch tunnel
+        </button>
+        <span style={{ fontSize: 11, color: 'var(--fg-2)' }}>
+          {optIn ? 'No tunnel running.' : 'Tunnel disabled.'}
+        </span>
+      </div>
+
+      {notice && (
+        <div
+          style={{
+            marginTop: 14,
+            padding: 10,
+            fontSize: 11,
+            lineHeight: 1.5,
+            color: 'var(--fg-2)',
+            background: 'var(--bg-2)',
+            border: '1px solid var(--panel-border)',
+            borderRadius: 'var(--r-sm)',
+          }}
+        >
+          {notice}
         </div>
       )}
     </div>

--- a/zeus-web/src/remote/connect.ts
+++ b/zeus-web/src/remote/connect.ts
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Browser remote-access connect flow (Phase 1 client). Mirror of the server's
+// RemoteWebRtcSession: opens a WebRTC peer, runs the SPAKE2+ password handshake
+// over the control DataChannel, and surfaces radio frames once UNLOCKED.
+//
+// The crypto here is covered by spake2plus.test.ts / registration.test.ts. The
+// live WebRTC connection itself needs a real browser (no RTCPeerConnection in
+// node/vitest), so it is verified on a bench, not in CI.
+//
+// NOTE: Argon2id runs on the calling thread; for production move deriveScalars
+// into a Web Worker so the 64 MiB derivation doesn't jank the UI.
+
+import { Spake2Plus, verifyPeerConfirm, type Spake2Outcome } from './spake2plus';
+import { deriveScalars, type Argon2Params } from './registration';
+
+const CONTEXT = new TextEncoder().encode('zeus-remote-access/v1');
+const ID_PROVER = new Uint8Array(0);
+const ID_VERIFIER = new Uint8Array(0);
+
+export interface RemoteConnection {
+  pc: RTCPeerConnection;
+  frames: RTCDataChannel;
+  close(): void;
+}
+
+export interface RemoteConnectOptions {
+  password: string;
+  /** API origin; '' (default) = same-origin. */
+  apiBase?: string;
+  /** ICE servers; production fills this from broker-minted TURN credentials. */
+  iceServers?: RTCIceServer[];
+  /** Called with each binary radio frame after unlock. */
+  onFrame?: (data: ArrayBuffer) => void;
+}
+
+/**
+ * Connect to the operator's radio: signal via POST /api/remote/connect, then
+ * prove the session password over SPAKE2+. Resolves once UNLOCKED; rejects on a
+ * wrong password, a disabled remote endpoint, or signalling failure.
+ */
+export async function connectRemote(opts: RemoteConnectOptions): Promise<RemoteConnection> {
+  const pc = new RTCPeerConnection({
+    iceServers: opts.iceServers ?? [{ urls: 'stun:stun.cloudflare.com:3478' }],
+  });
+
+  const control = pc.createDataChannel('control'); // reliable, ordered
+  const frames = pc.createDataChannel('frames', { ordered: false, maxRetransmits: 0 });
+  if (opts.onFrame) {
+    frames.onmessage = (e: MessageEvent) => opts.onFrame!(e.data as ArrayBuffer);
+  }
+
+  const prover = new Spake2Plus('prover', CONTEXT, ID_PROVER, ID_VERIFIER);
+  let outcome: Spake2Outcome | undefined;
+
+  const unlocked = new Promise<void>((resolve, reject) => {
+    control.onopen = () => control.send(JSON.stringify({ t: 'hello' }));
+    control.onmessage = (e: MessageEvent) => {
+      try {
+        const raw = typeof e.data === 'string' ? e.data : new TextDecoder().decode(e.data);
+        const msg = JSON.parse(raw);
+        switch (msg.t) {
+          case 'auth-params': {
+            const params: Argon2Params = {
+              iterations: msg.iterations,
+              memoryKib: msg.memoryKib,
+              parallelism: msg.parallelism,
+            };
+            const { w0, w1 } = deriveScalars(opts.password, b64decode(msg.salt), params);
+            control.send(JSON.stringify({ t: 'auth-share', share: b64encode(prover.startProver(w0, w1)) }));
+            break;
+          }
+          case 'auth-share': {
+            outcome = prover.process(b64decode(msg.share));
+            control.send(JSON.stringify({ t: 'auth-confirm', confirm: b64encode(outcome.localConfirm) }));
+            break;
+          }
+          case 'auth-ok': {
+            if (outcome && verifyPeerConfirm(outcome, b64decode(msg.confirm))) resolve();
+            else reject(new Error('server authentication failed'));
+            break;
+          }
+          case 'auth-fail':
+            reject(new Error('incorrect password'));
+            break;
+        }
+      } catch (err) {
+        reject(err as Error);
+      }
+    };
+  });
+
+  const offer = await pc.createOffer();
+  await pc.setLocalDescription(offer);
+  await iceComplete(pc);
+
+  const resp = await fetch(`${opts.apiBase ?? ''}/api/remote/connect`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ sdp: pc.localDescription!.sdp }),
+  });
+  if (resp.status === 403) throw new Error('Remote access is not enabled (no session password set).');
+  if (!resp.ok) throw new Error(`connect failed: HTTP ${resp.status}`);
+  const answer = await resp.json();
+  await pc.setRemoteDescription({ type: 'answer', sdp: answer.sdp });
+
+  await unlocked;
+  return { pc, frames, close: () => pc.close() };
+}
+
+function iceComplete(pc: RTCPeerConnection): Promise<void> {
+  return new Promise((resolve) => {
+    if (pc.iceGatheringState === 'complete') return resolve();
+    const timer = setTimeout(resolve, 750); // vanilla-ICE cap; host candidates suffice on LAN
+    pc.onicegatheringstatechange = () => {
+      if (pc.iceGatheringState === 'complete') {
+        clearTimeout(timer);
+        resolve();
+      }
+    };
+  });
+}
+
+function b64encode(b: Uint8Array): string {
+  let s = '';
+  for (const x of b) s += String.fromCharCode(x);
+  return btoa(s);
+}
+
+function b64decode(s: string): Uint8Array {
+  const bin = atob(s);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}

--- a/zeus-web/src/remote/registration.test.ts
+++ b/zeus-web/src/remote/registration.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { deriveScalars } from './registration';
+
+// Cross-language agreement: the browser's Argon2id (noble) MUST derive the same
+// (w0, w1) as the C# server's (Konscious), or a password set on the radio won't
+// unlock from the phone. This vector is pinned identically in the C# test
+// Spake2PlusRegistrationTests.DeriveScalars_MatchesCrossLanguageVector.
+describe('SPAKE2+ registration — Argon2id cross-language agreement', () => {
+  it('derives the same (w0, w1) as the C# server', () => {
+    const salt = new Uint8Array(16);
+    for (let i = 0; i < 16; i++) salt[i] = i;
+
+    const { w0, w1 } = deriveScalars('zeus-cross-vector', salt, {
+      iterations: 1,
+      memoryKib: 8,
+      parallelism: 1,
+    });
+
+    expect(w0.toString(16).padStart(64, '0')).toBe(
+      '5038ef6d5486f2dd9321ec16a6d4e0d91379299bc14650db32c78dfd58e43818',
+    );
+    expect(w1.toString(16).padStart(64, '0')).toBe(
+      '5df0c3ed05e170c4296186f19639c7c79de43fddb39f7745d6a3c61241b5175f',
+    );
+  });
+});

--- a/zeus-web/src/remote/registration.ts
+++ b/zeus-web/src/remote/registration.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Browser side of SPAKE2+ password registration (ADR-0008): turns the typed
+// password + the salt/params delivered by the radio into the (w0, w1) scalars,
+// byte-identically to the C# server (Zeus.Server.Hosting/Remote/Spake2PlusRegistration.cs).
+// The browser never sends the password; it proves knowledge via SPAKE2+.
+
+import { argon2id } from '@noble/hashes/argon2.js';
+import { reduceToScalar } from './spake2plus';
+
+// Must match RemoteAuthConstants on the server.
+const ID_PROVER = new Uint8Array(0);
+const ID_VERIFIER = new Uint8Array(0);
+const ARGON2_OUTPUT_BYTES = 96; // 2 × 48-byte wide scalars → reduce mod n
+
+export interface Argon2Params {
+  iterations: number;
+  memoryKib: number;
+  parallelism: number;
+}
+
+/** Derive (w0, w1) from password + salt. Mirror of the C# DeriveScalars. */
+export function deriveScalars(
+  password: string,
+  salt: Uint8Array,
+  params: Argon2Params,
+): { w0: bigint; w1: bigint } {
+  const input = buildPasswordInput(password);
+  const wide = argon2id(input, salt, {
+    t: params.iterations,
+    m: params.memoryKib,
+    p: params.parallelism,
+    dkLen: ARGON2_OUTPUT_BYTES,
+  });
+  const half = wide.length / 2;
+  return {
+    w0: reduceToScalar(wide.slice(0, half)),
+    w1: reduceToScalar(wide.slice(half)),
+  };
+}
+
+// RFC 9383 §3.2: input = len(pw)||pw || len(idProver)||idProver || len(idVerifier)||idVerifier
+function buildPasswordInput(password: string): Uint8Array {
+  const pw = new TextEncoder().encode(password);
+  const parts: Uint8Array[] = [];
+  for (const field of [pw, ID_PROVER, ID_VERIFIER]) {
+    parts.push(u64le(field.length));
+    parts.push(field);
+  }
+  const total = parts.reduce((n, p) => n + p.length, 0);
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.length;
+  }
+  return out;
+}
+
+function u64le(n: number): Uint8Array {
+  const out = new Uint8Array(8);
+  let v = BigInt(n);
+  for (let i = 0; i < 8; i++) {
+    out[i] = Number(v & 0xffn);
+    v >>= 8n;
+  }
+  return out;
+}

--- a/zeus-web/src/remote/spake2plus.test.ts
+++ b/zeus-web/src/remote/spake2plus.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { Spake2Plus, verifyPeerConfirm } from './spake2plus';
+
+// RFC 9383 Appendix C, Vector 1 (P256-SHA256-HKDF-SHA256-HMAC-SHA256) — the same
+// vector the C# verifier is pinned to, so the two implementations interoperate.
+const CONTEXT = utf8('SPAKE2+-P256-SHA256-HKDF-SHA256-HMAC-SHA256 Test Vectors');
+const ID_PROVER = utf8('client');
+const ID_VERIFIER = utf8('server');
+
+const W0 = BigInt('0xbb8e1bbcf3c48f62c08db243652ae55d3e5586053fca77102994f23ad95491b3');
+const W1 = BigInt('0x7e945f34d78785b8a3ef44d0df5a1a97d6b3b460409a345ca7830387a74b1dba');
+const L = '04eb7c9db3d9a9eb1f8adab81b5794c1f13ae3e225efbe91ea487425854c7fc00f00bfedcbd09b2400142d40a14f2064ef31dfaa903b91d1faea7093d835966efd';
+const X = BigInt('0xd1232c8e8693d02368976c174e2088851b8365d0d79a9eee709c6a05a2fad539');
+const Y = BigInt('0x717a72348a182085109c8d3917d6c43d59b224dc6a7fc4f0483232fa6516d8b3');
+const SHARE_P = '04ef3bd051bf78a2234ec0df197f7828060fe9856503579bb1733009042c15c0c1de127727f418b5966afadfdd95a6e4591d171056b333dab97a79c7193e341727';
+const SHARE_V = '04c0f65da0d11927bdf5d560c69e1d7d939a05b0e88291887d679fcadea75810fb5cc1ca7494db39e82ff2f50665255d76173e09986ab46742c798a9a68437b048';
+const Z = '04bbfce7dd7f277819c8da21544afb7964705569bdf12fb92aa388059408d50091a0c5f1d3127f56813b5337f9e4e67e2ca633117a4fbd559946ab474356c41839';
+const V = '0458bf27c6bca011c9ce1930e8984a797a3419797b936629a5a937cf2f11c8b9514b82b993da8a46e664f23db7c01edc87faa530db01c2ee405230b18997f16b68';
+const K_MAIN = '4c59e1ccf2cfb961aa31bd9434478a1089b56cd11542f53d3576fb6c2a438a29';
+const K_CONFIRM_P = '871ae3f7b78445e34438fb284504240239031c39d80ac23eb5ab9be5ad6db58a';
+const K_CONFIRM_V = 'ccd53c7c1fa37b64a462b40db8be101cedcf838950162902054e644b400f1680';
+const K_SHARED = '0c5f8ccd1413423a54f6c1fb26ff01534a87f893779c6e68666d772bfd91f3e7';
+const CONFIRM_P = '926cc713504b9b4d76c9162ded04b5493e89109f6d89462cd33adc46fda27527';
+const CONFIRM_V = '9747bcc4f8fe9f63defee53ac9b07876d907d55047e6ff2def2e7529089d3e68';
+
+const prover = () => new Spake2Plus('prover', CONTEXT, ID_PROVER, ID_VERIFIER);
+const verifier = () => new Spake2Plus('verifier', CONTEXT, ID_PROVER, ID_VERIFIER);
+
+describe('SPAKE2+ browser prover (RFC 9383 Appendix C, Vector 1)', () => {
+  it('prover share matches the vector', () => {
+    expect(hex(prover().startProver(W0, W1, X))).toBe(SHARE_P);
+  });
+
+  it('verifier share matches the vector', () => {
+    expect(hex(verifier().startVerifier(W0, bytes(L), Y))).toBe(SHARE_V);
+  });
+
+  it('prover derives every intermediate per the RFC', () => {
+    const p = prover();
+    p.startProver(W0, W1, X);
+    const o = p.process(bytes(SHARE_V));
+
+    expect(hex(o.zEnc)).toBe(Z);
+    expect(hex(o.vEnc)).toBe(V);
+    expect(hex(o.kMain)).toBe(K_MAIN);
+    expect(hex(o.kConfirmP)).toBe(K_CONFIRM_P);
+    expect(hex(o.kConfirmV)).toBe(K_CONFIRM_V);
+    expect(hex(o.sharedKey)).toBe(K_SHARED);
+    expect(hex(o.confirmP)).toBe(CONFIRM_P);
+    expect(hex(o.confirmV)).toBe(CONFIRM_V);
+    expect(hex(o.localConfirm)).toBe(CONFIRM_P); // prover sends confirmP
+    expect(hex(o.expectedPeerConfirm)).toBe(CONFIRM_V);
+  });
+
+  it('verifier derives the same shared key and confirms', () => {
+    const v = verifier();
+    v.startVerifier(W0, bytes(L), Y);
+    const o = v.process(bytes(SHARE_P));
+
+    expect(hex(o.zEnc)).toBe(Z);
+    expect(hex(o.vEnc)).toBe(V);
+    expect(hex(o.sharedKey)).toBe(K_SHARED);
+    expect(hex(o.localConfirm)).toBe(CONFIRM_V); // verifier sends confirmV
+    expect(hex(o.expectedPeerConfirm)).toBe(CONFIRM_P);
+  });
+
+  it('full exchange: both sides agree and confirms verify', () => {
+    const p = prover();
+    const v = verifier();
+    const sp = p.startProver(W0, W1);   // random x
+    const sv = v.startVerifier(W0, bytes(L)); // random y
+    const po = p.process(sv);
+    const vo = v.process(sp);
+
+    expect(hex(po.sharedKey)).toBe(hex(vo.sharedKey));
+    expect(verifyPeerConfirm(po, vo.localConfirm)).toBe(true);
+    expect(verifyPeerConfirm(vo, po.localConfirm)).toBe(true);
+  });
+
+  it('wrong password: confirms do not verify', () => {
+    const p = prover();
+    const v = verifier();
+    const sp = p.startProver(W0, W1);
+    const sv = v.startVerifier(W0 + 1n, bytes(L)); // verifier's stored secret differs
+    const po = p.process(sv);
+    const vo = v.process(sp);
+
+    expect(hex(po.sharedKey)).not.toBe(hex(vo.sharedKey));
+    expect(verifyPeerConfirm(po, vo.localConfirm)).toBe(false);
+    expect(verifyPeerConfirm(vo, po.localConfirm)).toBe(false);
+  });
+
+  it('invalid peer share fails closed', () => {
+    const v = verifier();
+    v.startVerifier(W0, bytes(L));
+    expect(() => v.process(new Uint8Array([0x00]))).toThrow();
+  });
+});
+
+function utf8(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+function bytes(h: string): Uint8Array {
+  const out = new Uint8Array(h.length / 2);
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(h.slice(i * 2, i * 2 + 2), 16);
+  return out;
+}
+function hex(b: Uint8Array): string {
+  return Array.from(b, (x) => x.toString(16).padStart(2, '0')).join('');
+}

--- a/zeus-web/src/remote/spake2plus.ts
+++ b/zeus-web/src/remote/spake2plus.ts
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Browser SPAKE2+ (RFC 9383, ciphersuite P256-SHA256-HKDF-SHA256-HMAC-SHA256).
+// The prover half of the remote-access password handshake (ADR-0008); the radio
+// runs the matching C# verifier (Zeus.Server.Hosting/Remote/Spake2Plus.cs). Both
+// are pinned to the RFC 9383 Appendix C test vectors so they interoperate.
+//
+// EC point math: @noble/curves (audited). Hashing/KDF/MAC: @noble/hashes.
+
+import { p256 } from '@noble/curves/nist.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { hkdf } from '@noble/hashes/hkdf.js';
+import { hmac } from '@noble/hashes/hmac.js';
+
+const Point = p256.Point;
+const ORDER = Point.Fn.ORDER;
+
+// RFC 9382/9383 constant points (compressed SEC1); discrete log unknown.
+const M = Point.fromHex('02886e2f97ace46e55ba9dd7242579f2993b64e16ef3dcab95afd497333d8fa12f');
+const N = Point.fromHex('03d8bbd6c639c62937b04d997f38c3770719c629d7014d49a24b4f98baa1292b49');
+
+export type Spake2Role = 'prover' | 'verifier';
+
+export interface Spake2Outcome {
+  sharedKey: Uint8Array;
+  localConfirm: Uint8Array;
+  expectedPeerConfirm: Uint8Array;
+  // Intermediates, exposed for RFC-vector tests.
+  transcript: Uint8Array;
+  kMain: Uint8Array;
+  kConfirmP: Uint8Array;
+  kConfirmV: Uint8Array;
+  confirmP: Uint8Array;
+  confirmV: Uint8Array;
+  zEnc: Uint8Array;
+  vEnc: Uint8Array;
+}
+
+export class Spake2Plus {
+  private scalar?: bigint;
+  private share?: Uint8Array;
+  private w0?: bigint;
+  private w1?: bigint;
+  private bigL?: InstanceType<typeof Point>;
+
+  constructor(
+    private readonly role: Spake2Role,
+    private readonly context: Uint8Array,
+    private readonly idProver: Uint8Array,
+    private readonly idVerifier: Uint8Array,
+  ) {}
+
+  /** Prover (client) share: shareP = x·P + w0·M. `x` is for tests; omit for random. */
+  startProver(w0: bigint, w1: bigint, x?: bigint): Uint8Array {
+    if (this.role !== 'prover') throw new Error('role mismatch');
+    this.w0 = w0;
+    this.w1 = w1;
+    this.scalar = x ?? randomScalar();
+    this.share = Point.BASE.multiply(this.scalar).add(M.multiply(w0)).toBytes(false);
+    return this.share;
+  }
+
+  /** Verifier (radio) share: shareV = y·P + w0·N. Mainly for the in-TS round-trip test. */
+  startVerifier(w0: bigint, encodedL: Uint8Array, y?: bigint): Uint8Array {
+    if (this.role !== 'verifier') throw new Error('role mismatch');
+    this.w0 = w0;
+    this.bigL = decodePoint(encodedL);
+    this.scalar = y ?? randomScalar();
+    this.share = Point.BASE.multiply(this.scalar).add(N.multiply(w0)).toBytes(false);
+    return this.share;
+  }
+
+  /** Process the peer share → session key + confirmation MACs. Throws (fails closed) on bad input. */
+  process(peerShare: Uint8Array): Spake2Outcome {
+    if (this.w0 === undefined || this.scalar === undefined || this.share === undefined)
+      throw new Error('start* not called');
+
+    // Capture into locals before any call — TS drops `this.field` narrowing across calls.
+    const w0 = this.w0;
+    const scalar = this.scalar;
+    const myShare = this.share;
+    const peer = decodePoint(peerShare);
+
+    let z: InstanceType<typeof Point>;
+    let v: InstanceType<typeof Point>;
+    let shareP: Uint8Array;
+    let shareV: Uint8Array;
+
+    if (this.role === 'prover') {
+      const t = peer.subtract(N.multiply(w0)); // Y − w0·N
+      z = t.multiply(scalar); // x·(Y − w0·N)
+      v = t.multiply(this.w1!); // w1·(Y − w0·N)
+      shareP = myShare;
+      shareV = peer.toBytes(false);
+    } else {
+      const t = peer.subtract(M.multiply(w0)); // X − w0·M
+      z = t.multiply(scalar); // y·(X − w0·M)
+      v = this.bigL!.multiply(scalar); // y·L
+      shareP = peer.toBytes(false);
+      shareV = myShare;
+    }
+
+    const zEnc = z.toBytes(false);
+    const vEnc = v.toBytes(false);
+
+    const transcript = buildTranscript(
+      this.context, this.idProver, this.idVerifier,
+      M.toBytes(false), N.toBytes(false),
+      shareP, shareV, zEnc, vEnc, scalarTo32(w0),
+    );
+    const kMain = sha256(transcript);
+
+    const confirmKeys = hkdf(sha256, kMain, undefined, utf8('ConfirmationKeys'), 64);
+    const kConfirmP = confirmKeys.slice(0, 32);
+    const kConfirmV = confirmKeys.slice(32);
+    const sharedKey = hkdf(sha256, kMain, undefined, utf8('SharedKey'), 32);
+
+    // RFC 9383 §3.4: confirmP = MAC(K_confirmP, shareV); confirmV = MAC(K_confirmV, shareP).
+    const confirmP = hmac(sha256, kConfirmP, shareV);
+    const confirmV = hmac(sha256, kConfirmV, shareP);
+
+    const [localConfirm, expectedPeerConfirm] =
+      this.role === 'prover' ? [confirmP, confirmV] : [confirmV, confirmP];
+
+    return {
+      sharedKey, localConfirm, expectedPeerConfirm,
+      transcript, kMain, kConfirmP, kConfirmV, confirmP, confirmV, zEnc, vEnc,
+    };
+  }
+}
+
+/** Constant-time confirmation-MAC check. */
+export function verifyPeerConfirm(outcome: Spake2Outcome, received: Uint8Array): boolean {
+  const a = outcome.expectedPeerConfirm;
+  if (a.length !== received.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a[i]! ^ received[i]!;
+  return diff === 0;
+}
+
+// --- helpers ---------------------------------------------------------------
+
+function decodePoint(bytes: Uint8Array): InstanceType<typeof Point> {
+  const p = Point.fromBytes(bytes);
+  p.assertValidity(); // reject off-curve / identity — mandatory for PAKE security
+  return p;
+}
+
+// TT = len(Context)||Context || len(idProver)||idProver || len(idVerifier)||idVerifier
+//   || len(M)||M || len(N)||N || len(shareP)||shareP || len(shareV)||shareV
+//   || len(Z)||Z || len(V)||V || len(w0)||w0     (RFC 9383 §3.3; 8-byte LE lengths)
+function buildTranscript(...fields: Uint8Array[]): Uint8Array {
+  const parts: Uint8Array[] = [];
+  for (const f of fields) {
+    parts.push(u64le(f.length));
+    parts.push(f);
+  }
+  return concat(parts);
+}
+
+function u64le(n: number): Uint8Array {
+  const out = new Uint8Array(8);
+  let v = BigInt(n);
+  for (let i = 0; i < 8; i++) {
+    out[i] = Number(v & 0xffn);
+    v >>= 8n;
+  }
+  return out;
+}
+
+function scalarTo32(w: bigint): Uint8Array {
+  const out = new Uint8Array(32);
+  let v = w;
+  for (let i = 31; i >= 0; i--) {
+    out[i] = Number(v & 0xffn);
+    v >>= 8n;
+  }
+  if (v !== 0n) throw new Error('scalar too large');
+  return out;
+}
+
+export function reduceToScalar(wide: Uint8Array): bigint {
+  let v = 0n;
+  for (const b of wide) v = (v << 8n) | BigInt(b);
+  return v % ORDER;
+}
+
+function randomScalar(): bigint {
+  const buf = new Uint8Array(48); // oversample → reduce, low bias
+  while (true) {
+    crypto.getRandomValues(buf);
+    const s = reduceToScalar(buf);
+    if (s > 0n) return s;
+  }
+}
+
+function utf8(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((n, p) => n + p.length, 0);
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.length;
+  }
+  return out;
+}


### PR DESCRIPTION
## What this is

The secure foundation for **remote access to a Zeus radio from anywhere on the internet** — the design, the password authentication system, and the scan-to-connect QR. The actual WebRTC data plane and the Cloudflare broker build on top of this in follow-up PRs (scope below), so this PR stays reviewable and is **100% covered by tests** (30 green).

## Why WebRTC (architecture pivot)

The earlier direction tunnelled everything through a Cloudflare Quick Tunnel. That is the *worst* option for a real-time SDR — every audio sample and IQ frame hairpins through an edge POP. This pivots the data plane to **WebRTC peer-to-peer** (direct UDP, relay only as fallback), which is simultaneously:

- **Hyper low-latency** — direct P2P, no middle hop on the common path
- **Scalable** — peers carry their own bytes; cost does not grow per user
- **Free** — signalling/identity fit Cloudflare's free tier; only the ~15-30% relayed minority touches metered TURN (1,000 GB/mo free)

Decisions are recorded as ADRs **0005-0008** (superseding the Quick-Tunnel ADRs) + `docs/designs/remote-access-webrtc.md`.

## In this PR

- **Design**: ADR-0005 (WebRTC data plane), 0006 (broker = signalling + TURN, reusing the chat relay), 0007 (QRZ-verified callsign identity), 0008 (mandatory session password), + the staged plan.
- **Deny-by-default session gate** (`RemoteSession`): a remote session starts **LOCKED** and refuses every frame and control verb until the password proves out. Enforced server-side.
- **SPAKE2+ password verifier** (RFC 9383, P256-SHA256-HKDF-HMAC) — augmented PAKE: the server stores only a verifier (\`w0\`, \`L = w1·P\`), never the password; a stolen prefs DB does not yield it, and a malicious broker cannot MITM. **Pinned byte-for-byte to the RFC 9383 Appendix C test vectors.**
- **Argon2id registration + password UI**: operator sets a password in the Server menu (set/change/clear); turned into the SPAKE2+ verifier. End-to-end tested: typed password → register → client re-derives → unlock; wrong password stays locked.
- **Scan-to-remote QR**: Server menu renders the operator's \`openhpsdrzeus.com/go/<callsign>\` address as a QR (callsign from the existing QRZ sign-in).

## Security model

- **Nothing happens without the password.** Deny-by-default, verified end-to-end at the radio over the (future) DTLS-encrypted channel; the broker never learns it. Remote access cannot be enabled without a password set — a deliberate transmitter-safety stance.
- **PureSignal / TX paths untouched.** This PR adds no TX, PA, or PureSignal behaviour.

## Tests (30, all green)

SPAKE2+ vectors (8), registration + full password flow (4), auth gate (3), deny-by-default session (5), password store (2), QR (7), WebRTC DataChannel spike (1). Frontend type-checks (\`tsc -b\`).

## New dependencies (all pure-managed, cross-platform incl. linux-arm64/Pi)

- \`SIPSorcery\` 10.0.10 (WebRTC peer; DataChannel path proven on net10)
- \`QRCoder\` 1.8.0 (SVG QR, no System.Drawing)
- \`Konscious.Security.Cryptography.Argon2\` 1.3.1

## NOT in this PR (follow-ups)

1. Browser SPAKE2+ **prover** (\`@noble/curves\`) — vector-tested, to interoperate with the server gate.
2. **Phase 1** WebRTC transport carrying the real radio frames (audio track + IQ/display DataChannels), replacing the current \`/ws\` path for remote.
3. **Phase 3** Cloudflare broker (Worker + Durable Object, sibling of \`zeuschat-relay\`, QRZ identity + TURN credential minting).

## Verification note

The full Vite build can't run in the worktree (unrelated \`deepcw\` submodule \`model.onnx\` not checked out); \`tsc -b\` passes. All backend tests run headless.