### PR TITLE
fix(dsp): lossless bulk-feed opt-in — fixes macos-arm64 NR fixture CI failure

### DIFF
--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -293,6 +293,18 @@ public sealed class WdspDspEngine : IDspEngine
         return Math.Clamp(target, InQueueFloorFrames, InQueueCeilFrames);
     }
 
+    /// <summary>
+    /// Feed policy for <see cref="FeedIq"/> when a channel's hand-off queue is
+    /// full. Default (<c>false</c>) is non-blocking <b>drop-oldest</b>: the
+    /// realtime RX sink thread must never block, because a stall cascades into
+    /// kernel UDP drops. Set <c>true</c> only for <b>offline / faster-than-realtime
+    /// bulk feeders</b> (unit tests, file/fixture replay) that push IQ with no
+    /// network pacing and need <b>lossless</b> delivery — it restores the
+    /// self-pacing blocking back-pressure the realtime path deliberately avoids.
+    /// MUST stay <c>false</c> for any live radio.
+    /// </summary>
+    public bool BlockingIqFeed { get; init; }
+
     private readonly ConcurrentDictionary<int, ChannelState> _channels = new();
     private readonly object _nativeSlotLock = new();
     private readonly HashSet<int> _reservedNativeSlots = new();
@@ -676,19 +688,28 @@ public sealed class WdspDspEngine : IDspEngine
                     if (!state.InQueue.IsAddingCompleted)
                     {
                         state.DiagFramesIn++;
-                        // Non-blocking hand-off with drop-OLDEST. FeedIq runs on
-                        // the realtime P1/P2 RX sink thread; a blocking Add would
-                        // stall UDP intake whenever the worker falls behind, and a
-                        // stalled intake lets the kernel socket buffer overflow →
-                        // dropped packets → sequence gaps (the cascading failure
-                        // this guard prevents). Instead, when the queue is full we
-                        // evict the OLDEST queued frame and keep the newest, so
-                        // display/audio latency stays bounded and the glitch is a
-                        // single counted dropped frame rather than a stall. Pairs
-                        // with the rate-scaled capacity (ComputeInQueueCapacity).
                         try
                         {
-                            if (!state.InQueue.TryAdd(frame))
+                            if (BlockingIqFeed)
+                            {
+                                // Lossless back-pressure for offline / faster-than-
+                                // realtime bulk feeders (tests, fixture/file replay):
+                                // block until the worker makes room so no frame is
+                                // dropped. NEVER used on the realtime RX path — see
+                                // BlockingIqFeed.
+                                state.InQueue.Add(frame);
+                            }
+                            // Non-blocking hand-off with drop-OLDEST (default). FeedIq
+                            // runs on the realtime P1/P2 RX sink thread; a blocking Add
+                            // would stall UDP intake whenever the worker falls behind,
+                            // and a stalled intake lets the kernel socket buffer
+                            // overflow → dropped packets → sequence gaps (the cascading
+                            // failure this guard prevents). Instead, when the queue is
+                            // full we evict the OLDEST queued frame and keep the newest,
+                            // so display/audio latency stays bounded and the glitch is a
+                            // single counted dropped frame rather than a stall. Pairs
+                            // with the rate-scaled capacity (ComputeInQueueCapacity).
+                            else if (!state.InQueue.TryAdd(frame))
                             {
                                 state.DiagEnqueueFull++;
                                 if (state.InQueue.TryTake(out var stale))

--- a/tests/Zeus.Dsp.Tests/NoiseReductionSyntheticFixtureTests.cs
+++ b/tests/Zeus.Dsp.Tests/NoiseReductionSyntheticFixtureTests.cs
@@ -202,7 +202,11 @@ public class NoiseReductionSyntheticFixtureTests
         if (fixture.Path != DspBenchmarkPath.RxIq || fixture.IqInterleaved is null)
             throw new ArgumentException("WDSP fixture runner requires RX IQ fixtures.", nameof(fixture));
 
-        using var engine = new WdspDspEngine();
+        // Bulk fixture feed is faster than realtime, so use lossless blocking
+        // back-pressure — otherwise the default drop-oldest RX policy discards
+        // frames under a busy/slow runner (e.g. macos-arm64 CI), starving EMNR
+        // adaptation and collapsing its output level. Production RX never sets this.
+        using var engine = new WdspDspEngine { BlockingIqFeed = true };
         int channel = engine.OpenChannel(fixture.SampleRateHz, PixelWidth);
         try
         {


### PR DESCRIPTION
## Problem
The `Build and Test` workflow went red on **macos-arm64** after #808 merged:
`NoiseReductionSyntheticFixtureTests.Wdsp_CurrentWeakSignalFixtures_ProduceBoundedAudio` failed with
`weak-cw-carrier/Emnr RMS collapsed … ratio=0.00` (other 4 platforms passed).

## Root cause
#808 made the RX hand-off **non-blocking drop-oldest** — correct for the realtime sink thread (a stall cascades into kernel UDP drops). But the NR synthetic-fixture tests feed whole fixtures **faster than realtime** in a tight loop. On the slower macos-arm64 runner the WDSP worker fell behind, the bounded queue overflowed, and drop-oldest discarded frames. EMNR (heavier per-frame) was hit hardest: fed a choppy, truncated signal it adapted to silence → RMS collapse. Timing-dependent, hence single-platform.

## Fix
Add `WdspDspEngine.BlockingIqFeed` (default **false**). When **true**, `FeedIq` blocks (self-pacing back-pressure → lossless) instead of dropping the oldest frame — intended only for **offline / faster-than-realtime bulk feeders** (tests, fixture/file replay). The realtime RX path keeps the default drop-oldest, so production behavior is unchanged. The NR fixture runner opts in, so every fixture frame is processed deterministically on every platform.

## Testing
- `Zeus.Dsp.Tests` **172/172** (96 skipped) locally.
- Deterministic by construction: lossless feed = zero drops = EMNR can't be starved, independent of runner speed.

Restores `develop` to green.