### PR TITLE
feat(remote): RX-monitoring client over WebRTC (?remote=<callsign>)

### DIFF
--- a/Zeus.Server.Hosting/Remote/RemoteWebRtcSession.cs
+++ b/Zeus.Server.Hosting/Remote/RemoteWebRtcSession.cs
@@ -33,6 +33,15 @@ public sealed class RemoteWebRtcSession
     private RTCDataChannel? _frames;
     private RemoteFrameSink? _sink;
 
+    // Post-unlock binary stream-request control frames (RX monitoring, Phase A):
+    //   first byte 0x22 = display request, 0x21 = audio request; byte[1] 1/0 = enable/disable.
+    // We track the session's current wanted-state so a duplicate enable can't
+    // double-count the hub's global gate and a disconnect always unwinds it.
+    private const byte MsgTypeAudioStreamRequest = 0x21;
+    private const byte MsgTypeDisplayStreamRequest = 0x22;
+    private bool _wantsDisplay;
+    private bool _wantsAudio;
+
     public RemoteWebRtcSession(
         RemoteVerifierMaterial verifier, ILogger log,
         IReadOnlyList<RTCIceServer>? iceServers = null, Zeus.Server.StreamingHub? hub = null)
@@ -101,7 +110,15 @@ public sealed class RemoteWebRtcSession
     {
         if (Interlocked.Exchange(ref _closed, 1) != 0) return;
         _session.Close();
-        if (_hub is not null) _hub.DetachSink(_sinkId);
+        if (_hub is not null)
+        {
+            // Release any RX display/audio request still held so a remote
+            // disconnect can't pin the global gates on (mirrors the /ws
+            // ClientSession cleanup in StreamingHub.AttachClientAsync).
+            if (_wantsDisplay) { _wantsDisplay = false; _hub.AdjustDisplayRequests(-1); }
+            if (_wantsAudio) { _wantsAudio = false; _hub.AdjustAudioRequests(-1); }
+            _hub.DetachSink(_sinkId);
+        }
         _sink?.Dispose();
         try { _pc.close(); } catch { /* already torn down */ }
         Closed?.Invoke();
@@ -116,7 +133,7 @@ public sealed class RemoteWebRtcSession
                 // Client-initiated: it sends {t:"hello"} once its channel opens
                 // and we reply with auth-params. Avoids depending on the
                 // answerer-side onopen firing.
-                dc.onmessage += (_, _, data) => _ = HandleControlAsync(data);
+                dc.onmessage += (_, _, data) => OnControlMessage(data);
                 break;
             case "frames":
                 _frames = dc;
@@ -137,6 +154,53 @@ public sealed class RemoteWebRtcSession
             memoryKib = _verifier.MemoryKib,
             parallelism = _verifier.Parallelism,
         }));
+    }
+
+    /// <summary>
+    /// Split control-channel input: pre-unlock and JSON auth messages go to the
+    /// SPAKE2+ gate; post-unlock binary stream-request frames (0x21/0x22) drive
+    /// the RX display/audio gates. The two are unambiguous on the wire — auth is
+    /// always JSON (first byte '{' = 0x7B), stream-requests lead with 0x21/0x22,
+    /// so a 0x21/0x22 first byte is treated as binary control, never JSON.
+    /// Deny-by-default: binary control is honoured ONLY after unlock; anything
+    /// non-auth while LOCKED still fails the session closed via HandleControlAsync.
+    /// </summary>
+    private void OnControlMessage(byte[] data)
+    {
+        if (_session.IsUnlocked
+            && data.Length >= 1
+            && data[0] is MsgTypeDisplayStreamRequest or MsgTypeAudioStreamRequest)
+        {
+            HandleStreamRequest(data);
+            return;
+        }
+
+        _ = HandleControlAsync(data);
+    }
+
+    /// <summary>
+    /// Apply a post-unlock binary stream-request frame: [type][enable:u8].
+    /// 0x22 toggles the display gate, 0x21 the audio gate. Tracks the session's
+    /// current wanted-state so the hub's global counter moves at most once per
+    /// transition (and Close can unwind it exactly).
+    /// </summary>
+    private void HandleStreamRequest(byte[] data)
+    {
+        if (_hub is null) return;
+        bool enable = data.Length > 1 && data[1] != 0;
+        switch (data[0])
+        {
+            case MsgTypeDisplayStreamRequest:
+                if (enable == _wantsDisplay) return;
+                _wantsDisplay = enable;
+                _hub.AdjustDisplayRequests(enable ? 1 : -1);
+                break;
+            case MsgTypeAudioStreamRequest:
+                if (enable == _wantsAudio) return;
+                _wantsAudio = enable;
+                _hub.AdjustAudioRequests(enable ? 1 : -1);
+                break;
+        }
     }
 
     private async Task HandleControlAsync(byte[] data)

--- a/Zeus.Server.Hosting/StreamingHub.cs
+++ b/Zeus.Server.Hosting/StreamingHub.cs
@@ -367,6 +367,23 @@ public sealed class StreamingHub
     /// </summary>
     internal void AttachSink(Guid id, IClientSink sink) => _clients[id] = sink;
 
+    /// <summary>
+    /// Bump the global display-stream gate by <paramref name="delta"/> (+1/−1).
+    /// A non-WebSocket sink (the remote WebRTC session) holds no ClientSession,
+    /// so it adjusts the aggregate directly here — mirroring how
+    /// <c>ClientSession.SetWantsDisplay</c> moves the same counter — to open the
+    /// panadapter frame fan-out (Broadcast(in DisplayFrame) gates on this).
+    /// </summary>
+    internal void AdjustDisplayRequests(int delta) => Interlocked.Add(ref _displayStreamRequests, delta);
+
+    /// <summary>
+    /// Bump the global audio-stream gate by <paramref name="delta"/> (+1/−1) for
+    /// a non-WebSocket sink (remote WebRTC session), mirroring
+    /// <c>ClientSession.SetWantsAudio</c>. Drives the desktop-mode on-demand
+    /// 0x02 RX-audio stream the same way a /ws client's 0x21 does.
+    /// </summary>
+    internal void AdjustAudioRequests(int delta) => Interlocked.Add(ref _audioStreamRequests, delta);
+
     /// <summary>Remove a previously-attached remote sink.</summary>
     internal void DetachSink(Guid id) => _clients.TryRemove(id, out _);
 

--- a/tests/Zeus.Server.Tests/RemoteWebRtcSessionTests.cs
+++ b/tests/Zeus.Server.Tests/RemoteWebRtcSessionTests.cs
@@ -84,11 +84,90 @@ public sealed class RemoteWebRtcSessionTests
 
         // A normal hub broadcast (always-on RX meter, 5 bytes) reaches the remote
         // client through the StreamingHub fan-out → RemoteFrameSink → frames channel.
-        hub.Broadcast(new Zeus.Contracts.RxMeterFrame(-73.0f));
-        var received = await client.NextFrame().WaitAsync(TimeSpan.FromSeconds(5));
+        // Re-broadcast on a loop (mirroring the real 5–60 Hz frame flow) so the
+        // RemoteFrameSink attach-race + async hop can't time the single send out
+        // on a slow/loaded CI runner — TrySetResult is a no-op once resolved.
+        var received = await BroadcastUntilReceived(
+            client, () => hub.Broadcast(new Zeus.Contracts.RxMeterFrame(-73.0f)));
 
         Assert.Equal(5, received.Length);
         server.Close();
+    }
+
+    [Fact]
+    public async Task DisplayRequest_OpensGate_AndDisplayFrameReachesRemotePeer()
+    {
+        var hub = new Zeus.Server.StreamingHub(NullLogger<Zeus.Server.StreamingHub>.Instance);
+        var server = new RemoteWebRtcSession(RegisterVerifier(Password), NullLogger.Instance, hub: hub);
+        await using var client = new ProverClient(Password);
+
+        var answer = await server.CreateAnswerAsync(await client.CreateOfferAsync());
+        await client.AcceptAnswerAsync(answer);
+        await client.Unlocked.WaitAsync(TimeSpan.FromSeconds(20));
+        Assert.True(server.IsUnlocked);
+
+        // The display gate starts closed, so a DisplayFrame broadcast is dropped.
+        Assert.False(hub.DisplayStreamRequested);
+
+        // Client asks for the RX display stream over the control channel (0x22 01).
+        client.SendControlBinary(new byte[] { 0x22, 0x01 });
+
+        // The hub's global display gate must open (the remote session bumped it).
+        await WaitForAsync(() => hub.DisplayStreamRequested, TimeSpan.FromSeconds(5));
+        Assert.True(hub.DisplayStreamRequested);
+
+        // A DisplayFrame broadcast now fans out through RemoteFrameSink → frames
+        // channel and reaches the remote peer. Re-broadcast on a loop so the
+        // sink attach-race + async hop can't time out on a slow CI runner.
+        const ushort width = 4;
+        var pan = new float[width] { -100f, -90f, -80f, -70f };
+        var wf = new float[width] { -100f, -90f, -80f, -70f };
+        var frame = new Zeus.Contracts.DisplayFrame(
+            Seq: 1,
+            TsUnixMs: 0,
+            RxId: 0,
+            BodyFlags: Zeus.Contracts.DisplayBodyFlags.PanValid | Zeus.Contracts.DisplayBodyFlags.WfValid,
+            Width: width,
+            CenterHz: 14_200_000,
+            HzPerPixel: 1f,
+            PanDb: pan,
+            WfDb: wf);
+        var received = await BroadcastUntilReceived(client, () => hub.Broadcast(frame));
+        Assert.NotEmpty(received);
+
+        // Closing the session unwinds the gate it opened — no pinned display.
+        server.Close();
+        await WaitForAsync(() => !hub.DisplayStreamRequested, TimeSpan.FromSeconds(5));
+        Assert.False(hub.DisplayStreamRequested);
+    }
+
+    private static async Task WaitForAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition()) return;
+            await Task.Delay(20);
+        }
+    }
+
+    /// <summary>
+    /// Drive <paramref name="broadcast"/> repeatedly (≈10 Hz, ≤15 s) until the
+    /// client's next-frame task completes, then return the received bytes. This
+    /// mirrors the real radio's continuous frame flow and removes both the
+    /// RemoteFrameSink attach-race and the single-shot latency-timeout fragility
+    /// that flakes on slow/loaded CI runners. Re-firing is safe — the prover's
+    /// frame TCS uses TrySetResult, so a late frame still resolves the await.
+    /// </summary>
+    private static async Task<byte[]> BroadcastUntilReceived(ProverClient client, Action broadcast)
+    {
+        var next = client.NextFrame();
+        for (int i = 0; i < 150 && !next.IsCompleted; i++)
+        {
+            broadcast();
+            await Task.WhenAny(next, Task.Delay(100));
+        }
+        return await next.WaitAsync(TimeSpan.FromSeconds(1));
     }
 
     /// <summary>Minimal in-process SPAKE2+ prover over WebRTC — what the browser will do.</summary>
@@ -119,6 +198,9 @@ public sealed class RemoteWebRtcSessionTests
 
         public Task Unlocked => _unlocked.Task;
         public Task<byte[]> NextFrame() => _frame.Task;
+
+        /// <summary>Send a raw binary control frame (post-unlock stream-request, e.g. 0x22 01).</summary>
+        public void SendControlBinary(byte[] frame) => _control.send(frame);
 
         public async Task<string> CreateOfferAsync()
         {

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -89,6 +89,8 @@ import { useFilterRibbonOpenSync } from './components/filter/filterRibbonShared'
 import { CONTACTS, bandOf } from './components/design/data';
 import { bearingDeg, distanceKm } from './components/design/geo';
 import { startRealtime } from './realtime/ws-client';
+import { isRemoteMode } from './remote/remote-client';
+import { RemoteGate } from './remote/RemoteGate';
 import { getServerBaseUrl, isCapacitorRuntime } from './serverUrl';
 import { getAudioClient } from './audio/audio-client';
 import { setAudioHostMode } from './audio/host-mode';
@@ -130,6 +132,10 @@ const STATE_POLL_MS = 1000;
 
 export default function App() {
   const detachedLayoutId = useMemo(() => currentDetachedWorkspaceLayoutId(), []);
+  // Remote (WebRTC) RX-monitoring mode — ?remote=<CALLSIGN>. Frames arrive over
+  // the broker instead of the local /ws; RemoteGate prompts for the session
+  // password and owns that transport.
+  const remoteMode = useMemo(() => isRemoteMode(), []);
   const settingsViewOpen = useLayoutStore((s) => s.settingsViewOpen);
   const settingsInitialTab = useLayoutStore((s) => s.settingsInitialTab);
   const setSettingsView = useLayoutStore((s) => s.setSettingsView);
@@ -276,11 +282,15 @@ export default function App() {
   }, []);
 
   useEffect(() => {
+    // Remote (WebRTC) mode sources frames over the broker, not the local
+    // websocket — RemoteGate owns that transport. Starting startRealtime() here
+    // too would open a second, doomed /ws connection.
+    if (remoteMode) return;
     const stop = startRealtime();
     return () => {
       stop();
     };
-  }, []);
+  }, [remoteMode]);
 
   useEffect(() => {
     const ctrl = new AbortController();
@@ -894,6 +904,7 @@ export default function App() {
           <Suspense fallback={null}>
             <MobileApp />
           </Suspense>
+          {remoteMode && <RemoteGate />}
         </SpectrumWheelActionsContext.Provider>
       </WorkspaceContext.Provider>
     );
@@ -1132,6 +1143,7 @@ export default function App() {
       />
       <UpdatePrompt show={updateAvailable} onUpdate={installUpdate} />
       <ReportProblemModal />
+      {remoteMode && <RemoteGate />}
     </div>
     </SpectrumWheelActionsContext.Provider>
     </WorkspaceContext.Provider>

--- a/zeus-web/src/realtime/ws-client.ts
+++ b/zeus-web/src/realtime/ws-client.ts
@@ -244,6 +244,23 @@ const SPOT_LIST_MIN_BYTES = 3; // type + count
 let activeWs: WebSocket | null = null;
 let micTransportWaiters: Array<() => void> = [];
 
+// Optional control-frame override. When a remote (WebRTC) client is active it
+// installs a sender here so the 2-byte stream-request control frames
+// (0x21/0x22) travel over the WebRTC control DataChannel instead of the local
+// websocket. Null (the default) leaves the WS behaviour untouched for local
+// clients. Mic PCM (0x20) deliberately stays WS-only — no TX over remote in
+// Phase A.
+let controlSender: ((bytes: ArrayBuffer) => void) | null = null;
+
+/**
+ * Install (or clear, with null) a transport for the 2-byte stream-request
+ * control frames. The remote client sets this after the WebRTC session unlocks
+ * so display/audio enables reach the radio over the control DataChannel.
+ */
+export function setRemoteControlSender(fn: ((bytes: ArrayBuffer) => void) | null): void {
+  controlSender = fn;
+}
+
 // Speaker playback is just another RX audio bus consumer. AudioClient.push()
 // self-suppresses in native/desktop mode, so this single subscription is
 // correct in every host mode — the decoder subscribes separately. Registered
@@ -258,12 +275,16 @@ getAudioBus().subscribe((frame) => getAudioClient().push(frame));
 const MSG_TYPE_AUDIO_STREAM_REQUEST = 0x21;
 export const MSG_TYPE_DISPLAY_STREAM_REQUEST = 0x22;
 export function sendAudioStreamRequest(enable: boolean): void {
-  const ws = activeWs;
-  if (!ws || ws.readyState !== WebSocket.OPEN) return;
   const buf = new ArrayBuffer(2);
   const view = new DataView(buf);
   view.setUint8(0, MSG_TYPE_AUDIO_STREAM_REQUEST);
   view.setUint8(1, enable ? 1 : 0);
+  if (controlSender) {
+    controlSender(buf);
+    return;
+  }
+  const ws = activeWs;
+  if (!ws || ws.readyState !== WebSocket.OPEN) return;
   try {
     ws.send(buf);
   } catch (err) {
@@ -272,12 +293,16 @@ export function sendAudioStreamRequest(enable: boolean): void {
 }
 
 export function sendDisplayStreamRequest(enable: boolean): void {
-  const ws = activeWs;
-  if (!ws || ws.readyState !== WebSocket.OPEN) return;
   const buf = new ArrayBuffer(2);
   const view = new DataView(buf);
   view.setUint8(0, MSG_TYPE_DISPLAY_STREAM_REQUEST);
   view.setUint8(1, enable ? 1 : 0);
+  if (controlSender) {
+    controlSender(buf);
+    return;
+  }
+  const ws = activeWs;
+  if (!ws || ws.readyState !== WebSocket.OPEN) return;
   try {
     ws.send(buf);
   } catch (err) {
@@ -362,13 +387,389 @@ export function sendMicPcm(samples: Float32Array): MicPcmSendResult {
   }
 }
 
+/**
+ * Decode and dispatch a single binary radio frame into the stores. Transport-
+ * agnostic: the local websocket path (startRealtime) and the remote WebRTC
+ * client (remote-client.ts) both feed frames through here, so display /
+ * waterfall / meters / audio render identically regardless of origin.
+ *
+ * The body is the verbatim former ws.onmessage switch; `ev` is a thin shim so
+ * every `ev.data` reference resolves without a per-site rewrite.
+ */
+export function dispatchServerFrame(data: ArrayBuffer): void {
+  const ev = { data };
+  try {
+    const peekType = new DataView(ev.data).getUint8(0);
+    if (peekType === MSG_TYPE_DISPLAY_FRAME) {
+      // Skip the decode + push when no spectrum surface is mounted.
+      // decodeDisplayFrame allocates two Float32Arrays per tick and
+      // pushFrame fans the new state through every store subscriber —
+      // both are wasted when the panadapter, waterfall, and filter
+      // mini-pan are all closed. Consumers register via
+      // registerFrameConsumer() in display-store.ts; the moment any of
+      // them mounts we resume decoding on the next tick.
+      if (!hasActiveFrameConsumers()) return;
+      const frame = decodeDisplayFrame(ev.data);
+      useDisplayStore.getState().pushFrame(frame);
+      return;
+    }
+    if (peekType === MSG_TYPE_AUDIO_PCM) {
+      // Decode once and publish to the RX audio bus, which fans the single
+      // stream out to speaker playback (AudioClient — which self-suppresses
+      // in native/desktop mode) and any taps (the CW decoder). We do NOT
+      // gate on isNativeAudio() here on purpose: in desktop mode the server
+      // sends 0x02 only on demand (when a decoder asks via 0x21), and those
+      // frames must reach the bus so the decoder can consume them. Playback
+      // opts out downstream in AudioClient.push(), not here.
+      const audio = decodeAudioFrame(ev.data);
+      getAudioBus().publish(audio);
+      return;
+    }
+    if (peekType === MSG_TYPE_TX_METERS_V2) {
+      if (ev.data.byteLength < TX_METERS_V2_BYTES) {
+        warnOnce(
+          'ws-tx-meters-v2-short',
+          `tx meters v2 frame too short: ${ev.data.byteLength}`,
+        );
+        return;
+      }
+      const dv = new DataView(ev.data);
+      useTxStore.getState().setMeters({
+        fwdWatts: dv.getFloat32(1, true),
+        refWatts: dv.getFloat32(5, true),
+        swr: dv.getFloat32(9, true),
+        micPk: dv.getFloat32(13, true),
+        micAv: dv.getFloat32(17, true),
+        eqPk: dv.getFloat32(21, true),
+        eqAv: dv.getFloat32(25, true),
+        lvlrPk: dv.getFloat32(29, true),
+        lvlrAv: dv.getFloat32(33, true),
+        lvlrGr: dv.getFloat32(37, true),
+        cfcPk: dv.getFloat32(41, true),
+        cfcAv: dv.getFloat32(45, true),
+        cfcGr: dv.getFloat32(49, true),
+        compPk: dv.getFloat32(53, true),
+        compAv: dv.getFloat32(57, true),
+        alcPk: dv.getFloat32(61, true),
+        alcAv: dv.getFloat32(65, true),
+        alcGr: dv.getFloat32(69, true),
+        outPk: dv.getFloat32(73, true),
+        outAv: dv.getFloat32(77, true),
+      });
+      return;
+    }
+    if (peekType === MSG_TYPE_MIC_PEAK) {
+      // Phase 4 — desktop-mode mic level. In browser mode the server
+      // does not emit this frame (NativeMicCapture isn't registered);
+      // if a misconfigured server ever pushes it, the existing
+      // AudioWorklet path is authoritative and we drop the wire frame.
+      if (!isNativeAudio()) return;
+      if (ev.data.byteLength < MIC_PEAK_BYTES) {
+        warnOnce(
+          'ws-mic-peak-short',
+          `mic peak frame too short: ${ev.data.byteLength}`,
+        );
+        return;
+      }
+      const dv = new DataView(ev.data);
+      const peakDbfs = dv.getFloat32(1, true);
+      // i64 LE — DataView gives us BigInt; convert to number (safe up
+      // to 2^53 ms ≈ year +287,000 AD, comfortably beyond any wall
+      // clock we'll see).
+      const tsUnixMs = Number(dv.getBigInt64(5, true));
+      useMicPeakStore.getState().setPeak(peakDbfs, tsUnixMs);
+      return;
+    }
+    if (peekType === MSG_TYPE_AUDIO_CHAIN_ORDER) {
+      // Variable-length CSV payload — empty payload encodes the
+      // "no plugins installed" empty-chain case.
+      const bytes = new Uint8Array(ev.data, 1);
+      const csv = new TextDecoder('utf-8').decode(bytes);
+      const ids = csv.length === 0 ? [] : csv.split(',');
+      useAudioSuiteStore.getState().setChainOrderFromServer(ids);
+      return;
+    }
+    if (peekType === MSG_TYPE_RX_AUDIO_CHAIN_ORDER) {
+      const bytes = new Uint8Array(ev.data, 1);
+      const csv = new TextDecoder('utf-8').decode(bytes);
+      const ids = csv.length === 0 ? [] : csv.split(',');
+      useAudioSuiteStore.getState().setRxChainOrderFromServer(ids);
+      return;
+    }
+    if (peekType === MSG_TYPE_CHAT_EVENT) {
+      // Variable-length UTF-8 JSON payload after the type byte.
+      const bytes = new Uint8Array(ev.data, 1);
+      const json = new TextDecoder('utf-8').decode(bytes);
+      try {
+        const envelope = JSON.parse(json) as ChatEnvelope;
+        useChatStore.getState().ingest(envelope);
+      } catch (err) {
+        warnOnce('ws-chat-event-parse', 'chat event frame parse failed', err);
+      }
+      return;
+    }
+    if (peekType === MSG_TYPE_CW_ENGINE_STATUS) {
+      if (ev.data.byteLength < CW_ENGINE_STATUS_HEADER_BYTES) {
+        warnOnce(
+          'ws-cw-status-short',
+          `cw status frame too short: ${ev.data.byteLength}`,
+        );
+        return;
+      }
+      const dv = new DataView(ev.data);
+      const stateByte = dv.getUint8(1);
+      const wpm = dv.getUint16(2, true);
+      const queueDepth = dv.getUint16(4, true);
+      const textLen = dv.getUint16(6, true);
+      if (ev.data.byteLength < CW_ENGINE_STATUS_HEADER_BYTES + textLen) {
+        warnOnce(
+          'ws-cw-status-truncated',
+          `cw status text claims ${textLen} bytes but only ${
+            ev.data.byteLength - CW_ENGINE_STATUS_HEADER_BYTES
+          } follow`,
+        );
+        return;
+      }
+      const text =
+        textLen === 0
+          ? ''
+          : new TextDecoder('utf-8').decode(
+              new Uint8Array(ev.data, CW_ENGINE_STATUS_HEADER_BYTES, textLen),
+            );
+      const state = CW_STATE_FROM_BYTE[stateByte] ?? 'idle';
+      useCwStore.getState().setStatusFromServer({
+        state,
+        text,
+        wpm,
+        queueDepth,
+        receivedAtMs: Date.now(),
+      });
+      return;
+    }
+    // 0x31 CwDecodedText (classic server-side decoder) was retired in
+    // favour of the browser-side DeepCW neural decoder (plugins/deepcw).
+    // The MSG_TYPE_CW_DECODED_TEXT value stays reserved; the server no
+    // longer broadcasts it.
+    if (peekType === MSG_TYPE_AUDIO_MASTER_BYPASS) {
+      if (ev.data.byteLength < AUDIO_MASTER_BYPASS_BYTES) {
+        warnOnce(
+          'ws-audio-master-bypass-short',
+          `audio master-bypass frame too short: ${ev.data.byteLength}`,
+        );
+        return;
+      }
+      const bypassed = new DataView(ev.data).getUint8(1) !== 0;
+      useAudioSuiteStore.getState().setMasterBypassedFromServer(bypassed);
+      return;
+    }
+    if (peekType === MSG_TYPE_RX_AUDIO_MASTER_BYPASS) {
+      if (ev.data.byteLength < RX_AUDIO_MASTER_BYPASS_BYTES) {
+        warnOnce(
+          'ws-rx-audio-master-bypass-short',
+          `rx audio master-bypass frame too short: ${ev.data.byteLength}`,
+        );
+        return;
+      }
+      const bypassed = new DataView(ev.data).getUint8(1) !== 0;
+      useAudioSuiteStore.getState().setRxMasterBypassedFromServer(bypassed);
+      return;
+    }
+    if (peekType === MSG_TYPE_PTT_STATUS) {
+      if (ev.data.byteLength < PTT_STATUS_BYTES) {
+        warnOnce(
+          'ws-ptt-status-short',
+          `PTT status frame too short: ${ev.data.byteLength}`,
+        );
+        return;
+      }
+      const keyed = new DataView(ev.data).getUint8(1) !== 0;
+      usePttStore.getState().setKeyed(keyed);
+      return;
+    }
+    if (peekType === MSG_TYPE_PA_TEMP) {
+      if (ev.data.byteLength < PA_TEMP_BYTES) {
+        warnOnce(
+          'ws-pa-temp-short',
+          `PA temp frame too short: ${ev.data.byteLength}`,
+        );
+        return;
+      }
+      const tempC = new DataView(ev.data).getFloat32(1, true);
+      useTxStore.getState().setPaTempC(tempC);
+      return;
+    }
+    if (peekType === MSG_TYPE_PS_METERS) {
+      if (ev.data.byteLength < PS_METERS_BYTES) {
+        warnOnce(
+          'ws-ps-meters-short',
+          `PS meters frame too short: ${ev.data.byteLength}`,
+        );
+        return;
+      }
+      const dv = new DataView(ev.data);
+      useTxStore.getState().setPsMeters({
+        feedbackLevel: dv.getFloat32(1, true),
+        correctionDb: dv.getFloat32(5, true),
+        calState: dv.getUint8(9),
+        correcting: dv.getUint8(10) !== 0,
+        maxTxEnvelope: dv.getFloat32(11, true),
+      });
+      return;
+    }
+    if (peekType === MSG_TYPE_RX_METER) {
+      if (ev.data.byteLength < RX_METER_BYTES) {
+        warnOnce(
+          'ws-rx-meter-short',
+          `rx meter frame too short: ${ev.data.byteLength}`,
+        );
+        return;
+      }
+      const dbm = new DataView(ev.data).getFloat32(1, true);
+      useTxStore.getState().setRxDbm(dbm);
+      return;
+    }
+    if (peekType === MSG_TYPE_RX_METERS_V2) {
+      if (ev.data.byteLength < RX_METERS_V2_BYTES) {
+        warnOnce(
+          'ws-rx-meters-v2-short',
+          `rx meters v2 frame too short: ${ev.data.byteLength}`,
+        );
+        return;
+      }
+      const dv = new DataView(ev.data);
+      useRxMetersStore.getState().setMeters({
+        signalPk: dv.getFloat32(1, true),
+        signalAv: dv.getFloat32(5, true),
+        adcPk: dv.getFloat32(9, true),
+        adcAv: dv.getFloat32(13, true),
+        agcGain: dv.getFloat32(17, true),
+        agcEnvPk: dv.getFloat32(21, true),
+        agcEnvAv: dv.getFloat32(25, true),
+      });
+      return;
+    }
+    if (peekType === MSG_TYPE_WISDOM_STATUS) {
+      if (ev.data.byteLength < WISDOM_STATUS_MIN_BYTES) {
+        warnOnce(
+          'ws-wisdom-short',
+          `wisdom frame too short: ${ev.data.byteLength}`,
+        );
+        return;
+      }
+      const raw = new DataView(ev.data).getUint8(1);
+      const phase: WisdomPhase =
+        raw === 1 ? 'building' : raw === 2 ? 'ready' : 'idle';
+      const status =
+        ev.data.byteLength > WISDOM_STATUS_MIN_BYTES
+          ? new TextDecoder('utf-8').decode(
+              new Uint8Array(ev.data, WISDOM_STATUS_MIN_BYTES),
+            )
+          : '';
+      const store = useConnectionStore.getState();
+      store.setWisdomPhase(phase);
+      store.setWisdomStatus(status);
+      return;
+    }
+    if (peekType === MSG_TYPE_ALERT) {
+      if (ev.data.byteLength < 2) {
+        warnOnce('ws-alert-short', `alert frame too short: ${ev.data.byteLength}`);
+        return;
+      }
+      const dv = new DataView(ev.data);
+      const kind = dv.getUint8(1);
+      const msgBytes = new Uint8Array(ev.data, 2);
+      const message = new TextDecoder('utf-8').decode(msgBytes);
+      useTxStore.getState().setAlert({ kind, message });
+      // A SWR / TX-timeout trip force-drops MOX on the server, which also
+      // disarms any running two-tone test. Clear the local latch so the
+      // TwoTone button doesn't stay lit (and desynced) after the trip —
+      // moxOn/tunOn are cleared separately by the MoxStateFrame off-edge.
+      if (kind === AlertKind.SwrTrip || kind === AlertKind.TxTimeout) {
+        useTxStore.getState().setTwoToneOn(false);
+      }
+      return;
+    }
+    if (peekType === MSG_TYPE_BAND_PLAN_CHANGED) {
+      void useBandPlanStore.getState().refresh();
+      return;
+    }
+    if (peekType === MSG_TYPE_MOX_STATE) {
+      if (ev.data.byteLength < MOX_STATE_BYTES) {
+        warnOnce('ws-mox-state-short', `mox state frame too short: ${ev.data.byteLength}`);
+        return;
+      }
+      const dv = new DataView(ev.data);
+      const moxOn = dv.getUint8(1) !== 0;
+      const tunOn = dv.getUint8(2) !== 0;
+      const txStore = useTxStore.getState();
+      if (moxOn) {
+        txStore.setMoxOn(true);
+        txStore.setTxMonitorEnabled(false);
+      } else if (tunOn) {
+        txStore.setTunOn(true);
+        txStore.setTxMonitorEnabled(false);
+      } else {
+        txStore.setMoxOn(false);
+        txStore.setTunOn(false);
+        // Server forced MOX off (SWR trip, TX timeout, TCI key-up) — also
+        // disarm the local mic so the browser stops pushing samples even if
+        // the operator never released their MoxButton / spacebar. Inverse
+        // is intentional asymmetric: server-side MOX-on never raises
+        // localMicArmed (only local interaction does — see issue #346).
+        if (txStore.localMicArmed) txStore.setLocalMicArmed(false);
+      }
+      return;
+    }
+    if (peekType === MSG_TYPE_SPOT_LIST) {
+      if (ev.data.byteLength < SPOT_LIST_MIN_BYTES) {
+        warnOnce('ws-spot-list-short', `spot list frame too short: ${ev.data.byteLength}`);
+        return;
+      }
+      const dv = new DataView(ev.data);
+      const count = dv.getUint16(1, true);
+      const spots: { callsign: string; mode: string; freqHz: number; argb: number; comment?: string }[] = [];
+      let offset = 3;
+      const td = new TextDecoder('utf-8');
+      for (let i = 0; i < count; i++) {
+        if (offset + 16 > ev.data.byteLength) break; // minimum per-spot fixed bytes
+        const freqHz = Number(dv.getBigInt64(offset, true)); offset += 8;
+        const argb = dv.getUint32(offset, true); offset += 4;
+        const callsignLen = dv.getUint8(offset); offset += 1;
+        if (offset + callsignLen > ev.data.byteLength) break;
+        const callsign = td.decode(new Uint8Array(ev.data, offset, callsignLen)); offset += callsignLen;
+        const modeLen = dv.getUint8(offset); offset += 1;
+        if (offset + modeLen > ev.data.byteLength) break;
+        const mode = td.decode(new Uint8Array(ev.data, offset, modeLen)); offset += modeLen;
+        if (offset + 2 > ev.data.byteLength) break;
+        const commentLen = dv.getUint16(offset, true); offset += 2;
+        if (offset + commentLen > ev.data.byteLength) break;
+        const comment = commentLen > 0 ? td.decode(new Uint8Array(ev.data, offset, commentLen)) : undefined;
+        offset += commentLen;
+        spots.push({ callsign, mode, freqHz, argb, comment });
+      }
+      useSpotStore.getState().setSpots(spots);
+      return;
+    }
+    warnOnce(
+      `ws-msgtype-${peekType}`,
+      `ignoring msgType 0x${peekType.toString(16)}`,
+    );
+  } catch (err) {
+    if (err instanceof FrameDecodeError || err instanceof AudioFrameDecodeError) {
+      warnOnce(`ws-decode-${err.message.slice(0, 32)}`, err.message);
+    } else {
+      warnOnce('ws-decode-unknown', 'frame decode failed', err);
+    }
+  }
+}
+
 export function startRealtime(path = '/ws'): () => void {
   let ws: WebSocket | null = null;
   let backoff = INITIAL_BACKOFF_MS;
   let timer: ReturnType<typeof setTimeout> | null = null;
   let stopped = false;
 
-  const { pushFrame, setConnected } = useDisplayStore.getState();
+  const { setConnected } = useDisplayStore.getState();
   const syncDisplayStreamRequest = (active = hasActiveFrameConsumers()) => {
     sendDisplayStreamRequest(active);
   };
@@ -414,369 +815,7 @@ export function startRealtime(path = '/ws'): () => void {
     };
     ws.onmessage = (ev) => {
       if (!(ev.data instanceof ArrayBuffer)) return;
-      try {
-        const peekType = new DataView(ev.data).getUint8(0);
-        if (peekType === MSG_TYPE_DISPLAY_FRAME) {
-          // Skip the decode + push when no spectrum surface is mounted.
-          // decodeDisplayFrame allocates two Float32Arrays per tick and
-          // pushFrame fans the new state through every store subscriber —
-          // both are wasted when the panadapter, waterfall, and filter
-          // mini-pan are all closed. Consumers register via
-          // registerFrameConsumer() in display-store.ts; the moment any of
-          // them mounts we resume decoding on the next tick.
-          if (!hasActiveFrameConsumers()) return;
-          const frame = decodeDisplayFrame(ev.data);
-          pushFrame(frame);
-          return;
-        }
-        if (peekType === MSG_TYPE_AUDIO_PCM) {
-          // Decode once and publish to the RX audio bus, which fans the single
-          // stream out to speaker playback (AudioClient — which self-suppresses
-          // in native/desktop mode) and any taps (the CW decoder). We do NOT
-          // gate on isNativeAudio() here on purpose: in desktop mode the server
-          // sends 0x02 only on demand (when a decoder asks via 0x21), and those
-          // frames must reach the bus so the decoder can consume them. Playback
-          // opts out downstream in AudioClient.push(), not here.
-          const audio = decodeAudioFrame(ev.data);
-          getAudioBus().publish(audio);
-          return;
-        }
-        if (peekType === MSG_TYPE_TX_METERS_V2) {
-          if (ev.data.byteLength < TX_METERS_V2_BYTES) {
-            warnOnce(
-              'ws-tx-meters-v2-short',
-              `tx meters v2 frame too short: ${ev.data.byteLength}`,
-            );
-            return;
-          }
-          const dv = new DataView(ev.data);
-          useTxStore.getState().setMeters({
-            fwdWatts: dv.getFloat32(1, true),
-            refWatts: dv.getFloat32(5, true),
-            swr: dv.getFloat32(9, true),
-            micPk: dv.getFloat32(13, true),
-            micAv: dv.getFloat32(17, true),
-            eqPk: dv.getFloat32(21, true),
-            eqAv: dv.getFloat32(25, true),
-            lvlrPk: dv.getFloat32(29, true),
-            lvlrAv: dv.getFloat32(33, true),
-            lvlrGr: dv.getFloat32(37, true),
-            cfcPk: dv.getFloat32(41, true),
-            cfcAv: dv.getFloat32(45, true),
-            cfcGr: dv.getFloat32(49, true),
-            compPk: dv.getFloat32(53, true),
-            compAv: dv.getFloat32(57, true),
-            alcPk: dv.getFloat32(61, true),
-            alcAv: dv.getFloat32(65, true),
-            alcGr: dv.getFloat32(69, true),
-            outPk: dv.getFloat32(73, true),
-            outAv: dv.getFloat32(77, true),
-          });
-          return;
-        }
-        if (peekType === MSG_TYPE_MIC_PEAK) {
-          // Phase 4 — desktop-mode mic level. In browser mode the server
-          // does not emit this frame (NativeMicCapture isn't registered);
-          // if a misconfigured server ever pushes it, the existing
-          // AudioWorklet path is authoritative and we drop the wire frame.
-          if (!isNativeAudio()) return;
-          if (ev.data.byteLength < MIC_PEAK_BYTES) {
-            warnOnce(
-              'ws-mic-peak-short',
-              `mic peak frame too short: ${ev.data.byteLength}`,
-            );
-            return;
-          }
-          const dv = new DataView(ev.data);
-          const peakDbfs = dv.getFloat32(1, true);
-          // i64 LE — DataView gives us BigInt; convert to number (safe up
-          // to 2^53 ms ≈ year +287,000 AD, comfortably beyond any wall
-          // clock we'll see).
-          const tsUnixMs = Number(dv.getBigInt64(5, true));
-          useMicPeakStore.getState().setPeak(peakDbfs, tsUnixMs);
-          return;
-        }
-        if (peekType === MSG_TYPE_AUDIO_CHAIN_ORDER) {
-          // Variable-length CSV payload — empty payload encodes the
-          // "no plugins installed" empty-chain case.
-          const bytes = new Uint8Array(ev.data, 1);
-          const csv = new TextDecoder('utf-8').decode(bytes);
-          const ids = csv.length === 0 ? [] : csv.split(',');
-          useAudioSuiteStore.getState().setChainOrderFromServer(ids);
-          return;
-        }
-        if (peekType === MSG_TYPE_RX_AUDIO_CHAIN_ORDER) {
-          const bytes = new Uint8Array(ev.data, 1);
-          const csv = new TextDecoder('utf-8').decode(bytes);
-          const ids = csv.length === 0 ? [] : csv.split(',');
-          useAudioSuiteStore.getState().setRxChainOrderFromServer(ids);
-          return;
-        }
-        if (peekType === MSG_TYPE_CHAT_EVENT) {
-          // Variable-length UTF-8 JSON payload after the type byte.
-          const bytes = new Uint8Array(ev.data, 1);
-          const json = new TextDecoder('utf-8').decode(bytes);
-          try {
-            const envelope = JSON.parse(json) as ChatEnvelope;
-            useChatStore.getState().ingest(envelope);
-          } catch (err) {
-            warnOnce('ws-chat-event-parse', 'chat event frame parse failed', err);
-          }
-          return;
-        }
-        if (peekType === MSG_TYPE_CW_ENGINE_STATUS) {
-          if (ev.data.byteLength < CW_ENGINE_STATUS_HEADER_BYTES) {
-            warnOnce(
-              'ws-cw-status-short',
-              `cw status frame too short: ${ev.data.byteLength}`,
-            );
-            return;
-          }
-          const dv = new DataView(ev.data);
-          const stateByte = dv.getUint8(1);
-          const wpm = dv.getUint16(2, true);
-          const queueDepth = dv.getUint16(4, true);
-          const textLen = dv.getUint16(6, true);
-          if (ev.data.byteLength < CW_ENGINE_STATUS_HEADER_BYTES + textLen) {
-            warnOnce(
-              'ws-cw-status-truncated',
-              `cw status text claims ${textLen} bytes but only ${
-                ev.data.byteLength - CW_ENGINE_STATUS_HEADER_BYTES
-              } follow`,
-            );
-            return;
-          }
-          const text =
-            textLen === 0
-              ? ''
-              : new TextDecoder('utf-8').decode(
-                  new Uint8Array(ev.data, CW_ENGINE_STATUS_HEADER_BYTES, textLen),
-                );
-          const state = CW_STATE_FROM_BYTE[stateByte] ?? 'idle';
-          useCwStore.getState().setStatusFromServer({
-            state,
-            text,
-            wpm,
-            queueDepth,
-            receivedAtMs: Date.now(),
-          });
-          return;
-        }
-        // 0x31 CwDecodedText (classic server-side decoder) was retired in
-        // favour of the browser-side DeepCW neural decoder (plugins/deepcw).
-        // The MSG_TYPE_CW_DECODED_TEXT value stays reserved; the server no
-        // longer broadcasts it.
-        if (peekType === MSG_TYPE_AUDIO_MASTER_BYPASS) {
-          if (ev.data.byteLength < AUDIO_MASTER_BYPASS_BYTES) {
-            warnOnce(
-              'ws-audio-master-bypass-short',
-              `audio master-bypass frame too short: ${ev.data.byteLength}`,
-            );
-            return;
-          }
-          const bypassed = new DataView(ev.data).getUint8(1) !== 0;
-          useAudioSuiteStore.getState().setMasterBypassedFromServer(bypassed);
-          return;
-        }
-        if (peekType === MSG_TYPE_RX_AUDIO_MASTER_BYPASS) {
-          if (ev.data.byteLength < RX_AUDIO_MASTER_BYPASS_BYTES) {
-            warnOnce(
-              'ws-rx-audio-master-bypass-short',
-              `rx audio master-bypass frame too short: ${ev.data.byteLength}`,
-            );
-            return;
-          }
-          const bypassed = new DataView(ev.data).getUint8(1) !== 0;
-          useAudioSuiteStore.getState().setRxMasterBypassedFromServer(bypassed);
-          return;
-        }
-        if (peekType === MSG_TYPE_PTT_STATUS) {
-          if (ev.data.byteLength < PTT_STATUS_BYTES) {
-            warnOnce(
-              'ws-ptt-status-short',
-              `PTT status frame too short: ${ev.data.byteLength}`,
-            );
-            return;
-          }
-          const keyed = new DataView(ev.data).getUint8(1) !== 0;
-          usePttStore.getState().setKeyed(keyed);
-          return;
-        }
-        if (peekType === MSG_TYPE_PA_TEMP) {
-          if (ev.data.byteLength < PA_TEMP_BYTES) {
-            warnOnce(
-              'ws-pa-temp-short',
-              `PA temp frame too short: ${ev.data.byteLength}`,
-            );
-            return;
-          }
-          const tempC = new DataView(ev.data).getFloat32(1, true);
-          useTxStore.getState().setPaTempC(tempC);
-          return;
-        }
-        if (peekType === MSG_TYPE_PS_METERS) {
-          if (ev.data.byteLength < PS_METERS_BYTES) {
-            warnOnce(
-              'ws-ps-meters-short',
-              `PS meters frame too short: ${ev.data.byteLength}`,
-            );
-            return;
-          }
-          const dv = new DataView(ev.data);
-          useTxStore.getState().setPsMeters({
-            feedbackLevel: dv.getFloat32(1, true),
-            correctionDb: dv.getFloat32(5, true),
-            calState: dv.getUint8(9),
-            correcting: dv.getUint8(10) !== 0,
-            maxTxEnvelope: dv.getFloat32(11, true),
-          });
-          return;
-        }
-        if (peekType === MSG_TYPE_RX_METER) {
-          if (ev.data.byteLength < RX_METER_BYTES) {
-            warnOnce(
-              'ws-rx-meter-short',
-              `rx meter frame too short: ${ev.data.byteLength}`,
-            );
-            return;
-          }
-          const dbm = new DataView(ev.data).getFloat32(1, true);
-          useTxStore.getState().setRxDbm(dbm);
-          return;
-        }
-        if (peekType === MSG_TYPE_RX_METERS_V2) {
-          if (ev.data.byteLength < RX_METERS_V2_BYTES) {
-            warnOnce(
-              'ws-rx-meters-v2-short',
-              `rx meters v2 frame too short: ${ev.data.byteLength}`,
-            );
-            return;
-          }
-          const dv = new DataView(ev.data);
-          useRxMetersStore.getState().setMeters({
-            signalPk: dv.getFloat32(1, true),
-            signalAv: dv.getFloat32(5, true),
-            adcPk: dv.getFloat32(9, true),
-            adcAv: dv.getFloat32(13, true),
-            agcGain: dv.getFloat32(17, true),
-            agcEnvPk: dv.getFloat32(21, true),
-            agcEnvAv: dv.getFloat32(25, true),
-          });
-          return;
-        }
-        if (peekType === MSG_TYPE_WISDOM_STATUS) {
-          if (ev.data.byteLength < WISDOM_STATUS_MIN_BYTES) {
-            warnOnce(
-              'ws-wisdom-short',
-              `wisdom frame too short: ${ev.data.byteLength}`,
-            );
-            return;
-          }
-          const raw = new DataView(ev.data).getUint8(1);
-          const phase: WisdomPhase =
-            raw === 1 ? 'building' : raw === 2 ? 'ready' : 'idle';
-          const status =
-            ev.data.byteLength > WISDOM_STATUS_MIN_BYTES
-              ? new TextDecoder('utf-8').decode(
-                  new Uint8Array(ev.data, WISDOM_STATUS_MIN_BYTES),
-                )
-              : '';
-          const store = useConnectionStore.getState();
-          store.setWisdomPhase(phase);
-          store.setWisdomStatus(status);
-          return;
-        }
-        if (peekType === MSG_TYPE_ALERT) {
-          if (ev.data.byteLength < 2) {
-            warnOnce('ws-alert-short', `alert frame too short: ${ev.data.byteLength}`);
-            return;
-          }
-          const dv = new DataView(ev.data);
-          const kind = dv.getUint8(1);
-          const msgBytes = new Uint8Array(ev.data, 2);
-          const message = new TextDecoder('utf-8').decode(msgBytes);
-          useTxStore.getState().setAlert({ kind, message });
-          // A SWR / TX-timeout trip force-drops MOX on the server, which also
-          // disarms any running two-tone test. Clear the local latch so the
-          // TwoTone button doesn't stay lit (and desynced) after the trip —
-          // moxOn/tunOn are cleared separately by the MoxStateFrame off-edge.
-          if (kind === AlertKind.SwrTrip || kind === AlertKind.TxTimeout) {
-            useTxStore.getState().setTwoToneOn(false);
-          }
-          return;
-        }
-        if (peekType === MSG_TYPE_BAND_PLAN_CHANGED) {
-          void useBandPlanStore.getState().refresh();
-          return;
-        }
-        if (peekType === MSG_TYPE_MOX_STATE) {
-          if (ev.data.byteLength < MOX_STATE_BYTES) {
-            warnOnce('ws-mox-state-short', `mox state frame too short: ${ev.data.byteLength}`);
-            return;
-          }
-          const dv = new DataView(ev.data);
-          const moxOn = dv.getUint8(1) !== 0;
-          const tunOn = dv.getUint8(2) !== 0;
-          const txStore = useTxStore.getState();
-          if (moxOn) {
-            txStore.setMoxOn(true);
-            txStore.setTxMonitorEnabled(false);
-          } else if (tunOn) {
-            txStore.setTunOn(true);
-            txStore.setTxMonitorEnabled(false);
-          } else {
-            txStore.setMoxOn(false);
-            txStore.setTunOn(false);
-            // Server forced MOX off (SWR trip, TX timeout, TCI key-up) — also
-            // disarm the local mic so the browser stops pushing samples even if
-            // the operator never released their MoxButton / spacebar. Inverse
-            // is intentional asymmetric: server-side MOX-on never raises
-            // localMicArmed (only local interaction does — see issue #346).
-            if (txStore.localMicArmed) txStore.setLocalMicArmed(false);
-          }
-          return;
-        }
-        if (peekType === MSG_TYPE_SPOT_LIST) {
-          if (ev.data.byteLength < SPOT_LIST_MIN_BYTES) {
-            warnOnce('ws-spot-list-short', `spot list frame too short: ${ev.data.byteLength}`);
-            return;
-          }
-          const dv = new DataView(ev.data);
-          const count = dv.getUint16(1, true);
-          const spots: { callsign: string; mode: string; freqHz: number; argb: number; comment?: string }[] = [];
-          let offset = 3;
-          const td = new TextDecoder('utf-8');
-          for (let i = 0; i < count; i++) {
-            if (offset + 16 > ev.data.byteLength) break; // minimum per-spot fixed bytes
-            const freqHz = Number(dv.getBigInt64(offset, true)); offset += 8;
-            const argb = dv.getUint32(offset, true); offset += 4;
-            const callsignLen = dv.getUint8(offset); offset += 1;
-            if (offset + callsignLen > ev.data.byteLength) break;
-            const callsign = td.decode(new Uint8Array(ev.data, offset, callsignLen)); offset += callsignLen;
-            const modeLen = dv.getUint8(offset); offset += 1;
-            if (offset + modeLen > ev.data.byteLength) break;
-            const mode = td.decode(new Uint8Array(ev.data, offset, modeLen)); offset += modeLen;
-            if (offset + 2 > ev.data.byteLength) break;
-            const commentLen = dv.getUint16(offset, true); offset += 2;
-            if (offset + commentLen > ev.data.byteLength) break;
-            const comment = commentLen > 0 ? td.decode(new Uint8Array(ev.data, offset, commentLen)) : undefined;
-            offset += commentLen;
-            spots.push({ callsign, mode, freqHz, argb, comment });
-          }
-          useSpotStore.getState().setSpots(spots);
-          return;
-        }
-        warnOnce(
-          `ws-msgtype-${peekType}`,
-          `ignoring msgType 0x${peekType.toString(16)}`,
-        );
-      } catch (err) {
-        if (err instanceof FrameDecodeError || err instanceof AudioFrameDecodeError) {
-          warnOnce(`ws-decode-${err.message.slice(0, 32)}`, err.message);
-        } else {
-          warnOnce('ws-decode-unknown', 'frame decode failed', err);
-        }
-      }
+      dispatchServerFrame(ev.data);
     };
   };
 

--- a/zeus-web/src/remote/RemoteGate.tsx
+++ b/zeus-web/src/remote/RemoteGate.tsx
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// In-app password gate for remote (WebRTC) RX monitoring. Rendered only in
+// remote mode (?remote=<CALLSIGN>). Prompts for the session password using the
+// project's in-app dialog chrome (NEVER window.prompt — hard project rule),
+// connects via the broker, and once the SPAKE2+ handshake unlocks it marks the
+// display store connected and unmounts itself so the normal UI takes over.
+// Connection errors (wrong password, radio offline, broker unreachable) surface
+// inline with a retry.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ConfirmDialog } from '../layout/ConfirmDialog';
+import { useDisplayStore } from '../state/display-store';
+import { getRemoteCallsign, startRemoteClient } from './remote-client';
+import type { RemoteConnection } from './connect';
+
+type Phase = 'prompt' | 'connecting' | 'connected';
+
+export function RemoteGate() {
+  const callsign = getRemoteCallsign() ?? '';
+  const [password, setPassword] = useState('');
+  const [phase, setPhase] = useState<Phase>('prompt');
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const connRef = useRef<RemoteConnection | null>(null);
+
+  // Focus the password field once the dialog's own focus trap settles.
+  useEffect(() => {
+    if (phase !== 'prompt') return;
+    const t = setTimeout(() => inputRef.current?.focus(), 0);
+    return () => clearTimeout(t);
+  }, [phase]);
+
+  // Tear the WebRTC session down if the gate unmounts mid-flight.
+  useEffect(() => () => connRef.current?.close(), []);
+
+  const connect = useCallback(() => {
+    const pw = password;
+    if (!pw) return;
+    setError(null);
+    setPhase('connecting');
+    startRemoteClient(callsign, pw)
+      .then((conn) => {
+        connRef.current = conn;
+        // Flip the panadapter/UI to "connected" — display frames now arrive
+        // over WebRTC and dispatchServerFrame feeds the same stores.
+        useDisplayStore.getState().setConnected(true);
+        setPhase('connected');
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : 'Connection failed.');
+        setPhase('prompt');
+      });
+  }, [callsign, password]);
+
+  // Once unlocked the gate has nothing to render — the live UI shows through.
+  if (phase === 'connected') return null;
+
+  const connecting = phase === 'connecting';
+
+  return (
+    <ConfirmDialog
+      title={`Remote · ${callsign}`}
+      intent="primary"
+      confirmLabel={connecting ? 'Connecting…' : 'Connect'}
+      cancelLabel="Cancel"
+      onCancel={() => {
+        // No local app to fall back to in remote mode; closing the tab is the
+        // operator's exit. Keep the gate up so they can retry.
+        setError(null);
+      }}
+      onConfirm={connect}
+    >
+      <p>Enter the session password to monitor {callsign}'s radio.</p>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (!connecting) connect();
+        }}
+      >
+        <input
+          ref={inputRef}
+          type="password"
+          className="mono"
+          autoComplete="current-password"
+          placeholder="Session password"
+          value={password}
+          disabled={connecting}
+          onChange={(e) => setPassword(e.currentTarget.value)}
+          style={{
+            width: '100%',
+            padding: '6px 8px',
+            borderRadius: 'var(--r-sm)',
+            border: '1px solid var(--line-strong)',
+            background: '#0c0c10',
+            color: '#d8d8dc',
+            fontSize: 13,
+            outline: 'none',
+          }}
+        />
+      </form>
+      {error && (
+        <p role="alert" style={{ color: 'var(--tx)', marginTop: 8 }}>
+          {error}
+        </p>
+      )}
+    </ConfirmDialog>
+  );
+}

--- a/zeus-web/src/remote/connect.ts
+++ b/zeus-web/src/remote/connect.ts
@@ -26,6 +26,12 @@ const DEFAULT_STUN: RTCIceServer[] = [{ urls: 'stun:stun.cloudflare.com:3478' }]
 export interface RemoteConnection {
   pc: RTCPeerConnection;
   frames: RTCDataChannel;
+  /**
+   * The reliable, ordered control channel. After unlock it also carries the
+   * 2-byte stream-request control frames (0x21 audio / 0x22 display) the client
+   * sends to enable RX egress — see setRemoteControlSender in ws-client.ts.
+   */
+  control: RTCDataChannel;
   close(): void;
 }
 
@@ -147,7 +153,7 @@ async function establish(
   await pc.setRemoteDescription({ type: 'answer', sdp: answerSdp });
 
   await unlocked;
-  return { pc, frames, close: () => pc.close() };
+  return { pc, frames, control, close: () => pc.close() };
 }
 
 // --- signalling transports -------------------------------------------------

--- a/zeus-web/src/remote/remote-client.test.ts
+++ b/zeus-web/src/remote/remote-client.test.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Unit tests for the remote-mode URL parsing — the ?remote=<CALLSIGN> gate that
+// decides whether the SPA runs as a local /ws client or a WebRTC RX monitor.
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { getRemoteCallsign, isRemoteMode } from './remote-client';
+
+function setSearch(search: string): void {
+  // jsdom honours replaceState for location.search without a real navigation.
+  window.history.replaceState(null, '', `/${search}`);
+}
+
+describe('remote-client URL parsing', () => {
+  afterEach(() => setSearch(''));
+
+  it('returns null when ?remote is absent', () => {
+    setSearch('?foo=bar');
+    expect(getRemoteCallsign()).toBeNull();
+    expect(isRemoteMode()).toBe(false);
+  });
+
+  it('returns null for an empty ?remote', () => {
+    setSearch('?remote=');
+    expect(getRemoteCallsign()).toBeNull();
+    expect(isRemoteMode()).toBe(false);
+  });
+
+  it('returns the upper-cased, trimmed callsign', () => {
+    setSearch('?remote=n9war');
+    expect(getRemoteCallsign()).toBe('N9WAR');
+    expect(isRemoteMode()).toBe(true);
+  });
+
+  it('treats a whitespace-only ?remote as not-remote', () => {
+    setSearch('?remote=%20%20');
+    expect(getRemoteCallsign()).toBeNull();
+    expect(isRemoteMode()).toBe(false);
+  });
+});

--- a/zeus-web/src/remote/remote-client.ts
+++ b/zeus-web/src/remote/remote-client.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Remote-access RX-monitoring bootstrap (Phase A). When the SPA is opened at
+// `…/?remote=<CALLSIGN>` it connects to the operator's radio over WebRTC through
+// the Cloudflare broker instead of the local websocket, then feeds the unlocked
+// binary radio frames through the exact same dispatch path the local /ws client
+// uses (dispatchServerFrame) — so panadapter / waterfall / meters / audio render
+// identically, just sourced over WebRTC.
+//
+// Scope is RX MONITORING ONLY: display + audio + meters. There is no TX, mic
+// uplink, or tuning/control RPC in this phase. Deny-by-default holds: nothing
+// flows until connectViaBroker's SPAKE2+ password handshake unlocks.
+
+import { connectViaBroker, type RemoteConnection } from './connect';
+import {
+  dispatchServerFrame,
+  sendAudioStreamRequest,
+  sendDisplayStreamRequest,
+  setRemoteControlSender,
+} from '../realtime/ws-client';
+
+/** Parse `?remote=<CALLSIGN>` from the current URL; '' / absent → not remote. */
+export function getRemoteCallsign(): string | null {
+  try {
+    const cs = new URLSearchParams(window.location.search).get('remote');
+    const trimmed = cs?.trim();
+    return trimmed ? trimmed.toUpperCase() : null;
+  } catch {
+    return null;
+  }
+}
+
+/** True when the SPA should run as a remote (WebRTC) monitor rather than a local client. */
+export function isRemoteMode(): boolean {
+  return getRemoteCallsign() !== null;
+}
+
+/**
+ * Connect to the operator's radio via the broker, unlock with the supplied
+ * password, then route the unlocked frame stream into the stores and request
+ * the RX display + audio streams over the control DataChannel.
+ *
+ * Resolves with the live connection once unlocked; rejects with a human-readable
+ * Error (incorrect password, radio offline, broker unreachable) the gate UI can
+ * surface for retry. No frame flows before this resolves.
+ */
+export async function startRemoteClient(
+  callsign: string,
+  password: string,
+): Promise<RemoteConnection> {
+  const conn = await connectViaBroker({
+    callsign,
+    password,
+    onFrame: (data) => dispatchServerFrame(data),
+  });
+
+  // Route the 2-byte stream-request control frames (0x21/0x22) over the WebRTC
+  // control channel instead of the (absent) local websocket. Drop the override
+  // and tear the session down if the peer connection dies.
+  setRemoteControlSender((bytes) => {
+    try {
+      conn.control.send(new Uint8Array(bytes));
+    } catch {
+      /* channel closed underneath us — onclose/onconnectionstatechange clean up */
+    }
+  });
+
+  conn.pc.addEventListener('connectionstatechange', () => {
+    const s = conn.pc.connectionState;
+    if (s === 'closed' || s === 'failed' || s === 'disconnected') {
+      setRemoteControlSender(null);
+    }
+  });
+
+  // Ask the radio to start the RX display + audio streams. The server bumps its
+  // global display/audio gates on these (RemoteWebRtcSession → hub), which is
+  // what actually opens the panadapter frame fan-out for this session.
+  sendDisplayStreamRequest(true);
+  sendAudioStreamRequest(true);
+
+  return conn;
+}


### PR DESCRIPTION
Builds on #811 (SPAKE2+ password + QR) and #820 (media bridge + broker-signaling client), both merged. This is the piece that makes scanning the QR actually *do* something: a browser opened at `…/?remote=<CALLSIGN>` connects to the operator's radio over WebRTC through the Cloudflare broker and renders the live panadapter / waterfall / meters and plays RX audio — the same SPA, just sourced over WebRTC instead of the local websocket.

**Scope: RX monitoring only.** No TX, no mic uplink, no tuning/control RPC — those are a deliberate later phase. Deny-by-default holds: nothing renders until the SPAKE2+ session password unlocks.

## Frontend
- **Transport-agnostic dispatch** — the entire `ws.onmessage` binary-frame switch is extracted into an exported `dispatchServerFrame(data)`. The `/ws` handler is now a thin caller, **byte-for-byte unchanged for local clients** (verified).
- **Control-send override** (`setRemoteControlSender`) routes the 2-byte `0x21`/`0x22` stream-request frames over the WebRTC control channel in remote mode, else the websocket as before. Mic uplink stays websocket-only.
- `connect.ts` exposes the control `RTCDataChannel`; `remote-client.ts` parses `?remote` and wires `connectViaBroker` → `dispatchServerFrame` → RX display+audio request.
- `RemoteGate.tsx` — in-app password gate on the existing `ConfirmDialog` chrome (**never** a browser dialog — hard project rule), surfacing incorrect-password / radio-offline / broker-unreachable with retry.
- `App.tsx` — in remote mode, skip the local `startRealtime` (no doomed second `/ws`) and mount the gate.

## Server
- `StreamingHub.AdjustDisplayRequests/AdjustAudioRequests` move the global RX gates that decide whether display/audio frames broadcast.
- `RemoteWebRtcSession` splits control input: **post-unlock** binary `0x21`/`0x22` frames drive the gates (tracked per session, moved at most once per transition, **unwound on `Close`** so a remote disconnect can't pin a gate on); pre-unlock / JSON stays the SPAKE2+ auth path and still fails closed.

## Also fixes a flake from #820
Hardens both WebRTC frame-delivery tests to **broadcast-until-received** (≤15 s). #820's `UnlockedSession_ReceivesHubBroadcastFrame` was timing-fragile on the emulated windows-arm64 runner (a one-shot frame exceeding a 5 s wait); this removes the attach-race/latency flake on slow CI.

## Verification
- `tsc --noEmit` (zeus-web): clean.
- `dotnet build tests/Zeus.Server.Tests`: 0 warnings, 0 errors (against current `develop`).
- Targeted suite (Remote/Hub/Streaming/Client/Broadcast): **54 passed, 0 failed**, incl. new `DisplayRequest_OpensGate_AndDisplayFrameReachesRemotePeer`.
- Remote vitest: **12 passed**.
- No new dependencies, no wire-format change, `/ws` hot path preserved.

## Remaining to operate end-to-end (next, not in this PR)
Deploy the web client to a subdomain (don't overwrite `openhpsdrzeus.com`) and point the broker's `WEB_APP_ORIGIN` at it; optional Cloudflare TURN secrets for CGNAT. Then: radio running with a session password + QRZ sign-in → scan QR → monitor.