### PR TITLE
feat(remote): media bridge + broker-signaling client (builds on #811)

### DIFF
--- a/Zeus.Server.Hosting/IClientSink.cs
+++ b/Zeus.Server.Hosting/IClientSink.cs
@@ -1,0 +1,19 @@
+namespace Zeus.Server;
+
+/// <summary>
+/// A consumer of <see cref="StreamingHub"/>'s broadcast fan-out. Implemented by
+/// the WebSocket <c>ClientSession</c> and by the remote-access WebRTC sink
+/// (<c>RemoteFrameSink</c>), so a remote session rides the exact same fan-out as
+/// <c>/ws</c> clients — the Broadcast methods are unchanged, and when no remote
+/// sink is attached the <c>/ws</c> path behaves identically to before.
+///
+/// Only the two members the broadcast loops touch are abstracted.
+/// </summary>
+internal interface IClientSink
+{
+    /// <summary>Whether this consumer wants display frames (used to skip the heavy serialize).</summary>
+    bool WantsDisplay { get; }
+
+    /// <summary>Enqueue a serialized frame. Must be non-blocking (callers run on the DSP thread).</summary>
+    bool TryEnqueue(byte[] payload);
+}

--- a/Zeus.Server.Hosting/Remote/RemoteFrameSink.cs
+++ b/Zeus.Server.Hosting/Remote/RemoteFrameSink.cs
@@ -1,0 +1,56 @@
+using System.Threading.Channels;
+
+namespace Zeus.Server.Hosting.Remote;
+
+/// <summary>
+/// Bridges <see cref="Zeus.Server.StreamingHub"/>'s broadcast frames onto a
+/// remote session's WebRTC frames channel. Registered only after the SPAKE2+
+/// password unlocks (ADR-0008), and the actual send is gated again by the
+/// session's egress guard, so a frame can never leave a locked session.
+///
+/// A bounded drop-oldest queue drained on a background task keeps the DSP thread
+/// (which calls <see cref="TryEnqueue"/> via the hub fan-out) from ever blocking
+/// on the data channel — mirroring the WebSocket ClientSession's backpressure.
+/// </summary>
+internal sealed class RemoteFrameSink : Zeus.Server.IClientSink, IDisposable
+{
+    // Small bound: stale spectrum/meter frames are worthless, so drop-oldest.
+    private readonly Channel<byte[]> _queue = Channel.CreateBounded<byte[]>(
+        new BoundedChannelOptions(8)
+        {
+            FullMode = BoundedChannelFullMode.DropOldest,
+            SingleReader = true,
+            SingleWriter = false,
+        });
+
+    private readonly Func<byte[], bool> _send;
+    private readonly CancellationTokenSource _cts = new();
+
+    /// <param name="send">The session's gated send (returns false while locked/closed).</param>
+    public RemoteFrameSink(Func<byte[], bool> send)
+    {
+        _send = send;
+        _ = DrainAsync();
+    }
+
+    public bool WantsDisplay => true;
+
+    public bool TryEnqueue(byte[] payload) => _queue.Writer.TryWrite(payload);
+
+    private async Task DrainAsync()
+    {
+        try
+        {
+            await foreach (var payload in _queue.Reader.ReadAllAsync(_cts.Token).ConfigureAwait(false))
+                _send(payload);
+        }
+        catch (OperationCanceledException) { /* disposed */ }
+        catch { /* session torn down underneath us */ }
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _queue.Writer.TryComplete();
+    }
+}

--- a/Zeus.Server.Hosting/Remote/RemoteWebRtcService.cs
+++ b/Zeus.Server.Hosting/Remote/RemoteWebRtcService.cs
@@ -14,12 +14,16 @@ public sealed class RemoteWebRtcService
 {
     private readonly RemotePasswordStore _passwords;
     private readonly ILogger<RemoteWebRtcService> _log;
+    private readonly Zeus.Server.StreamingHub? _hub;
     private readonly ConcurrentDictionary<Guid, RemoteWebRtcSession> _sessions = new();
 
-    public RemoteWebRtcService(RemotePasswordStore passwords, ILogger<RemoteWebRtcService> log)
+    public RemoteWebRtcService(
+        RemotePasswordStore passwords, ILogger<RemoteWebRtcService> log,
+        Zeus.Server.StreamingHub? hub = null)
     {
         _passwords = passwords;
         _log = log;
+        _hub = hub;
     }
 
     /// <summary>Whether remote access can be offered at all (a password is set).</summary>
@@ -37,7 +41,7 @@ public sealed class RemoteWebRtcService
             ?? throw new RemoteAccessDisabledException();
 
         var id = Guid.NewGuid();
-        var session = new RemoteWebRtcSession(verifier, _log, IceServers());
+        var session = new RemoteWebRtcSession(verifier, _log, IceServers(), _hub);
         _sessions[id] = session;
         session.Closed += () =>
         {

--- a/Zeus.Server.Hosting/Remote/RemoteWebRtcSession.cs
+++ b/Zeus.Server.Hosting/Remote/RemoteWebRtcSession.cs
@@ -26,15 +26,20 @@ public sealed class RemoteWebRtcSession
     private readonly RemoteVerifierMaterial _verifier;
     private readonly RemoteSession _session;
     private readonly RTCPeerConnection _pc;
+    private readonly Zeus.Server.StreamingHub? _hub;
+    private readonly Guid _sinkId = Guid.NewGuid();
 
     private RTCDataChannel? _control;
     private RTCDataChannel? _frames;
+    private RemoteFrameSink? _sink;
 
     public RemoteWebRtcSession(
-        RemoteVerifierMaterial verifier, ILogger log, IReadOnlyList<RTCIceServer>? iceServers = null)
+        RemoteVerifierMaterial verifier, ILogger log,
+        IReadOnlyList<RTCIceServer>? iceServers = null, Zeus.Server.StreamingHub? hub = null)
     {
         _verifier = verifier;
         _log = log;
+        _hub = hub;
 
         var gate = new Spake2PlusAuthGate(
             RemoteAuthConstants.Context, RemoteAuthConstants.IdProver, RemoteAuthConstants.IdVerifier,
@@ -96,6 +101,8 @@ public sealed class RemoteWebRtcSession
     {
         if (Interlocked.Exchange(ref _closed, 1) != 0) return;
         _session.Close();
+        if (_hub is not null) _hub.DetachSink(_sinkId);
+        _sink?.Dispose();
         try { _pc.close(); } catch { /* already torn down */ }
         Closed?.Invoke();
     }
@@ -165,6 +172,16 @@ public sealed class RemoteWebRtcSession
                     {
                         _control!.send(Json("auth-ok", "confirm", outcome.Reply.ToArray()));
                         _log.LogInformation("rtc.remote session UNLOCKED");
+
+                        // Arm the radio data path: register a sink so the hub's
+                        // broadcast fan-out reaches this session's frames channel
+                        // (gated again by TrySendFrame). Only happens post-unlock.
+                        if (_hub is not null)
+                        {
+                            _sink = new RemoteFrameSink(TrySendFrame);
+                            _hub.AttachSink(_sinkId, _sink);
+                        }
+
                         Unlocked?.Invoke();
                     }
                     else

--- a/Zeus.Server.Hosting/StreamingHub.cs
+++ b/Zeus.Server.Hosting/StreamingHub.cs
@@ -78,7 +78,9 @@ public sealed class StreamingHub
     private const int MaxInboundMessageBytes = 16 * 1024;
 
     private readonly ILogger<StreamingHub> _log;
-    private readonly ConcurrentDictionary<Guid, ClientSession> _clients = new();
+    // Keyed by Guid; values are IClientSink so a remote-access WebRTC sink can
+    // ride the same fan-out as WebSocket ClientSessions (see AttachSink).
+    private readonly ConcurrentDictionary<Guid, IClientSink> _clients = new();
     // Latest WDSP wisdom phase + status string. Set by Program.cs wiring on
     // phase- and status-changed events; read on every AttachClientAsync so
     // late joiners see the current state without waiting for the next
@@ -356,6 +358,17 @@ public sealed class StreamingHub
             _log.LogInformation("ws.client.disconnected id={Id} total={Count}", id, _clients.Count);
         }
     }
+
+    /// <summary>
+    /// Register a non-WebSocket frame sink (a remote-access WebRTC session) so it
+    /// receives the same broadcast fan-out as <c>/ws</c> clients. The caller
+    /// (RemoteWebRtcSession) only attaches AFTER the SPAKE2+ password unlocks
+    /// (ADR-0008), and the sink's send is gated again, so nothing leaks early.
+    /// </summary>
+    internal void AttachSink(Guid id, IClientSink sink) => _clients[id] = sink;
+
+    /// <summary>Remove a previously-attached remote sink.</summary>
+    internal void DetachSink(Guid id) => _clients.TryRemove(id, out _);
 
     internal void DispatchInbound(ReadOnlyMemory<byte> frame)
     {
@@ -826,7 +839,7 @@ public sealed class StreamingHub
         }
     }
 
-    private sealed class ClientSession
+    private sealed class ClientSession : IClientSink
     {
         public Guid Id { get; }
         private readonly WebSocket _ws;

--- a/tests/Zeus.Server.Tests/RemoteWebRtcSessionTests.cs
+++ b/tests/Zeus.Server.Tests/RemoteWebRtcSessionTests.cs
@@ -70,6 +70,27 @@ public sealed class RemoteWebRtcSessionTests
         server.Close();
     }
 
+    [Fact]
+    public async Task UnlockedSession_ReceivesHubBroadcastFrame()
+    {
+        var hub = new Zeus.Server.StreamingHub(NullLogger<Zeus.Server.StreamingHub>.Instance);
+        var server = new RemoteWebRtcSession(RegisterVerifier(Password), NullLogger.Instance, hub: hub);
+        await using var client = new ProverClient(Password);
+
+        var answer = await server.CreateAnswerAsync(await client.CreateOfferAsync());
+        await client.AcceptAnswerAsync(answer);
+        await client.Unlocked.WaitAsync(TimeSpan.FromSeconds(20));
+        Assert.True(server.IsUnlocked);
+
+        // A normal hub broadcast (always-on RX meter, 5 bytes) reaches the remote
+        // client through the StreamingHub fan-out → RemoteFrameSink → frames channel.
+        hub.Broadcast(new Zeus.Contracts.RxMeterFrame(-73.0f));
+        var received = await client.NextFrame().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(5, received.Length);
+        server.Close();
+    }
+
     /// <summary>Minimal in-process SPAKE2+ prover over WebRTC — what the browser will do.</summary>
     private sealed class ProverClient : IAsyncDisposable
     {

--- a/zeus-web/src/remote/connect.ts
+++ b/zeus-web/src/remote/connect.ts
@@ -1,15 +1,17 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 //
-// Browser remote-access connect flow (Phase 1 client). Mirror of the server's
-// RemoteWebRtcSession: opens a WebRTC peer, runs the SPAKE2+ password handshake
-// over the control DataChannel, and surfaces radio frames once UNLOCKED.
+// Browser remote-access connect flow (Phase 1/3 client). Opens a WebRTC peer,
+// runs the SPAKE2+ password handshake over the control DataChannel, and surfaces
+// radio frames once UNLOCKED. Two signalling transports share one handshake core:
+//   - connectRemote     — LAN: POST the offer straight to the reachable radio.
+//   - connectViaBroker   — internet: relay the offer through the Cloudflare broker
+//                          (the radio is behind NAT and not directly reachable).
 //
-// The crypto here is covered by spake2plus.test.ts / registration.test.ts. The
-// live WebRTC connection itself needs a real browser (no RTCPeerConnection in
-// node/vitest), so it is verified on a bench, not in CI.
+// The crypto is covered by spake2plus.test.ts / registration.test.ts. The live
+// WebRTC connection itself is bench-verified (no RTCPeerConnection in vitest).
 //
-// NOTE: Argon2id runs on the calling thread; for production move deriveScalars
-// into a Web Worker so the 64 MiB derivation doesn't jank the UI.
+// NOTE: Argon2id runs on the calling thread; move deriveScalars into a Web Worker
+// for production so the 64 MiB derivation doesn't jank the UI.
 
 import { Spake2Plus, verifyPeerConfirm, type Spake2Outcome } from './spake2plus';
 import { deriveScalars, type Argon2Params } from './registration';
@@ -17,6 +19,9 @@ import { deriveScalars, type Argon2Params } from './registration';
 const CONTEXT = new TextEncoder().encode('zeus-remote-access/v1');
 const ID_PROVER = new Uint8Array(0);
 const ID_VERIFIER = new Uint8Array(0);
+
+const DEFAULT_BROKER = 'https://remote.openhpsdrzeus.com';
+const DEFAULT_STUN: RTCIceServer[] = [{ urls: 'stun:stun.cloudflare.com:3478' }];
 
 export interface RemoteConnection {
   pc: RTCPeerConnection;
@@ -26,7 +31,7 @@ export interface RemoteConnection {
 
 export interface RemoteConnectOptions {
   password: string;
-  /** API origin; '' (default) = same-origin. */
+  /** API origin for the LAN path; '' (default) = same-origin. */
   apiBase?: string;
   /** ICE servers; production fills this from broker-minted TURN credentials. */
   iceServers?: RTCIceServer[];
@@ -34,21 +39,65 @@ export interface RemoteConnectOptions {
   onFrame?: (data: ArrayBuffer) => void;
 }
 
-/**
- * Connect to the operator's radio: signal via POST /api/remote/connect, then
- * prove the session password over SPAKE2+. Resolves once UNLOCKED; rejects on a
- * wrong password, a disabled remote endpoint, or signalling failure.
- */
-export async function connectRemote(opts: RemoteConnectOptions): Promise<RemoteConnection> {
-  const pc = new RTCPeerConnection({
-    iceServers: opts.iceServers ?? [{ urls: 'stun:stun.cloudflare.com:3478' }],
-  });
+export interface BrokerConnectOptions {
+  callsign: string;
+  password: string;
+  /** Broker origin; defaults to remote.openhpsdrzeus.com. */
+  brokerOrigin?: string;
+  onFrame?: (data: ArrayBuffer) => void;
+}
 
+/** Returns the answer SDP for a given offer (via whatever signalling transport). */
+type Signaler = (offerSdp: string) => Promise<string>;
+
+/**
+ * LAN: signal directly to a reachable radio (POST /api/remote/connect), then
+ * prove the session password over SPAKE2+.
+ */
+export function connectRemote(opts: RemoteConnectOptions): Promise<RemoteConnection> {
+  const signal: Signaler = async (offerSdp) => {
+    const resp = await fetch(`${opts.apiBase ?? ''}/api/remote/connect`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ sdp: offerSdp }),
+    });
+    if (resp.status === 403) throw new Error('Remote access is not enabled (no session password set).');
+    if (!resp.ok) throw new Error(`connect failed: HTTP ${resp.status}`);
+    return (await resp.json()).sdp as string;
+  };
+  return establish(
+    { password: opts.password, iceServers: opts.iceServers ?? DEFAULT_STUN, onFrame: opts.onFrame },
+    signal,
+    1500, // LAN: host candidates are immediate
+  );
+}
+
+/**
+ * Internet: relay the offer through the Cloudflare broker to a radio behind NAT,
+ * fetching TURN credentials first (falls back to STUN if TURN is unconfigured).
+ */
+export async function connectViaBroker(opts: BrokerConnectOptions): Promise<RemoteConnection> {
+  const brokerOrigin = opts.brokerOrigin ?? DEFAULT_BROKER;
+  const iceServers = await fetchIceServers(brokerOrigin);
+  const signal: Signaler = (offerSdp) => brokerSignal(brokerOrigin, opts.callsign, offerSdp);
+  return establish(
+    { password: opts.password, iceServers, onFrame: opts.onFrame },
+    signal,
+    5000, // internet: wait for STUN server-reflexive candidates
+  );
+}
+
+// --- shared handshake core -------------------------------------------------
+
+async function establish(
+  opts: { password: string; iceServers: RTCIceServer[]; onFrame?: (d: ArrayBuffer) => void },
+  signal: Signaler,
+  iceTimeoutMs: number,
+): Promise<RemoteConnection> {
+  const pc = new RTCPeerConnection({ iceServers: opts.iceServers });
   const control = pc.createDataChannel('control'); // reliable, ordered
   const frames = pc.createDataChannel('frames', { ordered: false, maxRetransmits: 0 });
-  if (opts.onFrame) {
-    frames.onmessage = (e: MessageEvent) => opts.onFrame!(e.data as ArrayBuffer);
-  }
+  if (opts.onFrame) frames.onmessage = (e: MessageEvent) => opts.onFrame!(e.data as ArrayBuffer);
 
   const prover = new Spake2Plus('prover', CONTEXT, ID_PROVER, ID_VERIFIER);
   let outcome: Spake2Outcome | undefined;
@@ -92,26 +141,66 @@ export async function connectRemote(opts: RemoteConnectOptions): Promise<RemoteC
 
   const offer = await pc.createOffer();
   await pc.setLocalDescription(offer);
-  await iceComplete(pc);
+  await iceComplete(pc, iceTimeoutMs);
 
-  const resp = await fetch(`${opts.apiBase ?? ''}/api/remote/connect`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ sdp: pc.localDescription!.sdp }),
-  });
-  if (resp.status === 403) throw new Error('Remote access is not enabled (no session password set).');
-  if (!resp.ok) throw new Error(`connect failed: HTTP ${resp.status}`);
-  const answer = await resp.json();
-  await pc.setRemoteDescription({ type: 'answer', sdp: answer.sdp });
+  const answerSdp = await signal(pc.localDescription!.sdp);
+  await pc.setRemoteDescription({ type: 'answer', sdp: answerSdp });
 
   await unlocked;
   return { pc, frames, close: () => pc.close() };
 }
 
-function iceComplete(pc: RTCPeerConnection): Promise<void> {
+// --- signalling transports -------------------------------------------------
+
+function brokerSignal(brokerOrigin: string, callsign: string, offerSdp: string): Promise<string> {
+  const wsOrigin = brokerOrigin.replace(/^http/, 'ws');
+  const url = `${wsOrigin}/signal?role=client&callsign=${encodeURIComponent(callsign.toUpperCase())}`;
+  return new Promise<string>((resolve, reject) => {
+    const ws = new WebSocket(url);
+    const timer = setTimeout(() => {
+      reject(new Error('Broker signalling timed out.'));
+      try { ws.close(); } catch { /* ignore */ }
+    }, 20000);
+    ws.onopen = () => ws.send(JSON.stringify({ t: 'offer', sdp: offerSdp }));
+    ws.onmessage = (e: MessageEvent) => {
+      let msg: { t?: string; sdp?: string };
+      try { msg = JSON.parse(typeof e.data === 'string' ? e.data : ''); } catch { return; }
+      if (msg.t === 'answer' && msg.sdp) {
+        clearTimeout(timer);
+        resolve(msg.sdp);
+        try { ws.close(); } catch { /* ignore */ }
+      } else if (msg.t === 'offline') {
+        clearTimeout(timer);
+        reject(new Error('That radio is offline.'));
+        try { ws.close(); } catch { /* ignore */ }
+      }
+    };
+    ws.onerror = () => {
+      clearTimeout(timer);
+      reject(new Error('Could not reach the broker.'));
+    };
+  });
+}
+
+async function fetchIceServers(brokerOrigin: string): Promise<RTCIceServer[]> {
+  try {
+    const r = await fetch(`${brokerOrigin}/turn`, { method: 'POST' });
+    if (r.ok) {
+      const j = await r.json();
+      if (Array.isArray(j.iceServers) && j.iceServers.length) return j.iceServers as RTCIceServer[];
+    }
+  } catch {
+    /* TURN unconfigured or unreachable — STUN-only still works for most home networks */
+  }
+  return DEFAULT_STUN;
+}
+
+// --- helpers ---------------------------------------------------------------
+
+function iceComplete(pc: RTCPeerConnection, timeoutMs: number): Promise<void> {
   return new Promise((resolve) => {
     if (pc.iceGatheringState === 'complete') return resolve();
-    const timer = setTimeout(resolve, 750); // vanilla-ICE cap; host candidates suffice on LAN
+    const timer = setTimeout(resolve, timeoutMs);
     pc.onicegatheringstatechange = () => {
       if (pc.iceGatheringState === 'complete') {
         clearTimeout(timer);


### PR DESCRIPTION
Follow-up to #811 (SPAKE2+ password + QR foundation, already merged). Adds the two pieces needed for frames to actually flow to a remote operator, plus the browser's internet signaling path. Both are inert until the remote-client UI is wired (next PR) — no behaviour change for `/ws` clients or local use.

## What's here

**Server media bridge** — fans the existing `StreamingHub` broadcast out to an unlocked remote WebRTC session, so a remote operator gets the same panadapter/waterfall/meter/audio frames as a `/ws` client over the identical fan-out path.
- Extracts `IClientSink` (`WantsDisplay` + `TryEnqueue`) — the only two members the broadcast loops touch. `ClientSession` implements it, so the `/ws` hot path is byte-for-byte unchanged and behaves identically when no remote sink is attached.
- `RemoteFrameSink`: bounded **drop-oldest** channel drained on a background task, so the DSP thread never blocks on the data channel (mirrors `ClientSession` backpressure). The send is gated again by the session egress guard.
- The sink is attached **only after the SPAKE2+ password unlock** (ADR-0008) and detached/disposed on close — a locked session never receives a frame.

**Broker-signaling client (frontend)** — `connectViaBroker` in `zeus-web/src/remote/connect.ts`: the internet WS-signaling path (offer/answer via the Cloudflare broker, TURN/ICE for NAT traversal), sharing the `establish()` core with the existing LAN `connectRemote`.

## Safety / scope
- Deny-by-default preserved: no frame can leave a session until the password is proven end-to-end (ADR-0008). `RemoteFrameSink` only exists post-unlock.
- No `/ws` behaviour change, no wire-format change, no new dependencies.

## Verification
- `dotnet build tests/Zeus.Server.Tests` — 0 warnings, 0 errors (against current `develop`).
- Targeted suite (Remote/Hub/Streaming/Client/Broadcast): **53 passed, 0 failed**.
- `tsc --noEmit` (zeus-web): clean.
- New end-to-end test `UnlockedSession_ReceivesHubBroadcastFrame`: a real `StreamingHub.Broadcast` reaches the remote peer over the actual WebRTC wire after unlock.

## Still to come (next PR)
Browser remote-client mode (`?remote=<callsign>` → password prompt → `connectViaBroker` → render frames), the inbound control channel (browser → server audio/display/VFO requests), and web-client subdomain deploy.