### PR TITLE
fix(agc): track the band noise floor from the spectrum like Thetis (#806)

### DIFF
--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -951,6 +951,17 @@ public class DspPipelineService : BackgroundService,
     private long _calPanCenterHz;
     private long _calPanSnapshotMs;
     private readonly object _calPanLock = new();
+
+    // Scratch buffer for the auto-AGC noise-floor estimate (issue #806). Filled
+    // and sorted in-place by TryComputeAutoAgcNoiseFloorDbm on the single meter
+    // thread; never read concurrently, so it needs no lock.
+    private readonly float[] _autoAgcFloorBuf = new float[Width];
+    // Low percentile of the valid panadapter bins ⇒ the band noise floor. 0.20
+    // rejects up to ~80% spectrum occupancy (signals are the high bins).
+    private const double AutoAgcFloorPercentile = 0.20;
+    // Reject the estimate unless this many bins are real (not the -200 invalid
+    // sentinel); a near-dead span gives a meaningless floor.
+    private const int AutoAgcFloorMinValidBins = 64;
     private readonly float[] _diagWfSnapshot = new float[Width];
     private long _diagWfSnapshotMs;
     private long _diagDisplayFrameMs;
@@ -4192,6 +4203,53 @@ public class DspPipelineService : BackgroundService,
         return true;
     }
 
+    /// <summary>
+    /// Estimates the band noise floor (raw display dB) for Auto-AGC from the
+    /// panadapter FFT — the same pre-AGC, per-bin spectrum Thetis tracks
+    /// (display.cs:5240-5264), not the post-AGC S-meter. Reads the cached
+    /// snapshot and delegates the percentile to <see cref="TryNoiseFloorFromDisplayBins"/>.
+    /// Returns false (caller passes NaN; the loop falls back to the S-meter) when
+    /// no fresh spectrum is available — a stale frame, a near-dead span, or any
+    /// engine/display state that did not produce a fresh analyzer frame within
+    /// the freshness window. The caller adds the board RX cal offset. Issue #806.
+    /// </summary>
+    private bool TryComputeAutoAgcNoiseFloorDbm(out double floorDbm)
+    {
+        floorDbm = double.NaN;
+        if (!TryCapturePanadapterSnapshot(_autoAgcFloorBuf, out _, out _, maxAgeMs: 300))
+            return false;
+        return TryNoiseFloorFromDisplayBins(
+            _autoAgcFloorBuf, AutoAgcFloorPercentile, AutoAgcFloorMinValidBins, out floorDbm);
+    }
+
+    /// <summary>
+    /// Pure noise-floor percentile over a panadapter display-dB buffer. Compacts
+    /// the valid bins to the front (SanitizeDisplayBuffer pins invalid bins to
+    /// DisplayInvalidBinDb = -200; excluding those and any absurdly low value
+    /// keeps the estimate on real noise, not dead band edges), then returns the
+    /// requested low percentile of the survivors. Returns false when fewer than
+    /// <paramref name="minValidBins"/> bins are real. NOTE: mutates
+    /// <paramref name="bins"/> in place (compacts + sorts); pass a scratch buffer.
+    /// </summary>
+    internal static bool TryNoiseFloorFromDisplayBins(
+        Span<float> bins, double percentile, int minValidBins, out double floorDbm)
+    {
+        floorDbm = double.NaN;
+        int n = 0;
+        for (int i = 0; i < bins.Length; i++)
+        {
+            float v = bins[i];
+            if (float.IsFinite(v) && v > -190f)
+                bins[n++] = v;
+        }
+        if (n < minValidBins) return false;
+
+        bins.Slice(0, n).Sort();
+        int idx = Math.Clamp((int)Math.Round((n - 1) * percentile), 0, n - 1);
+        floorDbm = bins[idx];
+        return true;
+    }
+
     internal static void FeedProtocol1Iq(
         IDspEngine engine,
         int channel,
@@ -5016,7 +5074,22 @@ public class DspPipelineService : BackgroundService,
             //
             var rx = engine.GetRxStageMeters(channel);
             var v2 = BuildRxMetersV2(rx, rxCalOffsetDb);
-            _radio.HandleRxMetersForAutoAgc(dbm, v2.AdcPk, v2.AgcGain, Environment.TickCount64);
+            // Feed Auto-AGC a real spectrum-derived noise floor when one is
+            // available (#806); NaN falls the loop back to the S-meter `dbm`.
+            // Only pay for the snapshot copy + percentile sort when Auto-AGC is
+            // actually engaged — the loop early-returns otherwise anyway.
+            double spectrumFloorDbm = double.NaN;
+            if (state.AutoAgcEnabled &&
+                TryComputeAutoAgcNoiseFloorDbm(out double floorDbm))
+            {
+                // Put the display-pixel floor on the same calibrated dBm scale as
+                // the S-meter path (RX pixels carry no cal offset of their own),
+                // so the loop's TargetAudioDb / [20,100] constants — tuned against
+                // S-meter dBm — apply. Any residual WDSP-display-vs-S-meter delta
+                // beyond this board offset is a bench-tune item (#806).
+                spectrumFloorDbm = floorDbm + rxCalOffsetDb;
+            }
+            _radio.HandleRxMetersForAutoAgc(dbm, spectrumFloorDbm, v2.AdcPk, v2.AgcGain, Environment.TickCount64);
             lock (_rxMeterDiagLock)
             {
                 _diagRxMetersValid = true;

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -206,6 +206,16 @@ public sealed class RadioService : IDisposable
     private readonly double[] _noiseFloorWindow = new double[AgcNoiseFloorWindowSamples];
     private int _noiseFloorWindowIdx;
     private int _noiseFloorWindowFill;
+    // Which source is currently filling the floor window (0 none / 1 spectrum /
+    // 2 S-meter fallback) and the last time a real spectrum floor arrived
+    // (Environment.TickCount64 ms). Together these (a) keep the two differently-
+    // calibrated sources from being mixed in one percentile window, and (b) make
+    // the loop fall back to the S-meter ONLY after the spectrum has been absent
+    // long enough to be a true outage, not a single dropped frame — without this,
+    // a sustained stale-spectrum period under steady RX would freeze tracking.
+    private int _autoAgcWindowSource;
+    private long _lastSpectrumFloorMs = long.MinValue;
+    private const long AgcSpectrumStaleMs = 1500;  // 3 ticks; > normal frame gaps
 
     // 100 ms between 1-dB steps. Events arrive at ~1.2 kHz (192 kSps), so
     // without throttling the offset would saturate at 31 dB in ~30 ms. At 10 Hz
@@ -1595,6 +1605,10 @@ public sealed class RadioService : IDisposable
         Mutate(s =>
         {
             _preampOn = on;
+            // Fast-attack (#806): a preamp/LNA change steps the noise floor, so
+            // drop the auto-AGC floor window to re-seed on the new level (Thetis
+            // display.cs:893-906). No-op when Auto-AGC is off. Mutate holds _sync.
+            ResetAutoAgcNoiseFloorWindow();
             return s with { PreampOn = on };
         });
         // P1 path: Protocol1Client owns the bit; SetPreamp pushes the
@@ -1619,6 +1633,12 @@ public sealed class RadioService : IDisposable
         {
             effective = Math.Clamp(_atten.ClampedDb + _attOffsetDb, HpsdrAtten.MinDb, HpsdrAtten.MaxDb);
             _lastAppliedEffectiveDb = effective;
+            // Fast-attack (#806): an operator attenuator step shifts the noise
+            // floor by that many dB, so re-seed the auto-AGC floor window. (The
+            // gradual auto-ATT ramp pushes effective attenuation through
+            // ActiveClient directly, NOT this setter, so it does not re-seed and
+            // the floor follows it smoothly.)
+            ResetAutoAgcNoiseFloorWindow();
         }
         ActiveClient?.SetAttenuator(new HpsdrAtten(effective));
         return Snapshot();
@@ -1784,16 +1804,14 @@ public sealed class RadioService : IDisposable
                 // to the user's baseline immediately.
                 _agcOffsetDb = 0.0;
                 _lastAgcTickMs = long.MinValue;
-                _noiseFloorWindowFill = 0;
-                _noiseFloorWindowIdx = 0;
+                ResetAutoAgcNoiseFloorWindow();
                 _state = _state with { AgcOffsetDb = 0.0 };
             }
             else
             {
                 // Turning auto on: reset timer + window so we recalibrate.
                 _lastAgcTickMs = long.MinValue;
-                _noiseFloorWindowFill = 0;
-                _noiseFloorWindowIdx = 0;
+                ResetAutoAgcNoiseFloorWindow();
             }
         }
         var snap = Snapshot();
@@ -1806,6 +1824,20 @@ public sealed class RadioService : IDisposable
         return snap;
     }
 
+    // Drops the auto-AGC noise-floor window so the next samples re-seed the floor
+    // estimate from scratch. This is Thetis's "fast-attack": a band change,
+    // attenuator step, preamp/LNA toggle, power-on, or a TX pause all invalidate
+    // the old floor (Thetis display.cs:893-919). Also clears the window-source tag
+    // so the next seed re-establishes which source is live. (_lastSpectrumFloorMs
+    // is intentionally NOT cleared — it is a rolling availability timestamp.)
+    // Caller MUST hold _sync.
+    private void ResetAutoAgcNoiseFloorWindow()
+    {
+        _noiseFloorWindowFill = 0;
+        _noiseFloorWindowIdx = 0;
+        _autoAgcWindowSource = 0;
+    }
+
     /// <summary>
     /// Auto-AGC control loop. Estimates the band noise floor from a sliding
     /// window of S-meter samples and chooses an absolute effective AGC-T that
@@ -1815,9 +1847,21 @@ public sealed class RadioService : IDisposable
     /// slider baseline. Slew-limited so adjustments are inaudibly gradual.
     /// </summary>
     internal void HandleRxMeterForAutoAgc(double signalDbm, long nowMs) =>
-        HandleRxMetersForAutoAgc(signalDbm, double.NaN, double.NaN, nowMs);
+        HandleRxMetersForAutoAgc(signalDbm, double.NaN, double.NaN, double.NaN, nowMs);
 
-    internal void HandleRxMetersForAutoAgc(double signalDbm, double adcPkDbfs, double agcGainDb, long nowMs)
+    // Back-compat overload (no spectrum floor): callers/tests that only have the
+    // S-meter delegate here. spectrumFloorDbm = NaN makes the loop fall back to
+    // signalDbm exactly as before.
+    internal void HandleRxMetersForAutoAgc(double signalDbm, double adcPkDbfs, double agcGainDb, long nowMs) =>
+        HandleRxMetersForAutoAgc(signalDbm, double.NaN, adcPkDbfs, agcGainDb, nowMs);
+
+    // Primary overload (issue #806). spectrumFloorDbm is a real per-band noise
+    // floor measured from the panadapter FFT — the same physical quantity Thetis
+    // tracks. When finite it REPLACES signalDbm as the floor source. signalDbm,
+    // which in this integration is the post-AGC audio-RMS fallback (it moves with
+    // the signal, not the floor), is kept only as the degraded fallback for when
+    // no fresh spectrum is available (stale analyzer frame / near-dead span).
+    internal void HandleRxMetersForAutoAgc(double signalDbm, double spectrumFloorDbm, double adcPkDbfs, double agcGainDb, long nowMs)
     {
         bool changedOffset = false;
         double newOffset = 0.0;
@@ -1827,19 +1871,19 @@ public sealed class RadioService : IDisposable
         {
             if (!_state.AutoAgcEnabled) return;
             if (_mox) return;   // Pause during TX
+            bool hasSpectrumFloor = double.IsFinite(spectrumFloorDbm) && spectrumFloorDbm > -250.0;
             bool hasSignalMeter = double.IsFinite(signalDbm) && signalDbm > -250.0;
             bool hasAgcGain = double.IsFinite(agcGainDb) && agcGainDb > -199.5;
             bool hasAdcPeak = double.IsFinite(adcPkDbfs) && adcPkDbfs > -199.5;
             bool adcUnderPressure = hasAdcPeak && adcPkDbfs > AgcAdcPressureThresholdDbfs;
-            if (!hasSignalMeter && !hasAgcGain) return;
+            if (!hasSpectrumFloor && !hasSignalMeter && !hasAgcGain) return;
 
             // If we paused for longer than the analysis window (TX,
             // just-toggled-on, RX dropout) the
             // window may hold stale samples — clear before re-accumulating.
             if (_lastAgcTickMs != long.MinValue && nowMs - _lastAgcTickMs > AgcNoiseFloorWindowSamples * 500)
             {
-                _noiseFloorWindowFill = 0;
-                _noiseFloorWindowIdx = 0;
+                ResetAutoAgcNoiseFloorWindow();
             }
 
             // Fast-attack: a band-scale VFO move makes the old band's samples
@@ -1849,8 +1893,7 @@ public sealed class RadioService : IDisposable
             if (_lastAutoAgcVfoHz != long.MinValue &&
                 Math.Abs(_state.VfoHz - _lastAutoAgcVfoHz) > AgcFastAttackVfoDeltaHz)
             {
-                _noiseFloorWindowFill = 0;
-                _noiseFloorWindowIdx = 0;
+                ResetAutoAgcNoiseFloorWindow();
             }
             _lastAutoAgcVfoHz = _state.VfoHz;
 
@@ -1858,9 +1901,30 @@ public sealed class RadioService : IDisposable
                 return;
             _lastAgcTickMs = nowMs;
 
-            if (hasSignalMeter)
+            // Choose the floor source for this tick. A real spectrum floor (#806)
+            // always wins. A BRIEF spectrum dropout (< AgcSpectrumStaleMs) is
+            // treated as transient — hold the window rather than inject the
+            // S-meter proxy, which sits on a different scale and moves with the
+            // signal. Only a SUSTAINED outage (stale frame / <64 valid bins for
+            // longer than that, e.g. an engine that genuinely never produces a
+            // spectrum) falls back to signalDbm, so the loop keeps tracking
+            // instead of freezing. The two sources are never mixed in one
+            // percentile window: switching source re-seeds the window.
+            if (hasSpectrumFloor) _lastSpectrumFloorMs = nowMs;
+            bool spectrumRecent = _lastSpectrumFloorMs != long.MinValue &&
+                                  nowMs - _lastSpectrumFloorMs < AgcSpectrumStaleMs;
+            int floorSource;        // 0 hold, 1 spectrum, 2 S-meter fallback
+            double floorSample;
+            if (hasSpectrumFloor) { floorSource = 1; floorSample = spectrumFloorDbm; }
+            else if (spectrumRecent) { floorSource = 0; floorSample = 0.0; }   // transient: hold
+            else if (hasSignalMeter) { floorSource = 2; floorSample = signalDbm; }
+            else { floorSource = 0; floorSample = 0.0; }
+            if (floorSource != 0)
             {
-                _noiseFloorWindow[_noiseFloorWindowIdx] = signalDbm;
+                if (_autoAgcWindowSource != 0 && _autoAgcWindowSource != floorSource)
+                    ResetAutoAgcNoiseFloorWindow();
+                _autoAgcWindowSource = floorSource;
+                _noiseFloorWindow[_noiseFloorWindowIdx] = floorSample;
                 _noiseFloorWindowIdx = (_noiseFloorWindowIdx + 1) % _noiseFloorWindow.Length;
                 if (_noiseFloorWindowFill < _noiseFloorWindow.Length) _noiseFloorWindowFill++;
             }
@@ -1892,14 +1956,28 @@ public sealed class RadioService : IDisposable
                 const double TargetAudioDb = -40.0;     // desired audio-output noise level
                 double targetEffective = Math.Clamp(
                     TargetAudioDb - noiseFloor, AgcMinEffectiveAgcT, AgcMaxEffectiveAgcT);
-                // Preserve weak/quiet-band behavior: noise-floor tracking can
-                // add live gain, but it does not lower the user's baseline.
-                // Normal WDSP AGC reduction is the loudness normalizer; only
-                // ADC pressure below is allowed to pull AGC-T down.
-                desiredOffset = Math.Max(0.0, targetEffective - _state.AgcTopDb);
+                // SYMMETRIC noise-floor tracking (Thetis parity, #806). Effective
+                // AGC-T follows the floor in BOTH directions: a quiet band raises
+                // gain, a noisy band lowers it. The old Math.Max(0, …) clamp let
+                // the loop only ADD gain above the slider baseline, so with the
+                // default 80 dB baseline the offset stayed pinned at 0 on any
+                // normal band (floor > −120 dBm) — the operator "barely heard a
+                // change". The [20,100] clamp on targetEffective above is the
+                // safety rail (Thetis's threshold clamp equivalent); ADC-pressure
+                // protection below can still pull further. Manual AGC-T is
+                // untouched: SetAgcTop zeroes the offset and disables auto, so
+                // this line never runs in manual mode.
+                desiredOffset = targetEffective - _state.AgcTopDb;
             }
             else if (_agcOffsetDb < 0.0 && (!hasAgcGain || agcGainDb >= AgcCutStressThresholdDb || !adcUnderPressure))
             {
+                // Warm-up release: the window isn't ready yet (just re-seeded / too
+                // few samples) but a leftover negative offset from an earlier
+                // ADC-pressure cut is still applied. If the stress has cleared,
+                // release it to 0 until the noise-floor path can take over once the
+                // window fills. (With symmetric tracking, a steady-state negative
+                // offset is normal and is owned by the windowReady branch above —
+                // this branch only governs the not-ready transient.)
                 desiredOffset = 0.0;
             }
 
@@ -2335,8 +2413,7 @@ public sealed class RadioService : IDisposable
         {
             _agcOffsetDb = 0.0;
             _lastAgcTickMs = long.MinValue;
-            _noiseFloorWindowFill = 0;
-            _noiseFloorWindowIdx = 0;
+            ResetAutoAgcNoiseFloorWindow();
             return s with { AgcTopDb = clamped, AgcOffsetDb = 0.0, AutoAgcEnabled = false };
         });
         // Persist only the user-baseline (AgcTopDb); the offset is live-recomputed.

--- a/tests/Zeus.Server.Tests/DspPipelineAutoAgcFloorTests.cs
+++ b/tests/Zeus.Server.Tests/DspPipelineAutoAgcFloorTests.cs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Unit coverage for the Auto-AGC noise-floor percentile (#806). Exercises the
+/// pure <see cref="DspPipelineService.TryNoiseFloorFromDisplayBins"/> directly —
+/// the integration path injects a panadapter snapshot, so this is where the
+/// sentinel filtering, the min-valid-bins gate, and the percentile math are
+/// pinned down.
+/// </summary>
+public sealed class DspPipelineAutoAgcFloorTests
+{
+    [Fact]
+    public void NoiseFloor_RejectsWhenTooFewValidBins()
+    {
+        // All-invalid span (the -200 sentinel from SanitizeDisplayBuffer) → no
+        // trustworthy floor.
+        var bins = new float[2048];
+        Array.Fill(bins, -200f);
+
+        bool ok = DspPipelineService.TryNoiseFloorFromDisplayBins(
+            bins, percentile: 0.20, minValidBins: 64, out double floor);
+
+        Assert.False(ok);
+        Assert.True(double.IsNaN(floor));
+    }
+
+    [Fact]
+    public void NoiseFloor_FiltersSentinelBins_AndReturnsValidPercentile()
+    {
+        // 100 real bins at -110 dB surrounded by -200 sentinels: the floor must
+        // ignore the sentinels and land on the real noise.
+        var bins = new float[2048];
+        Array.Fill(bins, -200f);
+        for (int i = 0; i < 100; i++) bins[i * 5] = -110f;
+
+        bool ok = DspPipelineService.TryNoiseFloorFromDisplayBins(
+            bins, percentile: 0.20, minValidBins: 64, out double floor);
+
+        Assert.True(ok);
+        Assert.Equal(-110.0, floor);
+    }
+
+    [Fact]
+    public void NoiseFloor_LowPercentile_PicksNoiseNotSignals()
+    {
+        // 100 bins ramped -120..-21 dB (signals are the high bins). The 20th
+        // percentile must sit down in the noise: sorted idx = round(99*0.2)=20 →
+        // value -120+20 = -100.
+        var bins = new float[100];
+        for (int i = 0; i < bins.Length; i++) bins[i] = -120f + i;
+
+        bool ok = DspPipelineService.TryNoiseFloorFromDisplayBins(
+            bins, percentile: 0.20, minValidBins: 64, out double floor);
+
+        Assert.True(ok);
+        Assert.Equal(-100.0, floor);
+    }
+
+    [Fact]
+    public void NoiseFloor_MinValidBins_IsInclusiveBoundary()
+    {
+        var exactly = new float[2048];
+        Array.Fill(exactly, -200f);
+        for (int i = 0; i < 64; i++) exactly[i] = -105f;
+        Assert.True(DspPipelineService.TryNoiseFloorFromDisplayBins(
+            exactly, 0.20, 64, out _));
+
+        var oneShort = new float[2048];
+        Array.Fill(oneShort, -200f);
+        for (int i = 0; i < 63; i++) oneShort[i] = -105f;
+        Assert.False(DspPipelineService.TryNoiseFloorFromDisplayBins(
+            oneShort, 0.20, 64, out _));
+    }
+}

--- a/tests/Zeus.Server.Tests/RadioServiceAutoAgcTests.cs
+++ b/tests/Zeus.Server.Tests/RadioServiceAutoAgcTests.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Protocol1;
 using Zeus.Server;
 
 namespace Zeus.Server.Tests;
@@ -42,18 +43,26 @@ public sealed class RadioServiceAutoAgcTests : IDisposable
     }
 
     [Fact]
-    public void AutoAgc_NoBoostWhenBaselineAlreadyAboveTarget()
+    public void AutoAgc_LowersEffectiveBelowBaseline_OnNoisyBand()
     {
-        // Default baseline AgcTopDb is 80; a -105 dBm floor wants effective ~65,
-        // which is BELOW the baseline, so the noise-floor path never boosts
-        // (offset stays 0 — Auto-AGC only adds gain, never lowers the baseline).
+        // Symmetric tracking (#806): default baseline AgcTopDb is 80; a noisy
+        // -80 dBm floor wants effective = clamp(-40-(-80)=40, 20, 100) = 40, so
+        // the offset goes NEGATIVE (40-80 = -40) — the loop lowers gain below the
+        // slider baseline on a noisy band. This is the behavior the old
+        // Math.Max(0, …) clamp suppressed (making auto-AGC inaudible at the 80 dB
+        // default); the spectrum-floor source is exercised here explicitly.
         using var radio = NewRadio();
         radio.SetAutoAgc(true);
 
-        for (int i = 0; i < 11; i++)
-            radio.HandleRxMeterForAutoAgc(-105.0, i * 500);
+        for (int i = 0; i < 6; i++)
+            radio.HandleRxMetersForAutoAgc(
+                signalDbm: -50.0, spectrumFloorDbm: -80.0,
+                adcPkDbfs: double.NaN, agcGainDb: double.NaN, nowMs: i * 500);
 
-        Assert.Equal(0.0, radio.Snapshot().AgcOffsetDb);
+        var snap = radio.Snapshot();
+        Assert.Equal(80.0, snap.AgcTopDb);
+        Assert.Equal(-40.0, snap.AgcOffsetDb);
+        Assert.Equal(40.0, snap.AgcTopDb + snap.AgcOffsetDb); // effective AGC-T
     }
 
     [Fact]
@@ -106,24 +115,80 @@ public sealed class RadioServiceAutoAgcTests : IDisposable
         for (int i = 4; i < 8; i++)
             radio.HandleRxMeterForAutoAgc(-70.0, i * 500); // noisier band
 
-        // New floor -70 -> effective clamp(-40-(-70),20,100)=30 -> offset 30-45<0
-        // -> 0. It re-seeded to the new band and dropped the boost, fast.
-        Assert.Equal(0.0, radio.Snapshot().AgcOffsetDb);
+        // New floor -70 -> effective clamp(-40-(-70),20,100)=30 -> offset 30-45 =
+        // -15. Symmetric tracking (#806): it re-seeded to the new band and now
+        // LOWERS gain below baseline on the noisier band (the old clamp pinned
+        // this at 0). The re-seed is what makes the jump fast and complete.
+        Assert.Equal(-15.0, radio.Snapshot().AgcOffsetDb);
     }
 
     [Fact]
-    public void AutoAgc_DoesNotPullEffectiveGainBelowUserBaseline()
+    public void AutoAgc_TracksSpectrumFloor_WhenProvided_IgnoringContaminatedSignalDbm()
     {
+        // The spectrum floor MUST win over signalDbm (#806). Feed a quiet real
+        // floor (-105) alongside a loud, contaminated signalDbm (-50, the kind of
+        // post-AGC RMS value that fooled the old loop). The result must reflect
+        // the spectrum floor: target = clamp(-40-(-105)=65, 20, 100) = 65 ⇒
+        // offset = 65-60 = +5. If signalDbm had been used, target would clamp to
+        // 20 ⇒ offset -40 — so +5 proves the spectrum source is authoritative.
         using var radio = NewRadio();
-        radio.SetAgcTop(80.0);
+        radio.SetAgcTop(60.0);
         radio.SetAutoAgc(true);
 
-        for (int i = 0; i < 12; i++)
-            radio.HandleRxMeterForAutoAgc(-90.0, i * 500);
+        for (int i = 0; i < 4; i++)
+            radio.HandleRxMetersForAutoAgc(
+                signalDbm: -50.0, spectrumFloorDbm: -105.0,
+                adcPkDbfs: double.NaN, agcGainDb: double.NaN, nowMs: i * 500);
 
-        var snap = radio.Snapshot();
-        Assert.Equal(80.0, snap.AgcTopDb);
-        Assert.Equal(0.0, snap.AgcOffsetDb);
+        Assert.Equal(5.0, radio.Snapshot().AgcOffsetDb);
+    }
+
+    [Fact]
+    public void AutoAgc_FallsBackToSignalDbm_WhenSpectrumFloorIsNaN()
+    {
+        // No spectrum available (synthetic engine / stale frame): the loop falls
+        // back to signalDbm and behaves exactly as the S-meter-only path. baseline
+        // 45, floor -100 ⇒ target clamp(-40-(-100)=60,20,100)=60 ⇒ offset +15.
+        using var radio = NewRadio();
+        radio.SetAgcTop(45.0);
+        radio.SetAutoAgc(true);
+
+        for (int i = 0; i < 4; i++)
+            radio.HandleRxMetersForAutoAgc(
+                signalDbm: -100.0, spectrumFloorDbm: double.NaN,
+                adcPkDbfs: double.NaN, agcGainDb: double.NaN, nowMs: i * 500);
+
+        Assert.Equal(15.0, radio.Snapshot().AgcOffsetDb);
+    }
+
+    [Fact]
+    public void AutoAgc_ReengagesSignalFallback_AfterSustainedSpectrumOutage()
+    {
+        // Regression for the latch-freeze bug: once seeded from the spectrum, a
+        // SUSTAINED spectrum outage (NaN) under steady RX must NOT freeze the
+        // loop. It holds briefly (transient), then re-engages the S-meter
+        // fallback and resumes tracking.
+        using var radio = NewRadio();
+        radio.SetAgcTop(45.0);
+        radio.SetAutoAgc(true);
+
+        // Converge on the spectrum floor: -100 ⇒ target clamp(60) ⇒ offset +15.
+        for (int i = 0; i < 4; i++)
+            radio.HandleRxMetersForAutoAgc(
+                signalDbm: -50.0, spectrumFloorDbm: -100.0,
+                adcPkDbfs: double.NaN, agcGainDb: double.NaN, nowMs: i * 500);
+        Assert.Equal(15.0, radio.Snapshot().AgcOffsetDb);
+
+        // Spectrum goes dark for several seconds while a noisier S-meter floor
+        // (-70) keeps arriving. After the transient hold (< 1.5 s) the fallback
+        // re-engages, re-seeds, and converges: target clamp(-40-(-70)=30) ⇒
+        // offset 30-45 = -15. Before the fix the offset stayed frozen at +15.
+        for (int i = 4; i < 16; i++)
+            radio.HandleRxMetersForAutoAgc(
+                signalDbm: -70.0, spectrumFloorDbm: double.NaN,
+                adcPkDbfs: double.NaN, agcGainDb: double.NaN, nowMs: i * 500);
+
+        Assert.Equal(-15.0, radio.Snapshot().AgcOffsetDb);
     }
 
     [Fact]
@@ -146,12 +211,17 @@ public sealed class RadioServiceAutoAgcTests : IDisposable
     [Fact]
     public void AutoAgc_DoesNotLowerEffectiveGainWhenWdspAgcCutsWithCleanAdcHeadroom()
     {
+        // The protective ADC cut must require ADC pressure: WDSP AGC cutting
+        // (agcGain -24.5) with clean ADC headroom (-60 dBfs) must NOT pull gain
+        // down. The floor is chosen neutral so the noise-floor path itself wants
+        // offset 0 (baseline 52, floor -92 ⇒ target clamp(-40-(-92)=52,20,100)=52
+        // ⇒ 52-52 = 0), isolating the protective path: it stays disengaged.
         using var radio = NewRadio();
         radio.SetAgcTop(52.0);
         radio.SetAutoAgc(true);
 
         for (int i = 0; i < 20; i++)
-            radio.HandleRxMetersForAutoAgc(signalDbm: -75.0, adcPkDbfs: -60.0, agcGainDb: -24.5, nowMs: i * 500);
+            radio.HandleRxMetersForAutoAgc(signalDbm: -92.0, adcPkDbfs: -60.0, agcGainDb: -24.5, nowMs: i * 500);
 
         var snap = radio.Snapshot();
         Assert.Equal(52.0, snap.AgcTopDb);
@@ -165,18 +235,21 @@ public sealed class RadioServiceAutoAgcTests : IDisposable
         radio.SetAgcTop(60.0);
         radio.SetAutoAgc(true);
 
-        // Sustained overload drives the protective cut negative (jumps fast).
+        // Sustained overload drives the protective cut negative (jumps fast). The
+        // floor source here is a quiet -105 dBm so the noise-floor path itself
+        // wants a positive offset; only the ADC-pressure protection forces it
+        // negative.
         for (int i = 0; i < 4; i++)
-            radio.HandleRxMetersForAutoAgc(signalDbm: -72.0, adcPkDbfs: -5.0, agcGainDb: -28.0, nowMs: i * 500);
+            radio.HandleRxMetersForAutoAgc(signalDbm: -105.0, adcPkDbfs: -5.0, agcGainDb: -28.0, nowMs: i * 500);
 
         Assert.True(radio.Snapshot().AgcOffsetDb < 0.0, "overload should pull the offset negative");
 
         // ADC pressure clears and WDSP is no longer cutting: the offset recovers
-        // (jumps) back to the noise-floor target — here 0 (baseline already high
-        // enough for the -92 dBm floor).
-        radio.HandleRxMetersForAutoAgc(signalDbm: -92.0, adcPkDbfs: -18.0, agcGainDb: 0.0, nowMs: 2_000);
+        // (jumps) back to the noise-floor target — baseline 60, floor -105 ⇒
+        // target clamp(-40-(-105)=65,20,100)=65 ⇒ offset +5.
+        radio.HandleRxMetersForAutoAgc(signalDbm: -105.0, adcPkDbfs: -18.0, agcGainDb: 0.0, nowMs: 2_000);
 
-        Assert.Equal(0.0, radio.Snapshot().AgcOffsetDb);
+        Assert.Equal(5.0, radio.Snapshot().AgcOffsetDb);
     }
 
     // ── issue #733: AGC-T slider must be authoritative ────────────────────────
@@ -203,6 +276,65 @@ public sealed class RadioServiceAutoAgcTests : IDisposable
         Assert.Equal(0.0, snap.AgcOffsetDb);
         Assert.False(snap.AutoAgcEnabled);
         Assert.Equal(55.0, snap.AgcTopDb + snap.AgcOffsetDb);
+
+        // HARD SAFETY GATE (#806): once manual control is taken, NO subsequent
+        // metering — spectrum floor or signalDbm, quiet or noisy, ADC pressure or
+        // not — may move the effective AGC-T off the slider. Hammer the loop with
+        // wildly varying inputs and assert the slider stays authoritative.
+        for (int i = 0; i < 20; i++)
+            radio.HandleRxMetersForAutoAgc(
+                signalDbm: -50.0 - i,
+                spectrumFloorDbm: -140.0 + (i * 4),
+                adcPkDbfs: -3.0,
+                agcGainDb: -30.0,
+                nowMs: i * 500);
+
+        var after = radio.Snapshot();
+        Assert.Equal(55.0, after.AgcTopDb);
+        Assert.Equal(0.0, after.AgcOffsetDb);
+        Assert.False(after.AutoAgcEnabled);
+        Assert.Equal(55.0, after.AgcTopDb + after.AgcOffsetDb);
+    }
+
+    [Fact]
+    public void AutoAgc_ReSeedsOnAttenuatorChange()
+    {
+        // An operator attenuator step shifts the noise floor; the floor window
+        // must re-seed (Thetis fast-attack) instead of averaging the pre-step
+        // band in. Converge on a quiet floor, step the attenuator, then feed a
+        // noisier floor: with the re-seed the offset jumps to the new band's
+        // target (-15); WITHOUT it the stale quiet samples would still dominate
+        // the percentile and hold the offset positive (+15).
+        using var radio = NewRadio();
+        radio.SetAgcTop(45.0);
+        radio.SetAutoAgc(true);
+        for (int i = 0; i < 4; i++)
+            radio.HandleRxMeterForAutoAgc(-100.0, i * 500);
+        Assert.Equal(15.0, radio.Snapshot().AgcOffsetDb);
+
+        radio.SetAttenuator(new HpsdrAtten(20)); // operator step => re-seed
+        for (int i = 4; i < 8; i++)
+            radio.HandleRxMeterForAutoAgc(-70.0, i * 500);
+
+        Assert.Equal(-15.0, radio.Snapshot().AgcOffsetDb);
+    }
+
+    [Fact]
+    public void AutoAgc_ReSeedsOnPreampChange()
+    {
+        // Same fast-attack contract for a preamp/LNA toggle.
+        using var radio = NewRadio();
+        radio.SetAgcTop(45.0);
+        radio.SetAutoAgc(true);
+        for (int i = 0; i < 4; i++)
+            radio.HandleRxMeterForAutoAgc(-100.0, i * 500);
+        Assert.Equal(15.0, radio.Snapshot().AgcOffsetDb);
+
+        radio.SetPreamp(true); // toggle => re-seed
+        for (int i = 4; i < 8; i++)
+            radio.HandleRxMeterForAutoAgc(-70.0, i * 500);
+
+        Assert.Equal(-15.0, radio.Snapshot().AgcOffsetDb);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Makes Auto AGC-T track the band noise floor as quickly and accurately as Thetis. Closes the "barely audible" gap reported in #806 **without changing the manual AGC-T behavior** (which is already excellent).

This is a **draft** — the relative tracking is verified analytically and by unit tests, but the *absolute* landing point (`TargetAudioDb`) wants a bench A/B on a real G2/HL2 before merge (see "Needs bench" below). KB2UKA cannot bench-test auto AGC-T right now, so it is intentionally left as a draft for sign-off.

## Root cause (from a deep-dive against Thetis source)

1. **Wrong floor source (dominant).** The auto loop seeded its noise-floor window from `signalDbm`, which in this integration is the post-AGC **audio-RMS fallback** (`GetRxaSignalDbm` returns the `-400` sentinel → `20·log10(rms) − 50`). That value moves *with the signal and with AGC action* — it is not a band noise floor. Thetis instead measures from the panadapter FFT spectrum (a pre-AGC, per-bin power array).
2. **Non-negative offset clamp.** `desiredOffset = Math.Max(0, targetEffective − AgcTopDb)` let the loop only *add* gain above the slider baseline. With the default `AgcTopDb = 80`, any floor above ≈ −120 dBm produced a target below 80 → offset pinned at **0**, so on a normal band the loop did nothing. Thetis tracks the floor symmetrically.
3. **No fast-attack on attenuator / preamp changes** (only on a VFO band jump), so an ATT/preamp step left a stale floor for up to ~3 s.

## What changed

- **Real spectrum floor:** new `DspPipelineService.TryComputeAutoAgcNoiseFloorDbm` reads the cached panadapter snapshot (the proven `TryCapturePanadapterSnapshot` path used by frequency calibration), drops invalid `-200` bins, and takes the 20th-percentile of the valid bins as the band noise floor in dBm. Fed to a new `HandleRxMetersForAutoAgc` overload. Computed only when Auto-AGC is engaged.
- **Symmetric tracking:** removed the `Math.Max(0, …)` clamp so effective AGC-T follows the floor both ways (quiet band → more gain, noisy band → less). The `[20, 100]` clamp on `targetEffective` remains as the safety rail (Thetis's threshold-clamp equivalent); the ADC-pressure protective cut is unchanged.
- **Calibration:** the display-pixel floor gets the board `rxCalOffsetDb` applied so it lands on the same calibrated dBm scale the loop's constants are tuned to (RX pixels carry no offset of their own).
- **Robust source handling:** when no fresh spectrum is available the loop falls back to `signalDbm`. A *brief* spectrum dropout is treated as transient (the window holds); only a **sustained** outage re-engages the S-meter fallback, and the two differently-scaled sources are never mixed in one percentile window. This avoids both proxy contamination and the freeze-when-spectrum-stalls failure mode.
- **Fast-attack** window re-seed now also fires on operator attenuator and preamp/LNA changes (the gradual auto-ATT ramp does *not* re-seed, so the floor follows it smoothly).

## Review

An adversarial review pass confirmed the manual-AGC-safety property, thread-safety of the scratch buffer, and the clock math are clean, and surfaced two real issues that are fixed here: a latch that could freeze tracking during a sustained spectrum outage (now time-based with fallback re-engage), and the uncalibrated display-floor scale (now offset-corrected). A suggested final `[20,100]` clamp at the WDSP push site was **deliberately not applied** — that path also carries manual AGC-T, whose range is `[-20,120]`; clamping it would break manual. In auto mode the pushed value already equals `targetEffective ∈ [20,100]` by construction.

## Manual AGC-T is untouched

`SetAgcTop` still zeroes the offset, disables Auto-AGC, and clears the window under `_sync`, so effective AGC-T = slider exactly. The change only ever touches the `AutoAgcEnabled` branch. A hardened lock-test hammers the loop with 20 wildly-varying spectrum/signal/ADC inputs after the slider is grabbed and asserts the slider stays authoritative every time.

## Tests

Full server suite **1431 passed / 0 failed**. New/changed:
- `AutoAgc_TracksSpectrumFloor_WhenProvided_IgnoringContaminatedSignalDbm` — spectrum source wins over a loud `signalDbm`.
- `AutoAgc_FallsBackToSignalDbm_WhenSpectrumFloorIsNaN` — fallback regression guard.
- `AutoAgc_ReengagesSignalFallback_AfterSustainedSpectrumOutage` — the freeze-bug regression test.
- `AutoAgc_LowersEffectiveBelowBaseline_OnNoisyBand` — proves the clamp removal.
- `AutoAgc_ReSeedsOnAttenuatorChange` / `AutoAgc_ReSeedsOnPreampChange` — fast-attack.
- `SetAgcTop_TakesManualControl_…` — extended into the hard manual-safety gate (20 varied inputs after grabbing the slider).
- `DspPipelineAutoAgcFloorTests` — pure percentile / sentinel-filtering / min-bins coverage for the floor estimator.
- ADC-pressure protective-cut tests reworked to isolate that path; all still green.

## Deliberate behavior change (needs sign-off)

Removing the clamp means Auto-AGC can now **reduce** effective max-gain below the slider on a noisy band — an operator will feel this on first connect with Auto-AGC on. This is the correct Thetis match and exactly what makes the feature audible, but per the repo's red-light rules it is a default an operator notices and wants Brian's / Doug's OK.

## Needs bench (why this is a draft)

- The board `rxCalOffsetDb` is now applied to the floor, but any residual WDSP **display-scale-vs-S-meter-scale** delta (beyond the board offset) is not yet measured. Confirm on G2 + HL2 that the display floor and the S-meter dBm agree (log both at 1 Hz); if they differ, nudge `TargetAudioDb` by the delta.
- `TargetAudioDb = −40` and the `[20,100]` effective range were tuned loosely against the S-meter scale. Relative tracking is correct regardless; the absolute landing point is a one-line bench tune.
- Not pursued here: driving WDSP's `SetRXAAGCThresh` directly (Thetis's true architecture). That changes *which* register moves and can't be unit-verified or bench-tested now, so it is deliberately out of scope.

## Cross-platform

Pure managed C# (float[] percentile, `TickCount64`); no native/path/endianness/culture concerns. Builds + tests pass on macOS; CI covers Windows/Linux.
