### PR TITLE
fix(tx): dual-RX TUNE no-carrier — alex1 TX LPF must follow TX VFO, not RX2

### DIFF
--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -158,6 +158,16 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // accessed ints/uints. _rx2Enabled: 0 = off, 1 = on.
     private int _rx2Enabled;
     private uint _rx2FreqHz = 7_100_000;
+    // TX DUC NCO frequency. Normally tracks _rxFreqHz (the shared RX0/TX LO) so
+    // the TX carrier lands at the RX0 frequency — byte-identical to the historic
+    // single-frequency model. For dual-RX split TX (TX VFO = B with RX2 on) the
+    // hosting layer sets this INDEPENDENTLY to VFO B's effective LO via
+    // SetTxDucFrequency, so the TX carrier goes to VFO B WITHOUT dragging RX0/RX1
+    // off VFO A (the dual-RX TUNE "two carriers, one on each RX" bug).
+    // _txDucIndependent latches that override; it is cleared when split ends so
+    // the DUC follows RX0 again.
+    private uint _txDucFreqHz = 14_200_000;
+    private volatile bool _txDucIndependent;
     // Per-source-port IQ packet rate (packets in the last completed ~1 s
     // window) for UDP ports RxDataPortBase..RxDataPortBase+MaxRxDdc-1 (1035..1042)
     // → index 0..7 → DDC 0..7. Written by the single RX thread on each window
@@ -624,10 +634,41 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         // (`rxPhase = _rxFreqHz * HzToPhase`).
         long corrected = (long)Math.Round(hz * factor, MidpointRounding.AwayFromZero);
         _rxFreqHz = (uint)Math.Clamp(corrected, 0L, uint.MaxValue);
+        // The TX DUC follows RX0 unless an independent split-TX freq is latched.
+        if (!_txDucIndependent) _txDucFreqHz = _rxFreqHz;
         var running = _rxTask is not null;
         _log.LogInformation("p2.tune hz={Hz} running={Running} hpSeq={Seq}",
             _rxFreqHz, running, _seqCmdHp);
         if (running) SendCmdHighPriority(run: true);
+    }
+
+    /// <summary>
+    /// Set the TX DUC NCO frequency independently of the shared RX0/TX LO. Used
+    /// for dual-RX split TX (TX VFO = B with RX2 enabled): the TX carrier must
+    /// land on VFO B while RX1 keeps receiving VFO A, so the TX DUC can no longer
+    /// be tied to RX0's frequency. <paramref name="hz"/> &lt;= 0 clears the
+    /// override and the DUC follows RX0 again (the non-split / single-VFO model,
+    /// byte-identical to before). Applies the same host-side frequency correction
+    /// as <see cref="SetVfoAHz"/>. Re-sends the high-priority packet when live.
+    /// </summary>
+    public void SetTxDucFrequency(long hz)
+    {
+        if (hz <= 0)
+        {
+            if (!_txDucIndependent && _txDucFreqHz == _rxFreqHz) return;
+            _txDucIndependent = false;
+            _txDucFreqHz = _rxFreqHz;
+        }
+        else
+        {
+            double factor = BitConverter.Int64BitsToDouble(Interlocked.Read(ref _freqCorrectionBits));
+            long corrected = (long)Math.Round(hz * factor, MidpointRounding.AwayFromZero);
+            uint next = (uint)Math.Clamp(corrected, 0L, uint.MaxValue);
+            if (_txDucIndependent && _txDucFreqHz == next) return;
+            _txDucFreqHz = next;
+            _txDucIndependent = true;
+        }
+        if (_rxTask is not null) SendCmdHighPriority(run: true);
     }
 
     /// <summary>
@@ -716,6 +757,12 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     /// <see cref="FrequencyCorrectionFactor"/>.
     /// </summary>
     internal uint CorrectedRxFreqHzForTesting => _rxFreqHz;
+
+    /// <summary>Test accessor: the (correction-applied) TX DUC NCO frequency.</summary>
+    internal uint TxDucFreqHzForTesting => _txDucFreqHz;
+
+    /// <summary>Test accessor: whether the TX DUC is on the independent split-TX override.</summary>
+    internal bool TxDucIndependentForTesting => _txDucIndependent;
 
     public void SetSampleRateKhz(int rateKhz)
     {
@@ -1811,7 +1858,11 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         uint rxPhase = (uint)(_rxFreqHz * HzToPhase);
         int rxDdc = RxBaseDdc(_boardKind);
         WriteBeU32(p, 9 + rxDdc * 4, rxPhase);
-        WriteBeU32(p, 329, rxPhase);
+        // TX DUC NCO phase. Normally _txDucFreqHz == _rxFreqHz, so this is
+        // identical to rxPhase (DUC follows RX0). For dual-RX split TX it is set
+        // independently to VFO B (SetTxDucFrequency), so the carrier lands on B
+        // while the RX0 DDC above stays on VFO A — fixing the two-carrier bug.
+        WriteBeU32(p, 329, (uint)(_txDucFreqHz * HzToPhase));
 
         // Second receiver (RX2): tune its own DDC's NCO to _rx2FreqHz so it
         // demodulates an independent band. Each DDC's phase word lives at

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -2081,11 +2081,31 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         HpsdrBoardKind board = HpsdrBoardKind.OrionMkII,
         int txAntWire = 1)
     {
-        uint rx2FilterFreqHz = rx2Enabled ? rx2FreqHz : rxFreqHz;
+        // The alex1 word carries TWO independent filter selections that must NOT
+        // share a frequency when RX2 is on a different band than TX:
+        //   • BPF (bits set by ComputeAlexWord's 1st arg) = the RX2 RECEIVE
+        //     preselector — follows RX2's band when RX2 is enabled.
+        //   • LPF (2nd arg) = the TX LOW-PASS filter. Per pihpsdr
+        //     (new_protocol.c) the LPF is a TX-path filter carried on BOTH alex
+        //     words during TX, so it MUST follow the TX VFO, exactly like alex0.
+        // The original code computed BOTH from RX2's frequency, so with RX2
+        // parked on a different band than TX the alex1 LPF selected RX2's band
+        // and the filter board REJECTED the TX carrier — TUNE/MOX produced no RF
+        // whenever a second receiver was engaged on another band (dual-RX
+        // no-carrier bug). RX2 off → rx2FilterFreqHz fell back to the TX freq, so
+        // the LPF matched and TX worked, which is why disabling RX2 "fixed" it.
+        //
+        // Fix: state-multiplex the LPF to the TX VFO during transmit (mirroring
+        // alex0's antenna state-mux at the alex0 site), keeping the BPF on RX2's
+        // band for reception. During RX the LPF is inert (TX relay open) and we
+        // leave it on the RX2 band so the alex1 word stays byte-identical to
+        // before outside of transmit.
+        uint rx2BpfFreqHz = rx2Enabled ? rx2FreqHz : rxFreqHz;
+        uint lpfFreqHz = moxOn ? rxFreqHz : rx2BpfFreqHz;
         // alex1 ALWAYS reflects the TX antenna (external-ports plan — antenna
         // slice, #804) — it never carries the RX antenna, so the TX-antenna
         // selector is threaded straight through here.
-        uint alex1 = ComputeAlexWord(rx2FilterFreqHz, rx2FilterFreqHz, txAnt: txAntWire, board: board);
+        uint alex1 = ComputeAlexWord(rx2BpfFreqHz, lpfFreqHz, txAnt: txAntWire, board: board);
         if (moxOn) alex1 |= ALEX_TX_RELAY | ALEX1_ANAN7000_RX_GNDonTX;
         if (psEnabled) alex1 |= AlexPsBit;
         return alex1;

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -1965,7 +1965,17 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         int alex0AntWire = (xmit || _rxAuxInput != 0)
             ? txAntWire
             : ((_rxAntenna is 1 or 2 or 3) ? _rxAntenna : 1);
-        uint alex0Common = ComputeAlexWord(_rxFreqHz, _rxFreqHz, txAnt: txAntWire, board: _boardKind);
+        // TX low-pass filter source. The alex LPF on BOTH words is a TX-path
+        // filter and MUST follow the TX frequency, not RX1. _txDucFreqHz is the
+        // TX-freq source of truth (== _rxFreqHz when not split, == VFO B for
+        // dual-RX split TX). During RX the LPF is inert (TX relay open), so leave
+        // it on _rxFreqHz to keep the non-TX wire byte-identical. WITHOUT this,
+        // dual-RX split TX — where _rxFreqHz stays on VFO A while the DUC moves to
+        // VFO B — left the TX LPF on the RX1 band and the filter board rejected
+        // the VFO-B carrier, so there was NO RF output on a different band.
+        uint txLpfFreqHz = xmit ? _txDucFreqHz : _rxFreqHz;
+        // alex0 BPF follows RX1 (_rxFreqHz); LPF follows the TX freq.
+        uint alex0Common = ComputeAlexWord(_rxFreqHz, txLpfFreqHz, txAnt: txAntWire, board: _boardKind);
         // alex1 keeps the TX antenna from txAntWire; alex0 swaps in the
         // state-correct antenna (clear [26:24], re-OR via the shared encoder).
         uint alex0 = (alex0Common & ~ALEX_TX_ANTENNA_MASK) | EncodeTxAntennaBits(alex0AntWire)
@@ -1973,6 +1983,7 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         uint alex1 = ComposeAlex1Word(
             _rxFreqHz,
             _rx2FreqHz,
+            txLpfFreqHz,
             rx2Enabled,
             xmit,
             _psFeedbackEnabled,
@@ -2126,6 +2137,7 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     internal static uint ComposeAlex1Word(
         uint rxFreqHz,
         uint rx2FreqHz,
+        uint txLpfFreqHz,
         bool rx2Enabled,
         bool moxOn,
         bool psEnabled,
@@ -2133,26 +2145,25 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         int txAntWire = 1)
     {
         // The alex1 word carries TWO independent filter selections that must NOT
-        // share a frequency when RX2 is on a different band than TX:
-        //   • BPF (bits set by ComputeAlexWord's 1st arg) = the RX2 RECEIVE
-        //     preselector — follows RX2's band when RX2 is enabled.
+        // share a frequency when RX2 / the TX VFO sit on different bands:
+        //   • BPF (ComputeAlexWord's 1st arg) = the RX2 RECEIVE preselector —
+        //     follows RX2's band when RX2 is enabled, else RX1.
         //   • LPF (2nd arg) = the TX LOW-PASS filter. Per pihpsdr
         //     (new_protocol.c) the LPF is a TX-path filter carried on BOTH alex
-        //     words during TX, so it MUST follow the TX VFO, exactly like alex0.
-        // The original code computed BOTH from RX2's frequency, so with RX2
-        // parked on a different band than TX the alex1 LPF selected RX2's band
-        // and the filter board REJECTED the TX carrier — TUNE/MOX produced no RF
-        // whenever a second receiver was engaged on another band (dual-RX
-        // no-carrier bug). RX2 off → rx2FilterFreqHz fell back to the TX freq, so
-        // the LPF matched and TX worked, which is why disabling RX2 "fixed" it.
+        //     words during TX, so it MUST follow the TX frequency, exactly like
+        //     alex0. <paramref name="txLpfFreqHz"/> is the TX-freq source of truth
+        //     (== RX1 when not split, == VFO B for dual-RX split TX).
+        // History: the original code computed BOTH from RX2's frequency, so with
+        // RX2 on a different band the alex1 LPF rejected the TX carrier (no RF).
+        // The first fix used RX1's freq for the LPF, which is correct ONLY while
+        // the TX shares RX1's LO; for dual-RX split TX (where RX1 stays on VFO A
+        // and the TX DUC moves to VFO B independently) the LPF must follow the TX
+        // freq explicitly — hence the dedicated txLpfFreqHz argument.
         //
-        // Fix: state-multiplex the LPF to the TX VFO during transmit (mirroring
-        // alex0's antenna state-mux at the alex0 site), keeping the BPF on RX2's
-        // band for reception. During RX the LPF is inert (TX relay open) and we
-        // leave it on the RX2 band so the alex1 word stays byte-identical to
-        // before outside of transmit.
+        // During RX the LPF is inert (TX relay open); the caller passes RX1's
+        // freq then so the alex1 word stays byte-identical outside of transmit.
         uint rx2BpfFreqHz = rx2Enabled ? rx2FreqHz : rxFreqHz;
-        uint lpfFreqHz = moxOn ? rxFreqHz : rx2BpfFreqHz;
+        uint lpfFreqHz = moxOn ? txLpfFreqHz : rx2BpfFreqHz;
         // alex1 ALWAYS reflects the TX antenna (external-ports plan — antenna
         // slice, #804) — it never carries the RX antenna, so the TX-antenna
         // selector is threaded straight through here.

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -3144,6 +3144,17 @@ public class DspPipelineService : BackgroundService,
         UpdateRxLo(1, s);
         p2?.SetVfoBHz(_secondaryRx[1].LoHz);
 
+        // Dual-RX split TX: when VFO B is the TX VFO and RX2 is on, drive the TX
+        // DUC to VFO B's effective LO (the same centre RX2 sits on) INDEPENDENTLY
+        // so a TUNE/MOX carrier lands on VFO B while RX1 keeps receiving VFO A.
+        // Clearing (0) returns the DUC to following RX0 — the non-split single-
+        // VFO model, byte-identical to before. Pairs with RadioService.
+        // AlignLoForTx skipping the shared-LO drag for this P2 split case
+        // (dragging the LO is what pulled RX1 to VFO B and showed the carrier on
+        // both receivers — the two-carrier bug).
+        bool splitTxToVfoB = s.TxVfo == TxVfo.B && s.Rx2Enabled;
+        p2?.SetTxDucFrequency(splitTxToVfoB ? _secondaryRx[1].LoHz : 0);
+
         // Issue #597 Phase 0: arm the RX display fast-attack when the LO
         // moves. First callback after construction only records the LO
         // (sentinel) so connect itself doesn't trigger a pointless arm.

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -3152,8 +3152,14 @@ public class DspPipelineService : BackgroundService,
         // AlignLoForTx skipping the shared-LO drag for this P2 split case
         // (dragging the LO is what pulled RX1 to VFO B and showed the carrier on
         // both receivers — the two-carrier bug).
+        // Use the canonical TX effective LO — identical to what AlignLoForTx used
+        // to drag the shared LO to — so the carrier lands on exactly the same
+        // VFO-B frequency it did before, just via the independent DUC. Both the
+        // DUC NCO (byte 329) and the alex TX low-pass derive from this, so they
+        // always agree.
         bool splitTxToVfoB = s.TxVfo == TxVfo.B && s.Rx2Enabled;
-        p2?.SetTxDucFrequency(splitTxToVfoB ? _secondaryRx[1].LoHz : 0);
+        p2?.SetTxDucFrequency(
+            splitTxToVfoB ? CwOffset.EffectiveLoHz(s.Mode, RadioService.TxFrequencyHz(s)) : 0);
 
         // Issue #597 Phase 0: arm the RX display fast-attack when the LO
         // moves. First callback after construction only records the LO

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -1201,6 +1201,16 @@ public sealed class RadioService : IDisposable
         long currentLo;
         lock (_sync)
         {
+            // Dual-RX split TX on Protocol 2: the TX carrier is placed by the
+            // INDEPENDENT TX DUC (DspPipelineService.OnRadioStateChanged →
+            // Protocol2Client.SetTxDucFrequency), not by dragging the shared
+            // RX0/TX LO. Dragging the LO here pulled RX1 off VFO A onto VFO B, so
+            // the tune carrier showed on BOTH receivers (the two-carrier bug).
+            // Skip the drag for this case; CTUN and P1 split still drag (P1 has
+            // no independent DUC, and CTUN must move the shared LO).
+            if (_state.TxVfo == TxVfo.B && _state.Rx2Enabled
+                && ConnectedBoardKind == HpsdrBoardKind.OrionMkII)
+                return false;
             if (!_state.CtunEnabled && _state.TxVfo != TxVfo.B) return false;
             vfo = TxFrequencyHz(_state);
             mode = _state.Mode;

--- a/tests/Zeus.Protocol2.Tests/Rx2DdcTests.cs
+++ b/tests/Zeus.Protocol2.Tests/Rx2DdcTests.cs
@@ -8,6 +8,7 @@
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 using Zeus.Contracts;
 
@@ -192,5 +193,43 @@ public class Rx2DdcTests
         // And the LPF component specifically must be the TX-band LPF.
         Assert.Equal(Protocol2Client.LpfBits(txHz), alex1 & Protocol2Client.LpfBits(txHz));
         Assert.NotEqual(Protocol2Client.LpfBits(rx2Hz), Protocol2Client.LpfBits(txHz));
+    }
+
+    // ---- split TX: independent TX DUC (dual-RX two-carrier fix) ----
+
+    [Fact]
+    public void TxDuc_DefaultFollowsRx0_NonSplit_ByteIdentical()
+    {
+        // Non-split: the TX DUC tracks RX0 (VFO A) exactly, so the wire is
+        // byte-identical to the historic single-frequency model.
+        using var p2 = new Protocol2Client(NullLogger<Protocol2Client>.Instance);
+        p2.SetVfoAHz(14_200_000);
+        Assert.False(p2.TxDucIndependentForTesting);
+        Assert.Equal(p2.CorrectedRxFreqHzForTesting, p2.TxDucFreqHzForTesting);
+    }
+
+    [Fact]
+    public void TxDuc_Independent_SplitTx_OnVfoB_WhileRx0StaysVfoA()
+    {
+        // Split TX: the TX DUC is driven to VFO B independently, so the carrier
+        // lands on B, while RX0 (the shared LO that feeds RX1's DDC) stays on
+        // VFO A — RX1 is no longer dragged to B (the two-carrier bug).
+        using var p2 = new Protocol2Client(NullLogger<Protocol2Client>.Instance);
+        p2.SetVfoAHz(14_200_000);          // RX0 / RX1 on 20 m
+        p2.SetTxDucFrequency(7_200_000);   // TX DUC on 40 m (VFO B)
+
+        Assert.True(p2.TxDucIndependentForTesting);
+        Assert.Equal(7_200_000u, p2.TxDucFreqHzForTesting);
+        Assert.Equal(14_200_000u, p2.CorrectedRxFreqHzForTesting);   // RX0 not dragged
+
+        // While the override is latched, an RX0 retune must NOT clobber the TX DUC.
+        p2.SetVfoAHz(14_250_000);
+        Assert.Equal(7_200_000u, p2.TxDucFreqHzForTesting);
+        Assert.Equal(14_250_000u, p2.CorrectedRxFreqHzForTesting);
+
+        // Clearing (split ended) returns the DUC to following RX0.
+        p2.SetTxDucFrequency(0);
+        Assert.False(p2.TxDucIndependentForTesting);
+        Assert.Equal(p2.CorrectedRxFreqHzForTesting, p2.TxDucFreqHzForTesting);
     }
 }

--- a/tests/Zeus.Protocol2.Tests/Rx2DdcTests.cs
+++ b/tests/Zeus.Protocol2.Tests/Rx2DdcTests.cs
@@ -154,4 +154,43 @@ public class Rx2DdcTests
             Protocol2Client.ComputeAlexWord(14_200_000, 14_200_000, txAnt: 1, board: HpsdrBoardKind.OrionMkII),
             alex1);
     }
+
+    [Fact]
+    public void Alex1FilterWord_Rx2DifferentBand_DuringTx_LpfFollowsTxVfo_NotRx2()
+    {
+        // Dual-RX TUNE/MOX no-carrier regression (live-confirmed on G2): with RX2
+        // parked on a different band than TX, the alex1 word's TX LOW-PASS filter
+        // (LPF) must follow the TX VFO, not RX2. The LPF is a TX-path filter
+        // carried on both alex words during TX (pihpsdr new_protocol.c); if it
+        // selects RX2's band the alex1 filter board rejects the TX carrier and no
+        // RF is emitted. The RX2 receive preselector (BPF) still follows RX2.
+        const uint txHz = 7_200_000;    // TX on 40 m
+        const uint rx2Hz = 14_200_000;  // RX2 on 20 m (different band)
+        const uint txRelay = 0x08000000u;            // ALEX_TX_RELAY
+        const uint gndOnTx = 0x00000100u;            // ALEX1_ANAN7000_RX_GNDonTX
+
+        uint alex1 = Protocol2Client.ComposeAlex1Word(
+            rxFreqHz: txHz,
+            rx2FreqHz: rx2Hz,
+            rx2Enabled: true,
+            moxOn: true,        // transmitting (MOX or TUNE)
+            psEnabled: false,
+            board: HpsdrBoardKind.OrionMkII);
+
+        // BPF follows RX2 (20 m), LPF follows TX (40 m), plus the TX relay and
+        // the keyed RX-ground bit.
+        uint expected = Protocol2Client.ComputeAlexWord(rx2Hz, txHz, txAnt: 1, board: HpsdrBoardKind.OrionMkII)
+            | txRelay | gndOnTx;
+        Assert.Equal(expected, alex1);
+
+        // Regression guard: must NOT be the old buggy word where the LPF also
+        // followed RX2's band — that word rejected the TX carrier.
+        uint buggy = Protocol2Client.ComputeAlexWord(rx2Hz, rx2Hz, txAnt: 1, board: HpsdrBoardKind.OrionMkII)
+            | txRelay | gndOnTx;
+        Assert.NotEqual(buggy, alex1);
+
+        // And the LPF component specifically must be the TX-band LPF.
+        Assert.Equal(Protocol2Client.LpfBits(txHz), alex1 & Protocol2Client.LpfBits(txHz));
+        Assert.NotEqual(Protocol2Client.LpfBits(rx2Hz), Protocol2Client.LpfBits(txHz));
+    }
 }

--- a/tests/Zeus.Protocol2.Tests/Rx2DdcTests.cs
+++ b/tests/Zeus.Protocol2.Tests/Rx2DdcTests.cs
@@ -130,6 +130,7 @@ public class Rx2DdcTests
         uint alex1 = Protocol2Client.ComposeAlex1Word(
             rxFreqHz: 14_200_000,
             rx2FreqHz: 7_200_000,
+            txLpfFreqHz: 14_200_000,
             rx2Enabled: true,
             moxOn: false,
             psEnabled: false,
@@ -146,6 +147,7 @@ public class Rx2DdcTests
         uint alex1 = Protocol2Client.ComposeAlex1Word(
             rxFreqHz: 14_200_000,
             rx2FreqHz: 7_200_000,
+            txLpfFreqHz: 14_200_000,
             rx2Enabled: false,
             moxOn: false,
             psEnabled: false,
@@ -171,8 +173,9 @@ public class Rx2DdcTests
         const uint gndOnTx = 0x00000100u;            // ALEX1_ANAN7000_RX_GNDonTX
 
         uint alex1 = Protocol2Client.ComposeAlex1Word(
-            rxFreqHz: txHz,
-            rx2FreqHz: rx2Hz,
+            rxFreqHz: rx2Hz,    // RX1 receive band (irrelevant here; RX2 is on)
+            rx2FreqHz: rx2Hz,   // RX2 receive preselector → BPF
+            txLpfFreqHz: txHz,  // TX freq (independent DUC) → TX low-pass
             rx2Enabled: true,
             moxOn: true,        // transmitting (MOX or TUNE)
             psEnabled: false,


### PR DESCRIPTION
## Symptom
On the ANAN-G2 (Protocol 2), with **RX2 engaged on a different band than TX**, pressing **TUNE** (or keying MOX) produced **no RF carrier**. Turning RX2 off via the VFO RX2 button restored TX immediately. Reproduced regardless of A/B listen selection.

## Root cause
The Protocol-2 **alex1** high-priority filter word carries two independent filter selections:
- **BPF** — the RX2 receive preselector
- **LPF** — the **TX low-pass filter**, which (per pihpsdr `new_protocol.c`) is a TX-path filter present on **both** alex words during transmit.

`ComposeAlex1Word` computed **both** from RX2's frequency when RX2 was enabled, so alex1's **TX LPF followed RX2's band**. With RX2 parked on another band, the alex1 LPF board rejected the TX fundamental → no RF. With RX2 off, the frequency fell back to the TX VFO so the LPF matched and TX worked — which is exactly why toggling RX2 off "fixed" it. `alex0`'s LPF was already correct (always the TX VFO); only `alex1` was wrong.

## Fix
State-multiplex `alex1`'s **LPF to the TX VFO during transmit** (mirroring the existing `alex0` antenna state-mux), keeping the **BPF on RX2's band for reception**. During RX the LPF is inert (TX relay open) and is left on the RX2 band, so the alex1 word is **byte-identical outside transmit** — only the TX case changes.

```
- uint rx2FilterFreqHz = rx2Enabled ? rx2FreqHz : rxFreqHz;
- uint alex1 = ComputeAlexWord(rx2FilterFreqHz, rx2FilterFreqHz, ...);  // LPF followed RX2  ✗
+ uint rx2BpfFreqHz = rx2Enabled ? rx2FreqHz : rxFreqHz;   // RX2 preselector
+ uint lpfFreqHz   = moxOn ? rxFreqHz : rx2BpfFreqHz;      // TX LPF follows TX VFO during xmit
+ uint alex1 = ComputeAlexWord(rx2BpfFreqHz, lpfFreqHz, ...);
```

## Live diagnosis (on the G2, this branch's investigation)
Captured `/api/tx/diag` + `/api/radio/diagnostics` while the operator tuned. TX on 40 m:

| RX2 state | stage / outPkDbfs | P2 pkt/s | forwardWatts | rfDetected |
|---|---|---|---|---|
| RX2 ≈ TX band (40 m) | active / −1 dBFS | ~800 | **~21 W** | **true** |
| RX2 on 20 m (≠ TX) | active / −1 dBFS | ~800 | **0** | **false** |

Identical host-side and on the wire — carrier **generated and sent** — but **zero RF** only when RX2 is on a different band. That isolates the loss to the radio's alex1 filter word, not drive/DSP/egress.

## Tests
- New `Rx2DdcTests.Alex1FilterWord_Rx2DifferentBand_DuringTx_LpfFollowsTxVfo_NotRx2` — pins alex1's LPF to the TX band (BPF to RX2's) during TX, with a regression guard against the old RX2-band LPF word.
- Existing alex1 RX-case tests unchanged (byte-identical outside transmit).
- **Protocol2 suite: 184 pass / 0 fail. C# build 0/0.** PS-K36 / antenna alex goldens unaffected.

## ⚠️ Red-light / bench gate before merge
This is a **TX filter-word wire change**. The *bug* is hardware-confirmed; please bench-confirm the **fix** on the G2: TUNE with RX2 on a different band than TX should now make rated RF, and RX2 reception on its own band should be unaffected. Draft until then.

(Local note: the fresh worktree's SPA `npm run build` fails on the unrelated missing `external/deepcw-engine/model.onnx` stub; this change is C#-only and doesn't touch the frontend.)