### PR TITLE
feat(prefs): add Export to the connect-screen database selector

### DIFF
--- a/Zeus.Server.Hosting/PrefsDbPath.cs
+++ b/Zeus.Server.Hosting/PrefsDbPath.cs
@@ -336,6 +336,26 @@ public static class PrefsDbPath
         return ProfilesDirName + "/" + safe + ".db";
     }
 
+    // Read a profile's raw bytes for export/download. Opens with
+    // FileShare.ReadWrite so the active (currently open) database can still be
+    // exported. Throws if the path escapes the data dir or the file is missing.
+    public static byte[] ReadProfileBytes(string relativePath, out string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(relativePath))
+            throw new ArgumentException("Relative path is required.", nameof(relativePath));
+
+        var full = ResolveUnderDataDir(relativePath)
+            ?? throw new ArgumentException("Path is outside the Zeus data directory.", nameof(relativePath));
+        if (!File.Exists(full))
+            throw new FileNotFoundException("Database does not exist.", full);
+
+        fileName = Path.GetFileName(full);
+        using var fs = new FileStream(full, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var ms = new MemoryStream();
+        fs.CopyTo(ms);
+        return ms.ToArray();
+    }
+
     private static PrefsDatabaseInfo DescribeDefault(string active)
     {
         var path = Path.Combine(DataDir, LegacyFileName);

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -2500,6 +2500,28 @@ public static class ZeusEndpoints
             }
         }).DisableAntiforgery();
 
+        // Download an existing profile's .db so the operator can back it up or
+        // move it to another machine. Opens the file shared so the active
+        // database can be exported while it's in use.
+        app.MapGet("/api/prefs/databases/export", (string? relativePath) =>
+        {
+            if (string.IsNullOrWhiteSpace(relativePath))
+                return Results.BadRequest(new { error = "relativePath required" });
+            try
+            {
+                var bytes = PrefsDbPath.ReadProfileBytes(relativePath, out var fileName);
+                return Results.File(bytes, "application/octet-stream", fileName);
+            }
+            catch (FileNotFoundException)
+            {
+                return Results.NotFound(new { error = "Database not found." });
+            }
+            catch (Exception ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+        });
+
         app.MapPost("/api/app/restart", (AppRestartService restart) =>
         {
             restart.RequestRestart();

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -4993,7 +4993,7 @@ export async function exportPrefsDatabase(
   // the relative path.
   const cd = res.headers.get('content-disposition') ?? '';
   const match = /filename\*?=(?:UTF-8'')?"?([^";]+)"?/i.exec(cd);
-  const fileName = match
+  const fileName = match?.[1]
     ? decodeURIComponent(match[1])
     : relativePath.split('/').pop() || 'zeus-prefs.db';
 

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -4967,6 +4967,49 @@ export function uploadPrefsDatabase(
   );
 }
 
+/** Download an existing prefs database (.db) to the user's machine. Fetches the
+ *  bytes and saves them via a temporary object URL (rather than navigating to
+ *  the endpoint) so server-side errors surface as exceptions the caller can show
+ *  instead of opening a JSON error blob in a new tab. */
+export async function exportPrefsDatabase(
+  relativePath: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  const url = `/api/prefs/databases/export?relativePath=${encodeURIComponent(relativePath)}`;
+  const res = await fetch(url, { signal });
+  if (!res.ok) {
+    let message = `${res.status} ${res.statusText}`;
+    try {
+      const body = (await res.json()) as { error?: unknown };
+      if (typeof body?.error === 'string') message = body.error;
+    } catch {
+      /* non-JSON body — keep status text */
+    }
+    throw new ApiError(res.status, message);
+  }
+
+  const blob = await res.blob();
+  // Prefer the server's Content-Disposition filename; fall back to the leaf of
+  // the relative path.
+  const cd = res.headers.get('content-disposition') ?? '';
+  const match = /filename\*?=(?:UTF-8'')?"?([^";]+)"?/i.exec(cd);
+  const fileName = match
+    ? decodeURIComponent(match[1])
+    : relativePath.split('/').pop() || 'zeus-prefs.db';
+
+  const objectUrl = URL.createObjectURL(blob);
+  try {
+    const a = document.createElement('a');
+    a.href = objectUrl;
+    a.download = fileName;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}
+
 /** Ask the backend to relaunch itself (a fresh copy with the same args, after
  *  this process exits). Used after switching the active prefs database. */
 export function restartApp(

--- a/zeus-web/src/components/ConnectPanel.tsx
+++ b/zeus-web/src/components/ConnectPanel.tsx
@@ -55,6 +55,7 @@ import {
   setActivePrefsDatabase,
   createPrefsDatabase,
   uploadPrefsDatabase,
+  exportPrefsDatabase,
   restartApp,
   type PrefsDatabaseInfo,
   type RadioInfoDto,
@@ -182,6 +183,22 @@ function PrefsDatabaseRow() {
     }
   }, []);
 
+  // Export the active database so the operator can back it up or move it to
+  // another machine. The dropdown's value tracks the active profile, so this
+  // downloads whichever DB is currently selected.
+  const onExport = useCallback(async () => {
+    if (!activeRel) return;
+    setError(null);
+    setBusy(true);
+    try {
+      await exportPrefsDatabase(activeRel);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to export database');
+    } finally {
+      setBusy(false);
+    }
+  }, [activeRel]);
+
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Open the native OS file dialog; the upload runs in onFileChosen once the
@@ -261,6 +278,16 @@ function PrefsDatabaseRow() {
           title="Import an existing .db file"
         >
           Import
+        </button>
+        <button
+          type="button"
+          className="label-xs"
+          disabled={disabled || !activeRel}
+          onClick={() => void onExport()}
+          style={prefsDbButtonStyle}
+          title="Export the active database to a .db file"
+        >
+          Export
         </button>
         <input
           ref={fileInputRef}


### PR DESCRIPTION
## What

Adds an **Export** button to the connect/login screen's database selector, next to the existing picker, **＋ New**, and **Import** controls. It downloads the active prefs database as a `.db` file so an operator can back it up or move it to another machine — the natural counterpart to the existing Import.

## Changes

- **`PrefsDbPath.ReadProfileBytes`** — reads a profile's bytes with `FileShare.ReadWrite` so the currently-open *active* database can still be exported while in use. Reuses the existing `ResolveUnderDataDir` path-traversal guard, so it can't read outside the Zeus data dir.
- **`GET /api/prefs/databases/export?relativePath=`** — streams the file via `Results.File(...)` with a download filename, mirroring the import/upload endpoints' error handling (`400` on bad path, `404` when missing).
- **`exportPrefsDatabase()`** (client) — fetches the bytes and saves them via a temporary object URL rather than navigating to the endpoint, so a server error surfaces as a caught message in the panel's error row instead of opening a JSON blob in a new tab.
- **`ConnectPanel.tsx`** — Export button wired to export whichever DB the dropdown shows (always the active profile, since switching restarts).

## Scope note

Export acts on the **active** database — the only one the dropdown can show without triggering a switch+restart. Exporting an arbitrary non-active profile would be a larger UI change; happy to follow up if wanted.

## Verification

- `tsc --noEmit` clean.
- `dotnet build Zeus.Server.Hosting` clean (0 warnings, 0 errors).
- Behavior (browser file download) isn't observable in the headless preview; the compile checks are the evidence here.