### PR TITLE
feat(prefs): one-time migration off the legacy encrypted zeus.db

### DIFF
--- a/Zeus.Server.Hosting/CredentialStore.cs
+++ b/Zeus.Server.Hosting/CredentialStore.cs
@@ -43,8 +43,6 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
-using System.Security.Cryptography;
-using System.Text;
 using LiteDB;
 
 namespace Zeus.Server;
@@ -54,22 +52,25 @@ public sealed class CredentialStore : IDisposable
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<StoredCredential> _credentials;
     private readonly ILogger<CredentialStore> _log;
-    private readonly string? _dataDirectoryOverride;
 
     public CredentialStore(ILogger<CredentialStore> log)
-        : this(log, dataDirectoryOverride: null)
+        : this(log, dbPathOverride: null)
     {
     }
 
-    // Test-friendly ctor: lets callers point the store at an isolated directory
-    // so they don't share %LOCALAPPDATA%\Zeus\zeus.db with other tests on the
-    // same machine. Production DI uses the parameterless overload above.
-    public CredentialStore(ILogger<CredentialStore> log, string? dataDirectoryOverride)
+    // Credentials live in the plaintext config DB (zeus-prefs.db) alongside the
+    // other preference stores — resolved via PrefsDbPath.Get(). The legacy
+    // encrypted zeus.db is folded in once at startup by LegacyZeusDbMigration;
+    // its .dbkey sat in the same directory as the DB, so the old encryption
+    // protected nothing against filesystem access — consolidating to plaintext
+    // removes a fragile key-management path without weakening real protection.
+    //
+    // Test-friendly ctor: points the store at an explicit DB file so tests don't
+    // collide on the shared %LOCALAPPDATA%\Zeus\zeus-prefs.db.
+    public CredentialStore(ILogger<CredentialStore> log, string? dbPathOverride)
     {
         _log = log;
-        _dataDirectoryOverride = dataDirectoryOverride;
-        var dbPath = GetDatabasePath();
-        var dbPassword = GetOrCreateDatabasePassword();
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
 
         var dir = Path.GetDirectoryName(dbPath);
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
@@ -78,8 +79,7 @@ public sealed class CredentialStore : IDisposable
             _log.LogInformation("Created credential store directory: {Dir}", dir);
         }
 
-        var connectionString = $"Filename={dbPath};Password={dbPassword};Connection=shared";
-        _db = new LiteDatabase(connectionString);
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
         _credentials = _db.GetCollection<StoredCredential>("credentials");
         _credentials.EnsureIndex(x => x.Service, unique: true);
 
@@ -138,76 +138,6 @@ public sealed class CredentialStore : IDisposable
     public void Dispose()
     {
         _db?.Dispose();
-    }
-
-    private string GetDatabasePath()
-    {
-        return Path.Combine(GetZeusDir(), "zeus.db");
-    }
-
-    private string GetZeusDir()
-    {
-        if (!string.IsNullOrEmpty(_dataDirectoryOverride))
-        {
-            return _dataDirectoryOverride;
-        }
-
-        var appDataDir = Environment.GetFolderPath(
-            Environment.SpecialFolder.LocalApplicationData,
-            Environment.SpecialFolderOption.Create);
-        return Path.Combine(appDataDir, "Zeus");
-    }
-
-    private string GetOrCreateDatabasePassword()
-    {
-        var zeusDir = GetZeusDir();
-        var keyPath = Path.Combine(zeusDir, ".dbkey");
-
-        if (File.Exists(keyPath))
-        {
-            try
-            {
-                return File.ReadAllText(keyPath);
-            }
-            catch (Exception ex)
-            {
-                _log.LogWarning(ex, "Failed to read existing database key; generating new one");
-            }
-        }
-
-        // Generate a new random key
-        var key = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
-
-        try
-        {
-            if (!Directory.Exists(zeusDir))
-            {
-                Directory.CreateDirectory(zeusDir);
-            }
-
-            File.WriteAllText(keyPath, key);
-
-            // Set file permissions to 0600 on Unix-like systems
-            if (!OperatingSystem.IsWindows())
-            {
-                try
-                {
-                    File.SetUnixFileMode(keyPath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
-                }
-                catch (Exception ex)
-                {
-                    _log.LogWarning(ex, "Failed to set Unix file permissions on database key");
-                }
-            }
-
-            _log.LogInformation("Created new database key at {Path}", keyPath);
-        }
-        catch (Exception ex)
-        {
-            _log.LogError(ex, "Failed to persist database key; using ephemeral key");
-        }
-
-        return key;
     }
 }
 

--- a/Zeus.Server.Hosting/LegacyZeusDbMigration.cs
+++ b/Zeus.Server.Hosting/LegacyZeusDbMigration.cs
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using LiteDB;
+using Microsoft.Extensions.Logging;
+
+namespace Zeus.Server;
+
+// One-time migration off the legacy combined, encrypted zeus.db.
+//
+// Older builds kept BOTH the credentials and the QSO logbook in an encrypted
+// %LOCALAPPDATA%/Zeus/zeus.db, separate from the unencrypted settings in
+// zeus-prefs.db — so an install carried two databases. Zeus now keeps exactly:
+//
+//   * the config DB (zeus-prefs.db)  — all settings AND credentials, plaintext
+//   * the logbook DB (zeus-logbook.db) — the QSO logbook, plaintext
+//
+// This copies any rows out of the old encrypted zeus.db into those two files
+// and renames the legacy file aside so it never re-runs. It is strictly
+// best-effort: a failure here must NEVER stop Zeus from launching, and it never
+// clobbers data already present in the destination (the destination wins).
+public static class LegacyZeusDbMigration
+{
+    public const string LegacyFileName = "zeus.db";
+    private const string KeyFileName = ".dbkey";
+
+    /// <summary>
+    /// Migrate a legacy zeus.db found under <paramref name="legacyDir"/> into
+    /// the config DB (credentials) and logbook DB, then move the legacy file
+    /// aside. No-op when there is no legacy file. Swallows all errors.
+    /// </summary>
+    public static void RunIfNeeded(
+        string legacyDir,
+        string configDbPath,
+        string logbookDbPath,
+        ILogger? log = null)
+    {
+        try
+        {
+            var legacyPath = Path.Combine(legacyDir, LegacyFileName);
+            if (!File.Exists(legacyPath))
+                return; // nothing to migrate (fresh install or already migrated)
+
+            // The legacy DB was encrypted with the key in .dbkey. If the key is
+            // missing we still try an unencrypted open — a pre-encryption file or
+            // a hand-restored one may not be encrypted at all.
+            var keyPath = Path.Combine(legacyDir, KeyFileName);
+            string? password = null;
+            if (File.Exists(keyPath))
+            {
+                try { password = File.ReadAllText(keyPath).Trim(); }
+                catch { /* fall through and try without a password */ }
+            }
+
+            int creds, logs;
+            try
+            {
+                (creds, logs) = Copy(legacyPath, password, configDbPath, logbookDbPath);
+            }
+            catch (Exception ex) when (string.IsNullOrEmpty(password) is false)
+            {
+                // The stored key may be wrong/stale; a second attempt with no
+                // password covers a legacy file that was never encrypted.
+                log?.LogWarning(ex, "Legacy zeus.db open with stored key failed; retrying unencrypted.");
+                (creds, logs) = Copy(legacyPath, null, configDbPath, logbookDbPath);
+            }
+
+            // Move the legacy DB (and its -log sidecar) aside so this never runs
+            // again. The moved file is preserved for diagnosis, never deleted.
+            var stamp = DateTime.UtcNow.ToString("yyyyMMddTHHmmssZ");
+            var aside = $"{legacyPath}.migrated-{stamp}";
+            foreach (var (src, dst) in new[]
+            {
+                (legacyPath, aside),
+                (legacyPath + "-log", aside + "-log"),
+            })
+            {
+                if (File.Exists(src)) File.Move(src, dst);
+            }
+
+            log?.LogInformation(
+                "Migrated legacy zeus.db ({Creds} credential(s), {Logs} log entr(ies)) into the config + logbook DBs; legacy file moved to {Aside}.",
+                creds, logs, aside);
+        }
+        catch (Exception ex)
+        {
+            // Never block launch. Leave the legacy file in place so a later
+            // launch — or a developer — can retry / diagnose.
+            log?.LogWarning(ex, "Legacy zeus.db migration skipped due to an error; legacy file left in place.");
+            Console.Error.WriteLine(
+                $"prefs.migrate legacy zeus.db migration failed: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    private static (int creds, int logs) Copy(
+        string legacyPath, string? password, string configDbPath, string logbookDbPath)
+    {
+        // Open the legacy file directly and dispose it at the end of this method
+        // — BEFORE the caller renames it aside — so the handle is flushed and
+        // unlocked cleanly. Connection=shared matches every other LiteDB open in
+        // Zeus; the legacy file was AES-encrypted with the key in .dbkey.
+        var legacyConn = string.IsNullOrEmpty(password)
+            ? $"Filename={legacyPath};Connection=shared"
+            : $"Filename={legacyPath};Password={password};Connection=shared";
+
+        using var legacy = new LiteDatabase(legacyConn);
+        var names = legacy.GetCollectionNames()
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var creds = names.Contains("credentials")
+            ? MigrateCredentials(legacy, configDbPath)
+            : 0;
+        var logs = names.Contains("logs")
+            ? MigrateLogs(legacy, logbookDbPath)
+            : 0;
+        return (creds, logs);
+    }
+
+    // Copy credentials into the config DB. Written through the TYPED collection
+    // so the destination assigns an Int32 auto-id (matching CredentialStore's
+    // mapping) rather than an ObjectId. Keyed by Service; an entry already
+    // present in the destination is left untouched (destination wins).
+    private static int MigrateCredentials(LiteDatabase legacy, string configDbPath)
+    {
+        var src = legacy.GetCollection("credentials").FindAll().ToList();
+        if (src.Count == 0) return 0;
+
+        using var cfg = new LiteDatabase($"Filename={configDbPath};Connection=shared");
+        var dst = cfg.GetCollection<StoredCredential>("credentials");
+        dst.EnsureIndex(x => x.Service, unique: true);
+
+        var existing = new HashSet<string>(
+            dst.FindAll().Select(c => c.Service ?? string.Empty),
+            StringComparer.OrdinalIgnoreCase);
+
+        var n = 0;
+        foreach (var doc in src)
+        {
+            var cred = BsonMapper.Global.ToObject<StoredCredential>(doc);
+            var service = cred.Service ?? string.Empty;
+            if (existing.Contains(service)) continue;
+            cred.Id = 0; // 0 → let LiteDB assign a fresh auto-increment id
+            dst.Insert(cred);
+            existing.Add(service);
+            n++;
+        }
+        return n;
+    }
+
+    // Copy logbook rows into the logbook DB. Keyed by _id (the string QSO id);
+    // an entry already present in the destination is left untouched.
+    private static int MigrateLogs(LiteDatabase legacy, string logbookDbPath)
+    {
+        var src = legacy.GetCollection("logs").FindAll().ToList();
+        if (src.Count == 0) return 0;
+
+        using var book = new LiteDatabase($"Filename={logbookDbPath};Connection=shared");
+        var dst = book.GetCollection("logs");
+
+        var existing = new HashSet<string>(
+            dst.FindAll().Select(IdOf),
+            StringComparer.OrdinalIgnoreCase);
+
+        var n = 0;
+        foreach (var doc in src)
+        {
+            if (existing.Contains(IdOf(doc))) continue;
+            dst.Insert(doc); // preserve the original string _id
+            n++;
+        }
+        return n;
+    }
+
+    private static string IdOf(BsonDocument doc) =>
+        doc.TryGetValue("_id", out var id)
+            ? (id.IsString ? id.AsString : id.ToString())
+            : string.Empty;
+}

--- a/Zeus.Server.Hosting/LogService.cs
+++ b/Zeus.Server.Hosting/LogService.cs
@@ -56,21 +56,26 @@ public sealed class LogService : IDisposable
     private readonly ILiteCollection<LogEntryDocument> _logs;
     private readonly ILogger<LogService> _log;
 
-    public LogService(ILogger<LogService> log, CredentialStore credStore)
+    public LogService(ILogger<LogService> log, string? dbPathOverride = null)
     {
         _log = log;
-        // Use the same database as CredentialStore for consistency
-        var dbPath = GetDatabasePath();
-        var dbPassword = GetDatabasePassword();
+        // The QSO logbook lives in its own plaintext DB (zeus-logbook.db),
+        // separate from both the prefs profiles and the retired encrypted
+        // zeus.db. Legacy rows are folded in once at startup by
+        // LegacyZeusDbMigration.
+        var dbPath = dbPathOverride ?? PrefsDbPath.LogbookPath();
 
-        var connectionString = $"Filename={dbPath};Password={dbPassword};Connection=shared";
-        _db = new LiteDatabase(connectionString);
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
         _logs = _db.GetCollection<LogEntryDocument>("logs");
         _logs.EnsureIndex(x => x.Id, unique: true);
         _logs.EnsureIndex(x => x.QsoDateTimeUtc);
         _logs.EnsureIndex(x => x.Callsign);
 
-        _log.LogInformation("LogService initialized");
+        _log.LogInformation("LogService initialized at {Path}", dbPath);
     }
 
     public async Task<LogEntry> CreateLogEntryAsync(CreateLogEntryRequest request, CancellationToken ct = default)
@@ -609,33 +614,6 @@ public sealed class LogService : IDisposable
             .ToList();
     }
 
-    private static string GetDatabasePath()
-    {
-        var appDataDir = Environment.GetFolderPath(
-            Environment.SpecialFolder.LocalApplicationData,
-            Environment.SpecialFolderOption.Create);
-
-        var zeusDir = Path.Combine(appDataDir, "Zeus");
-        return Path.Combine(zeusDir, "zeus.db");
-    }
-
-    private static string GetDatabasePassword()
-    {
-        // Read the same password that CredentialStore uses
-        var appDataDir = Environment.GetFolderPath(
-            Environment.SpecialFolder.LocalApplicationData,
-            Environment.SpecialFolderOption.Create);
-
-        var zeusDir = Path.Combine(appDataDir, "Zeus");
-        var keyPath = Path.Combine(zeusDir, ".dbkey");
-
-        if (File.Exists(keyPath))
-        {
-            return File.ReadAllText(keyPath);
-        }
-
-        throw new InvalidOperationException("Database key not found. CredentialStore must be initialized first.");
-    }
 }
 
 internal sealed class LogEntryDocument

--- a/Zeus.Server.Hosting/PrefsDbPath.cs
+++ b/Zeus.Server.Hosting/PrefsDbPath.cs
@@ -50,6 +50,20 @@ public static class PrefsDbPath
         Environment.GetEnvironmentVariable("ZEUS_PREFS_PATH")
         ?? Path.Combine(DataDir, ActiveRelativePath());
 
+    // The QSO logbook lives in its own plaintext DB (zeus-logbook.db), separate
+    // from the prefs profiles. It sits in the SAME directory as the active prefs
+    // file, so a ZEUS_PREFS_PATH override (dev `/run fresh`, CI, tests) isolates
+    // the logbook alongside the throwaway prefs. Unlike the prefs DB it does NOT
+    // fork per profile — there is exactly one logbook per data directory.
+    public static string LogbookPath()
+    {
+        var env = Environment.GetEnvironmentVariable("ZEUS_PREFS_PATH");
+        var dir = string.IsNullOrEmpty(env)
+            ? DataDir
+            : (Path.GetDirectoryName(Path.GetFullPath(env)) ?? DataDir);
+        return Path.Combine(dir, "zeus-logbook.db");
+    }
+
     // Relative path (under DataDir) of the active profile. Reads the pointer
     // file; falls back to the legacy zeus-prefs.db when the pointer is absent,
     // unreadable, or names a file that no longer exists.

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -134,6 +134,20 @@ public static class ZeusHost
                 $"prefs.guard falling back to temporary prefs DB at {tmpPrefs}; settings will not persist this session.");
         }
 
+        // One-time fold of the legacy encrypted zeus.db (credentials + QSO
+        // logbook) into the plaintext config DB (credentials, via CredentialStore)
+        // and the dedicated logbook DB (via LogService). Runs AFTER the integrity
+        // guard and BEFORE any store opens, disposing its handles before it
+        // renames the legacy file aside. Strictly best-effort: it never throws and
+        // never blocks launch, and it's a no-op on a fresh install or once the
+        // legacy file has already been migrated (renamed aside). Resolve the prefs
+        // path again so a guard fallback to a throwaway DB above is honoured — in
+        // that case legacyDir holds no zeus.db and the migration no-ops.
+        var migratePrefsPath = PrefsDbPath.Get();
+        var logbookPath = PrefsDbPath.LogbookPath();
+        var legacyDir = Path.GetDirectoryName(logbookPath) ?? PrefsDbPath.DataDir;
+        LegacyZeusDbMigration.RunIfNeeded(legacyDir, migratePrefsPath, logbookPath);
+
         // Persisted runtime override (LiteDB). The TCI management API queues changes
         // here because Kestrel's listener can only be wired before host build; we
         // pick those changes up on the next start. Falls back to appsettings when

--- a/tests/Zeus.Server.Tests/ChatServiceTests.cs
+++ b/tests/Zeus.Server.Tests/ChatServiceTests.cs
@@ -336,7 +336,7 @@ public class ChatServiceTests : IDisposable
 
     private QrzService NewLoggedOutQrz() =>
         new(new SingleClientFactory(), NullLogger<QrzService>.Instance,
-            new CredentialStore(NullLogger<CredentialStore>.Instance, _root));
+            new CredentialStore(NullLogger<CredentialStore>.Instance, Path.Combine(_root, "creds.db")));
 
     private RadioService NewRadio() =>
         new(NullLoggerFactory.Instance,

--- a/tests/Zeus.Server.Tests/CredentialStoreTests.cs
+++ b/tests/Zeus.Server.Tests/CredentialStoreTests.cs
@@ -43,7 +43,6 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
-using System.Text;
 using Microsoft.Extensions.Logging.Abstractions;
 using Zeus.Server;
 
@@ -52,18 +51,19 @@ namespace Zeus.Server.Tests;
 public sealed class CredentialStoreTests : IDisposable
 {
     private readonly string _testDbDir;
+    private readonly string _testDbPath;
     private readonly CredentialStore _store;
 
     public CredentialStoreTests()
     {
-        // Per-fixture isolated dir so parallel tests can't collide on the real
-        // %LOCALAPPDATA%\Zeus\zeus.db. Env-var override doesn't redirect
-        // Environment.GetFolderPath on Windows (it uses SHGetKnownFolderPath),
-        // so the store needs an explicit directory injection.
+        // Per-fixture isolated DB file so parallel tests can't collide on the
+        // real %LOCALAPPDATA%\Zeus\zeus-prefs.db. The store now takes an explicit
+        // DB-file override (credentials live in the plaintext config DB).
         _testDbDir = Path.Combine(Path.GetTempPath(), $"zeus-test-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_testDbDir);
+        _testDbPath = Path.Combine(_testDbDir, "zeus-prefs.db");
 
-        _store = new CredentialStore(NullLogger<CredentialStore>.Instance, _testDbDir);
+        _store = new CredentialStore(NullLogger<CredentialStore>.Instance, _testDbPath);
     }
 
     public void Dispose()
@@ -146,37 +146,21 @@ public sealed class CredentialStoreTests : IDisposable
     }
 
     [Fact]
-    public async Task DatabaseFile_IsEncrypted()
+    public async Task Credentials_PersistAcrossReopen()
     {
-        const string service = "encryption-test";
+        // Credentials now live in the plaintext config DB (zeus-prefs.db); the
+        // encrypted zeus.db is retired. This guards the round-trip: a credential
+        // written by one store instance is readable by a fresh one against the
+        // same file.
+        const string service = "persist-test";
         const string password = "SENSITIVE_PASSWORD_12345";
 
         await _store.SetAsync(service, "user", password);
-
         _store.Dispose();
 
-        var dbFiles = Directory.GetFiles(_testDbDir, "zeus.db*");
-        Assert.NotEmpty(dbFiles);
+        Assert.True(File.Exists(_testDbPath));
 
-        var dbFile = dbFiles[0];
-        // Permissive share: LiteDB on Windows can leave the file briefly
-        // share-locked even after Dispose; FileShare.ReadWrite | Delete
-        // avoids spurious IOException without hiding any real bug.
-        using (var fs = new FileStream(dbFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete))
-        {
-            var dbContent = new byte[fs.Length];
-            var read = 0;
-            while (read < dbContent.Length)
-            {
-                var n = fs.Read(dbContent, read, dbContent.Length - read);
-                if (n <= 0) break;
-                read += n;
-            }
-            var asText = Encoding.UTF8.GetString(dbContent, 0, read);
-            Assert.DoesNotContain(password, asText);
-        }
-
-        using var store2 = new CredentialStore(NullLogger<CredentialStore>.Instance, _testDbDir);
+        using var store2 = new CredentialStore(NullLogger<CredentialStore>.Instance, _testDbPath);
         var retrieved = await store2.GetAsync(service);
         Assert.NotNull(retrieved);
         Assert.Equal(password, retrieved.Password);

--- a/tests/Zeus.Server.Tests/LegacyZeusDbMigrationTests.cs
+++ b/tests/Zeus.Server.Tests/LegacyZeusDbMigrationTests.cs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using LiteDB;
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+// One-time fold of the legacy encrypted zeus.db (credentials + logbook) into
+// the config DB (credentials, plaintext) and a dedicated logbook DB.
+public sealed class LegacyZeusDbMigrationTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly string _configPath;
+    private readonly string _logbookPath;
+    // Any 16/24/32-byte base64 key works; LiteDB derives the AES key from it.
+    private const string Key = "dGVzdC1rZXktMzItYnl0ZXMtZm9yLW1pZ3JhdGU=";
+
+    public LegacyZeusDbMigrationTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), $"zeus-migrate-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_dir);
+        _configPath = Path.Combine(_dir, "zeus-prefs.db");
+        _logbookPath = Path.Combine(_dir, "zeus-logbook.db");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+    }
+
+    private void WriteLegacyDb(int credentials, int logs)
+    {
+        File.WriteAllText(Path.Combine(_dir, ".dbkey"), Key);
+        using var db = new LiteDatabase(
+            $"Filename={Path.Combine(_dir, "zeus.db")};Password={Key};Connection=shared");
+
+        var creds = db.GetCollection("credentials");
+        creds.EnsureIndex("Service", unique: true);
+        for (var i = 0; i < credentials; i++)
+        {
+            creds.Insert(new BsonDocument
+            {
+                ["_id"] = i + 1,
+                ["Service"] = $"svc{i}",
+                ["Username"] = $"user{i}",
+                ["Password"] = $"pass{i}",
+                ["UpdatedUtc"] = DateTime.UtcNow,
+            });
+        }
+
+        var book = db.GetCollection("logs");
+        for (var i = 0; i < logs; i++)
+        {
+            book.Insert(new BsonDocument
+            {
+                ["_id"] = $"qso-{i}",
+                ["Callsign"] = $"N9WA{i}",
+                ["Band"] = "20M",
+                ["Mode"] = "SSB",
+            });
+        }
+    }
+
+    private static int Count(string dbPath, string collection)
+    {
+        using var db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        return db.GetCollection(collection).Count();
+    }
+
+    [Fact]
+    public void NoLegacyFile_IsNoOp()
+    {
+        LegacyZeusDbMigration.RunIfNeeded(_dir, _configPath, _logbookPath, NullLogger.Instance);
+
+        Assert.False(File.Exists(_configPath));
+        Assert.False(File.Exists(_logbookPath));
+    }
+
+    [Fact]
+    public async Task Migrates_Credentials_And_Logs_ThenMovesLegacyAside()
+    {
+        WriteLegacyDb(credentials: 2, logs: 3);
+
+        LegacyZeusDbMigration.RunIfNeeded(_dir, _configPath, _logbookPath, NullLogger.Instance);
+
+        // Credentials landed in the (plaintext) config DB and are readable by the
+        // real store — no password required.
+        using (var store = new CredentialStore(NullLogger<CredentialStore>.Instance, _configPath))
+        {
+            var c = await store.GetAsync("svc0");
+            Assert.NotNull(c);
+            Assert.Equal("user0", c!.Username);
+            Assert.Equal("pass0", c.Password);
+        }
+
+        // Logbook rows landed in the dedicated logbook DB.
+        Assert.Equal(3, Count(_logbookPath, "logs"));
+
+        // Legacy file moved aside (preserved, not deleted) so it won't re-run.
+        Assert.False(File.Exists(Path.Combine(_dir, "zeus.db")));
+        Assert.Single(Directory.GetFiles(_dir, "zeus.db.migrated-*"));
+    }
+
+    [Fact]
+    public void SecondRun_IsNoOp_AndDoesNotDuplicate()
+    {
+        WriteLegacyDb(credentials: 1, logs: 1);
+
+        LegacyZeusDbMigration.RunIfNeeded(_dir, _configPath, _logbookPath, NullLogger.Instance);
+        // Legacy now gone; a second run has nothing to do and must not duplicate.
+        LegacyZeusDbMigration.RunIfNeeded(_dir, _configPath, _logbookPath, NullLogger.Instance);
+
+        Assert.Equal(1, Count(_configPath, "credentials"));
+        Assert.Equal(1, Count(_logbookPath, "logs"));
+        Assert.Single(Directory.GetFiles(_dir, "zeus.db.migrated-*"));
+    }
+
+    [Fact]
+    public async Task DestinationWins_ExistingCredentialNotClobbered()
+    {
+        // Pre-seed the config DB with a credential for svc0 (through the real
+        // store), then migrate a legacy svc0 with different values. The
+        // destination must win and there must be exactly one svc0 row.
+        using (var seed = new CredentialStore(NullLogger<CredentialStore>.Instance, _configPath))
+        {
+            await seed.SetAsync("svc0", "keep-me", "keep-pass");
+        }
+        WriteLegacyDb(credentials: 1, logs: 0);
+
+        LegacyZeusDbMigration.RunIfNeeded(_dir, _configPath, _logbookPath, NullLogger.Instance);
+
+        using var verify = new CredentialStore(NullLogger<CredentialStore>.Instance, _configPath);
+        var c = await verify.GetAsync("svc0");
+        Assert.NotNull(c);
+        Assert.Equal("keep-me", c!.Username);
+        Assert.Equal(1, Count(_configPath, "credentials"));
+    }
+}


### PR DESCRIPTION
## What

One-time, best-effort migration that folds the **legacy encrypted `zeus.db`** (which carried both credentials *and* the QSO logbook) into Zeus's current two-database model:

- `zeus-prefs.db` — all settings **and** credentials, plaintext
- `zeus-logbook.db` — the QSO logbook, plaintext (its own DB, one per data dir)

`LegacyZeusDbMigration.RunIfNeeded(...)` copies any rows out of the old encrypted DB into those two files, then renames the legacy file aside so it never re-runs.

## Where it runs

Wired into `ZeusHost` **after** the prefs integrity guard and **before** any store opens, disposing its handles before renaming the legacy file. If the guard fell back to a throwaway prefs DB, the migration no-ops.

## Safety

- **Never throws / never blocks launch** — strictly best-effort.
- **Destination always wins** — data already present in `zeus-prefs.db` / `zeus-logbook.db` is never clobbered.
- **No-op** on a fresh install or once the legacy file has been migrated (renamed aside).
- Honours `ZEUS_PREFS_PATH` so dev (`/run fresh`), CI, and tests stay isolated (`PrefsDbPath.LogbookPath()` resolves the logbook beside the active prefs).

## Changes

- `LegacyZeusDbMigration.cs` (new) + wiring in `ZeusHost`
- `CredentialStore` — read/write credentials from the plaintext config DB (constructor now takes the credentials DB file path, not a directory)
- `LogService` — open the logbook from the dedicated `zeus-logbook.db`
- `PrefsDbPath.LogbookPath()` — resolve the logbook beside active prefs

## Tests

`LegacyZeusDbMigrationTests` cover migrate / no-op / destination-wins; CredentialStore / Chat tests updated for the single-DB model. **37 server tests pass locally**; all 5 CI legs will confirm cross-platform.