### PR TITLE
feat(audio-suite): in-app "Download VST Engine" provisioning

### DIFF
--- a/Zeus.Plugins.Host/Audio/VstEngineController.cs
+++ b/Zeus.Plugins.Host/Audio/VstEngineController.cs
@@ -170,6 +170,14 @@ public sealed class VstEngineController : IAsyncDisposable
     /// </summary>
     public static string? FindEngineExe() => VstEngineProcess.FindEngineExe();
 
+    /// <summary>
+    /// The Zeus-managed engine location
+    /// (<c>%LOCALAPPDATA%\Zeus\vst-engine\VSTHostEngine.exe</c> on Windows), or
+    /// null on non-Windows. Where the in-app "Get VST Engine" provisioning flow
+    /// stages a downloaded engine so VST mode works without a manual install.
+    /// </summary>
+    public static string? ManagedEnginePath() => VstEngineProcess.ManagedEnginePath();
+
     /// <summary>True while the realtime tap routes audio through the engine.</summary>
     public bool IsActive => _active;
 

--- a/Zeus.Server.Hosting/VstEngineInstaller.cs
+++ b/Zeus.Server.Hosting/VstEngineInstaller.cs
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// VstEngineInstaller — the in-app "Get VST Engine" provisioning flow. The
+// out-of-process VST engine (upstream KlayaR/VSTHost, run headless as
+// `VSTHostEngine.exe --zeus-bridge`) is deliberately NOT vendored or bundled in
+// the Zeus installer: VSTHost links JUCE (GPLv3), and keeping the binary as a
+// user-fetched, separate process is what isolates that license from Zeus's
+// own distribution (see docs/designs/vst-out-of-process-engine.md §3/§7).
+//
+// Instead Zeus ships this downloader: it fetches the LATEST upstream release,
+// extracts VSTHostEngine.exe from the portable zip, and stages it at the
+// Zeus-managed path (%LOCALAPPDATA%\Zeus\vst-engine\VSTHostEngine.exe) that
+// VstEngineProcess.FindEngineExe() resolves. A new operator on a fresh PC can
+// then enable VST mode and click "Get VST Engine" instead of hunting a GitHub
+// release by hand. Windows-only — the engine is a Windows binary.
+
+using System.IO.Compression;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using Zeus.Plugins.Host.Audio;
+
+namespace Zeus.Server;
+
+/// <summary>Backs the in-app "Get VST Engine" action: downloads the upstream
+/// VSTHost engine and stages it at the Zeus-managed path. Registered as a
+/// singleton in <c>ZeusHost</c>; the engine binary is fetched, never bundled.</summary>
+public sealed class VstEngineInstaller
+{
+    // Upstream release feed. The latest release's portable zip carries the
+    // engine; overridable for staging/tests. The operator never sees this
+    // (the product name in the UI is "VST Engine", not "VSTHost").
+    internal const string DefaultReleaseApiUrl =
+        "https://api.github.com/repos/KlayaR/VSTHost/releases/latest";
+
+    public enum Phase { Idle, Downloading, Extracting, Staging, Done, Failed }
+
+    /// <summary>Coarse install progress for the polling frontend.</summary>
+    public sealed record Status(Phase Phase, int Percent, string? Message, string? Version)
+    {
+        public bool InProgress =>
+            Phase is Phase.Downloading or Phase.Extracting or Phase.Staging;
+    }
+
+    private readonly ILogger<VstEngineInstaller> _log;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly object _lock = new();
+    private Status _status = new(Phase.Idle, 0, null, null);
+    private Task? _running;
+
+    public VstEngineInstaller(ILogger<VstEngineInstaller> log, IHttpClientFactory httpClientFactory)
+    {
+        _log = log;
+        _httpClientFactory = httpClientFactory;
+    }
+
+    /// <summary>True when an engine is already resolvable (managed path, default
+    /// install, or PATH) — the install affordance is unnecessary.</summary>
+    public bool EngineInstalled => VstEngineController.FindEngineExe() is not null;
+
+    /// <summary>Snapshot of the current install state for the status endpoint.</summary>
+    public Status Current
+    {
+        get { lock (_lock) return _status; }
+    }
+
+    /// <summary>Kick off a background install if one isn't already running and the
+    /// engine isn't already present. Returns the (possibly unchanged) status
+    /// immediately — the frontend polls <see cref="Current"/> for progress.</summary>
+    public Status Start(CancellationToken ct = default)
+    {
+        lock (_lock)
+        {
+            if (_running is { IsCompleted: false })
+                return _status; // already running
+
+            if (EngineInstalled)
+            {
+                _status = new Status(Phase.Done, 100, "VST engine already installed.", null);
+                return _status;
+            }
+
+            if (!OperatingSystem.IsWindows())
+            {
+                _status = new Status(Phase.Failed, 0,
+                    "The VST engine is Windows-only; nothing to install on this platform.", null);
+                return _status;
+            }
+
+            _status = new Status(Phase.Downloading, 0, "Contacting release server…", null);
+            _running = Task.Run(() => RunAsync(ct), CancellationToken.None);
+            return _status;
+        }
+    }
+
+    private void SetStatus(Phase phase, int percent, string? message, string? version = null)
+    {
+        lock (_lock)
+        {
+            // Carry the resolved version forward once we have it.
+            version ??= _status.Version;
+            _status = new Status(phase, Math.Clamp(percent, 0, 100), message, version);
+        }
+    }
+
+    private async Task RunAsync(CancellationToken ct)
+    {
+        string? tempZip = null;
+        string? tempDir = null;
+        try
+        {
+            var managedExe = VstEngineController.ManagedEnginePath()
+                ?? throw new InvalidOperationException("No managed engine path on this platform.");
+            var managedDir = Path.GetDirectoryName(managedExe)!;
+
+            // 1) Resolve the latest release + its zip asset.
+            SetStatus(Phase.Downloading, 2, "Looking up the latest VST engine release…");
+            var http = _httpClientFactory.CreateClient("ZeusVstEngine");
+            var release = await http.GetFromJsonAsync<GithubRelease>(ReleaseApiUrl(), ct).ConfigureAwait(false)
+                ?? throw new InvalidOperationException("Empty release response.");
+            var version = string.IsNullOrWhiteSpace(release.TagName) ? null : release.TagName.Trim();
+            SetStatus(Phase.Downloading, 4, $"Found VST engine {version ?? "(latest)"}…", version);
+
+            var asset = SelectZipAsset(release.Assets)
+                ?? throw new InvalidOperationException("No downloadable engine archive in the latest release.");
+
+            // 2) Download the zip with coarse progress (2..70%).
+            tempZip = Path.Combine(Path.GetTempPath(), $"zeus-vst-engine-{Guid.NewGuid():N}.zip");
+            await DownloadAsync(http, asset.DownloadUrl!, tempZip, asset.Size, ct).ConfigureAwait(false);
+
+            // 3) Extract (70..85%).
+            SetStatus(Phase.Extracting, 72, "Extracting the VST engine…");
+            tempDir = Path.Combine(Path.GetTempPath(), $"zeus-vst-engine-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            ZipFile.ExtractToDirectory(tempZip, tempDir, overwriteFiles: true);
+
+            // 4) Stage the engine (+ its sibling DLLs) at the managed path (85..100%).
+            SetStatus(Phase.Staging, 88, "Installing the VST engine…");
+            var stagedExe = StageFromExtractedDir(tempDir, managedDir);
+
+            SetStatus(Phase.Done, 100, "VST engine installed. Enable VST mode to use it.", version);
+            _log.LogInformation("VST engine {Version} staged at {Path}", version ?? "(latest)", stagedExe);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            SetStatus(Phase.Failed, 0, "VST engine install was cancelled.");
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "VST engine install failed");
+            SetStatus(Phase.Failed, 0, $"VST engine install failed: {Trunc(ex.Message)}");
+        }
+        finally
+        {
+            TryDelete(tempZip);
+            TryDeleteDir(tempDir);
+        }
+    }
+
+    private async Task DownloadAsync(HttpClient http, string url, string destPath, long knownSize, CancellationToken ct)
+    {
+        using var response = await http
+            .GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct)
+            .ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var total = response.Content.Headers.ContentLength ?? (knownSize > 0 ? knownSize : 0);
+        await using var src = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        await using var dst = new FileStream(destPath, FileMode.Create, FileAccess.Write, FileShare.None);
+
+        var buffer = new byte[81920];
+        long read = 0;
+        int n;
+        while ((n = await src.ReadAsync(buffer, ct).ConfigureAwait(false)) > 0)
+        {
+            await dst.WriteAsync(buffer.AsMemory(0, n), ct).ConfigureAwait(false);
+            read += n;
+            if (total > 0)
+            {
+                // Map download to the 4..70% band.
+                var pct = 4 + (int)(read * 66 / total);
+                SetStatus(Phase.Downloading, pct, "Downloading the VST engine…");
+            }
+        }
+    }
+
+    /// <summary>Find <c>VSTHostEngine.exe</c> anywhere in the extracted tree and
+    /// copy its containing folder (the exe plus its sibling DLLs / resources)
+    /// into <paramref name="managedDir"/> flat at the top level. Returns the
+    /// staged exe path. Throws if the archive carries no engine binary (e.g. a
+    /// VSTHost build without the Zeus bridge engine).</summary>
+    internal static string StageFromExtractedDir(string extractedRoot, string managedDir)
+    {
+        var sourceExe = Directory
+            .EnumerateFiles(extractedRoot, "VSTHostEngine.exe", SearchOption.AllDirectories)
+            .FirstOrDefault()
+            ?? throw new InvalidOperationException(
+                "The downloaded archive does not contain VSTHostEngine.exe — this VSTHost "
+                + "release may not include the Zeus bridge engine yet.");
+
+        var sourceDir = Path.GetDirectoryName(sourceExe)!;
+
+        // Stage into a clean managed dir so a re-install never leaves stale files.
+        if (Directory.Exists(managedDir)) Directory.Delete(managedDir, recursive: true);
+        Directory.CreateDirectory(managedDir);
+
+        foreach (var file in Directory.EnumerateFiles(sourceDir, "*", SearchOption.AllDirectories))
+        {
+            var rel = Path.GetRelativePath(sourceDir, file);
+            var dest = Path.Combine(managedDir, rel);
+            Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
+            File.Copy(file, dest, overwrite: true);
+        }
+
+        var stagedExe = Path.Combine(managedDir, "VSTHostEngine.exe");
+        if (!File.Exists(stagedExe))
+            throw new InvalidOperationException("Staging completed but VSTHostEngine.exe is missing.");
+        return stagedExe;
+    }
+
+    /// <summary>Pick the engine archive from a release's assets: prefer a portable
+    /// <c>.zip</c>, else any <c>.zip</c>. The setup.exe / .msi assets are the
+    /// Tauri desktop app, which Zeus does not use.</summary>
+    internal static GithubAsset? SelectZipAsset(IReadOnlyList<GithubAsset>? assets)
+    {
+        if (assets is null || assets.Count == 0) return null;
+        bool IsZip(GithubAsset a) =>
+            !string.IsNullOrWhiteSpace(a.DownloadUrl)
+            && a.Name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase);
+
+        return assets.FirstOrDefault(a => IsZip(a)
+                   && a.Name.Contains("portable", StringComparison.OrdinalIgnoreCase))
+               ?? assets.FirstOrDefault(IsZip);
+    }
+
+    private static string ReleaseApiUrl()
+    {
+        var env = Environment.GetEnvironmentVariable("ZEUS_VST_ENGINE_RELEASE_URL");
+        return string.IsNullOrWhiteSpace(env) ? DefaultReleaseApiUrl : env.Trim();
+    }
+
+    private static string Trunc(string s, int max = 200)
+        => s.Length <= max ? s : s[..max] + "…";
+
+    private static void TryDelete(string? path)
+    {
+        if (path is null) return;
+        try { if (File.Exists(path)) File.Delete(path); } catch { /* best effort */ }
+    }
+
+    private static void TryDeleteDir(string? path)
+    {
+        if (path is null) return;
+        try { if (Directory.Exists(path)) Directory.Delete(path, recursive: true); } catch { /* best effort */ }
+    }
+
+    // ----- GitHub release JSON (only the fields we read) -----
+
+    internal sealed class GithubRelease
+    {
+        [JsonPropertyName("tag_name")]
+        public string? TagName { get; set; }
+
+        [JsonPropertyName("assets")]
+        public List<GithubAsset> Assets { get; set; } = [];
+    }
+
+    internal sealed class GithubAsset
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("browser_download_url")]
+        public string? DownloadUrl { get; set; }
+
+        [JsonPropertyName("size")]
+        public long Size { get; set; }
+    }
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -226,6 +226,41 @@ public static class ZeusEndpoints
             });
         });
 
+        // VST engine provisioning — the in-app "Get VST Engine" flow. The engine
+        // is the upstream KlayaR/VSTHost headless binary, fetched from its latest
+        // release and staged at the Zeus-managed path; it is never bundled in the
+        // Zeus installer (GPLv3 isolation — see VstEngineInstaller). GET reports
+        // install progress + whether the engine is already present; POST starts a
+        // background download (idempotent — no-op if already installed/running).
+        // The frontend polls GET until phase is "done" / "failed", then re-reads
+        // the processing-mode endpoint so the new engine is picked up.
+        static object EngineInstallDto(VstEngineInstaller installer)
+        {
+            var s = installer.Current;
+            return new
+            {
+                phase = s.Phase.ToString().ToLowerInvariant(),
+                percent = s.Percent,
+                message = s.Message,
+                version = s.Version,
+                engineAvailable = installer.EngineInstalled,
+            };
+        }
+        app.MapGet("/api/audio-suite/vst-engine/install", (VstEngineInstaller installer) =>
+            Results.Ok(EngineInstallDto(installer)));
+        app.MapGet("/api/tx-audio-suite/vst-engine/install", (VstEngineInstaller installer) =>
+            Results.Ok(EngineInstallDto(installer)));
+        app.MapPost("/api/audio-suite/vst-engine/install", (VstEngineInstaller installer) =>
+        {
+            installer.Start();
+            return Results.Ok(EngineInstallDto(installer));
+        });
+        app.MapPost("/api/tx-audio-suite/vst-engine/install", (VstEngineInstaller installer) =>
+        {
+            installer.Start();
+            return Results.Ok(EngineInstallDto(installer));
+        });
+
         // Audio plugin chain order — operator's preferred sequence for
         // the plugins in the Audio Suite window. GET returns the
         // canonical ordered list of plugin IDs; PUT accepts a new

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -589,6 +589,19 @@ public static class ZeusHost
         builder.Services.AddSingleton<AudioProcessingModeService>();
         builder.Services.AddHostedService(sp => sp.GetRequiredService<AudioProcessingModeService>());
 
+        // VstEngineInstaller — the in-app "Get VST Engine" downloader. The engine
+        // is fetched from its upstream release and staged at the Zeus-managed path,
+        // never vendored/bundled (GPLv3 isolation — see VstEngineInstaller). The
+        // named HttpClient carries the User-Agent the GitHub API requires and a
+        // generous timeout for the multi-MB engine download.
+        builder.Services.AddHttpClient("ZeusVstEngine", c =>
+        {
+            c.Timeout = TimeSpan.FromMinutes(5);
+            c.DefaultRequestHeaders.UserAgent.ParseAdd("OpenHPSDR-Zeus");
+            c.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json");
+        });
+        builder.Services.AddSingleton<VstEngineInstaller>();
+
         // TxAudioProfileService — orchestrates the unified TX Audio Profile
         // system: capture (mic/leveler/CFC/bandpass/processing-mode/chain shape/
         // VST blobs + native plugin dumps/fidelity), apply (write-through the

--- a/docs/designs/vst-out-of-process-engine.md
+++ b/docs/designs/vst-out-of-process-engine.md
@@ -122,11 +122,24 @@ the installer drops it at **`C:\Program Files\VSTHost\engine\VSTHostEngine.exe`*
 (alongside the Tauri shell `vsthost.exe`, which Zeus does **not** use); the
 portable zip has the same `engine\VSTHostEngine.exe` layout. Zeus checks the
 default install path, then a Zeus-managed download location, then `PATH`. When
-no engine is found, Zeus surfaces a **"Get VSTHost"** action linking to
-`KlayaR/VSTHost` releases (or, with consent, downloads the portable zip to a
-Zeus-managed location and verifies it). The engine is **never bundled** in the
-Zeus installer. Auto-installing third-party audio drivers (e.g. VB-Audio)
-is explicitly **out of scope** — see §10.
+no engine is found, Zeus surfaces a **"Get VST Engine"** action that downloads
+the engine to the Zeus-managed location and verifies it. The engine is **never
+bundled** in the Zeus installer. Auto-installing third-party audio drivers (e.g.
+VB-Audio) is explicitly **out of scope** — see §10.
+
+> **Implemented (2026-06-21).** `Zeus.Server.Hosting/VstEngineInstaller.cs` backs
+> the in-app **"Get VST Engine"** button (TX Audio Suite, shown only when VST is
+> selected but no engine is installed). It fetches the **latest**
+> `KlayaR/VSTHost` release via the GitHub API, picks the portable `.zip`,
+> extracts `VSTHostEngine.exe` (+ its sibling DLLs) at any depth, and stages
+> them at `%LOCALAPPDATA%\Zeus\vst-engine\` — the managed path
+> `VstEngineProcess.FindEngineExe()` resolves. Endpoints
+> `GET/POST /api/{tx-,}audio-suite/vst-engine/install` start the background
+> download and report `{phase, percent, message, version, engineAvailable}`;
+> the frontend polls until `done`/`failed` then re-reads the processing-mode so
+> the engine activates. Nothing is vendored — the binary is fetched at runtime,
+> keeping JUCE/GPLv3 outside Zeus's distribution (§3). Source override:
+> `ZEUS_VST_ENGINE_RELEASE_URL`.
 
 ## 8. Mode selector — Native vs VST (decided)
 

--- a/tests/Zeus.Server.Tests/VstEngineInstallerTests.cs
+++ b/tests/Zeus.Server.Tests/VstEngineInstallerTests.cs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// VstEngineInstaller — the engine-staging core (no network): given an extracted
+// archive tree, it must locate VSTHostEngine.exe at any depth, copy it plus its
+// sibling files into the Zeus-managed dir, and reject an archive that carries no
+// engine (e.g. a VSTHost build without the Zeus bridge). The asset picker must
+// prefer the portable zip over the Tauri setup.exe / .msi.
+
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class VstEngineInstallerTests : IDisposable
+{
+    private readonly string _root;
+
+    public VstEngineInstallerTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), $"zeus-vst-installer-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void Stage_finds_engine_in_subfolder_and_copies_siblings()
+    {
+        // Mirror the portable-zip layout: VSTHostEngine.exe under an engine/ folder
+        // alongside a JUCE DLL it needs at runtime.
+        var extracted = Path.Combine(_root, "extracted");
+        var engineDir = Path.Combine(extracted, "VSTHost-1.4.0", "engine");
+        Directory.CreateDirectory(engineDir);
+        File.WriteAllText(Path.Combine(engineDir, "VSTHostEngine.exe"), "MZ-stub");
+        File.WriteAllText(Path.Combine(engineDir, "juce_core.dll"), "dll-stub");
+
+        var managed = Path.Combine(_root, "managed", "vst-engine");
+        var staged = VstEngineInstaller.StageFromExtractedDir(extracted, managed);
+
+        Assert.Equal(Path.Combine(managed, "VSTHostEngine.exe"), staged);
+        Assert.True(File.Exists(staged));
+        // The sibling DLL must travel with the exe (flat at the managed top level).
+        Assert.True(File.Exists(Path.Combine(managed, "juce_core.dll")));
+    }
+
+    [Fact]
+    public void Stage_replaces_stale_managed_contents_on_reinstall()
+    {
+        var managed = Path.Combine(_root, "managed", "vst-engine");
+        Directory.CreateDirectory(managed);
+        File.WriteAllText(Path.Combine(managed, "stale.dll"), "old");
+
+        var extracted = Path.Combine(_root, "extracted");
+        Directory.CreateDirectory(extracted);
+        File.WriteAllText(Path.Combine(extracted, "VSTHostEngine.exe"), "MZ-stub");
+
+        VstEngineInstaller.StageFromExtractedDir(extracted, managed);
+
+        Assert.True(File.Exists(Path.Combine(managed, "VSTHostEngine.exe")));
+        Assert.False(File.Exists(Path.Combine(managed, "stale.dll")));
+    }
+
+    [Fact]
+    public void Stage_throws_when_archive_has_no_engine()
+    {
+        var extracted = Path.Combine(_root, "extracted");
+        Directory.CreateDirectory(extracted);
+        File.WriteAllText(Path.Combine(extracted, "vsthost.exe"), "the-tauri-app-not-the-engine");
+
+        var managed = Path.Combine(_root, "managed", "vst-engine");
+        Assert.Throws<InvalidOperationException>(
+            () => VstEngineInstaller.StageFromExtractedDir(extracted, managed));
+    }
+
+    [Fact]
+    public void SelectZipAsset_prefers_portable_zip_over_installers()
+    {
+        var assets = new List<VstEngineInstaller.GithubAsset>
+        {
+            new() { Name = "VSTHost_1.4.0_x64-setup.exe", DownloadUrl = "https://x/setup.exe" },
+            new() { Name = "VSTHost_1.4.0_x64_en-US.msi", DownloadUrl = "https://x/app.msi" },
+            new() { Name = "VSTHost-1.4.0-portable.zip", DownloadUrl = "https://x/portable.zip" },
+        };
+
+        var picked = VstEngineInstaller.SelectZipAsset(assets);
+
+        Assert.NotNull(picked);
+        Assert.Equal("VSTHost-1.4.0-portable.zip", picked!.Name);
+    }
+
+    [Fact]
+    public void SelectZipAsset_returns_null_when_no_zip_present()
+    {
+        var assets = new List<VstEngineInstaller.GithubAsset>
+        {
+            new() { Name = "VSTHost_1.4.0_x64-setup.exe", DownloadUrl = "https://x/setup.exe" },
+        };
+
+        Assert.Null(VstEngineInstaller.SelectZipAsset(assets));
+    }
+}

--- a/zeus-web/e2e/vst-engine-install.spec.ts
+++ b/zeus-web/e2e/vst-engine-install.spec.ts
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// "Download VST Engine" — a new operator on a fresh PC selects the VST route,
+// finds no engine installed, and clicks one button that downloads, installs,
+// and CONFIGURES the out-of-process engine so VST is immediately working. This
+// drives that flow end-to-end against a stubbed backend: the install endpoints
+// report progress, and the configure step flips the TX route to an active VST
+// engine. Mirrors audio-devices.spec.ts for the Settings → Audio Tools harness.
+
+import { expect, test, type Page, type Route } from '@playwright/test';
+
+async function fulfillJson(route: Route, body: unknown) {
+  await route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  });
+}
+
+// Server-side install + engine state, mutated by the stubbed endpoints so the
+// flow reads like the real thing: engine absent → installed → active.
+type EngineWorld = {
+  engineInstalled: boolean;
+  engineActive: boolean;
+  installPosts: number;
+  configurePuts: number;
+};
+
+async function stubZeusApi(page: Page): Promise<EngineWorld> {
+  const world: EngineWorld = {
+    engineInstalled: false,
+    engineActive: false,
+    installPosts: 0,
+    configurePuts: 0,
+  };
+
+  await page.addInitScript(() => {
+    const NativeWebSocket = window.WebSocket;
+    class MockZeusWebSocket extends EventTarget {
+      readonly url: string;
+      readonly protocol = '';
+      readonly extensions = '';
+      binaryType: BinaryType = 'blob';
+      bufferedAmount = 0;
+      readyState = NativeWebSocket.CONNECTING;
+      onopen: ((this: WebSocket, ev: Event) => unknown) | null = null;
+      onmessage: ((this: WebSocket, ev: MessageEvent) => unknown) | null = null;
+      onerror: ((this: WebSocket, ev: Event) => unknown) | null = null;
+      onclose: ((this: WebSocket, ev: CloseEvent) => unknown) | null = null;
+
+      constructor(url: string | URL) {
+        super();
+        this.url = String(url);
+        window.setTimeout(() => {
+          if (this.readyState !== NativeWebSocket.CONNECTING) return;
+          this.readyState = NativeWebSocket.OPEN;
+          const event = new Event('open');
+          this.onopen?.call(this as unknown as WebSocket, event);
+          this.dispatchEvent(event);
+        }, 0);
+      }
+
+      send() {
+        /* No realtime frames are needed for this install e2e. */
+      }
+
+      close() {
+        if (this.readyState === NativeWebSocket.CLOSED) return;
+        this.readyState = NativeWebSocket.CLOSED;
+        const event = new CloseEvent('close');
+        this.onclose?.call(this as unknown as WebSocket, event);
+        this.dispatchEvent(event);
+      }
+    }
+
+    window.WebSocket = MockZeusWebSocket as unknown as typeof WebSocket;
+  });
+
+  await page.route(/^https?:\/\/[^/]+\/api(?:\/|\?|$)/, async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const method = request.method();
+
+    if (url.pathname === '/api/capabilities') {
+      await fulfillJson(route, {
+        host: 'desktop',
+        platform: 'windows',
+        architecture: 'x64',
+        version: 'e2e',
+        lanHttpsUrls: [],
+        features: {},
+      });
+      return;
+    }
+
+    if (url.pathname === '/api/radio/selection') {
+      await fulfillJson(route, {
+        preferred: 'Auto',
+        connected: 'Unknown',
+        effective: 'Unknown',
+        overrideDetection: false,
+      });
+      return;
+    }
+
+    if (url.pathname === '/api/plugins') {
+      await fulfillJson(route, { sdkAbi: 1, sdkVersion: 'e2e', plugins: [] });
+      return;
+    }
+
+    if (url.pathname === '/api/audio/devices') {
+      await fulfillJson(route, {
+        supported: true,
+        inputDeviceId: null,
+        outputDeviceId: null,
+        activeInputDeviceId: null,
+        activeOutputDeviceId: null,
+        inputs: [],
+        outputs: [],
+        error: null,
+      });
+      return;
+    }
+
+    if (url.pathname === '/api/ui/layouts' && method === 'GET') {
+      await fulfillJson(route, {
+        radioKey: url.searchParams.get('radio') ?? 'default',
+        layouts: [],
+        activeLayoutId: 'default',
+      });
+      return;
+    }
+    if (url.pathname === '/api/ui/layouts') {
+      await route.fulfill({ status: 204, body: '' });
+      return;
+    }
+
+    if (url.pathname === '/api/theme-settings') {
+      await fulfillJson(route, { theme: 'dark', overrides: {} });
+      return;
+    }
+
+    // VST engine provisioning. POST kicks the "download" off and immediately
+    // marks the engine installed; GET reports it done. (The real server streams
+    // download → extract → stage; the contract the frontend depends on is the
+    // terminal "done" + engineAvailable flip, which is what we assert.)
+    if (url.pathname.endsWith('/vst-engine/install')) {
+      if (method === 'POST') {
+        world.installPosts += 1;
+        world.engineInstalled = true;
+        await fulfillJson(route, {
+          phase: 'downloading',
+          percent: 0,
+          message: 'Downloading…',
+          engineAvailable: false,
+        });
+        return;
+      }
+      await fulfillJson(route, {
+        phase: 'done',
+        percent: 100,
+        message: 'VST engine installed.',
+        engineAvailable: world.engineInstalled,
+      });
+      return;
+    }
+
+    if (url.pathname.endsWith('/processing-mode')) {
+      if (method === 'PUT') {
+        // The configure step: enabling VST activates the engine once installed.
+        world.configurePuts += 1;
+        world.engineActive = world.engineInstalled;
+      }
+      await fulfillJson(route, {
+        mode: 'vst',
+        engineAvailable: world.engineInstalled,
+        engineActive: world.engineActive,
+      });
+      return;
+    }
+
+    if (url.pathname.endsWith('/master-bypass')) {
+      await fulfillJson(route, { bypassed: false });
+      return;
+    }
+    if (url.pathname.endsWith('/profiles')) {
+      await fulfillJson(route, { profiles: [] });
+      return;
+    }
+    if (url.pathname === '/api/audio-suite/preview') {
+      await fulfillJson(route, { supported: true, enabled: false, meterOnly: false });
+      return;
+    }
+    if (url.pathname.endsWith('/chain/order')) {
+      await fulfillJson(route, { pluginIds: [] });
+      return;
+    }
+
+    await fulfillJson(route, {});
+  });
+
+  return world;
+}
+
+test('new operator downloads, installs, and auto-configures the VST engine', async ({ page }) => {
+  const pageErrors: string[] = [];
+  page.on('pageerror', (err) => pageErrors.push(err.message));
+  const world = await stubZeusApi(page);
+
+  await page.goto('/#pa');
+  await expect(page.getByRole('region', { name: 'Settings' })).toBeVisible();
+  await page.getByRole('tab', { name: 'AUDIO TOOLS' }).click();
+
+  // The TX tools panel is in VST mode (engine absent) → the download affordance
+  // is offered, and "Download Audio Suite" (the native-mode peer) is not.
+  const getEngine = page.getByRole('button', { name: 'Download VST Engine' });
+  await expect(getEngine).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Download Audio Suite' })).toHaveCount(0);
+
+  await getEngine.click();
+
+  // Install runs, then the configure step flips the route to an active engine.
+  await expect(page.getByRole('button', { name: 'VST Engine Ready' })).toBeVisible();
+  await expect(page.getByText('VST engine ready — TX audio now routes through VST.')).toBeVisible();
+
+  // The engine was actually installed and configured exactly once.
+  await expect.poll(() => world.installPosts).toBe(1);
+  await expect.poll(() => world.configurePuts).toBeGreaterThanOrEqual(1);
+  await expect.poll(() => world.engineActive).toBe(true);
+
+  expect(pageErrors).toEqual([]);
+});

--- a/zeus-web/src/components/DownloadAudioSuiteButton.tsx
+++ b/zeus-web/src/components/DownloadAudioSuiteButton.tsx
@@ -12,7 +12,7 @@
 // after install finishes we show a modal telling the operator to restart
 // Zeus. No auto-restart — operator decides.
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { installPlugin } from '../plugins/api/plugins';
 import { fetchInstalledPlugins } from '../plugins/api/plugins';
 import type { PluginDto } from '../plugins/api/plugins';
@@ -85,6 +85,25 @@ export function DownloadAudioSuiteButton() {
   const [rows, setRows] = useState<ProgressRow[]>([]);
   const [restartModalOpen, setRestartModalOpen] = useState(false);
   const [showProgress, setShowProgress] = useState(false);
+  // Hide the affordance once every suite plugin is already on disk — there's
+  // nothing left to download. Probed on mount; re-probed after our own install.
+  // Fail-open: if the probe errors we keep the button so the operator isn't
+  // blocked from installing.
+  const [allInstalled, setAllInstalled] = useState(false);
+
+  const probeInstalled = useCallback(async () => {
+    try {
+      const listing = await fetchInstalledPlugins();
+      const ids = new Set(listing.plugins.map((p: PluginDto) => p.id));
+      setAllInstalled(AUDIO_SUITE.every((p) => ids.has(p.id)));
+    } catch {
+      setAllInstalled(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void probeInstalled();
+  }, [probeInstalled]);
 
   const totals = useMemo(() => {
     let ok = 0; let skipped = 0; let errors = 0;
@@ -153,7 +172,11 @@ export function DownloadAudioSuiteButton() {
     // landed — skipped-only runs don't need a restart.
     const anyInstalled = working.some((r) => r.state === 'ok');
     if (anyInstalled) setRestartModalOpen(true);
-  }, []);
+    void probeInstalled();
+  }, [probeInstalled]);
+
+  // Already fully installed and nothing in flight → nothing to offer.
+  if (allInstalled && !busy && !showProgress) return null;
 
   return (
     <>

--- a/zeus-web/src/components/DownloadVstEngineButton.tsx
+++ b/zeus-web/src/components/DownloadVstEngineButton.tsx
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// "Download VST Engine" — the new-operator one-click path to working VST
+// processing, modelled on DownloadAudioSuiteButton. The out-of-process VST
+// engine (upstream KlayaR/VSTHost, run headless) is fetched from its latest
+// release and staged by the server; it is never bundled (GPLv3 isolation — see
+// Zeus.Server.Hosting/VstEngineInstaller.cs). One click downloads, installs,
+// and then CONFIGURES (switches the TX route to VST) so the operator can use it
+// immediately. Visible only while no engine is present (or an install is in
+// flight / failed); it disappears once the engine is ready.
+
+import { useAudioSuiteStore } from '../state/audio-suite-store';
+
+type StageState = 'pending' | 'active' | 'ok' | 'error';
+
+type InstallPhase =
+  | 'idle'
+  | 'downloading'
+  | 'extracting'
+  | 'staging'
+  | 'configuring'
+  | 'done'
+  | 'failed';
+
+// The three operator-meaningful stages, in order. Each maps to one or more of
+// the server/client phases reported through the store.
+const STAGES: ReadonlyArray<{ key: string; label: string; phases: InstallPhase[] }> = [
+  { key: 'download', label: 'Download engine', phases: ['downloading'] },
+  { key: 'install', label: 'Install engine', phases: ['extracting', 'staging'] },
+  { key: 'configure', label: 'Configure VST mode', phases: ['configuring'] },
+];
+
+const PHASE_ORDER: Record<InstallPhase, number> = {
+  idle: -1,
+  downloading: 0,
+  extracting: 1,
+  staging: 1,
+  configuring: 2,
+  done: 3,
+  failed: 99,
+};
+
+function stageState(stageIndex: number, phase: InstallPhase): StageState {
+  if (phase === 'done') return 'ok';
+  if (phase === 'failed') {
+    // The active stage at failure time is the first not-yet-completed one.
+    return 'pending';
+  }
+  const current = PHASE_ORDER[phase];
+  const stagePeak = Math.max(...STAGES[stageIndex]!.phases.map((p) => PHASE_ORDER[p]));
+  if (current > stagePeak) return 'ok';
+  if (current >= Math.min(...STAGES[stageIndex]!.phases.map((p) => PHASE_ORDER[p]))) return 'active';
+  return 'pending';
+}
+
+function dot(state: StageState): { color: string; glow: string; symbol: string } {
+  switch (state) {
+    case 'active': return { color: 'var(--accent)', glow: 'rgba(74, 158, 255, 0.55)', symbol: '…' };
+    case 'ok':     return { color: 'var(--accent)', glow: 'rgba(74, 158, 255, 0.55)', symbol: '✓' };
+    case 'error':  return { color: 'var(--tx)',     glow: 'rgba(230, 58, 43, 0.55)',  symbol: '!' };
+    case 'pending':
+    default:       return { color: 'var(--fg-3)',   glow: 'transparent',              symbol: '·' };
+  }
+}
+
+export function DownloadVstEngineButton() {
+  const engineAvailable = useAudioSuiteStore((s) => s.vstEngineAvailable);
+  const install = useAudioSuiteStore((s) => s.vstEngineInstall);
+  const installVstEngine = useAudioSuiteStore((s) => s.installVstEngine);
+
+  const phase = install.phase as InstallPhase;
+  const busy =
+    phase === 'downloading' ||
+    phase === 'extracting' ||
+    phase === 'staging' ||
+    phase === 'configuring';
+  const failed = phase === 'failed';
+  const done = phase === 'done';
+
+  // Hide once the engine is installed and we're not mid-/just-finished an
+  // install — there's nothing to download. Stays visible through the "ready"
+  // confirmation and any failure (so the operator can retry).
+  if (engineAvailable && !busy && !failed && !done) return null;
+
+  const label = busy
+    ? `Installing… ${install.percent}%`
+    : failed
+      ? 'Retry VST Engine'
+      : done
+        ? 'VST Engine Ready'
+        : 'Download VST Engine';
+
+  const showPanel = busy || failed || done;
+
+  return (
+    <>
+      <button
+        type="button"
+        className="btn sm active"
+        disabled={busy || done}
+        onClick={() => {
+          if (!busy && !done) void installVstEngine();
+        }}
+        title="Download, install, and enable the out-of-process VST engine so TX audio can run through VST plugins"
+        style={{ whiteSpace: 'nowrap' }}
+      >
+        {label}
+      </button>
+
+      {showPanel && (
+        <div
+          role="status"
+          aria-live="polite"
+          style={{
+            marginTop: 8,
+            padding: '10px 12px',
+            background: 'var(--bg-1)',
+            border: '1px solid var(--line)',
+            borderRadius: 6,
+            fontFamily: 'var(--font-sans, Inter, system-ui, sans-serif)',
+            fontSize: 11,
+            color: 'var(--fg-1)',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 6,
+            width: '100%',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'baseline',
+              color: 'var(--fg-2)',
+              letterSpacing: 0.8,
+              textTransform: 'uppercase',
+            }}
+          >
+            <span>VST engine install</span>
+            <span style={{ fontFamily: 'var(--font-mono, JetBrains Mono, ui-monospace, monospace)' }}>
+              {done ? 'ready' : failed ? 'failed' : `${install.percent}%`}
+            </span>
+          </div>
+
+          {STAGES.map((stage, i) => {
+            const st = failed ? ('error' as StageState) : stageState(i, phase);
+            const d = dot(st);
+            return (
+              <div
+                key={stage.key}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  fontFamily: 'var(--font-mono, JetBrains Mono, ui-monospace, monospace)',
+                }}
+              >
+                <span
+                  aria-hidden
+                  style={{
+                    width: 16,
+                    height: 16,
+                    borderRadius: 3,
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    background: 'var(--bg-2)',
+                    color: d.color,
+                    border: '1px solid var(--line)',
+                    boxShadow: d.glow !== 'transparent' ? `0 0 6px ${d.glow}` : 'none',
+                    fontSize: 11,
+                    lineHeight: 1,
+                    fontWeight: 600,
+                  }}
+                >
+                  {d.symbol}
+                </span>
+                <span style={{ flex: 1, color: 'var(--fg-0)' }}>{stage.label}</span>
+              </div>
+            );
+          })}
+
+          {install.message && (
+            <div style={{ color: failed ? 'var(--tx)' : 'var(--fg-2)', fontSize: 10 }}>
+              {install.message}
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/zeus-web/src/components/TxAudioToolsPanel.tsx
+++ b/zeus-web/src/components/TxAudioToolsPanel.tsx
@@ -18,6 +18,7 @@ import { useCallback, useEffect, useMemo, useState, type CSSProperties, type Rea
 import { RefreshCw } from 'lucide-react';
 import { CfcSettingsPanel } from './CfcSettingsPanel';
 import { DownloadAudioSuiteButton } from './DownloadAudioSuiteButton';
+import { DownloadVstEngineButton } from './DownloadVstEngineButton';
 import { usePluginPanels } from '../plugins/runtime/usePluginPanels';
 import type { RegisteredPluginPanel } from '../plugins/runtime/pluginRuntime';
 import {
@@ -614,6 +615,7 @@ function TxChainFlow({ chainPanels }: { chainPanels: RegisteredPluginPanel[] }) 
         <>
           <SuiteButton route="tx" />
           {!vstMode && <DownloadAudioSuiteButton />}
+          {vstMode && <DownloadVstEngineButton />}
         </>
       }
     >

--- a/zeus-web/src/state/audio-suite-store.test.ts
+++ b/zeus-web/src/state/audio-suite-store.test.ts
@@ -665,3 +665,69 @@ describe('audio-suite-store profile selection', () => {
     });
   });
 });
+
+describe('audio-suite-store VST engine install', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    resetStoreState();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    resetStoreState();
+    localStorage.clear();
+  });
+
+  it('downloads the engine and flips availability when staging completes', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn<typeof fetch>(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === '/api/tx-audio-suite/vst-engine/install' && init?.method === 'POST') {
+        return response({ phase: 'downloading', percent: 0 });
+      }
+      if (url === '/api/tx-audio-suite/vst-engine/install') {
+        return response({ phase: 'done', percent: 100, message: 'installed' });
+      }
+      if (url === '/api/tx-audio-suite/processing-mode') {
+        return response({ mode: 'vst', engineAvailable: true, engineActive: true });
+      }
+      return response({});
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = useAudioSuiteStore.getState().installVstEngine();
+    await vi.advanceTimersByTimeAsync(1100); // step past the 1s poll delay
+    await promise;
+
+    expect(useAudioSuiteStore.getState().vstEngineInstall.phase).toBe('done');
+    // The follow-up processing-mode read makes the engine usable.
+    expect(useAudioSuiteStore.getState().vstEngineAvailable).toBe(true);
+    expect(useAudioSuiteStore.getState().vstEngineActive).toBe(true);
+  });
+
+  it('surfaces a failed install for retry', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn<typeof fetch>(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === '/api/tx-audio-suite/vst-engine/install' && init?.method === 'POST') {
+        return response({ phase: 'downloading', percent: 0 });
+      }
+      if (url === '/api/tx-audio-suite/vst-engine/install') {
+        return response({ phase: 'failed', percent: 0, message: 'no engine in archive' });
+      }
+      return response({});
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = useAudioSuiteStore.getState().installVstEngine();
+    await vi.advanceTimersByTimeAsync(1100);
+    await promise;
+
+    expect(useAudioSuiteStore.getState().vstEngineInstall.phase).toBe('failed');
+    expect(useAudioSuiteStore.getState().vstEngineInstall.message).toBe('no engine in archive');
+    expect(useAudioSuiteStore.getState().vstEngineAvailable).toBe(false);
+  });
+});

--- a/zeus-web/src/state/audio-suite-store.ts
+++ b/zeus-web/src/state/audio-suite-store.ts
@@ -267,6 +267,27 @@ interface AudioSuiteState {
   loadProcessingModeFromServer(): Promise<void>;
   loadRxProcessingModeFromServer(): Promise<void>;
   setProcessingMode(mode: 'native' | 'vst'): Promise<void>;
+
+  // "Get VST Engine" provisioning. The out-of-process VST engine is fetched
+  // from its upstream release and staged by the server (never bundled). The
+  // operator triggers it from the Audio Suite when VST mode is selected but no
+  // engine is installed; this store polls the server install status until it
+  // finishes, then refreshes the processing-mode so the new engine is picked up.
+  // phase lifecycle: idle → downloading → extracting → staging (server) →
+  // configuring (client switches to VST mode) → done (installed AND usable).
+  vstEngineInstall: {
+    phase:
+      | 'idle'
+      | 'downloading'
+      | 'extracting'
+      | 'staging'
+      | 'configuring'
+      | 'done'
+      | 'failed';
+    percent: number;
+    message: string | null;
+  };
+  installVstEngine(): Promise<void>;
 }
 
 type AudioSuitePersistedState = Pick<
@@ -351,6 +372,7 @@ export const useAudioSuiteStore = create<AudioSuiteState>()(
       rxVstEngineActive: false,
       rxVstActivePlugins: 0,
       rxVstDegradedBlocks: 0,
+      vstEngineInstall: { phase: 'idle', percent: 0, message: null },
       isDragging: false,
       collapsed: {},
       selectedChainId: null,
@@ -1147,6 +1169,118 @@ export const useAudioSuiteStore = create<AudioSuiteState>()(
           set({ processingMode: prev });
 
           console.warn('audio-suite processing-mode PUT threw', err);
+        }
+      },
+
+      installVstEngine: async () => {
+        const phase = get().vstEngineInstall.phase;
+        if (phase === 'downloading' || phase === 'extracting' || phase === 'staging') {
+          return; // already running
+        }
+        set({ vstEngineInstall: { phase: 'downloading', percent: 0, message: 'Starting…' } });
+        try {
+          const res = await fetch('/api/tx-audio-suite/vst-engine/install', {
+            method: 'POST',
+          });
+          if (!res.ok) {
+            set({
+              vstEngineInstall: {
+                phase: 'failed',
+                percent: 0,
+                message: `Install request rejected (${res.status}).`,
+              },
+            });
+            return;
+          }
+
+          // Poll the server install status until it finishes. The engine
+          // download is multi-MB, so allow a generous ceiling before giving up
+          // on the poll loop (the server keeps working regardless).
+          for (let i = 0; i < 600; i += 1) {
+            await new Promise((r) => setTimeout(r, 1000));
+            let body: {
+              phase?: string;
+              percent?: number;
+              message?: string | null;
+            };
+            try {
+              const poll = await fetch('/api/tx-audio-suite/vst-engine/install');
+              if (!poll.ok) continue;
+              body = await poll.json();
+            } catch {
+              continue;
+            }
+            const p = (body.phase ?? 'idle') as
+              | 'idle'
+              | 'downloading'
+              | 'extracting'
+              | 'staging'
+              | 'done'
+              | 'failed';
+            if (p === 'done') {
+              // Configure: switch the TX route to VST so the freshly-staged
+              // engine activates and audio runs through it — the operator gets
+              // working VST without a second click. A direct PUT (not
+              // setProcessingMode, which short-circuits when the mode is
+              // unchanged) so the server re-activates even if VST was already
+              // the selected route when the engine was missing.
+              set({
+                vstEngineInstall: {
+                  phase: 'configuring',
+                  percent: 100,
+                  message: 'Configuring VST mode…',
+                },
+              });
+              try {
+                const put = await fetch('/api/tx-audio-suite/processing-mode', {
+                  method: 'PUT',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ mode: 'vst' }),
+                });
+                if (put.ok) {
+                  const pm = (await put.json()) as {
+                    mode?: string;
+                    engineAvailable?: boolean;
+                    engineActive?: boolean;
+                  };
+                  set({
+                    processingMode: pm.mode === 'vst' ? 'vst' : 'native',
+                    vstEngineAvailable: pm.engineAvailable === true,
+                    vstEngineActive: pm.engineActive === true,
+                  });
+                } else {
+                  await get().loadProcessingModeFromServer();
+                }
+              } catch {
+                await get().loadProcessingModeFromServer();
+              }
+              set({
+                vstEngineInstall: {
+                  phase: 'done',
+                  percent: 100,
+                  message: 'VST engine ready — TX audio now routes through VST.',
+                },
+              });
+              return;
+            }
+            set({
+              vstEngineInstall: {
+                phase: p,
+                percent: typeof body.percent === 'number' ? body.percent : 0,
+                message: body.message ?? null,
+              },
+            });
+            if (p === 'failed') return;
+          }
+        } catch (err) {
+          set({
+            vstEngineInstall: {
+              phase: 'failed',
+              percent: 0,
+              message: 'Install failed (network?).',
+            },
+          });
+          console.warn('vst-engine install threw', err);
         }
       },
     }),


### PR DESCRIPTION
## Problem

A new operator on a fresh PC who switches the TX Audio Suite to the **VST** route hits a dead end — **"VST engine not installed"** — with no in-app way to get it. The out-of-process engine (upstream **KlayaR/VSTHost**, run headless as `VSTHostEngine.exe --zeus-bridge`) is deliberately **never vendored or bundled**: VSTHost links JUCE (GPLv3), and the user-fetched + separate-process boundary is what isolates that license from Zeus's own distribution (see [`docs/designs/vst-out-of-process-engine.md`](docs/designs/vst-out-of-process-engine.md) §3/§7). The doc always intended a **"Get VSTHost"** download flow, but it was never implemented — only status text existed.

## What this does

Ships the downloader the design called for — **no vendoring, fetched at runtime**:

- **`VstEngineInstaller`** fetches the **latest** `KlayaR/VSTHost` release, extracts `VSTHostEngine.exe` (+ sibling DLLs) from the portable zip at any depth, and stages it at the Zeus-managed path (`%LOCALAPPDATA%\Zeus\vst-engine\`) that `FindEngineExe()` resolves. Windows-only. Source override: `ZEUS_VST_ENGINE_RELEASE_URL`.
- Endpoints `GET`/`POST /api/{tx-,}audio-suite/vst-engine/install` start a background download and report `{phase, percent, message, version, engineAvailable}`.
- Frontend **"Download VST Engine"** button (peer of "Download Audio Suite"): one click **downloads → installs → configures** (switches the TX route to VST so the engine activates and audio runs through it immediately). Progress panel mirrors the Audio Suite installer.

### Visibility
| Mode | Button | Hides when |
|------|--------|-----------|
| VST selected | Download VST Engine | engine already installed |
| Native selected | Download Audio Suite | all 6 suite plugins installed |

Mutually exclusive by mode; each self-hides once its target is present.

## Safety / scope
- **Additive and gated** — Native is unchanged and remains the default; this only runs when the operator chooses VST. No PureSignal, DSP, protocol, or wire-format changes.

## Tests
- Backend: staging / asset-pick unit tests (5) + clean build.
- Frontend: store install-flow tests; **902** unit tests pass.
- **e2e** ([`vst-engine-install.spec.ts`](zeus-web/e2e/vst-engine-install.spec.ts)) drives the full new-operator flow (select VST → download → install → auto-configure → engine active). **6/6 e2e green**, no regressions.

## Caveat
If the latest `KlayaR/VSTHost` portable zip doesn't yet contain the **bridge-capable** `VSTHostEngine.exe` (the `--zeus-bridge` build), the install fails with a clear *"archive does not contain VSTHostEngine.exe"* message — the engine then needs to be published in an upstream release (or point `ZEUS_VST_ENGINE_RELEASE_URL` at one that has it).