### PR TITLE
feat: run N hardware DDCs (RX3..RX8) end-to-end (multi-DDC server)

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -1200,6 +1200,20 @@ public sealed record Rx2SetRequest(
     Rx2AudioMode? AudioMode = null,
     double? AfGainDb = null);
 
+/// <summary>Configure one receiver by index (RX1=0, RX2=1, RX3+=2..) for the
+/// full multi-DDC model — the body of <c>POST /api/receivers/{index}</c>. Every
+/// field is optional; only the supplied ones change. For index ≥ 2 these drive
+/// an extra hardware DDC (<c>AdcSource</c> selects the phase-synchronous ADC 0/1).
+/// </summary>
+public sealed record ReceiverSetRequest(
+    bool? Enabled = null,
+    long? VfoHz = null,
+    byte? AdcSource = null,
+    RxMode? Mode = null,
+    int? FilterLowHz = null,
+    int? FilterHighHz = null,
+    double? AfGainDb = null);
+
 /// <summary>Operator settings for the POTA/SOTA Spots feature. Persisted in
 /// zeus-prefs.db (<c>SpotsSettingsStore</c>) and shared with the frontend.
 /// <para>The server-side poller honours <see cref="Enabled"/> /

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -1277,7 +1277,10 @@ public sealed class WdspDspEngine : IDspEngine
             return 0;
         }
 
-        EmitRxDiag(state);
+        // RX ingest health is emitted from the channel worker (RunWorker) now,
+        // not here — so a receiver whose audio isn't read out (e.g. RX3+ in
+        // multi-DDC, where only RX1/RX2 audio is currently mixed) still reports
+        // per-DDC health. Emitting here would gate health on audio consumption.
 
         lock (state.AudioGate)
         {
@@ -3375,7 +3378,7 @@ public sealed class WdspDspEngine : IDspEngine
         }
     }
 
-    private static void RunWorker(ChannelState state)
+    private void RunWorker(ChannelState state)
     {
         double[] audio = new double[state.OutDoubles];
         double[] spectrumIq = new double[2 * InSize];
@@ -3435,6 +3438,13 @@ public sealed class WdspDspEngine : IDspEngine
                 state.DiagWorkerFrames++;
                 state.DiagWorkerTotalTicks += frameTicks;
                 if (frameTicks > state.DiagWorkerMaxTicks) state.DiagWorkerMaxTicks = frameTicks;
+
+                // Latch per-DDC ingest health from the worker (the single thread
+                // that processes this channel's IQ). Self-gated to ~1 Hz. Doing it
+                // here rather than in ReadAudio means every fed receiver reports
+                // health — including RX3+ whose audio isn't read out — which is
+                // the realtime overflow/underrun signal for multi-DDC operation.
+                EmitRxDiag(state);
             }
         }
         catch (OperationCanceledException) { }

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -168,6 +168,18 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // the DUC follows RX0 again.
     private uint _txDucFreqHz = 14_200_000;
     private volatile bool _txDucIndependent;
+    // Extra user receivers (RX3+) for full multi-DDC. Contiguous after RX2:
+    // receiver index i (>= 2) sits on DDC RxBaseDdc(board)+i (so RX3 = DDC
+    // base+2). _extraReceiverCount counts RX3.. ; total user receivers =
+    // 2 + _extraReceiverCount and RX2 MUST be enabled (no DDC gaps). Indexed by
+    // receiver index: _extraRxFreqHz[2] = RX3 NCO, _extraRxAdc[2] = RX3 ADC
+    // source, etc. When _extraReceiverCount == 0 the RX1/RX2 path below is
+    // entirely unchanged and SendCmdRx keeps using the byte-pinned legacy
+    // composer — extras are purely additive and never touch the PureSignal
+    // DDC0/1 branch. Read on the RX thread + command threads (volatile-accessed).
+    private int _extraReceiverCount;
+    private readonly uint[] _extraRxFreqHz = new uint[MaxRxDdc];
+    private readonly byte[] _extraRxAdc = new byte[MaxRxDdc];
     // Per-source-port IQ packet rate (packets in the last completed ~1 s
     // window) for UDP ports RxDataPortBase..RxDataPortBase+MaxRxDdc-1 (1035..1042)
     // → index 0..7 → DDC 0..7. Written by the single RX thread on each window
@@ -691,6 +703,32 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
+    /// N-receiver overload: maps an incoming RX IQ stream (UDP source port
+    /// 1035+streamIndex) to its logical receiver index for the full multi-DDC
+    /// case. <paramref name="extraReceiverCount"/> is the number of receivers
+    /// beyond RX2 (RX3..). With no extras this delegates to the RX1/RX2 mapping.
+    /// Receivers are contiguous DDCs base+0..base+(1+extra); G2/Orion firmware
+    /// tags streams by DDC slot (preferred), other builds by logical stream
+    /// index (fallback).
+    /// </summary>
+    internal static int ReceiverIndexForRxStream(
+        int streamIndex,
+        HpsdrBoardKind board,
+        bool rx2Enabled,
+        int extraReceiverCount)
+    {
+        if (extraReceiverCount <= 0)
+            return ReceiverIndexForRxStream(streamIndex, board, rx2Enabled);
+        int baseDdc = RxBaseDdc(board);
+        int top = 1 + extraReceiverCount;          // highest active receiver index
+        if (streamIndex >= baseDdc && streamIndex - baseDdc <= top)
+            return streamIndex - baseDdc;          // DDC-slot firmware (G2/Orion)
+        if (streamIndex >= 0 && streamIndex <= top)
+            return streamIndex;                    // logical-stream firmware
+        return 0;
+    }
+
+    /// <summary>
     /// IQ packet rate (packets in the last completed ~1 s window) per UDP
     /// source port 1035..1042 → index 0..7 → DDC 0..7. The RX2 DDC is
     /// <see cref="Rx2Ddc"/>. A zero at an enabled DDC's index means the radio
@@ -735,6 +773,50 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         _rx2FreqHz = (uint)Math.Clamp(corrected, 0L, uint.MaxValue);
         if (_rxTask is not null && Volatile.Read(ref _rx2Enabled) != 0)
             SendCmdHighPriority(run: true);
+    }
+
+    /// <summary>
+    /// Configure the extra user receivers beyond RX2 (RX3..) for full multi-DDC.
+    /// <paramref name="count"/> is the number of receivers past RX2 (0 = RX1/RX2
+    /// only, the legacy path). Extras are contiguous — receiver index 2+i sits on
+    /// DDC <see cref="RxBaseDdc"/>+2+i — so RX2 must be enabled when count &gt; 0.
+    /// <paramref name="adcSources"/> gives the per-extra ADC source (index 0 =
+    /// RX3); null/short entries default to ADC0. Re-sends the RX command (DDC
+    /// enable mask) and high-priority packet (NCO phase words). The RX1/RX2 path
+    /// and the PureSignal DDC0/1 branch are untouched.
+    /// </summary>
+    public void SetExtraReceivers(int count, IReadOnlyList<byte>? adcSources = null)
+    {
+        int maxExtras = MaxRxDdc - RxBaseDdc(_boardKind) - 2;
+        int clamped = Math.Clamp(count, 0, Math.Max(0, maxExtras));
+        for (int k = 0; k < clamped; k++)
+        {
+            int rcvr = 2 + k;
+            _extraRxAdc[rcvr] = adcSources is not null && k < adcSources.Count ? adcSources[k] : (byte)0;
+        }
+        if (Interlocked.Exchange(ref _extraReceiverCount, clamped) == clamped) return;
+        if (_rxTask is not null)
+        {
+            SendCmdRx();
+            SendCmdHighPriority(run: true);
+        }
+    }
+
+    /// <summary>
+    /// Tune an extra receiver's DDC NCO. <paramref name="receiverIndex"/> is the
+    /// logical receiver index (2 = RX3, 3 = RX4, ...). Applies the host-side
+    /// frequency-correction factor like <see cref="SetVfoAHz"/> /
+    /// <see cref="SetVfoBHz"/>. No-op for indices outside the configured extra
+    /// range.
+    /// </summary>
+    public void SetExtraReceiverFreqHz(int receiverIndex, long hz)
+    {
+        if (receiverIndex < 2 || receiverIndex >= 2 + Volatile.Read(ref _extraReceiverCount))
+            return;
+        double factor = BitConverter.Int64BitsToDouble(Interlocked.Read(ref _freqCorrectionBits));
+        long corrected = (long)Math.Round(hz * factor, MidpointRounding.AwayFromZero);
+        _extraRxFreqHz[receiverIndex] = (uint)Math.Clamp(corrected, 0L, uint.MaxValue);
+        if (_rxTask is not null) SendCmdHighPriority(run: true);
     }
 
     /// <summary>
@@ -1719,15 +1801,45 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         //   ComposeCmdRxBuffer also enables DDC0, configures DDC0/1 at
         //   192 kHz / 24-bit, and sets byte 1363 = 0x02 to sync DDC1→DDC0
         //   (pihpsdr new_protocol.c:1611-1630).
-        var p = ComposeCmdRxBuffer(
-            _seqCmdRx++,
-            _numAdc,
-            (ushort)_sampleRateKhz,
-            _psFeedbackEnabled,
-            _boardKind,
-            _adcDitherEnabled,
-            _adcRandomEnabled,
-            Volatile.Read(ref _rx2Enabled) != 0);
+        int extras = Volatile.Read(ref _extraReceiverCount);
+        byte[] p;
+        if (extras > 0)
+        {
+            // Full multi-DDC: RX1 + RX2 + RX3.. as a contiguous DDC run via the
+            // N-receiver composer. For the RX1(+RX2)(+PS) subset this is
+            // byte-identical to the legacy composer (ComposeCmdRxBufferForReceivers
+            // tests), so existing behaviour is preserved; extras add DDC config
+            // blocks for RxBaseDdc+2.. only. PS DDC0/1 handling is inside the
+            // composer and untouched.
+            byte rxAdc = Rx2AdcSource(_numAdc, _boardKind); // ADC0 (same antenna)
+            var specs = new List<DdcReceiverSpec>(2 + extras)
+            {
+                new DdcReceiverSpec(rxAdc, (ushort)_sampleRateKhz),  // RX1
+                new DdcReceiverSpec(rxAdc, (ushort)_sampleRateKhz),  // RX2
+            };
+            for (int k = 0; k < extras; k++)
+                specs.Add(new DdcReceiverSpec(_extraRxAdc[2 + k], (ushort)_sampleRateKhz));
+            p = ComposeCmdRxBufferForReceivers(
+                _seqCmdRx++,
+                _numAdc,
+                specs,
+                _psFeedbackEnabled,
+                _boardKind,
+                _adcDitherEnabled,
+                _adcRandomEnabled);
+        }
+        else
+        {
+            p = ComposeCmdRxBuffer(
+                _seqCmdRx++,
+                _numAdc,
+                (ushort)_sampleRateKhz,
+                _psFeedbackEnabled,
+                _boardKind,
+                _adcDitherEnabled,
+                _adcRandomEnabled,
+                Volatile.Read(ref _rx2Enabled) != 0);
+        }
         _sock!.SendTo(p, new IPEndPoint(_radioEndpoint!.Address, 1025));
     }
 
@@ -1874,6 +1986,22 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
             int rx2Ddc = Rx2Ddc(_boardKind);
             uint rx2Phase = (uint)(_rx2FreqHz * HzToPhase);
             WriteBeU32(p, 9 + rx2Ddc * 4, rx2Phase);
+        }
+
+        // Extra receivers (RX3+): tune each contiguous DDC's NCO. Receiver index
+        // 2+k maps to DDC RxBaseDdc+2+k, phase word at 9 + ddc*4. Additive — only
+        // the configured extras are written; unused DDC slots stay zero. RX1/RX2
+        // and the PureSignal DDC0/1 phase writes above are untouched.
+        int extraN = Volatile.Read(ref _extraReceiverCount);
+        if (extraN > 0)
+        {
+            int baseDdc = RxBaseDdc(_boardKind);
+            for (int k = 0; k < extraN; k++)
+            {
+                int rcvr = 2 + k;
+                uint phase = (uint)(_extraRxFreqHz[rcvr] * HzToPhase);
+                WriteBeU32(p, 9 + (baseDdc + rcvr) * 4, phase);
+            }
         }
 
         // PureSignal — when armed, DDC0 + DDC1 phase words also need to
@@ -2504,7 +2632,8 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         int receiverIndex = ReceiverIndexForRxStream(
             ddcIndex,
             _boardKind,
-            Volatile.Read(ref _rx2Enabled) != 0);
+            Volatile.Read(ref _rx2Enabled) != 0,
+            Volatile.Read(ref _extraReceiverCount));
 
         var frame = new IqFrame(
             InterleavedSamples: new ReadOnlyMemory<double>(samples, 0, samplesPerPacket * 2),

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -712,6 +712,8 @@ public class DspPipelineService : BackgroundService,
         public int PanCnt;  // 1 Hz panadapter freshness tally (display probe)
         public int WfCnt;   // 1 Hz waterfall freshness tally
         public long IqRmsLogMs; // 1 Hz IQ RMS/peak probe gate
+        public long RoutedFrames; // diag: IQ frames routed to this receiver index
+        public long FedFrames;    // diag: IQ frames actually FeedIq'd (channel open)
     }
     private readonly SecondaryRx[] _secondaryRx;
     private int _sampleRateHz;
@@ -4396,7 +4398,13 @@ public class DspPipelineService : BackgroundService,
         // from "channel open but starved".
         var secondaryIds = new object[MaxReceivers - 1];
         for (int i = 1; i < MaxReceivers; i++)
-            secondaryIds[i - 1] = new { receiverIndex = i, channelId = Volatile.Read(ref _secondaryRx[i].ChannelId) };
+            secondaryIds[i - 1] = new
+            {
+                receiverIndex = i,
+                channelId = Volatile.Read(ref _secondaryRx[i].ChannelId),
+                routedFrames = _secondaryRx[i].RoutedFrames,
+                fedFrames = _secondaryRx[i].FedFrames,
+            };
 
         return new
         {
@@ -4607,9 +4615,13 @@ public class DspPipelineService : BackgroundService,
                 {
                     var rx = _secondaryRx[ri];
                     int secChan = Volatile.Read(ref rx.ChannelId);
+                    rx.RoutedFrames++;
                     LogRxIqRms(ri, frame.InterleavedSamples.Span, ref rx.IqRmsLogMs);
                     if (secChan >= 0)
+                    {
                         engine.FeedIq(secChan, frame.InterleavedSamples.Span);
+                        rx.FedFrames++;
+                    }
                 }
                 return;
             }

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -3188,6 +3188,37 @@ public class DspPipelineService : BackgroundService,
         if (engine is null) return;
         int rx2Channel = EnsureSecondaryRxChannel(engine, 1, s);
 
+        // RX3+ (full multi-DDC): count the contiguous enabled receivers beyond
+        // RX2 from the canonical Receivers[] array, push their DDC enable + NCO
+        // tunes to the radio (P2 only), then ensure each WDSP channel. The
+        // RX1/RX2 wire path above is unchanged; extras never touch the PureSignal
+        // DDC0/1 pair (SetExtraReceivers uses the N-receiver composer which keeps
+        // the PS branch intact).
+        int extraCount = 0;
+        if (s.Receivers is { } rcvrs)
+            for (int ri = 2; ri < rcvrs.Count && ri < MaxReceivers && rcvrs[ri].Enabled; ri++)
+                extraCount++;
+        if (p2 is not null)
+        {
+            if (extraCount > 0)
+            {
+                var adc = new byte[extraCount];
+                for (int k = 0; k < extraCount; k++) adc[k] = s.Receivers![2 + k].AdcSource;
+                p2.SetExtraReceivers(extraCount, adc);
+                for (int ri = 2; ri <= 1 + extraCount; ri++)
+                {
+                    UpdateRxLo(ri, s);
+                    p2.SetExtraReceiverFreqHz(ri, _secondaryRx[ri].LoHz);
+                }
+            }
+            else
+            {
+                p2.SetExtraReceivers(0);
+            }
+        }
+        for (int ri = 2; ri < MaxReceivers; ri++)
+            _ = EnsureSecondaryRxChannel(engine, ri, s);
+
         if (s.Mode != _appliedMode)
         {
             engine.SetMode(channel, s.Mode);
@@ -3644,8 +3675,27 @@ public class DspPipelineService : BackgroundService,
     // enabled for the current state. Today only slot 1 (the historical RX2) has
     // wire/UI state, so it's the only one that can be active; B3 replaces this with
     // s.Receivers[rxIndex].Enabled once StateDto carries the receiver array.
+    // RX2 (index 1) keeps reading the flat Rx2Enabled flag so its behaviour is
+    // byte-exact; RX3+ (index >= 2) read the canonical StateDto.Receivers[]
+    // (B3 projection / per-receiver store) so full multi-DDC lights up without
+    // touching the proven RX1/RX2 path.
     private static bool SecondaryReceiverEnabled(int rxIndex, StateDto s) =>
-        rxIndex == 1 && s.Rx2Enabled;
+        rxIndex == 1
+            ? s.Rx2Enabled
+            : rxIndex >= 2 && s.Receivers is { } rs && rxIndex < rs.Count && rs[rxIndex].Enabled;
+
+    // Per-secondary-receiver tuning params. RX2 reads the flat RX2/VFO-B fields
+    // (byte-exact); RX3+ read the per-receiver StateDto.Receivers[] entry.
+    private static (RxMode mode, long vfoHz, int filterLow, int filterHigh, double afGainDb)
+        SecondaryRxParams(StateDto s, int rxIndex)
+    {
+        if (rxIndex == 1)
+            return (s.ModeB, s.VfoBHz, s.FilterLowHzB, s.FilterHighHzB, s.Rx2AfGainDb);
+        var r = s.Receivers is { } rs && rxIndex >= 0 && rxIndex < rs.Count ? rs[rxIndex] : null;
+        return r is null
+            ? (RxMode.USB, 0L, 100, 2850, 0.0)
+            : (r.Mode, r.VfoHz, r.FilterLowHz, r.FilterHighHz, r.AfGainDb);
+    }
 
     // Convenience helper: open/sync/close the WDSP channel for one secondary
     // receiver, mirroring RX1's lifecycle. Returns the channel id (or -1 when the
@@ -3725,7 +3775,8 @@ public class DspPipelineService : BackgroundService,
             rx.LoInit = false; // re-enabling recentres from scratch
             return;
         }
-        long effB = CwOffset.EffectiveLoHz(s.ModeB, s.VfoBHz);
+        var (mode, vfoHz, _, _, _) = SecondaryRxParams(s, rxIndex);
+        long effB = CwOffset.EffectiveLoHz(mode, vfoHz);
         long span = Volatile.Read(ref _sampleRateHz);
         if (span <= 0) span = s.SampleRate > 0 ? s.SampleRate : SyntheticSampleRateHz;
         long edge = (long)(span * 0.45); // recentre before the dial hits the DDC edge
@@ -3747,28 +3798,41 @@ public class DspPipelineService : BackgroundService,
             : (int)(effectiveVfoBHz - s.RadioLoHz);
     }
 
+    // N-receiver generalization of ComputeRx2CtunShiftHz: the WDSP shift for any
+    // secondary, from its own mode/VFO. For RX2 (mode=ModeB, vfo=VfoBHz) this
+    // returns the same value as ComputeRx2CtunShiftHz, keeping RX2 byte-exact.
+    private static int ComputeSecondaryCtunShiftHz(
+        StateDto s, RxMode mode, long vfoHz, long rxLoHz, bool protocol2)
+    {
+        long eff = CwOffset.EffectiveLoHz(mode, vfoHz);
+        return protocol2 ? (int)(eff - rxLoHz) : (int)(eff - s.RadioLoHz);
+    }
+
     private void ApplyStateToSecondaryRxChannel(IDspEngine engine, int rxIndex, int channelId, StateDto s)
     {
         var rx = _secondaryRx[rxIndex];
         var nr = NormalizeNrConfig(s.Nr ?? new NrConfig());
         var agc = s.Agc ?? new AgcConfig(AgcMode.Med);
         var squelch = s.Squelch ?? new SquelchConfig();
-        engine.SetMode(channelId, s.ModeB);
-        engine.SetFilter(channelId, s.FilterLowHzB, s.FilterHighHzB);
-        engine.SetVfoHz(channelId, s.VfoBHz);
+        var (mode, vfoHz, filterLow, filterHigh, afGainDb) = SecondaryRxParams(s, rxIndex);
+        engine.SetMode(channelId, mode);
+        engine.SetFilter(channelId, filterLow, filterHigh);
+        engine.SetVfoHz(channelId, vfoHz);
         UpdateRxLo(rxIndex, s);
         // P2 true-DDC: the secondary's hardware DDC sits at rx.LoHz, so the WDSP
-        // shift roams the dial within that window — EffectiveLoHz(VfoB) − rx.LoHz.
-        // Under CTUN off, rx.LoHz == EffectiveLoHz(VfoB) so the shift is 0 and the
+        // shift roams the dial within that window — EffectiveLoHz(vfo) − rx.LoHz.
+        // Under CTUN off, rx.LoHz == EffectiveLoHz(vfo) so the shift is 0 and the
         // panel recentres on the dial. P1 / synthetic secondaries are sub-receivers
         // of RX1's window, so they still shift against RadioLoHz.
-        int shiftHz = ComputeRx2CtunShiftHz(
+        int shiftHz = ComputeSecondaryCtunShiftHz(
             s,
+            mode,
+            vfoHz,
             rx.LoHz,
             protocol2: _p2Client is not null);
         engine.SetCtunShift(channelId, shiftHz);
         engine.SetAgcTop(channelId, s.AgcTopDb + s.AgcOffsetDb);
-        engine.SetRxAfGainDb(channelId, s.Rx2AfGainDb);
+        engine.SetRxAfGainDb(channelId, afGainDb);
         engine.SetNoiseReduction(channelId, nr);
         engine.SetAgc(channelId, agc);
         engine.SetSquelch(channelId, squelch);

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -4390,12 +4390,22 @@ public class DspPipelineService : BackgroundService,
             };
         }
 
+        // Pipeline's raw per-receiver WDSP channel ids (not gated on health
+        // emission like `channels` above). -1 = receiver not open. Lets the
+        // diagnostics distinguish "DDC streaming but no channel" (a wiring bug)
+        // from "channel open but starved".
+        var secondaryIds = new object[MaxReceivers - 1];
+        for (int i = 1; i < MaxReceivers; i++)
+            secondaryIds[i - 1] = new { receiverIndex = i, channelId = Volatile.Read(ref _secondaryRx[i].ChannelId) };
+
         return new
         {
             schemaVersion = 1,
             maxRxDdc = Zeus.Protocol2.Protocol2Client.MaxRxDdc,
             activeChannels = channels.Count,
             rxPortPacketRates = portRates,
+            primaryChannelId = Volatile.Read(ref _channelId),
+            secondaryRxChannelIds = secondaryIds,
             channels = channelDtos,
         };
     }

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -138,6 +138,31 @@ public sealed class RadioService : IDisposable
 
     private StateDto _state;
 
+    // Session-only per-receiver config for the extra DDC receivers (RX3+, index
+    // 2..MaxReceivers-1). RX1/RX2 stay on the flat StateDto fields; these feed
+    // ProjectReceivers for the extra entries and, via that array, the
+    // DspPipelineService multi-DDC path. Not persisted — the operator re-enables
+    // extra receivers each session (no silent auto-spin-up of DDCs on restart).
+    // Guarded by _sync. Indices 0/1 are unused (RX1/RX2 are the flat fields).
+    private sealed class ExtraReceiver
+    {
+        public bool Enabled;
+        public long VfoHz = 14_200_000;
+        public RxMode Mode = RxMode.USB;
+        public int FilterLowHz = 100;
+        public int FilterHighHz = 2850;
+        public string? FilterPresetName = "VAR1";
+        public double AfGainDb;
+        public byte AdcSource;   // 0 = ADC0 (same antenna as RX1) by default
+    }
+    private readonly ExtraReceiver[] _extraReceivers = CreateExtraReceivers();
+    private static ExtraReceiver[] CreateExtraReceivers()
+    {
+        var a = new ExtraReceiver[Zeus.Contracts.WireContract.MaxReceivers];
+        for (int i = 2; i < a.Length; i++) a[i] = new ExtraReceiver();
+        return a;
+    }
+
     // Latched MOX bit — populated via SetMox so the auto-ATT loop can pause
     // itself during TX without a service-locator pattern back to TxService.
     private bool _mox;
@@ -934,16 +959,71 @@ public sealed class RadioService : IDisposable
 
     /// <summary>Receiver-indexed VFO setter for the multi-DDC model.
     /// <paramref name="rxIndex"/> 0 → RX1 (<see cref="SetVfo(long)"/>), 1 → RX2
-    /// (<see cref="SetVfoB(long)"/>). Generalizes the RX1/RX2 A/B split so
-    /// callers (the /api/vfo endpoint, CAT/TCI, future per-DDC controls) can
-    /// address a receiver by index. Indices ≥ 2 are reserved until DDC 2..N
-    /// control lands and currently return the snapshot unchanged.</summary>
+    /// (<see cref="SetVfoB(long)"/>), ≥ 2 → an extra DDC receiver
+    /// (<see cref="SetReceiver"/>). Generalizes the RX1/RX2 A/B split so callers
+    /// (the /api/vfo + /api/receivers endpoints, CAT/TCI) can address a receiver
+    /// by index.</summary>
     public StateDto SetReceiverVfo(int rxIndex, long hz) => rxIndex switch
     {
         0 => SetVfo(hz),
         1 => SetVfoB(hz),
-        _ => Snapshot(),
+        _ => SetReceiver(rxIndex, vfoHz: hz),
     };
+
+    /// <summary>
+    /// Configure any receiver by index for full multi-DDC operation. Index 0/1
+    /// delegate to the RX1/RX2 setters; index ≥ 2 updates the session per-receiver
+    /// store (RX3+) and re-projects + broadcasts so DspPipelineService opens the
+    /// WDSP channel and the P2 client is told to stream the new DDC. Only the
+    /// supplied fields change.
+    /// <para>Extra receivers are contiguous (the P2 DDC run has no gaps):
+    /// enabling RX(n) implicitly enables RX2..RX(n−1); disabling RX(n) disables
+    /// RX(n+1).. . Enabling any extra also turns RX2 on. This never touches the
+    /// PureSignal DDC0/1 pair.</para>
+    /// </summary>
+    public StateDto SetReceiver(
+        int index,
+        bool? enabled = null,
+        long? vfoHz = null,
+        byte? adcSource = null,
+        RxMode? mode = null,
+        int? filterLowHz = null,
+        int? filterHighHz = null,
+        double? afGainDb = null)
+    {
+        if (index == 0)
+            return vfoHz is long v0 ? SetVfo(v0) : Snapshot();
+        if (index == 1)
+            return SetRx2(new Rx2SetRequest(Enabled: enabled, VfoBHz: vfoHz, AfGainDb: afGainDb));
+        if (index < 2 || index >= _extraReceivers.Length)
+            throw new ArgumentOutOfRangeException(
+                nameof(index), index, $"receiver index out of range (0..{_extraReceivers.Length - 1})");
+
+        bool enabling = enabled == true;
+        lock (_sync)
+        {
+            var e = _extraReceivers[index];
+            if (vfoHz is long v) e.VfoHz = Math.Clamp(v, 0L, 60_000_000L);
+            if (adcSource is byte a) e.AdcSource = a;
+            if (mode is RxMode m) e.Mode = m;
+            if (filterLowHz is int fl) e.FilterLowHz = fl;
+            if (filterHighHz is int fh) e.FilterHighHz = fh;
+            if (afGainDb is double af) e.AfGainDb = Math.Clamp(af, -50.0, 20.0);
+            if (enabled is bool en)
+            {
+                e.Enabled = en;
+                if (en)
+                    for (int j = 2; j < index; j++) _extraReceivers[j].Enabled = true;       // contiguity below
+                else
+                    for (int j = index + 1; j < _extraReceivers.Length; j++) _extraReceivers[j].Enabled = false; // cascade above
+            }
+        }
+        // Re-project + broadcast (StateChanged → DspPipelineService opens channels
+        // and pushes SetExtraReceivers/SetExtraReceiverFreqHz to the radio).
+        // Enabling an extra DDC requires RX2 (no DDC gap), so turn it on.
+        Mutate(s => enabling && !s.Rx2Enabled ? s with { Rx2Enabled = true } : s);
+        return Snapshot();
+    }
 
     public StateDto SetRx2(Rx2SetRequest req)
     {
@@ -3086,8 +3166,10 @@ public sealed class RadioService : IDisposable
     // ADCs; SampleRateHz is the shared capture rate. Additional DDCs (index ≥ 2)
     // are appended here once DDC 2..N control exists. Pure + allocation-light
     // (called on every Mutate / Snapshot).
-    private static IReadOnlyList<ReceiverDto> ProjectReceivers(StateDto s) =>
-        new[]
+    // Caller holds _sync (Mutate / Snapshot) — reads _extraReceivers.
+    private IReadOnlyList<ReceiverDto> ProjectReceivers(StateDto s)
+    {
+        var list = new List<ReceiverDto>(2)
         {
             new ReceiverDto(
                 Index: 0, Enabled: true, AdcSource: 0,
@@ -3102,6 +3184,22 @@ public sealed class RadioService : IDisposable
                 FilterPresetName: s.FilterPresetNameB,
                 AfGainDb: s.Rx2AfGainDb, SampleRateHz: s.SampleRate),
         };
+        // Extra DDC receivers (RX3+). Appended contiguously while enabled — the
+        // P2 multi-DDC path requires no DDC gaps, so the first disabled slot
+        // ends the run. SampleRate is the shared capture rate for now.
+        for (int i = 2; i < _extraReceivers.Length; i++)
+        {
+            var e = _extraReceivers[i];
+            if (e is null || !e.Enabled) break;
+            list.Add(new ReceiverDto(
+                Index: i, Enabled: true, AdcSource: e.AdcSource,
+                VfoHz: e.VfoHz, Mode: e.Mode,
+                FilterLowHz: e.FilterLowHz, FilterHighHz: e.FilterHighHz,
+                FilterPresetName: e.FilterPresetName,
+                AfGainDb: e.AfGainDb, SampleRateHz: s.SampleRate));
+        }
+        return list;
+    }
 
     // Debounce flush: called by _stateFlushTimer every 1 s.
     // Captures the latest StateDto + family-filter memory under _sync and

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -1031,6 +1031,27 @@ public static class ZeusEndpoints
             return r.SetRx2(req);
         });
 
+        // Configure any receiver by index for full multi-DDC (RX1=0, RX2=1,
+        // RX3+=2..). Index 0/1 delegate to the RX1/RX2 setters; index >= 2 drives
+        // an extra hardware DDC. Only supplied fields change.
+        app.MapPost("/api/receivers/{index:int}", (int index, ReceiverSetRequest req, RadioService r) =>
+        {
+            if (index < 0 || index >= Zeus.Contracts.WireContract.MaxReceivers)
+                return Results.BadRequest(new { error = $"receiver index out of range (0..{Zeus.Contracts.WireContract.MaxReceivers - 1})" });
+            log.LogInformation(
+                "api.receivers index={Index} enabled={Enabled} vfoHz={VfoHz} adc={Adc} mode={Mode}",
+                index, req.Enabled, req.VfoHz, req.AdcSource, req.Mode);
+            return Results.Ok(r.SetReceiver(
+                index,
+                enabled: req.Enabled,
+                vfoHz: req.VfoHz,
+                adcSource: req.AdcSource,
+                mode: req.Mode,
+                filterLowHz: req.FilterLowHz,
+                filterHighHz: req.FilterHighHz,
+                afGainDb: req.AfGainDb));
+        });
+
         app.MapPost("/api/tx/vfo", (TxVfoSetRequest req, RadioService r) =>
         {
             if (!Enum.IsDefined(req.TxVfo))


### PR DESCRIPTION
## Multi-DDC build-out — B4-server: run N hardware DDCs (RX3..RX8) end-to-end

Generalizes the live Protocol-2 path from a fixed RX1/RX2 to **N concurrent hardware DDCs**, building on #808 (Phase A ingest + B1 wire foundation), #821 (B2 pipeline arrays), and #832 (B3 `Receivers[]` contract). RX1/RX2 stay byte/behaviour-exact; RX3+ are purely additive and **never touch the PureSignal DDC0/1 pair**.

### What changed
- **Protocol2Client** — extra-receiver state (RX3+): `SetExtraReceivers(count, adcSources)` + `SetExtraReceiverFreqHz`. `SendCmdRx` switches to the N-receiver composer (`ComposeCmdRxBufferForReceivers`) only when extras are configured (≤2 RX keeps the byte-pinned legacy composer). Per-DDC NCO phase words for RX3+ in `SendCmdHighPriority`. N-aware `ReceiverIndexForRxStream` (DDC slot → receiver). Receiver `i` → DDC `RxBaseDdc(board)+i` (G2: RX1→DDC2, RX3→DDC4).
- **DspPipelineService** — `SecondaryReceiverEnabled`/`SecondaryRxParams`/`UpdateRxLo`/`ApplyStateToSecondaryRxChannel` read per-receiver config from `StateDto.Receivers[]` for RX3+ (RX2 keeps the flat fields). `OnRadioStateChanged` opens a WDSP channel per extra and pushes `SetExtraReceivers`/`SetExtraReceiverFreqHz`. Tick already broadcasts a `DisplayFrame` per active secondary.
- **RadioService** — session per-receiver store for RX3+ (not persisted — no silent DDC auto-spin-up on restart); `ProjectReceivers` appends enabled extras; `SetReceiver(index, …)` control with contiguity (enabling RXn implies RX2..RXn-1; disabling cascades up; enabling any extra turns RX2 on). `SetReceiverVfo` routes idx≥2 to `SetReceiver`.
- **Contracts/endpoint** — `ReceiverSetRequest` + `POST /api/receivers/{index}`.
- **Diagnostics** — `rx-ingest-health` now emits per-DDC health from the channel **worker** (was gated on `ReadAudio`, so receivers whose audio isn't read were invisible). Added `primaryChannelId`, `secondaryRxChannelIds[]`, and per-receiver `routedFrames`/`fedFrames`.

### Verification (live, real ANAN G2, PS off)
RX1=14.074 / RX2=7.074 / RX3=10.130 MHz on DDC2/3/4 @ 192 kHz:
- `rx-ingest-health`: **`activeChannels=3`**, ports `[..,807,808,807,..]` (3 DDCs streaming), every channel **`droppedPerWindow=0`, `queueFullPerWindow=0`, worker headroom ~99%**.
- `routedFrames`/`fedFrames`: RX2 ~12.7k, **RX3 ~12.5k** frames/window fed to its own WDSP channel.
- Control: enabling RX3 auto-enables RX2 (contiguity); `receivers[]` reflects 3 distinct VFOs.
- Builds: full solution C# clean; Protocol2 tests 183/183 (RX1/RX2 wire bytes unchanged).

### Scope / known follow-up ([zeus-79qa] B4-UI)
This PR makes RX3+ **receive** (lossless IQ ingest, now visible in diagnostics). **Audio output routing for RX3+ is B4-UI**: their audio is currently computed but not consumed, so RX3+ audio rings overrun harmlessly (`audioOverrunPerWindow > 0` → selfcheck `warn` "audio consumer behind"). **IQ ingest is lossless regardless** (`dropped=0`). B4-UI will route/select RX3+ audio (clearing the warn), build the Settings DDC/dual-ADC panel, and render N panadapters from `Receivers[]`.

### Notes
- Cross-platform: pure C#; no platform-specific paths. PureSignal untouched (`PsEnabled` still inits false; PS DDC0/1 branch unmodified; validated PS-off only).
