### PR TITLE
feat(settings): consolidate RADIO SETTINGS tab into RADIO

### DIFF
--- a/zeus-web/src/components/SettingsMenu.test.tsx
+++ b/zeus-web/src/components/SettingsMenu.test.tsx
@@ -195,16 +195,56 @@ describe('SettingsView — RADIO tab gating', () => {
     seedRadioCaps({ hasHl2OptionalToggles: false });
   });
 
-  it('hides the RADIO tab when no board radio options are supported', async () => {
+  it('shows the RADIO tab with radio settings even when no board firmware options are supported', async () => {
+    // The RADIO tab is now always present — it hosts the universal radio
+    // settings (PTT-IN / TX audio / antenna). With no board firmware-option
+    // surface it shows those settings only; the per-board options section is
+    // omitted.
+    stubSettingsFetch({
+      '/api/radio/ptt-status': { keyed: false, enabled: false, hangMs: 250 },
+      '/api/radio/audio': {
+        hasOnboardCodec: false,
+        hermesLite2MicFrontEnd: false,
+        hasRadioLineIn: false,
+        hasBalancedXlr: false,
+        hasMicBias: false,
+        source: 'Host',
+        micBoost: false,
+        micBias: false,
+        lineInGain: 0,
+      },
+      '/api/radio/antenna': {
+        hasTxAntennaRelays: false,
+        hasRxAntennaRelays: false,
+        availableRxAux: [],
+        bands: [],
+      },
+    });
     seedRadioCaps({ hasHl2OptionalToggles: false, supportsG2AdcOptions: false });
     await act(async () => {
       root.render(<SettingsView onClose={() => {}} />);
       await flushEffects();
     });
-    const tabs = Array.from(
-      container.querySelectorAll('[role="tablist"] button'),
-    ).map((b) => b.textContent?.trim() ?? '');
-    expect(tabs).not.toContain('RADIO');
+    const tabButtons = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[role="tablist"] button'),
+    );
+    expect(tabButtons.map((b) => b.textContent?.trim() ?? '')).toContain('RADIO');
+    // The old standalone RADIO SETTINGS tab is gone — folded into RADIO.
+    expect(tabButtons.map((b) => b.textContent?.trim() ?? '')).not.toContain(
+      'RADIO SETTINGS',
+    );
+
+    const radioTab = tabButtons.find((b) => b.textContent?.trim() === 'RADIO');
+    expect(radioTab).toBeDefined();
+    await act(async () => {
+      radioTab!.click();
+      await flushEffects();
+    });
+    // Universal radio settings render (PTT-IN card from RadioSettingsPanel)…
+    expect(container.textContent).toContain('PTT-IN');
+    // …but no per-board firmware-option section.
+    expect(container.textContent).not.toContain('Band Volts');
+    expect(container.textContent).not.toContain('ANAN-G2 Options');
   });
 
   it('shows the RADIO tab and renders the panel on click when hasHl2OptionalToggles is true', async () => {

--- a/zeus-web/src/components/SettingsMenu.tsx
+++ b/zeus-web/src/components/SettingsMenu.tsx
@@ -61,7 +61,6 @@ export type SettingsTabId =
   | 'spots'
   | 'server'
   | 'radio'
-  | 'radio-settings'
   | 'calibration'
   | 'updates'
   | 'about';
@@ -82,7 +81,6 @@ const TABS: ReadonlyArray<{ id: SettingsTabId; label: string }> = [
   { id: 'spots', label: 'SPOTS' },
   { id: 'server', label: 'SERVER' },
   { id: 'radio', label: 'RADIO' },
-  { id: 'radio-settings', label: 'RADIO SETTINGS' },
   { id: 'calibration', label: 'CALIBRATION' },
   { id: 'updates', label: 'UPDATES' },
   { id: 'about', label: 'ABOUT' },
@@ -102,9 +100,12 @@ export function SettingsView({ initialTab, onClose }: Props) {
   const savePa = usePaStore((s) => s.save);
   const loadPa = usePaStore((s) => s.load);
   const paInflight = usePaStore((s) => s.inflight);
-  // RADIO tab is board-option-only. Hidden unless the active capability
-  // fingerprint advertises an option surface that writes a real firmware
-  // field (HL2 Band Volts or ANAN-G2 ADC dither/random).
+  // RADIO tab hosts the always-relevant radio settings (PTT-IN, TX audio
+  // source, antenna relays — RadioSettingsPanel) and, when the connected board
+  // advertises a firmware-option surface (HL2 Band Volts or ANAN-G2 ADC
+  // dither/random), the per-board RadioOptionsPanel below them. The tab itself
+  // is always visible because RadioSettingsPanel applies to every board;
+  // `hasRadioOptions` only gates the optional board-options section within it.
   const hasHl2OptionalToggles = useRadioStore(
     (s) => s.capabilities.hasHl2OptionalToggles,
   );
@@ -117,29 +118,15 @@ export function SettingsView({ initialTab, onClose }: Props) {
   // so a fresh session never lists it.
   const hardwareUnlocked = useEasterEggStore((s) => s.hardwareUnlocked);
   const visibleTabs = useMemo(
-    () =>
-      TABS.filter(
-        (t) =>
-          (t.id !== 'radio' || hasRadioOptions) &&
-          (t.id !== 'hardware' || hardwareUnlocked),
-      ),
-    [hasRadioOptions, hardwareUnlocked],
+    () => TABS.filter((t) => t.id !== 'hardware' || hardwareUnlocked),
+    [hardwareUnlocked],
   );
 
-  // If the operator was sitting on the RADIO tab and the board changed
-  // (re-discovery now reports no radio options), bounce them back to PA so they
-  // don't get stuck on an empty tabpanel.
-  useEffect(() => {
-    if (active === 'radio' && !hasRadioOptions) {
-      setActive('pa');
-    }
-  }, [active, hasRadioOptions]);
-
   // Effective tab for rendering. If the stored `active` tab isn't currently
-  // visible — a hidden HARDWARE folder, or RADIO opened via initialTab without
-  // board options — fall back to PA so the operator never lands on a hidden
-  // tabpanel. Deriving this (rather than bouncing in an effect) avoids racing
-  // the initialTab effect, which could otherwise re-select a hidden tab.
+  // visible — e.g. a hidden HARDWARE folder — fall back to PA so the operator
+  // never lands on a hidden tabpanel. Deriving this (rather than bouncing in an
+  // effect) avoids racing the initialTab effect, which could otherwise
+  // re-select a hidden tab.
   const activeTab = visibleTabs.some((t) => t.id === active) ? active : 'pa';
 
   useEffect(() => {
@@ -221,8 +208,12 @@ export function SettingsView({ initialTab, onClose }: Props) {
           {activeTab === 'hamclock' && <HamClockSettingsPanel />}
           {activeTab === 'spots' && <SpotsSettingsPanel />}
           {activeTab === 'server' && <ServerUrlPanel />}
-          {activeTab === 'radio' && hasRadioOptions && <RadioOptionsPanel />}
-          {activeTab === 'radio-settings' && <RadioSettingsPanel />}
+          {activeTab === 'radio' && (
+            <>
+              <RadioSettingsPanel />
+              {hasRadioOptions && <RadioOptionsPanel />}
+            </>
+          )}
           {activeTab === 'calibration' && <CalibrationPanel />}
           {activeTab === 'updates' && <UpdatesPanel />}
           {activeTab === 'about' && <AboutPanel />}


### PR DESCRIPTION
## What

Merges the redundant **RADIO SETTINGS** tab into the **RADIO** tab. They were two adjacent radio-scoped tabs in the Settings view:

- **RADIO SETTINGS** → `RadioSettingsPanel` (PTT-IN → MOX, TX audio source, antenna relays)
- **RADIO** → `RadioOptionsPanel` (per-board firmware options: HL2 Band Volts, ANAN-G2 ADC dither/random)

Now there is a single **RADIO** tab that shows the radio settings, and—when the connected board advertises a firmware-option surface—the per-board options below them.

## Why

Two side-by-side "Radio…" tabs is redundant and confusing. The split was an artifact of the antenna/audio/PTT external-ports work landing as its own tab next to the pre-existing board-options tab.

## How

- **No settings lost.** `RadioSettingsPanel` and `RadioOptionsPanel` are unchanged — only their host tab changed. The PTT/audio/antenna cards and the HL2/G2 option controls render exactly as before.
- RADIO is **always visible** now (it hosts `RadioSettingsPanel`, which applies to every board). Previously RADIO was hidden unless the board had firmware options.
- `hasRadioOptions` still gates the **per-board options section within** the tab (so a board with no HL2/G2 options shows just the radio settings).
- Removed the now-dead `'radio-settings'` `SettingsTabId` / `TABS` entry / render arm, and the bounce-to-PA effect (RADIO can no longer be hidden, so it can't strand the operator).

## Tests

- Updated the `SettingsView — RADIO tab gating` test: RADIO is now asserted **always present** (and `RADIO SETTINGS` absent); with no board options it renders the radio settings (`PTT-IN` card) but not the board-options section. The two existing tests (HL2 toggles / G2 options render under RADIO) still pass.
- `SettingsMenu` + `RadioSettingsPanel` + `RadioOptionsPanel` vitest: **20/20 pass**.
- Frontend `tsc -b` + `vite build`: clean.

## Notes

- Frontend-only change; no backend / wire / contract changes.
- Visual placement (order of the two panels within the tab, any heading/divider) is a UX/visual call — flagging for Brian/Doug sign-off. Current order: radio settings first, per-board options below.
