### PR TITLE
feat(contracts): per-receiver Receivers[] array on StateDto (B3, wire v2)

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -826,6 +826,50 @@ public sealed record NotchDto(double CenterHz, double WidthHz, bool Active = tru
 // connect), so the server/engine never has to reconcile deltas.
 public sealed record NotchListRequest(IReadOnlyList<NotchDto> Notches);
 
+/// <summary>Single source of truth for the SignalR / JSON wire contract
+/// version and the receiver-DDC ceiling shared between server and frontend.
+/// </summary>
+public static class WireContract
+{
+    /// <summary>Broadcast contract version. v1 was the implicit pre-multi-DDC
+    /// baseline (no <see cref="StateDto.Receivers"/>); v2 introduces the
+    /// per-receiver <see cref="StateDto.Receivers"/> array so the frontend can
+    /// feature-detect multi-DDC support. Surfaced on the wire via
+    /// <see cref="StateDto.WireVersion"/>.</summary>
+    public const int Version = 2;
+
+    /// <summary>Maximum concurrent DDC receivers. Protocol 2's DDC-enable
+    /// command is a single byte (8 bits ⇒ DDC0..DDC7), so the ceiling is 8.
+    /// <see cref="Zeus.Contracts"/> owns the canonical value;
+    /// <c>Zeus.Protocol2.Protocol2Client.MaxRxDdc</c> references it so the wire
+    /// foundation and the contract can never drift apart.</summary>
+    public const int MaxReceivers = 8;
+}
+
+/// <summary>Per-receiver (per-DDC) state for the multi-DDC model. Index 0 is
+/// RX1, index 1 is RX2, and indices ≥ 2 are additional DDCs (up to
+/// <see cref="WireContract.MaxReceivers"/> − 1).
+/// <para>The first usable dual-receive path mirrors the <see cref="StateDto"/>
+/// flat RX1 fields (<see cref="StateDto.VfoHz"/> etc.) into index 0 and the
+/// RX2 / VFO-B fields (<see cref="StateDto.VfoBHz"/> etc.) into index 1;
+/// <see cref="Zeus.Server"/>'s RadioService projects them on every state
+/// change. Additional DDCs live only in this array. The frontend migrates from
+/// the flat fields to this array (multi-DDC UI), after which the flat dupes are
+/// retired.</para></summary>
+public sealed record ReceiverDto(
+    int Index,
+    bool Enabled,
+    // Which phase-synchronous 16-bit ADC feeds this DDC (0 or 1). Defaults to
+    // ADC0; per-DDC ADC assignment is exposed in Settings by the multi-DDC UI.
+    byte AdcSource,
+    long VfoHz,
+    RxMode Mode,
+    int FilterLowHz,
+    int FilterHighHz,
+    string? FilterPresetName,
+    double AfGainDb,
+    int SampleRateHz);
+
 public sealed record StateDto(
     ConnectionStatus Status,
     string? Endpoint,
@@ -1085,7 +1129,27 @@ public sealed record StateDto(
     // pushing. The frontend hydrates the audio picker from this and never
     // clobbers the server on connect (PR #359/#360 anti-clobber pattern).
     // Default Host is byte-identical to today on every board.
-    TxAudioSource TxAudioSource = TxAudioSource.Host);
+    TxAudioSource TxAudioSource = TxAudioSource.Host,
+
+    // ---- Multi-DDC receivers array (wire v2) ----
+    // Canonical per-receiver list: index 0 = RX1, index 1 = RX2, index ≥ 2 =
+    // additional DDCs. The flat RX1 fields (VfoHz/Mode/Filter*/RxAfGainDb) and
+    // the RX2 / VFO-B fields (VfoBHz/ModeB/Filter*B/Rx2AfGainDb) remain the
+    // authoritative source for indices 0/1; RadioService projects them into
+    // this array on every state change (Mutate + Snapshot), so the array is
+    // never stale. Null only on a pre-projection seed — every wire-bound path
+    // populates it. The frontend migrates to this array (multi-DDC UI); the
+    // flat dupes are retired once that lands.
+    IReadOnlyList<ReceiverDto>? Receivers = null,
+
+    // Wire contract version (WireContract.Version) so the frontend can
+    // feature-detect the Receivers[] array and per-DDC controls. v1 = implicit
+    // pre-multi-DDC baseline; v2 = Receivers[] present.
+    int WireVersion = WireContract.Version,
+
+    // DDC / receiver ceiling for this build (WireContract.MaxReceivers). The
+    // multi-DDC UI gates the "exposed receivers" control against this.
+    int MaxReceivers = WireContract.MaxReceivers);
 
 /// <summary>Canonical CW constants shared between backend and wire DTOs.
 /// Single source of truth — CwOffset (server-side) and StateDto both

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -112,8 +112,10 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // are reserved for the PureSignal feedback pair when PS is armed, leaving 6
     // user receivers; with PS off, all 8. The N-receiver pipeline keys off this
     // constant so the ceiling is a single-line change if firmware ever extends
-    // the enable field.
-    public const int MaxRxDdc = 8;
+    // the enable field. Sourced from Zeus.Contracts.WireContract.MaxReceivers
+    // so the wire foundation and the StateDto Receivers[] contract can never
+    // drift apart.
+    public const int MaxRxDdc = Zeus.Contracts.WireContract.MaxReceivers;
 
     // RX IQ data arrives on UDP source ports RxDataPortBase + ddcIndex, i.e.
     // 1035 (DDC0) .. 1035 + MaxRxDdc - 1 (DDC7).

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -667,7 +667,7 @@ public sealed class RadioService : IDisposable
         get { lock (_sync) return _activeClient is not null || _p2Active; }
     }
 
-    public StateDto Snapshot() { lock (_sync) return _state; }
+    public StateDto Snapshot() { lock (_sync) return _state with { Receivers = ProjectReceivers(_state) }; }
 
     /// <summary>Current operator preamp toggle. PreampOn isn't on the
     /// StateDto wire format, so DspPipelineService reads it directly when
@@ -931,6 +931,19 @@ public sealed class RadioService : IDisposable
         }
         return Snapshot();
     }
+
+    /// <summary>Receiver-indexed VFO setter for the multi-DDC model.
+    /// <paramref name="rxIndex"/> 0 → RX1 (<see cref="SetVfo(long)"/>), 1 → RX2
+    /// (<see cref="SetVfoB(long)"/>). Generalizes the RX1/RX2 A/B split so
+    /// callers (the /api/vfo endpoint, CAT/TCI, future per-DDC controls) can
+    /// address a receiver by index. Indices ≥ 2 are reserved until DDC 2..N
+    /// control lands and currently return the snapshot unchanged.</summary>
+    public StateDto SetReceiverVfo(int rxIndex, long hz) => rxIndex switch
+    {
+        0 => SetVfo(hz),
+        1 => SetVfoB(hz),
+        _ => Snapshot(),
+    };
 
     public StateDto SetRx2(Rx2SetRequest req)
     {
@@ -3045,11 +3058,40 @@ public sealed class RadioService : IDisposable
         lock (_sync)
         {
             next = fn(_state);
+            // Project the canonical per-receiver array from the flat RX1/RX2
+            // fields on every mutation so StateChanged subscribers and the
+            // SignalR broadcast always carry an up-to-date Receivers[] (wire
+            // v2). Pure function of the flat fields — cheap (1–2 elements).
+            next = next with { Receivers = ProjectReceivers(next) };
             _state = next;
         }
         _stateDirty = true;
         StateChanged?.Invoke(next);
     }
+
+    // Build the canonical per-receiver array (wire v2) from the flat RX1/RX2
+    // fields. Index 0 = RX1 (always present); index 1 = RX2 with Enabled
+    // tracking Rx2Enabled so the frontend has the VFO-B config even when RX2 is
+    // off. AdcSource defaults to ADC0 until the multi-DDC UI assigns per-DDC
+    // ADCs; SampleRateHz is the shared capture rate. Additional DDCs (index ≥ 2)
+    // are appended here once DDC 2..N control exists. Pure + allocation-light
+    // (called on every Mutate / Snapshot).
+    private static IReadOnlyList<ReceiverDto> ProjectReceivers(StateDto s) =>
+        new[]
+        {
+            new ReceiverDto(
+                Index: 0, Enabled: true, AdcSource: 0,
+                VfoHz: s.VfoHz, Mode: s.Mode,
+                FilterLowHz: s.FilterLowHz, FilterHighHz: s.FilterHighHz,
+                FilterPresetName: s.FilterPresetName,
+                AfGainDb: s.RxAfGainDb, SampleRateHz: s.SampleRate),
+            new ReceiverDto(
+                Index: 1, Enabled: s.Rx2Enabled, AdcSource: 0,
+                VfoHz: s.VfoBHz, Mode: s.ModeB,
+                FilterLowHz: s.FilterLowHzB, FilterHighHz: s.FilterHighHzB,
+                FilterPresetName: s.FilterPresetNameB,
+                AfGainDb: s.Rx2AfGainDb, SampleRateHz: s.SampleRate),
+        };
 
     // Debounce flush: called by _stateFlushTimer every 1 s.
     // Captures the latest StateDto + family-filter memory under _sync and

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -1014,7 +1014,7 @@ public static class ZeusEndpoints
         app.MapPost("/api/vfo", (VfoSetRequest req, RadioService r) =>
         {
             log.LogInformation("api.vfo receiver={Receiver} hz={Hz}", req.Receiver, req.Hz);
-            return req.Receiver == 1 ? r.SetVfoB(req.Hz) : r.SetVfo(req.Hz);
+            return r.SetReceiverVfo(req.Receiver, req.Hz);
         });
 
         app.MapPost("/api/vfo/swap", (RadioService r) =>

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -381,6 +381,33 @@ export type RadioStateDto = {
   // the display on the tuned frequency. Toggled via setCtun → POST
   // /api/radio/ctun. See docs/prd/panfall_behavior.md.
   ctunEnabled: boolean;
+  // ---- Multi-DDC receivers array (wire v2) ----
+  // Canonical per-receiver list: index 0 = RX1, 1 = RX2, >= 2 = extra DDCs.
+  // Optional until the frontend migrates off the flat RX1/RX2 fields; the
+  // server projects these from the flat fields so [0]/[1] always mirror them.
+  receivers?: ReceiverDto[];
+  // Wire contract version (WireContract.Version). v2 = receivers[] present.
+  wireVersion?: number;
+  // DDC / receiver ceiling for this build (WireContract.MaxReceivers).
+  maxReceivers?: number;
+};
+
+// Mirrors Zeus.Contracts.ReceiverDto — per-receiver (per-DDC) state. Index 0 is
+// RX1, index 1 is RX2, indices >= 2 are additional DDCs. The multi-DDC UI reads
+// this array; the flat RX1/RX2 fields above remain the source for indices 0/1
+// until that migration completes.
+export type ReceiverDto = {
+  index: number;
+  enabled: boolean;
+  // Which phase-synchronous 16-bit ADC feeds this DDC (0 or 1).
+  adcSource: number;
+  vfoHz: number;
+  mode: RxMode;
+  filterLowHz: number;
+  filterHighHz: number;
+  filterPresetName: string | null;
+  afGainDb: number;
+  sampleRateHz: number;
 };
 
 // CFC mirrors Zeus.Contracts.CfcConfig. Bands array is fixed at 10 entries


### PR DESCRIPTION
## Multi-DDC build-out — B3: per-receiver `Receivers[]` array on `StateDto` (wire v2)

Lands the canonical multi-DDC **contract** surface. Follows #808 (Phase A ingest hardening + B1 8-DDC wire foundation) and #821 (B2 receiver-indexed pipeline arrays). B4 (frontend + Settings DDC/dual-ADC panel) builds on this.

### What changed
- **`Zeus.Contracts`**
  - New `ReceiverDto` — per-receiver/per-DDC state: `Index, Enabled, AdcSource, VfoHz, Mode, FilterLowHz, FilterHighHz, FilterPresetName, AfGainDb, SampleRateHz`.
  - New `WireContract` static — `Version = 2` (broadcast contract version, feature-detect `Receivers[]`) and `MaxReceivers = 8` (the P2 DDC-enable byte ceiling), as the single source of truth.
  - `StateDto` gains `Receivers[]`, `WireVersion`, `MaxReceivers` — all **additive and defaulted**.
- **`Protocol2Client.MaxRxDdc`** now references `WireContract.MaxReceivers` so the wire foundation and the contract can never drift.
- **`RadioService`** projects `Receivers[]` from the flat RX1/RX2 fields on every `Mutate` and `Snapshot` (index 0 = RX1 always; index 1 = RX2 with `Enabled` tracking `Rx2Enabled`). Pure, allocation-light. Adds receiver-indexed `SetReceiverVfo(rxIndex, hz)`; `/api/vfo` now routes through it, generalizing the RX1/RX2 A/B split to receiver index.
- **Frontend** (`client.ts`): optional `ReceiverDto` + `receivers`/`wireVersion`/`maxReceivers` on `RadioStateDto` (type-only; consumed by the B4 UI).

### Backward compatibility (deliberate sequencing)
The flat RX1/RX2 fields (`vfoHz`, `vfoBHz`, `modeB`, …) stay authoritative for indices 0/1 and remain on the wire, so the **current frontend (~360 flat-field usages) is untouched**. The flat dupes are retired only once B4 migrates the UI to `Receivers[]` — avoiding a flag-day break on a live app. `RxId` on the **binary** meter frames (`RxMeterFrame`/`RxMetersV2Frame`) is deferred to B4, bundled with the frontend decoder + multi-meter UI that consumes it (a binary layout change is meaningless without its decoder).

### Verification
- **Build:** full solution — C# (0 warnings/0 errors) **and** frontend (`npm run build`) green.
- **Live, against a real ANAN G2 (Protocol 2):** `GET /api/state` →
  - `wireVersion: 2`, `maxReceivers: 8`
  - disconnected: `receivers[0]` enabled (RX1), `receivers[1]` disabled mirroring VFO-B defaults
  - connected + RX2 on: receiver-indexed `POST /api/vfo {receiver:0}` set RX1 = 14.074 MHz and `{receiver:1}` set RX2 = 7.074 MHz, each reflected in `receivers[].vfoHz`; `receivers[1].enabled` tracked `rx2Enabled`.
- **Tests:** `Zeus.Server.Tests` running locally; cross-platform CI is the authoritative gate.

### Notes
- Cross-platform: pure C# + a type-only TS addition; no platform-specific paths.
- PureSignal untouched (`PsEnabled` still initializes false on startup).
- No removed fields / no behavior change for existing consumers — purely additive contract growth.
