### PR TITLE
feat(remote): read-write API tunnel — native remote control + TX

### DIFF
--- a/Zeus.Server.Hosting/Remote/RemoteWebRtcSession.cs
+++ b/Zeus.Server.Hosting/Remote/RemoteWebRtcSession.cs
@@ -1,4 +1,5 @@
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
@@ -31,11 +32,19 @@ public sealed class RemoteWebRtcSession
     private readonly Zeus.Server.StreamingHub? _hub;
     private readonly Guid _sinkId = Guid.NewGuid();
 
-    // Loopback REST tunnel (read-only). When supplied, post-unlock GET/HEAD
-    // requests on the "api" channel are proxied to the radio's own local
-    // Kestrel and the response returned. Null → the api channel is inert.
+    // Loopback REST tunnel (read-write). When supplied, post-unlock requests on
+    // the "api" channel are proxied to the radio's own local Kestrel and the
+    // response returned. GET/HEAD read the radio's chrome; POST/PUT/DELETE/PATCH
+    // drive it (VFO/mode/band/filter/AGC/drive/MOX/TUN/…). Null → channel inert.
     private readonly IHttpClientFactory? _httpFactory;
     private readonly string? _loopbackBaseUrl;
+
+    // Dead-man TX safety: set once this session proxies a TX-keying request
+    // (MOX/TUN on). If the WebRTC session then drops while still keyed, Close()
+    // best-effort un-keys the radio so a lost link can never leave a remote
+    // station transmitting into its antenna/amp. Volatile: written on the
+    // data-channel callback thread, read on the teardown thread.
+    private volatile bool _remoteTxArmed;
 
     private RTCDataChannel? _control;
     private RTCDataChannel? _frames;
@@ -54,20 +63,24 @@ public sealed class RemoteWebRtcSession
     // Named HttpClient used for the loopback REST tunnel (see ZeusHost.cs).
     internal const string LoopbackHttpClientName = "RemoteApiLoopback";
 
-    // Cap on a tunnelled response body (1 MiB). Larger replies are refused with
-    // 502 — the read-only chrome endpoints are all small JSON; a giant body
-    // would be an export/dump path we don't want to relay anyway.
+    // Cap on a tunnelled request/response body (1 MiB). Larger replies are
+    // refused with 502 and larger requests with 413 — the chrome/control
+    // endpoints are all small JSON; a giant body would be an export/dump or
+    // bulk-import path we don't want to relay either direction.
     private const int MaxResponseBytes = 1 * 1024 * 1024;
+    private const int MaxRequestBytes = 1 * 1024 * 1024;
 
     /// <summary>
-    /// Sensitive-endpoint denylist for the read-only API tunnel. Even a GET to
-    /// one of these paths is refused (403, no loopback) so a remote monitor
-    /// cannot exfiltrate credentials, secrets, or the prefs database. Matching
-    /// is case-insensitive prefix on the URL path (query string ignored).
+    /// Always-denied endpoints (BOTH read and write). A request to one of these
+    /// is refused (403, no loopback) so a remote operator cannot exfiltrate or
+    /// overwrite credentials, secrets, or identity. Matching is case-insensitive
+    /// prefix on the canonical URL path (query string ignored).
     ///
-    /// Derived by scanning ZeusEndpoints.cs for GET endpoints that touch
+    /// Derived by scanning ZeusEndpoints.cs for endpoints that touch
     /// credentials/identity/secrets or that export the prefs DB:
     ///   /api/remote/password   — remote-access session password store/status
+    ///                            (a write here would let a remote change the
+    ///                            very password gating it)
     ///   /api/qrz               — QRZ status carries the signed-in operator's
     ///                            callsign/identity; login/credentials live here
     ///   /api/chat              — chat identity/roster/friends derive from the
@@ -84,6 +97,22 @@ public sealed class RemoteWebRtcSession
         "/api/chat",
         "/api/prefs/databases/export",
         "/api/log/export",
+    };
+
+    /// <summary>
+    /// Write-denied endpoints (mutating methods only — GET still allowed). Reads
+    /// of these are safe chrome, but a remote MUST NOT change them:
+    ///   /api/tx/ps             — PureSignal. KB2UKA hard-stop: no remote arm,
+    ///                            disarm, calibration, or persistence change. An
+    ///                            inadvertently armed PS on an external-tap
+    ///                            feedback chain can saturate the feedback ADC.
+    ///   /api/prefs/databases   — switching/importing/deleting the active prefs
+    ///                            LiteDB out from under the running radio.
+    /// </summary>
+    private static readonly string[] WriteDeniedPrefixes =
+    {
+        "/api/tx/ps",
+        "/api/prefs/databases",
     };
 
     public RemoteWebRtcSession(
@@ -156,6 +185,16 @@ public sealed class RemoteWebRtcSession
     public void Close()
     {
         if (Interlocked.Exchange(ref _closed, 1) != 0) return;
+
+        // Dead-man TX safety: if this session left the radio keyed, drop the
+        // carrier before tearing anything else down. A remote link that fails
+        // mid-transmit must never strand the station on-air.
+        if (_remoteTxArmed)
+        {
+            _remoteTxArmed = false;
+            _ = BestEffortUnkeyAsync();
+        }
+
         _session.Close();
         if (_hub is not null)
         {
@@ -186,9 +225,10 @@ public sealed class RemoteWebRtcSession
                 _frames = dc;
                 break;
             case "api":
-                // Read-only REST tunnel. Deny-by-default: each message is
-                // ignored until the session is UNLOCKED (checked in the handler),
-                // and only GET/HEAD to non-denylisted paths ever reach loopback.
+                // Read-write REST tunnel. Deny-by-default: each message is
+                // ignored until the session is UNLOCKED (checked in the handler);
+                // only non-denylisted paths reach loopback, and writes are
+                // additionally barred from the burn-zone (PureSignal) + prefs DB.
                 _api = dc;
                 dc.onmessage += (_, _, data) => OnApiMessage(data);
                 break;
@@ -257,15 +297,19 @@ public sealed class RemoteWebRtcSession
         }
     }
 
-    // -- Read-only REST tunnel ----------------------------------------------
+    // -- Read-write REST tunnel ---------------------------------------------
     //
-    // Post-unlock only. Each "api" message is {id, method, path}. The radio
-    // loopback-proxies GET/HEAD to its own local Kestrel and replies with
-    // {id, status, contentType, body}. Safety gates, in order:
-    //   1. LOCKED            → ignore entirely (deny-by-default, fail-closed).
-    //   2. method != GET/HEAD→ 405 (read-only; never touches the radio).
-    //   3. denylisted path   → 403 (no loopback; can't exfiltrate secrets).
-    //   4. otherwise         → loopback GET; 502 on >1 MiB body or any error.
+    // Post-unlock only. Each "api" message is {id, method, path, body?,
+    // contentType?}. The radio loopback-proxies the request to its own local
+    // Kestrel and replies with {id, status, contentType, body}. Safety gates,
+    // in order:
+    //   1. LOCKED               → ignore entirely (deny-by-default, fail-closed).
+    //   2. unsupported method   → 405 (only GET/HEAD/POST/PUT/DELETE/PATCH).
+    //   3. request body >1 MiB  → 413 (no bulk import through the tunnel).
+    //   4. path traversal       → 403 (can't collapse "../" onto a denied path).
+    //   5. always-denied path   → 403 (secrets/identity/exports, any method).
+    //   6. write to write-denied→ 403 (PureSignal burn-zone, prefs DB).
+    //   7. otherwise            → loopback proxy; 502 on >1 MiB reply or error.
     // Fire-and-forget like the control handling — never block the data-channel
     // callback thread, and never throw out of the handler.
 
@@ -282,6 +326,8 @@ public sealed class RemoteWebRtcSession
         {
             string method;
             string path;
+            string? body;
+            string? contentType;
             using (var doc = JsonDocument.Parse(data))
             {
                 var root = doc.RootElement;
@@ -289,12 +335,23 @@ public sealed class RemoteWebRtcSession
                 method = (root.TryGetProperty("method", out var mEl) ? mEl.GetString() : null)
                     ?? "GET";
                 path = (root.TryGetProperty("path", out var pEl) ? pEl.GetString() : null) ?? "";
+                body = root.TryGetProperty("body", out var bEl) ? bEl.GetString() : null;
+                contentType = root.TryGetProperty("contentType", out var cEl) ? cEl.GetString() : null;
             }
 
-            // Read-only: only GET/HEAD ever leave this server toward the radio.
-            if (!IsReadOnlyMethod(method))
+            if (!IsAllowedMethod(method))
             {
                 SendApiReply(id, 405);
+                return;
+            }
+
+            bool mutating = IsMutatingMethod(method);
+
+            // Cap the request body so the tunnel can't be used as a bulk-import
+            // channel. UTF-16 length is a safe over-estimate of UTF-8 bytes.
+            if (body is not null && body.Length > MaxRequestBytes)
+            {
+                SendApiReply(id, 413);
                 return;
             }
 
@@ -307,9 +364,9 @@ public sealed class RemoteWebRtcSession
             // Reject path traversal outright. Without this, a path like
             // "/api/state/../prefs/databases/export" slips past the denylist
             // (it prefix-matches nothing) yet Uri canonicalisation collapses the
-            // "../" so the loopback GET lands on a denied endpoint — a bypass that
-            // would exfiltrate the prefs DB. Legit SPA /api paths never contain
-            // dot-segments or percent-encoded ones.
+            // "../" so the loopback request lands on a denied endpoint — a bypass
+            // that would exfiltrate the prefs DB. Legit SPA /api paths never
+            // contain dot-segments or percent-encoded ones.
             if (path.Contains("..", StringComparison.Ordinal)
                 || path.Contains("%2e", StringComparison.OrdinalIgnoreCase))
             {
@@ -320,8 +377,8 @@ public sealed class RemoteWebRtcSession
 
             // Build the loopback target once and denylist-check the CANONICAL
             // path that will actually be requested — never the raw input. Verify
-            // it stays on loopback so a crafted authority can't redirect the GET
-            // off-box (SSRF).
+            // it stays on loopback so a crafted authority can't redirect the
+            // request off-box (SSRF).
             if (!Uri.TryCreate(_loopbackBaseUrl + path, UriKind.Absolute, out var target)
                 || !target.IsLoopback)
             {
@@ -330,18 +387,35 @@ public sealed class RemoteWebRtcSession
             }
 
             // Sensitive-endpoint denylist — refuse before any loopback call.
-            if (IsDenied(target.AbsolutePath))
+            if (IsDenied(target.AbsolutePath, mutating))
             {
-                _log.LogWarning("rtc.remote api DENY {Path}", target.AbsolutePath);
+                _log.LogWarning("rtc.remote api DENY {Method} {Path}", method, target.AbsolutePath);
                 SendApiReply(id, 403);
                 return;
             }
 
+            // HEAD is proxied as GET and the body discarded; all other methods
+            // pass through verbatim with their request body (when present).
+            var httpMethod = string.Equals(method, "HEAD", StringComparison.OrdinalIgnoreCase)
+                ? HttpMethod.Get
+                : new HttpMethod(method.ToUpperInvariant());
+
             var client = _httpFactory.CreateClient(LoopbackHttpClientName);
-            using var req = new HttpRequestMessage(
-                HttpMethod.Get, target); // HEAD proxied as GET; body discarded below
+            using var req = new HttpRequestMessage(httpMethod, target);
+            if (mutating && !string.IsNullOrEmpty(body))
+            {
+                req.Content = new StringContent(body, Encoding.UTF8);
+                var ct = string.IsNullOrEmpty(contentType) ? "application/json" : contentType;
+                if (MediaTypeHeaderValue.TryParse(ct, out var parsed))
+                    req.Content.Headers.ContentType = parsed;
+            }
+
             using var resp = await client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead)
                 .ConfigureAwait(false);
+
+            // Track TX keying so a dropped link un-keys the radio (see Close()).
+            if (mutating && (int)resp.StatusCode is >= 200 and < 300)
+                TrackTxKeying(target.AbsolutePath, body);
 
             // Cap the body so the tunnel can't be used as a bulk-export channel.
             if (resp.Content.Headers.ContentLength is long len && len > MaxResponseBytes)
@@ -356,11 +430,11 @@ public sealed class RemoteWebRtcSession
                 return;
             }
 
-            var contentType = resp.Content.Headers.ContentType?.ToString();
-            var body = string.Equals(method, "HEAD", StringComparison.OrdinalIgnoreCase)
+            var respContentType = resp.Content.Headers.ContentType?.ToString();
+            var respBody = string.Equals(method, "HEAD", StringComparison.OrdinalIgnoreCase)
                 ? ""
                 : Encoding.UTF8.GetString(bytes);
-            SendApiReply(id, (int)resp.StatusCode, contentType, body);
+            SendApiReply(id, (int)resp.StatusCode, respContentType, respBody);
         }
         catch (Exception ex)
         {
@@ -369,11 +443,13 @@ public sealed class RemoteWebRtcSession
         }
     }
 
-    private static bool IsReadOnlyMethod(string method)
-        => string.Equals(method, "GET", StringComparison.OrdinalIgnoreCase)
-        || string.Equals(method, "HEAD", StringComparison.OrdinalIgnoreCase);
+    private static bool IsAllowedMethod(string method)
+        => method.ToUpperInvariant() is "GET" or "HEAD" or "POST" or "PUT" or "DELETE" or "PATCH";
 
-    private static bool IsDenied(string path)
+    private static bool IsMutatingMethod(string method)
+        => method.ToUpperInvariant() is "POST" or "PUT" or "DELETE" or "PATCH";
+
+    private static bool IsDenied(string path, bool mutating)
     {
         // Compare on the path only (strip any query string) so a denied prefix
         // can't be smuggled past with a "?..." suffix.
@@ -382,7 +458,59 @@ public sealed class RemoteWebRtcSession
         foreach (var prefix in DeniedPathPrefixes)
             if (p.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
                 return true;
+        if (mutating)
+            foreach (var prefix in WriteDeniedPrefixes)
+                if (p.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    return true;
         return false;
+    }
+
+    /// <summary>
+    /// Note a successful MOX/TUN keying request so the dead-man in Close() can
+    /// un-key a dropped session. Arms on {"on":true} to /api/tx/{mox,tun},
+    /// disarms on {"on":false}.
+    /// </summary>
+    private void TrackTxKeying(string path, string? body)
+    {
+        if (!path.Equals("/api/tx/mox", StringComparison.OrdinalIgnoreCase)
+            && !path.Equals("/api/tx/tun", StringComparison.OrdinalIgnoreCase))
+            return;
+        try
+        {
+            using var doc = JsonDocument.Parse(body ?? "");
+            if (doc.RootElement.TryGetProperty("on", out var onEl)
+                && onEl.ValueKind is JsonValueKind.True or JsonValueKind.False)
+                _remoteTxArmed = onEl.GetBoolean();
+        }
+        catch { /* unparseable body — leave the arm state unchanged */ }
+    }
+
+    /// <summary>
+    /// Best-effort un-key (MOX off + TUN off) over loopback when a keyed session
+    /// drops. Fire-and-forget; never throws. Short per-request timeout so a
+    /// wedged Kestrel can't hang teardown.
+    /// </summary>
+    private async Task BestEffortUnkeyAsync()
+    {
+        if (_httpFactory is null || string.IsNullOrEmpty(_loopbackBaseUrl)) return;
+        try
+        {
+            var client = _httpFactory.CreateClient(LoopbackHttpClientName);
+            foreach (var p in new[] { "/api/tx/mox", "/api/tx/tun" })
+            {
+                using var req = new HttpRequestMessage(HttpMethod.Post, _loopbackBaseUrl + p)
+                {
+                    Content = new StringContent("{\"on\":false}", Encoding.UTF8, "application/json"),
+                };
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+                using var _ = await client.SendAsync(req, cts.Token).ConfigureAwait(false);
+            }
+            _log.LogWarning("rtc.remote session dropped while keyed — sent dead-man un-key (MOX/TUN off)");
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "rtc.remote dead-man un-key failed");
+        }
     }
 
     private void SendApiReply(int id, int status, string? contentType = null, string? body = null)

--- a/tests/Zeus.Server.Tests/RemoteWebRtcSessionTests.cs
+++ b/tests/Zeus.Server.Tests/RemoteWebRtcSessionTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Net;
 using System.Text;
 using System.Text.Json;
@@ -142,7 +143,7 @@ public sealed class RemoteWebRtcSessionTests
         Assert.False(hub.DisplayStreamRequested);
     }
 
-    // -- Read-only API tunnel ------------------------------------------------
+    // -- Read-write API tunnel -----------------------------------------------
 
     private const string LoopbackBase = "http://127.0.0.1:6060";
 
@@ -191,20 +192,95 @@ public sealed class RemoteWebRtcSessionTests
     }
 
     [Fact]
-    public async Task PostUnlock_NonGet_Refused405_WithoutTouchingLoopback()
+    public async Task PostUnlock_TunneledPost_ReachesLoopback_WithMethodAndBody()
     {
-        var factory = new StubHttpClientFactory(_ =>
-            throw new InvalidOperationException("loopback must NOT be called for a non-GET"));
+        HttpMethod? seenMethod = null;
+        string? seenUri = null, seenBody = null, seenContentType = null;
+        var factory = new StubHttpClientFactory((req) =>
+        {
+            seenMethod = req.Method;
+            seenUri = req.RequestUri!.ToString();
+            seenBody = req.Content?.ReadAsStringAsync().Result;
+            seenContentType = req.Content?.Headers.ContentType?.MediaType;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"moxOn\":true}", Encoding.UTF8, "application/json"),
+            };
+        });
         ApiSession(factory, out var server);
         await using var client = new ProverClient(Password);
         await UnlockAsync(server, client);
 
-        var replyJson = await SendApiUntilReply(client, 3, "POST", "/api/state");
+        // A control write (key MOX) must pass through verbatim — method + body +
+        // content-type — and return the radio's reply. This is the core of native
+        // remote control: the SPA's POST drives the radio's own loopback Kestrel.
+        var replyJson = await SendApiUntilReply(
+            client, 5, "POST", "/api/tx/mox", "{\"on\":true}", "application/json");
         using var doc = JsonDocument.Parse(replyJson);
-        Assert.Equal(405, doc.RootElement.GetProperty("status").GetInt32());
-        Assert.Equal(0, factory.CallCount); // read-only: never reached the radio
+        Assert.Equal(200, doc.RootElement.GetProperty("status").GetInt32());
+        Assert.Equal("{\"moxOn\":true}", doc.RootElement.GetProperty("body").GetString());
+        Assert.Equal(HttpMethod.Post, seenMethod);
+        Assert.Equal($"{LoopbackBase}/api/tx/mox", seenUri);
+        Assert.Equal("{\"on\":true}", seenBody);
+        Assert.Equal("application/json", seenContentType);
 
         server.Close();
+    }
+
+    [Fact]
+    public async Task PostUnlock_WriteToPureSignal_Refused403_WithoutTouchingLoopback()
+    {
+        var factory = new StubHttpClientFactory(_ =>
+            throw new InvalidOperationException("loopback must NOT be called for a PureSignal write"));
+        ApiSession(factory, out var server);
+        await using var client = new ProverClient(Password);
+        await UnlockAsync(server, client);
+
+        // PureSignal arm is a KB2UKA hard-stop: a remote POST to /api/tx/ps must
+        // be refused (403) and never reach the radio's burn-zone subsystem.
+        var replyJson = await SendApiUntilReply(
+            client, 13, "POST", "/api/tx/ps", "{\"enabled\":true}", "application/json");
+        using var doc = JsonDocument.Parse(replyJson);
+        Assert.Equal(403, doc.RootElement.GetProperty("status").GetInt32());
+        Assert.Equal(0, factory.CallCount);
+
+        server.Close();
+    }
+
+    [Fact]
+    public async Task DroppedSessionWhileKeyed_SendsDeadManUnkey()
+    {
+        var calls = new List<(string Uri, string Body)>();
+        var gate = new object();
+        var factory = new StubHttpClientFactory((req) =>
+        {
+            lock (gate) calls.Add((req.RequestUri!.ToString(), req.Content?.ReadAsStringAsync().Result ?? ""));
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"moxOn\":true}", Encoding.UTF8, "application/json"),
+            };
+        });
+        ApiSession(factory, out var server);
+        await using var client = new ProverClient(Password);
+        await UnlockAsync(server, client);
+
+        // Key the radio over the tunnel, then drop the session — the dead-man must
+        // un-key BOTH MOX and TUN so a lost link never strands the station on-air.
+        await SendApiUntilReply(client, 21, "POST", "/api/tx/mox", "{\"on\":true}", "application/json");
+        server.Close();
+
+        await WaitForAsync(() =>
+        {
+            lock (gate)
+                return calls.Any(c => c.Uri.EndsWith("/api/tx/mox") && c.Body.Contains("\"on\":false"))
+                    && calls.Any(c => c.Uri.EndsWith("/api/tx/tun") && c.Body.Contains("\"on\":false"));
+        }, TimeSpan.FromSeconds(5));
+
+        lock (gate)
+        {
+            Assert.Contains(calls, c => c.Uri.EndsWith("/api/tx/mox") && c.Body.Contains("\"on\":false"));
+            Assert.Contains(calls, c => c.Uri.EndsWith("/api/tx/tun") && c.Body.Contains("\"on\":false"));
+        }
     }
 
     [Fact]
@@ -284,12 +360,13 @@ public sealed class RemoteWebRtcSessionTests
     /// a duplicate send is harmless (the prover keeps the latest reply slot).
     /// </summary>
     private static async Task<string> SendApiUntilReply(
-        ProverClient client, int id, string method, string path)
+        ProverClient client, int id, string method, string path,
+        string? body = null, string? contentType = null)
     {
         var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(15);
         while (true)
         {
-            var reply = client.SendApiRequest(id, method, path);
+            var reply = client.SendApiRequest(id, method, path, body, contentType);
             var done = await Task.WhenAny(reply, Task.Delay(250));
             if (done == reply) return await reply;
             if (DateTime.UtcNow > deadline) return await reply.WaitAsync(TimeSpan.FromSeconds(1));
@@ -360,7 +437,7 @@ public sealed class RemoteWebRtcSessionTests
             _pc = new RTCPeerConnection(new RTCConfiguration { iceServers = new List<RTCIceServer>() });
             _control = _pc.createDataChannel("control").Result;
             _frames = _pc.createDataChannel("frames").Result; // reliable for test determinism
-            _api = _pc.createDataChannel("api").Result;        // read-only REST tunnel
+            _api = _pc.createDataChannel("api").Result;        // read-write REST tunnel
             _control.onopen += () => _control.send("{\"t\":\"hello\"}");
             _control.onmessage += (_, _, data) => _ = HandleControlAsync(data);
             _frames.onmessage += (_, _, data) => _frame.TrySetResult(data);
@@ -374,11 +451,14 @@ public sealed class RemoteWebRtcSessionTests
         /// <summary>Send a raw binary control frame (post-unlock stream-request, e.g. 0x22 01).</summary>
         public void SendControlBinary(byte[] frame) => _control.send(frame);
 
-        /// <summary>Send a read-only API tunnel request {id, method, path} and await the next reply JSON.</summary>
-        public Task<string> SendApiRequest(int id, string method, string path)
+        /// <summary>Send an API tunnel request {id, method, path, body?, contentType?} and await the next reply JSON.</summary>
+        public Task<string> SendApiRequest(int id, string method, string path, string? body = null, string? contentType = null)
         {
             _apiReply = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
-            _api.send(JsonSerializer.Serialize(new { id, method, path }));
+            var msg = new Dictionary<string, object?> { ["id"] = id, ["method"] = method, ["path"] = path };
+            if (body is not null) msg["body"] = body;
+            if (contentType is not null) msg["contentType"] = contentType;
+            _api.send(JsonSerializer.Serialize(msg));
             return _apiReply.Task;
         }
 

--- a/zeus-web/src/remote/api-tunnel.test.ts
+++ b/zeus-web/src/remote/api-tunnel.test.ts
@@ -5,9 +5,9 @@
 //                         Douglas J. Cerrato (KB2UKA),
 //                         Christian Suarez (N9WAR), and contributors.
 //
-// Unit tests for the read-only /api/* fetch shim (api-tunnel.ts):
+// Unit tests for the read-write /api/* fetch shim (api-tunnel.ts):
 //   - GET /api/x tunnels over the data channel and resolves the radio's reply
-//   - non-GET (POST/…) resolves a synthetic 405 WITHOUT touching the channel
+//   - POST/PUT/… tunnel with their body + content-type over the channel
 //   - non-/api requests delegate to the original fetch untouched
 //   - requests issued BEFORE connect queue and flush once setApiChannel() lands
 
@@ -37,7 +37,13 @@ class FakeChannel {
   }
 }
 
-function lastRequest(ch: FakeChannel): { id: number; method: string; path: string } {
+function lastRequest(ch: FakeChannel): {
+  id: number;
+  method: string;
+  path: string;
+  body?: string;
+  contentType?: string;
+} {
   return JSON.parse(ch.sent[ch.sent.length - 1]!);
 }
 
@@ -89,14 +95,50 @@ describe('api-tunnel fetch shim', () => {
     await p;
   });
 
-  it('refuses a non-GET with a synthetic 405 and never touches the channel', async () => {
+  it('tunnels a POST with its body + content-type and resolves the reply', async () => {
     const ch = new FakeChannel();
     setApiChannel(ch as unknown as RTCDataChannel);
 
-    const resp = await window.fetch('/api/state', { method: 'POST', body: '{}' });
-    expect(resp.status).toBe(405);
-    expect(await resp.json()).toEqual({ error: 'Remote session is read-only' });
-    expect(ch.sent.length).toBe(0); // nothing reached the radio
+    const respPromise = window.fetch('/api/tx/mox', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ on: true }),
+    });
+    // extractBody awaits before the send (async body read); wait for the send.
+    await vi.waitFor(() => expect(ch.sent.length).toBe(1));
+    const req = lastRequest(ch);
+    expect(req.method).toBe('POST');
+    expect(req.path).toBe('/api/tx/mox');
+    expect(req.body).toBe('{"on":true}');
+    expect(req.contentType).toBe('application/json');
+    expect(originalFetch).not.toHaveBeenCalled();
+
+    ch.reply({ id: req.id, status: 200, body: '{"moxOn":true}' });
+    const resp = await respPromise;
+    expect(resp.status).toBe(200);
+    expect(await resp.json()).toEqual({ moxOn: true });
+  });
+
+  it('tunnels a body carried on a Request object', async () => {
+    const ch = new FakeChannel();
+    setApiChannel(ch as unknown as RTCDataChannel);
+
+    // Absolute same-origin URL: the test env's Request can't parse a relative
+    // path (no document base), but the shim still resolves it to /api/radio/lo.
+    const request = new Request(`${window.location.origin}/api/radio/lo`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ hz: 14200000 }),
+    });
+    const respPromise = window.fetch(request);
+    await vi.waitFor(() => expect(ch.sent.length).toBe(1));
+    const req = lastRequest(ch);
+    expect(req.method).toBe('POST');
+    expect(req.path).toBe('/api/radio/lo');
+    expect(req.body).toBe('{"hz":14200000}');
+
+    ch.reply({ id: req.id, status: 200, body: 'null' });
+    await respPromise;
   });
 
   it('delegates non-/api requests to the original fetch', async () => {

--- a/zeus-web/src/remote/api-tunnel.ts
+++ b/zeus-web/src/remote/api-tunnel.ts
@@ -5,25 +5,25 @@
 //                         Douglas J. Cerrato (KB2UKA),
 //                         Christian Suarez (N9WAR), and contributors.
 //
-// Read-only REST tunnel for remote (WebRTC) RX monitoring. On the static Pages
-// host the SPA has no same-origin `/api/*` backend, so its REST chrome (VFO,
-// mode, band, capabilities, AGC, …) renders empty. This module monkeypatches
-// `window.fetch` so that same-origin `/api/*` GET/HEAD requests are tunnelled
-// over the WebRTC "api" DataChannel to the operator's radio, which loopback-
-// proxies them to its own local Kestrel and returns the response.
+// Read-write REST tunnel for remote (WebRTC) operating. On the static Pages
+// host the SPA has no same-origin `/api/*` backend, so its REST chrome and
+// controls (VFO, mode, band, filter, AGC, drive, MOX/TUN, …) cannot reach the
+// radio. This module monkeypatches `window.fetch` so that same-origin `/api/*`
+// requests — reads AND writes — are tunnelled over the WebRTC "api" DataChannel
+// to the operator's radio, which loopback-proxies them to its own local Kestrel
+// and returns the response. This is what makes a remote session control the
+// radio natively, as if sitting at the desktop app.
 //
-// SAFETY POSTURE (matches the server-side gate):
-//   - READ-ONLY: only GET/HEAD tunnel. Any non-GET (POST/PUT/DELETE/PATCH) is
-//     refused locally with a synthetic 405 and NEVER reaches the radio — this
-//     preserves "RX monitoring only", no remote TX/tuning/control.
-//   - DENY-BY-DEFAULT: tunnelled GETs QUEUE until the channel is open AND the
-//     session is unlocked, then flush. Nothing is sent before unlock.
+// SAFETY POSTURE (the SERVER is the authority — this side mirrors it):
+//   - DENY-BY-DEFAULT: tunnelled requests QUEUE until the channel is open AND
+//     the session is unlocked, then flush. Nothing is sent before unlock.
+//   - The server enforces the real guards: an always-denied list (secrets /
+//     identity / exports), a write-denied list (PureSignal burn-zone + prefs
+//     DB), path-traversal/loopback/size caps, and a dead-man TX un-key if the
+//     link drops while keyed. See RemoteWebRtcSession.
 //   - Every tunnelled request has a timeout so a never-connecting session
 //     rejects rather than hanging the UI forever.
 //   - Non-`/api` requests delegate to the original fetch untouched.
-//
-// The complementary sensitive-endpoint denylist lives on the SERVER
-// (RemoteWebRtcSession) so the radio is the authority on what it will read.
 
 const API_PREFIX = '/api/';
 const REQUEST_TIMEOUT_MS = 15_000;
@@ -45,6 +45,8 @@ interface QueuedRequest {
   id: number;
   path: string;
   method: string;
+  body?: string;
+  contentType?: string;
 }
 
 let installed = false;
@@ -86,14 +88,24 @@ function methodOf(input: RequestInfo | URL, init?: RequestInit): string {
 
 /** Send the request over the channel now (channel is open + unlocked). */
 function dispatch(req: QueuedRequest): void {
-  channel!.send(JSON.stringify({ id: req.id, method: req.method, path: req.path }));
+  const msg: Record<string, unknown> = { id: req.id, method: req.method, path: req.path };
+  if (req.body !== undefined) msg.body = req.body;
+  if (req.contentType !== undefined) msg.contentType = req.contentType;
+  channel!.send(JSON.stringify(msg));
 }
 
 /**
- * Enqueue (or immediately dispatch) a tunnelled GET/HEAD and return a Promise
+ * Enqueue (or immediately dispatch) a tunnelled request and return a Promise
  * that resolves with the radio's response or rejects on timeout/disconnect.
+ * GET/HEAD carry no body; mutating methods carry the serialized request body
+ * and its content-type.
  */
-function tunnel(path: string, method: string): Promise<TunnelResponse> {
+function tunnel(
+  path: string,
+  method: string,
+  body?: string,
+  contentType?: string,
+): Promise<TunnelResponse> {
   const id = nextId++;
   return new Promise<TunnelResponse>((resolve, reject) => {
     const timer = setTimeout(() => {
@@ -105,10 +117,42 @@ function tunnel(path: string, method: string): Promise<TunnelResponse> {
     }, REQUEST_TIMEOUT_MS);
 
     pending.set(id, { resolve, reject, timer });
-    const req: QueuedRequest = { id, path, method };
+    const req: QueuedRequest = { id, path, method, body, contentType };
     if (channel && channel.readyState === 'open') dispatch(req);
     else queue.push(req);
   });
+}
+
+/**
+ * Extract a request's body (as text) and content-type from the fetch arguments,
+ * handling the shapes the SPA actually uses: an `init.body` string (the common
+ * `JSON.stringify(...)` case), a body carried on a `Request` object, and the
+ * other BodyInit kinds (Blob/ArrayBuffer/URLSearchParams) via a throwaway
+ * Response. GET/HEAD never call this.
+ */
+async function extractBody(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<{ body?: string; contentType?: string }> {
+  const initHeaders = init?.headers ? new Headers(init.headers) : null;
+  let contentType = initHeaders?.get('content-type') ?? undefined;
+
+  const raw = init?.body;
+  if (raw == null) {
+    if (input instanceof Request) {
+      if (!contentType) contentType = input.headers.get('content-type') ?? undefined;
+      const text = await input.clone().text();
+      return { body: text || undefined, contentType };
+    }
+    return { contentType };
+  }
+  if (typeof raw === 'string') return { body: raw, contentType };
+  try {
+    const text = await new Response(raw as BodyInit).text();
+    return { body: text || undefined, contentType };
+  } catch {
+    return { contentType };
+  }
 }
 
 /** Build a synthetic browser Response from the radio's tunnelled reply. */
@@ -117,13 +161,6 @@ function toResponse(r: TunnelResponse): Response {
   // HEAD/204/304 cannot carry a body per the Fetch spec — pass null.
   const bodyless = r.status === 204 || r.status === 304;
   return new Response(bodyless ? null : (r.body ?? ''), { status: r.status, headers });
-}
-
-function readOnlyRefusal(): Response {
-  return new Response(JSON.stringify({ error: 'Remote session is read-only' }), {
-    status: 405,
-    headers: { 'content-type': 'application/json' },
-  });
 }
 
 function onChannelMessage(ev: MessageEvent): void {
@@ -174,7 +211,7 @@ export function setApiChannel(ch: RTCDataChannel | null): void {
 }
 
 /**
- * Install the read-only `/api/*` fetch shim. Idempotent. Call once at remote-
+ * Install the read-write `/api/*` fetch shim. Idempotent. Call once at remote-
  * client module load (when isRemoteMode()) so the shim is live BEFORE the
  * app's mount effects fire their `/api/state` etc. requests — those queue
  * until setApiChannel() flushes them post-unlock.
@@ -189,11 +226,14 @@ export function installApiTunnel(): void {
     if (path === null) return originalFetch!(input, init);
 
     const method = methodOf(input, init);
-    if (method !== 'GET' && method !== 'HEAD') {
-      // Read-only: refuse locally, never touch the radio.
-      return Promise.resolve(readOnlyRefusal());
+    if (method === 'GET' || method === 'HEAD') {
+      return tunnel(path, method).then(toResponse);
     }
-    return tunnel(path, method).then(toResponse);
+    // Mutating request: extract its body, then tunnel to the radio, which
+    // loopback-proxies it (the server enforces the write denylist + caps).
+    return extractBody(input, init)
+      .then(({ body, contentType }) => tunnel(path, method, body, contentType))
+      .then(toResponse);
   };
 }
 

--- a/zeus-web/src/remote/remote-client.ts
+++ b/zeus-web/src/remote/remote-client.ts
@@ -5,16 +5,20 @@
 //                         Douglas J. Cerrato (KB2UKA),
 //                         Christian Suarez (N9WAR), and contributors.
 //
-// Remote-access RX-monitoring bootstrap (Phase A). When the SPA is opened at
-// `…/?remote=<CALLSIGN>` it connects to the operator's radio over WebRTC through
-// the Cloudflare broker instead of the local websocket, then feeds the unlocked
-// binary radio frames through the exact same dispatch path the local /ws client
-// uses (dispatchServerFrame) — so panadapter / waterfall / meters / audio render
+// Remote-access bootstrap. When the SPA is opened at `…/?remote=<CALLSIGN>` it
+// connects to the operator's radio over WebRTC through the Cloudflare broker
+// instead of the local websocket, then feeds the unlocked binary radio frames
+// through the exact same dispatch path the local /ws client uses
+// (dispatchServerFrame) — so panadapter / waterfall / meters / audio render
 // identically, just sourced over WebRTC.
 //
-// Scope is RX MONITORING ONLY: display + audio + meters. There is no TX, mic
-// uplink, or tuning/control RPC in this phase. Deny-by-default holds: nothing
-// flows until connectViaBroker's SPAKE2+ password handshake unlocks.
+// Scope: full native control. RX display + audio + meters stream over the frames
+// channel, and the read-write `/api/*` tunnel (api-tunnel.ts) carries the SPA's
+// control REST to the radio's loopback Kestrel — VFO/mode/band/filter/AGC/drive/
+// MOX/TUN, exactly as the desktop app does. The server gates the burn-zone
+// (PureSignal) + secrets and dead-man un-keys a dropped session. Voice-mic uplink
+// is the next phase (mic PCM stays WS-only for now). Deny-by-default holds:
+// nothing flows until connectViaBroker's SPAKE2+ password handshake unlocks.
 
 import { connectViaBroker, type RemoteConnection } from './connect';
 import { installApiTunnel, setApiChannel } from './api-tunnel';
@@ -41,10 +45,10 @@ export function isRemoteMode(): boolean {
   return getRemoteCallsign() !== null;
 }
 
-// Install the read-only /api/* fetch shim at module load — BEFORE the app's
+// Install the read-write /api/* fetch shim at module load — BEFORE the app's
 // mount effects fire their `/api/state` etc. requests. In remote mode there is
-// no same-origin backend, so those GETs must tunnel; the shim queues them until
-// the session unlocks and setApiChannel() flushes the queue. No-op outside
+// no same-origin backend, so those requests must tunnel; the shim queues them
+// until the session unlocks and setApiChannel() flushes the queue. No-op outside
 // remote mode (the local /ws client uses the real same-origin backend).
 if (isRemoteMode()) {
   installApiTunnel();


### PR DESCRIPTION
## What

Makes the remote-access (`?remote=<callsign>`) session **control the radio natively**, as if sitting at the desktop app. Until now the remote session was **RX-monitoring only**: the `/api` WebRTC tunnel refused every non-GET with a 405, so a remote operator saw the panadapter/waterfall/meters but couldn't change anything. Every radio-control action in the desktop UI is a REST `POST /api/*` (VFO, mode, band, filter, AGC, NR, zoom, RX2, drive, MOX/TUN…), so none of it reached the radio.

This makes the tunnel **read-write** end to end.

## Changes

- **`api-tunnel.ts`** — tunnel `POST/PUT/DELETE/PATCH`, carrying the request body + content-type over the `api` data channel. `extractBody` handles `init.body` strings (the common `JSON.stringify` case), a body carried on a `Request`, and other `BodyInit` kinds.
- **`RemoteWebRtcSession`** — loopback-proxy mutating methods (with body) to the radio's own Kestrel. Safety gates preserved + extended:
  - **Always-denied** (read+write): secrets / identity / exports (`/api/remote/password`, `/api/qrz`, `/api/chat`, `/api/prefs/databases/export`, `/api/log/export`).
  - **Write-denied**: `/api/tx/ps` (**PureSignal — KB2UKA hard-stop, no remote arm/adjust**) and `/api/prefs/databases` (no remote DB swap/import).
  - Traversal guard, loopback-only (anti-SSRF), 1 MiB request/response caps.
- **Dead-man TX un-key** — if a session keys MOX/TUN and the WebRTC link then drops, `Close()` best-effort un-keys the radio so a lost link can never strand the station on-air.

## Scope

Full native control **including TX keying** (MOX/TUN/CW/two-tone, all REST). The **voice mic uplink** (low-latency Opus over WebRTC) is the **next phase** — mic PCM stays WS-only for now, so voice TX has no audio path yet; CW/TUN/digital key fine.

## Safety

- Deny-by-default still holds (nothing flows pre-unlock; SPAKE2+ password gate unchanged).
- PureSignal arm is **not** remotely reachable — burn-zone untouched.
- Remote TX is enabled per operator (code-owner) decision; dead-man un-key mitigates dropped-link-while-keyed.

## Tests

- Server: read-write proxy forwards method+body+content-type to loopback; PureSignal write refused 403 without touching loopback; dropped-while-keyed fires the dead-man un-key. (11/11 `RemoteWebRtcSession` tests pass.)
- Frontend: POST body + `Request`-carried body tunnel correctly. (20/20 `src/remote` tests pass.)
- `npm run build` (tsc + vite) green; server test project builds clean.