### PR TITLE
ci: on-demand Windows dev installer workflow

### DIFF
--- a/.github/workflows/build-windows-dev.yml
+++ b/.github/workflows/build-windows-dev.yml
@@ -1,0 +1,147 @@
+name: Build Windows (dev)
+
+# On-demand Windows installer build for INTERNAL hand-off — NOT a release.
+#
+# Purpose: merge something to `develop`, run this, grab the setup.exe from the
+# run's Artifacts and send it to one person to test. It deliberately does NOT
+# create a GitHub Release, push a tag, or publish anywhere. Artifacts live only
+# on the run page and expire (retention below).
+#
+# Speed: unlike release.yml / nightly.yml this does NOT rebuild the native WDSP
+# / miniaudio / VST-bridge DLLs. It reuses the binaries committed under
+# Zeus.Dsp/runtimes/win-x64/native/ and Zeus.Plugins.Host/runtimes/win-x64/native/.
+# That makes it a single ~few-minute windows-latest job instead of the full
+# multi-OS native matrix. If you changed native C/C++ code and need it in the
+# exe, use the Release workflow (dry-run dispatch) instead — this one will ship
+# the last committed natives.
+#
+# Trigger: manual only (workflow_dispatch). Defaults to develop; override the
+# `ref` input to build any branch / tag / SHA.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch, tag, or SHA to build. Defaults to develop.'
+        required: false
+        default: 'develop'
+
+# Don't pile up concurrent dev builds of the same ref; cancel the older one.
+concurrency:
+  group: build-windows-dev-${{ github.event.inputs.ref || 'develop' }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Windows installer (win-x64)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout ${{ github.event.inputs.ref || 'develop' }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || 'develop' }}
+          # Need real history so the short SHA used in the version string is
+          # meaningful; submodules pulled selectively below.
+          fetch-depth: 0
+
+      # The frontend build (npm run build) imports the DeepCW ONNX model from
+      # this submodule (model.onnx?url); without it `npm run build` fails.
+      - name: Init DeepCW model submodule (frontend build dependency)
+        run: git submodule update --init zeus-web/external/deepcw-engine
+
+      - name: Determine dev version
+        id: version
+        shell: bash
+        run: |
+          SHORT_SHA="$(git rev-parse --short HEAD)"
+          # Clearly-non-release version: 0.0.0-dev.<shortsha>. Inno's AppVersion
+          # accepts arbitrary strings (no numeric VersionInfoVersion in the
+          # .iss), so this rides straight through to the installer filename.
+          VERSION="0.0.0-dev.${SHORT_SHA}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "Building dev installer version: ${VERSION}"
+
+      - name: Verify committed native DLLs are present
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "WDSP / miniaudio (Zeus.Dsp/runtimes/win-x64/native):"
+          ls -la Zeus.Dsp/runtimes/win-x64/native/
+          echo "VST bridge (Zeus.Plugins.Host/runtimes/win-x64/native):"
+          ls -la Zeus.Plugins.Host/runtimes/win-x64/native/
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: zeus-web/package-lock.json
+
+      - name: Build frontend
+        run: |
+          npm ci
+          npm run build
+        working-directory: zeus-web
+
+      - name: Publish OpenhpsdrZeus (win-x64, self-contained)
+        # Mirrors release.yml's publish step. Self-contained single binary that
+        # serves both launch modes (service + --desktop). Version suffix lands
+        # in InformationalVersion so the running app reports the dev SHA.
+        shell: bash
+        run: |
+          dotnet publish OpenhpsdrZeus/OpenhpsdrZeus.csproj \
+            -c Release \
+            -r win-x64 \
+            --self-contained true \
+            -p:PublishReadyToRun=true \
+            -p:VersionPrefix=0.0.0 \
+            -p:VersionSuffix=dev.${{ steps.version.outputs.short_sha }} \
+            -p:DebugType=embedded \
+            -p:DebugSymbols=false
+
+      - name: Verify Windows installer payload
+        shell: pwsh
+        run: ./tools/verify-windows-installer-payload.ps1 -PublishDir "OpenhpsdrZeus/bin/Release/net10.0/win-x64/publish" -Arch "x64"
+
+      # Bundled by zeus-windows.iss and run at install time behind a registry
+      # check, so a fresh Windows machine the recipient owns still works.
+      - name: Download Visual C++ Redistributable
+        shell: pwsh
+        run: |
+          $url = "https://aka.ms/vs/17/release/vc_redist.x64.exe"
+          $out = "installers\vc_redist.x64.exe"
+          Write-Host "Downloading $url -> $out"
+          Invoke-WebRequest -Uri $url -OutFile $out -UseBasicParsing
+          Get-Item $out | Select-Object Name, Length
+
+      - name: Download Edge WebView2 Runtime
+        shell: pwsh
+        run: |
+          $url = "https://go.microsoft.com/fwlink/p/?LinkId=2124703"
+          $out = "installers\MicrosoftEdgeWebview2Setup.exe"
+          Write-Host "Downloading $url -> $out"
+          Invoke-WebRequest -Uri $url -OutFile $out -UseBasicParsing
+          Get-Item $out | Select-Object Name, Length
+
+      - name: Build Windows Installer (Inno Setup)
+        shell: pwsh
+        run: |
+          choco install innosetup -y
+          $env:PATH += ";C:\Program Files (x86)\Inno Setup 6"
+          iscc /DMyAppVersion="${{ steps.version.outputs.version }}" /DArch="x64" installers\zeus-windows.iss
+
+      - name: Upload Windows Installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: zeus-windows-dev-${{ steps.version.outputs.version }}
+          path: installers/output/openhpsdr-zeus-${{ steps.version.outputs.version }}-win-x64-setup.exe
+          if-no-files-found: error
+          # Internal test builds — keep them short-lived. Bump if you need
+          # longer, but these are not meant to linger.
+          retention-days: 14


### PR DESCRIPTION
Adds `.github/workflows/build-windows-dev.yml` — a manual (`workflow_dispatch`) Windows installer build for **internal hand-off**, not a release.

## Why
Quickly produce a Windows `setup.exe` from `develop` (or any ref) to give one person for testing, without cutting a release.

## What it does
- **Manual trigger only.** Defaults to `develop`; `ref` input overrides to any branch/tag/SHA.
- Builds a single self-contained **win-x64 Inno Setup installer** (bundles VC++ redist + Edge WebView2, same as Release) and uploads it as a run artifact (14-day retention).
- **No GitHub Release, no tag, no publish** anywhere.
- **Fast:** reuses the committed native DLLs (`Zeus.Dsp/runtimes/win-x64/native`, VST bridge) instead of rebuilding the full native matrix → single ~few-minute `windows-latest` job.

## Why it targets `main`
`workflow_dispatch` triggers only register on the **default branch**, so the "Run workflow" button won't appear until this file is on `main`. Going direct to `main` (one-file CI-only change) makes it usable immediately instead of waiting for a `develop → main` merge.

> Caveat (noted in the file header): it ships the *last committed* native blobs, so a `develop` change to native C/C++ that hasn't been recommitted won't be in the exe — use the Release dry-run dispatch for that case.