### PR TITLE
feat(web): RECEIVERS settings panel for multi-DDC (B4-UI step 1)

### DIFF
--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -5503,6 +5503,43 @@ export function setRx2(
   );
 }
 
+// Configure any receiver by index for full multi-DDC (RX1=0, RX2=1, RX3+=2..).
+// Mirrors POST /api/receivers/{index}; index 0/1 delegate server-side to the
+// RX1/RX2 setters, index >= 2 drives an extra hardware DDC. Only the supplied
+// fields change. Returns the canonical state for `.then(applyState)`.
+export function setReceiver(
+  index: number,
+  req: {
+    enabled?: boolean;
+    vfoHz?: number;
+    adcSource?: number;
+    mode?: RxMode;
+    filterLowHz?: number;
+    filterHighHz?: number;
+    afGainDb?: number;
+  },
+  signal?: AbortSignal,
+): Promise<RadioStateDto> {
+  return jsonFetch(
+    `/api/receivers/${index}`,
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        enabled: req.enabled,
+        vfoHz: req.vfoHz,
+        adcSource: req.adcSource,
+        mode: req.mode,
+        filterLowHz: req.filterLowHz,
+        filterHighHz: req.filterHighHz,
+        afGainDb: req.afGainDb,
+      }),
+      signal,
+    },
+    normalizeState,
+  );
+}
+
 export function setTxVfo(
   txVfo: TxVfo,
   signal?: AbortSignal,

--- a/zeus-web/src/components/ReceiversPanel.test.tsx
+++ b/zeus-web/src/components/ReceiversPanel.test.tsx
@@ -87,8 +87,9 @@ describe('ReceiversPanel', () => {
     // One ADC select per active receiver (RX1, RX2).
     expect(adcSelects.length).toBe(2);
 
+    const sel = adcSelects[1];
+    if (!sel) throw new Error('expected an ADC select for RX2');
     await act(async () => {
-      const sel = adcSelects[1];
       sel.value = '1';
       sel.dispatchEvent(new Event('change', { bubbles: true }));
       await Promise.resolve();

--- a/zeus-web/src/components/ReceiversPanel.test.tsx
+++ b/zeus-web/src/components/ReceiversPanel.test.tsx
@@ -1,0 +1,100 @@
+/** @vitest-environment jsdom */
+
+import { createElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { setReceiver, type RadioStateDto, type ReceiverDto } from '../api/client';
+import { useConnectionStore } from '../state/connection-store';
+import { act, render } from './meters/__tests__/harness';
+import { ReceiversPanel } from './ReceiversPanel';
+
+function currentStateDto(): RadioStateDto {
+  return useConnectionStore.getState() as unknown as RadioStateDto;
+}
+
+vi.mock('../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../api/client')>('../api/client');
+  return {
+    ...actual,
+    setReceiver: vi.fn(async () => currentStateDto()),
+  };
+});
+
+function rx(index: number, enabled: boolean, adcSource = 0): ReceiverDto {
+  return {
+    index,
+    enabled,
+    adcSource,
+    vfoHz: 14_200_000 + index * 1_000_000,
+    mode: 'USB',
+    filterLowHz: 100,
+    filterHighHz: 2850,
+    filterPresetName: 'VAR1',
+    afGainDb: 0,
+    sampleRateHz: 192_000,
+  };
+}
+
+function setup(opts: {
+  protocol?: 'P1' | 'P2' | null;
+  receivers?: ReceiverDto[];
+}) {
+  useConnectionStore.setState({
+    status: 'Connected',
+    connectedProtocol: opts.protocol ?? 'P2',
+    receivers: opts.receivers ?? [rx(0, true)],
+    maxReceivers: 8,
+  });
+}
+
+describe('ReceiversPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('gates multi-DDC on a Protocol-2 connection', () => {
+    setup({ protocol: 'P1' });
+    const { container, unmount } = render(createElement(ReceiversPanel));
+    expect(container.textContent).toContain('Protocol 2 only');
+    // No exposed-count buttons on a non-P2 radio.
+    expect(container.querySelector('[aria-label="Exposed receiver count"]')).toBeNull();
+    unmount();
+  });
+
+  it('exposes a contiguous receiver count via the per-index endpoint', async () => {
+    setup({ protocol: 'P2', receivers: [rx(0, true)] });
+    const { container, unmount } = render(createElement(ReceiversPanel));
+
+    const three = Array.from(container.querySelectorAll<HTMLButtonElement>('button'))
+      .find((b) => b.textContent === '3');
+    expect(three).toBeTruthy();
+
+    await act(async () => {
+      three?.click();
+      await Promise.resolve();
+    });
+
+    // Exposing 3 enables index 2 (server contiguity turns on RX2..RX3).
+    expect(setReceiver).toHaveBeenCalledWith(2, { enabled: true });
+    unmount();
+  });
+
+  it('assigns a per-DDC ADC source', async () => {
+    setup({ protocol: 'P2', receivers: [rx(0, true), rx(1, true)] });
+    const { container, unmount } = render(createElement(ReceiversPanel));
+
+    const adcSelects = container.querySelectorAll<HTMLSelectElement>('select');
+    // One ADC select per active receiver (RX1, RX2).
+    expect(adcSelects.length).toBe(2);
+
+    await act(async () => {
+      const sel = adcSelects[1];
+      sel.value = '1';
+      sel.dispatchEvent(new Event('change', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(setReceiver).toHaveBeenCalledWith(1, { adcSource: 1 });
+    unmount();
+  });
+});

--- a/zeus-web/src/components/ReceiversPanel.tsx
+++ b/zeus-web/src/components/ReceiversPanel.tsx
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// RECEIVERS (multi-DDC) settings tab. Lets the operator choose how many
+// hardware DDC receivers to expose and which phase-synchronous ADC each one
+// reads — the front end for the B4-server N-receiver path (POST
+// /api/receivers/{index}, StateDto.Receivers[]). Multi-DDC is a Protocol-2
+// feature (ANAN G2 / Saturn class); the panel gates on a live P2 connection.
+//
+// Receivers are contiguous (the radio's DDC run has no gaps): exposing N means
+// RX1..RXN are active. The "exposed" button row composes the per-index calls;
+// per-receiver rows carry the ADC0/ADC1 selector. Visual idiom reuses the
+// shared `.ps-shell` / `.ps-card` / `.ps-field` surfaces (tokens only).
+
+import { setReceiver } from '../api/client';
+import { useConnectionStore } from '../state/connection-store';
+
+function formatMhz(hz: number): string {
+  return `${(hz / 1_000_000).toFixed(6)} MHz`;
+}
+
+export function ReceiversPanel() {
+  const receivers = useConnectionStore((s) => s.receivers);
+  const maxReceivers = useConnectionStore((s) => s.maxReceivers);
+  const status = useConnectionStore((s) => s.status);
+  const connectedProtocol = useConnectionStore((s) => s.connectedProtocol);
+  const applyState = useConnectionStore((s) => s.applyState);
+
+  const connected = status === 'Connected';
+  const isP2 = connectedProtocol === 'P2';
+
+  // Number of contiguous active receivers (RX1 always counts).
+  const exposedCount = Math.max(1, receivers.filter((r) => r.enabled).length);
+
+  // Set the exposed receiver count by composing the per-index endpoint. Server
+  // contiguity does the cascade: enabling index target-1 turns on RX2..target-1;
+  // disabling index target turns off everything above it.
+  function setExposedCount(target: number): void {
+    const n = Math.min(Math.max(target, 1), maxReceivers);
+    if (n === exposedCount) return;
+    if (n <= 1) {
+      setReceiver(1, { enabled: false }).then(applyState).catch(() => {});
+      return;
+    }
+    setReceiver(n - 1, { enabled: true })
+      .then((s) => {
+        applyState(s);
+        if (n < maxReceivers) {
+          return setReceiver(n, { enabled: false }).then(applyState);
+        }
+        return undefined;
+      })
+      .catch(() => {});
+  }
+
+  function setAdc(index: number, adcSource: number): void {
+    setReceiver(index, { adcSource }).then(applyState).catch(() => {});
+  }
+
+  const countOptions = Array.from({ length: maxReceivers }, (_, i) => i + 1);
+
+  return (
+    <div className="ps-shell">
+      <div className="ps-card">
+        <h4>
+          <svg className="ps-ic-sm" viewBox="0 0 12 12">
+            <path d="M1 6h2M9 6h2M6 1v2M6 9v2M3.5 3.5l1.2 1.2M7.3 7.3l1.2 1.2M8.5 3.5L7.3 4.7M4.7 7.3L3.5 8.5" />
+          </svg>
+          RECEIVERS (DDC)
+          <span className="ps-card-hint">independent hardware DDCs across the dual ADCs</span>
+        </h4>
+
+        {!connected ? (
+          <div className="ps-field">
+            <div className="ps-name">
+              Not connected
+              <em>Connect a radio to configure its DDC receivers.</em>
+            </div>
+          </div>
+        ) : !isP2 ? (
+          <div className="ps-field">
+            <div className="ps-name">
+              Protocol 2 only
+              <em>
+                Multiple independent DDC receivers require a Protocol-2 radio
+                (ANAN G2 / Saturn class). RX1/RX2 remain available on this radio.
+              </em>
+            </div>
+          </div>
+        ) : (
+          <>
+            <div className="ps-field">
+              <div className="ps-name">
+                Exposed receivers
+                <em>
+                  How many hardware DDC receivers to run concurrently. RX1..RXN
+                  are activated together (contiguous DDC run); each tunes to its
+                  own VFO. Up to {maxReceivers}.
+                </em>
+              </div>
+              <div className="btn-row wrap" role="group" aria-label="Exposed receiver count">
+                {countOptions.map((n) => (
+                  <button
+                    key={n}
+                    type="button"
+                    className={`btn sm ${n === exposedCount ? 'active' : ''}`}
+                    onClick={() => setExposedCount(n)}
+                  >
+                    {n}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {receivers.map((r) => (
+              <div className="ps-field" key={r.index}>
+                <div className="ps-name">
+                  {`RX${r.index + 1}`}
+                  <em>
+                    {`${r.mode} · ${formatMhz(r.vfoHz)}`}
+                    {r.index === 0 ? ' · clock master' : ''}
+                  </em>
+                </div>
+                <select
+                  className="ps-select-mini"
+                  value={r.adcSource}
+                  aria-label={`RX${r.index + 1} ADC source`}
+                  onChange={(e) => setAdc(r.index, Number(e.target.value))}
+                >
+                  <option value={0}>ADC 0</option>
+                  <option value={1}>ADC 1</option>
+                </select>
+              </div>
+            ))}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/zeus-web/src/components/SettingsMenu.tsx
+++ b/zeus-web/src/components/SettingsMenu.tsx
@@ -29,6 +29,7 @@ import { DisplayPanel } from './DisplayPanel';
 import { QrzSettingsPanel } from './QrzSettingsPanel';
 import { RadioOptionsPanel } from './RadioOptionsPanel';
 import { RadioSettingsPanel } from './RadioSettingsPanel';
+import { ReceiversPanel } from './ReceiversPanel';
 import { RotatorSettingsPanel } from './RotatorSettingsPanel';
 import { ServerUrlPanel } from './ServerUrlPanel';
 import { TciSettingsPanel } from './TciSettingsPanel';
@@ -61,6 +62,7 @@ export type SettingsTabId =
   | 'spots'
   | 'server'
   | 'radio'
+  | 'receivers'
   | 'calibration'
   | 'updates'
   | 'about';
@@ -81,6 +83,7 @@ const TABS: ReadonlyArray<{ id: SettingsTabId; label: string }> = [
   { id: 'spots', label: 'SPOTS' },
   { id: 'server', label: 'SERVER' },
   { id: 'radio', label: 'RADIO' },
+  { id: 'receivers', label: 'RECEIVERS' },
   { id: 'calibration', label: 'CALIBRATION' },
   { id: 'updates', label: 'UPDATES' },
   { id: 'about', label: 'ABOUT' },
@@ -208,6 +211,7 @@ export function SettingsView({ initialTab, onClose }: Props) {
           {activeTab === 'hamclock' && <HamClockSettingsPanel />}
           {activeTab === 'spots' && <SpotsSettingsPanel />}
           {activeTab === 'server' && <ServerUrlPanel />}
+          {activeTab === 'receivers' && <ReceiversPanel />}
           {activeTab === 'radio' && (
             <>
               <RadioSettingsPanel />

--- a/zeus-web/src/state/connection-store.ts
+++ b/zeus-web/src/state/connection-store.ts
@@ -60,6 +60,7 @@ import {
   type TxVfo,
   type TxLevelingConfigDto,
   type ZoomLevel,
+  type ReceiverDto,
 } from '../api/client';
 
 // WDSP wisdom bootstrap phase, mirroring the server's WisdomPhase enum.
@@ -102,6 +103,13 @@ export type ConnectionState = {
   autoAttEnabled: boolean;
   attOffsetDb: number;
   adcOverloadWarning: boolean;
+  // Multi-DDC receivers (wire v2). Server-projected per-receiver list: index
+  // 0 = RX1, 1 = RX2, >= 2 = extra hardware DDCs. Empty until the first state
+  // frame. The RECEIVERS settings panel reads this to render per-DDC controls.
+  receivers: ReceiverDto[];
+  // DDC / receiver ceiling for this build (WireContract.MaxReceivers); the
+  // RECEIVERS panel caps the exposed-count control against it.
+  maxReceivers: number;
   // Board kind only known from the discovery list at connect time — StateDto
   // doesn't echo it. Null after a page reload while already connected; the
   // preamp guard treats null as "show", which is the safe default (an HL2
@@ -165,6 +173,8 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
   rx2Enabled: false,
   rx2AudioMode: 'both',
   rx2AfGainDb: 0,
+  receivers: [],
+  maxReceivers: 8,
   txVfo: 'A',
   rxFocus: 'A',
   mode: 'USB',
@@ -221,6 +231,8 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
         rx2Enabled: s.rx2Enabled,
         rx2AudioMode: s.rx2AudioMode,
         rx2AfGainDb: s.rx2AfGainDb,
+        receivers: s.receivers ?? prev.receivers,
+        maxReceivers: s.maxReceivers ?? prev.maxReceivers,
         txVfo: s.txVfo,
         rxFocus: s.rx2Enabled ? prev.rxFocus : 'A',
         mode: s.mode,


### PR DESCRIPTION
## Multi-DDC build-out — B4-UI (step 1): RECEIVERS settings panel

Front end for the B4-server N-receiver path (#837). Adds a **Settings → RECEIVERS** tab to choose how many hardware DDC receivers to expose and which phase-synchronous ADC each one reads — the "configure DDCs from a menu" piece of the multi-DDC UX.

### What changed
- **`connection-store`** — carries `receivers[]` + `maxReceivers` from `StateDto` (wire v2), mapped in `applyState`.
- **`api/client`** — `setReceiver(index, {...})` → `POST /api/receivers/{index}`.
- **`ReceiversPanel`** (new) —
  - **Exposed-count selector** (1..`maxReceivers`): composes the per-index endpoint using server contiguity — exposing N enables index N-1 (turns on RX2..N-1) and disables index N (cascades the rest off).
  - **Per-receiver ADC0/ADC1 selector** + VFO/mode readout.
  - Gated on a live **Protocol-2** connection (multi-DDC is ANAN G2 / Saturn class); shows a clear note otherwise. Reuses the shared `.ps-card` / `.ps-field` surfaces (tokens only, no new palette).
- **`SettingsMenu`** — new RECEIVERS tab.

### Verification
- Frontend builds clean (`tsc`); **934 frontend tests pass**, incl. 3 new `ReceiversPanel` tests (P2 gating, contiguous exposed-count → `setReceiver(2,{enabled:true})`, per-DDC ADC assign).
- Backend endpoint (`/api/receivers/{index}`) already live-validated on the G2 in #837.

### Scope / follow-up ([zeus-79qa])
This is the **config UI**. Still to come in B4-UI: render N panadapters from `Receivers[]` (RX3+ `DisplayFrame` RxId≥2) and route/select RX3+ audio (clears the benign "audio consumer behind" warn). Visual/UX specifics are the maintainer's call — kept minimal and token-only.
