### PR TITLE
fix(audio-suite): point VST-mode editor errors at "Download VST Engine"

### DIFF
--- a/Zeus.Server.Hosting/VstEditorHint.cs
+++ b/Zeus.Server.Hosting/VstEditorHint.cs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// VstEditorHint — picks the operator-facing message when a plugin editor is
+// opened while the out-of-process VST route is selected but the engine isn't
+// routing. Without this, the open falls through to the in-process bridge and
+// surfaces its "set ZEUS_ENABLE_VST_LOAD=1" hint, which is irrelevant to VST
+// mode and points a new operator at the wrong fix. The real fix in VST mode is
+// to install the engine ("Download VST Engine") or wait for it to come up.
+
+namespace Zeus.Server;
+
+internal static class VstEditorHint
+{
+    /// <summary>
+    /// The error to return when opening an editor in VST mode without a routing
+    /// engine, or <c>null</c> when the guard does not apply — i.e. the route is
+    /// Native (in-process editor path is correct) or the engine is already
+    /// active (the editor open should be attempted normally).
+    /// </summary>
+    public static string? EngineUnavailableMessage(
+        AudioProcessingMode mode, bool engineActive, bool engineInstalled)
+    {
+        if (mode != AudioProcessingMode.Vst || engineActive)
+            return null;
+        return engineInstalled
+            ? "The VST engine is installed but isn't routing yet. Give it a moment, then reopen the editor."
+            : "The VST engine isn't installed yet. Open the TX Audio Suite and click "
+              + "\"Download VST Engine\" to download and enable it, then reopen the editor.";
+    }
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -675,6 +675,21 @@ public static class ZeusEndpoints
             _                            => Results.StatusCode(500),
         };
 
+        // When the operator has selected the out-of-process VST route but the
+        // engine isn't routing, an editor open would otherwise fall through to
+        // the in-process bridge and surface the in-process "set
+        // ZEUS_ENABLE_VST_LOAD=1" hint — which is irrelevant to VST mode and
+        // sends a new operator down the wrong path. Point them at the actual
+        // fix instead: install the engine (the "Download VST Engine" affordance)
+        // or wait for it to come up. Returns null in every other case so Native
+        // mode keeps the existing in-process editor behaviour unchanged.
+        static IResult? VstEngineEditorGuard(AudioProcessingModeService mode)
+        {
+            var error = VstEditorHint.EngineUnavailableMessage(
+                mode.Mode, mode.EngineActive, AudioProcessingModeService.FindEngineExe() is not null);
+            return error is null ? null : Results.Json(new { error }, statusCode: 409);
+        }
+
         // Editor routing is mode-aware (host consolidation): when the
         // out-of-process engine is active (VST processing mode) the editor is
         // hosted crash-isolated in the engine process — the same instance that
@@ -693,11 +708,15 @@ public static class ZeusEndpoints
         app.MapPost("/api/audio-suite/plugins/{id}/editor",
             (string id, AudioPluginBridge bridge, AudioProcessingModeService mode, RxVstEngineService rxVst) =>
             {
-                var result = rxVst.HasEngineSlot(id)
-                    ? rxVst.OpenEditor(id)
-                    : mode.EngineActive && mode.HasEngineSlot(id)
-                        ? mode.OpenEditor(id)
-                        : bridge.OpenEditor(id);
+                // RX engine slots route to the RX engine regardless of the TX
+                // processing mode; only the TX path is gated on the VST engine.
+                if (rxVst.HasEngineSlot(id))
+                    return MapEditorResult(rxVst.OpenEditor(id), open: true);
+                if (VstEngineEditorGuard(mode) is { } guard)
+                    return guard;
+                var result = mode.EngineActive && mode.HasEngineSlot(id)
+                    ? mode.OpenEditor(id)
+                    : bridge.OpenEditor(id);
                 return MapEditorResult(result, open: true);
             });
 
@@ -723,6 +742,8 @@ public static class ZeusEndpoints
         app.MapPost("/api/tx-audio-suite/plugins/{id}/editor",
             (string id, AudioPluginBridge bridge, AudioProcessingModeService mode) =>
             {
+                if (VstEngineEditorGuard(mode) is { } guard)
+                    return guard;
                 var result = mode.EngineActive && mode.HasEngineSlot(id)
                     ? mode.OpenEditor(id)
                     : bridge.OpenEditor(id);

--- a/tests/Zeus.Server.Tests/VstEditorEngineHintTests.cs
+++ b/tests/Zeus.Server.Tests/VstEditorEngineHintTests.cs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// When the operator has selected the out-of-process VST route but no engine is
+// routing, opening a plugin editor must point them at the actual fix (install
+// the engine via "Download VST Engine") — NOT the in-process
+// "set ZEUS_ENABLE_VST_LOAD=1" hint, which is irrelevant to VST mode and sends
+// a new operator down the wrong path. Native mode keeps the in-process hint.
+
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class VstEditorEngineHintTests
+{
+    [Fact]
+    public void VstMode_EngineMissing_PointsAtDownloadNotEnvVar()
+    {
+        var msg = VstEditorHint.EngineUnavailableMessage(
+            AudioProcessingMode.Vst, engineActive: false, engineInstalled: false);
+
+        Assert.NotNull(msg);
+        Assert.Contains("Download VST Engine", msg);
+        Assert.DoesNotContain("ZEUS_ENABLE_VST_LOAD", msg);
+    }
+
+    [Fact]
+    public void VstMode_EngineInstalledButIdle_SaysWaitNotDownload()
+    {
+        var msg = VstEditorHint.EngineUnavailableMessage(
+            AudioProcessingMode.Vst, engineActive: false, engineInstalled: true);
+
+        Assert.NotNull(msg);
+        Assert.Contains("routing yet", msg);
+        Assert.DoesNotContain("Download VST Engine", msg);
+        Assert.DoesNotContain("ZEUS_ENABLE_VST_LOAD", msg);
+    }
+
+    [Fact]
+    public void VstMode_EngineActive_NoGuard()
+    {
+        // Engine is routing — the editor open should be attempted normally.
+        Assert.Null(VstEditorHint.EngineUnavailableMessage(
+            AudioProcessingMode.Vst, engineActive: true, engineInstalled: true));
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void NativeMode_NeverGuards(bool engineActive, bool engineInstalled)
+    {
+        // Native is the in-process editor path; the VST-engine guard must never
+        // hijack it regardless of engine presence.
+        Assert.Null(VstEditorHint.EngineUnavailableMessage(
+            AudioProcessingMode.Native, engineActive, engineInstalled));
+    }
+}


### PR DESCRIPTION
> **Stacked on #812** ([feat: in-app "Download VST Engine" provisioning](https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus/pull/812)). Until #812 merges, the diff below includes its commits — **review only the `fix(audio-suite): point VST-mode editor errors…` commit** (`Zeus.Server.Hosting/VstEditorHint.cs`, the editor-endpoint guard in `ZeusEndpoints.cs`, and its test). Merge after #812.

## Problem

Opening a plugin editor while the **VST** processing route is selected but the out-of-process engine isn't routing fell through to the in-process bridge and surfaced its **"set `ZEUS_ENABLE_VST_LOAD=1`"** hint. That env var gates the *legacy in-process loader*, not the out-of-process engine — so in VST mode it's irrelevant and points a new operator at the wrong fix. This is the exact message a fresh-PC operator hit when first enabling VST.

## Fix

A mode-aware guard on the TX editor-open endpoints (`POST /api/{tx-,}audio-suite/plugins/{id}/editor`): in **VST mode with no routing engine**, return `409` pointing at the real fix —

- engine **not installed** → *"…open the TX Audio Suite and click **Download VST Engine**…"* (the affordance added in #812)
- engine **installed but idle** → *"…installed but isn't routing yet. Give it a moment, then reopen…"*

**Native** mode keeps the in-process editor path and its `ZEUS_ENABLE_VST_LOAD` hint unchanged; **RX** engine slots are unaffected (they route to the RX engine regardless of TX mode).

## Tests

Message selection is a pure helper (`VstEditorHint.EngineUnavailableMessage`), unit-tested across every mode × installed × active combination (7 cases) — deterministic, no dependency on whether a real engine is present on the test machine.