### PR TITLE
feat(dsp): route RX3+ audio across N receivers (multi-DDC B4)

### DIFF
--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -718,6 +718,15 @@ public class DspPipelineService : BackgroundService,
     private readonly SecondaryRx[] _secondaryRx;
     private int _sampleRateHz;
 
+    // One secondary-receiver audio block read during a Tick, paired with its
+    // sample count. Used to feed the N-receiver "Both" mixer without per-tick
+    // allocation (the scratch span below is reused every tick).
+    internal readonly record struct RxAudioSlice(float[] Buffer, int Count);
+    // Reused each tick to collect the enabled secondary RX audio blocks for the
+    // mixer. Sized for every secondary slot (1..N-1); only the populated prefix
+    // is passed to MixRxAudioN.
+    private readonly RxAudioSlice[] _mixSlices = new RxAudioSlice[MaxReceivers];
+
     // Protocol 2 path (parallel to the RadioService-owned P1 path). Held
     // directly here because RadioService is Protocol1Client-shaped and
     // growing a P2 variant there would require a larger refactor; for now
@@ -4785,7 +4794,10 @@ public class DspPipelineService : BackgroundService,
         return mode switch
         {
             Rx2AudioMode.Rx2 => rx2Count > 0 ? CopyRx2Audio(rx1, rx2, rx2Count) : rx1Count,
-            Rx2AudioMode.Both => MixRxAudio(rx1, rx1Count, rx2, rx2Count),
+            Rx2AudioMode.Both => MixRxAudioN(rx1, rx1Count, new[]
+            {
+                new RxAudioSlice(rx2.Length == 0 ? Array.Empty<float>() : rx2.ToArray(), rx2Count),
+            }),
             _ => rx1Count,
         };
     }
@@ -4797,21 +4809,44 @@ public class DspPipelineService : BackgroundService,
         return count;
     }
 
-    private static int MixRxAudio(
-        Span<float> output,
+    // N-receiver generalisation of the old 2-RX 0.5*(rx1+rx2) mix. The output
+    // block runs at the longest contributor; each output sample is the average
+    // of the contributors PRESENT at that index (a contributor "present" means
+    // its index is within its own sample count). The divisor is the number of
+    // streams that produced any samples — RX1 (when rx1Count>0) plus every slice
+    // with Count>0 — so a stalled stream never dilutes the others, and a single
+    // contributor passes through at full amplitude. With exactly one non-empty
+    // slice this is byte-identical to the original MixRxAudio (RX1+RX2 → /2; RX2
+    // only when rx1Count==0 → passthrough; no RX2 → rx1 untouched).
+    internal static int MixRxAudioN(
+        Span<float> rx1,
         int rx1Count,
-        ReadOnlySpan<float> rx2,
-        int rx2Count)
+        ReadOnlySpan<RxAudioSlice> slices)
     {
-        if (rx2Count <= 0) return rx1Count;
-        if (rx1Count <= 0) return CopyRx2Audio(output, rx2, rx2Count);
+        rx1Count = Math.Clamp(rx1Count, 0, rx1.Length);
 
-        int count = Math.Min(output.Length, Math.Max(rx1Count, rx2Count));
+        int contributors = rx1Count > 0 ? 1 : 0;
+        int count = rx1Count;
+        foreach (var s in slices)
+        {
+            int sc = Math.Clamp(s.Count, 0, s.Buffer.Length);
+            if (sc <= 0) continue;
+            contributors++;
+            if (sc > count) count = sc;
+        }
+        count = Math.Min(count, rx1.Length);
+        if (count == 0 || contributors == 0) return 0;
+
         for (int i = 0; i < count; i++)
         {
-            float a = i < rx1Count ? output[i] : 0f;
-            float b = i < rx2Count ? rx2[i] : 0f;
-            output[i] = 0.5f * (a + b);
+            float sum = i < rx1Count ? rx1[i] : 0f;
+            foreach (var s in slices)
+            {
+                int sc = Math.Clamp(s.Count, 0, s.Buffer.Length);
+                if (sc <= 0 || i >= sc) continue;
+                sum += s.Buffer[i];
+            }
+            rx1[i] = sum / contributors;
         }
         return count;
     }
@@ -5154,29 +5189,65 @@ public class DspPipelineService : BackgroundService,
         // so RX-side plugins keep running even while monitor is on.
         bool txMonitorOn = engine.IsTxMonitorOn;
         int audioSampleCount = engine.ReadAudio(channel, audioBuf);
-        int rx2AudioSampleCount = 0;
-        if (state.Rx2Enabled && rx2Channel >= 0)
+
+        // Secondary-receiver audio. Drain EVERY enabled secondary RX ring this
+        // tick so none can back up: RX3+ used to be computed-and-discarded, so
+        // their WDSP audio rings overran and tripped the rx-ingest "audio
+        // consumer behind" selfcheck warn (IQ ingest itself stays lossless).
+        // What we do with the drained audio follows Rx2AudioMode, generalised
+        // across N receivers:
+        //   Rx1  → secondaries drained & discarded (RX1 only).
+        //   Rx2  → RX2 drained fully and output; RX3+ drained & discarded.
+        //   Both → RX1 + every enabled secondary mixed (each clocked to RX1).
+        var rxAudioMode = state.Rx2AudioMode;
+        int mixSliceCount = 0;
+        int rx2OnlyCount = 0;
+        for (int ri = 1; ri < MaxReceivers; ri++)
         {
-            // RX1 is the audio clock-master when both receivers are mixed: read
-            // at most rx1Count samples from RX2 so the mixed stream is fed at
-            // exactly the RX sample rate. Draining RX2's ring fully and mixing
-            // max(rx1,rx2) over-feeds the sink — the two channels' per-tick
-            // counts jitter independently, so E[max] exceeds the true rate
-            // (~5% measured on a G2), saturating the output ring → overrun →
-            // dual-RX clicking (#787). The unread RX2 remainder stays buffered
-            // for the next tick, so no RX2 audio is dropped. RX2-only mode still
-            // drains RX2 fully (RX2 is the master there).
-            Span<float> rx2Span = state.Rx2AudioMode == Rx2AudioMode.Both
-                ? _secondaryRx[1].AudioBuf.AsSpan(0, Math.Min(audioSampleCount, _secondaryRx[1].AudioBuf.Length))
-                : _secondaryRx[1].AudioBuf.AsSpan();
-            rx2AudioSampleCount = engine.ReadAudio(rx2Channel, rx2Span);
+            if (!SecondaryReceiverEnabled(ri, state)) continue;
+            var sec = _secondaryRx[ri];
+            int secChan = Volatile.Read(ref sec.ChannelId);
+            if (secChan < 0) continue;
+
+            if (rxAudioMode == Rx2AudioMode.Both)
+            {
+                // RX1 is the audio clock-master when receivers are mixed: read at
+                // most rx1Count samples from each secondary so the mixed stream
+                // is fed at exactly the RX sample rate. Draining fully and mixing
+                // max() over-feeds the sink — per-tick counts jitter
+                // independently, so E[max] exceeds the true rate (~5% on a G2),
+                // saturating the output ring → overrun → dual-RX clicking (#787).
+                // The unread remainder stays buffered for the next tick, so no
+                // secondary audio is dropped. With RX1 silent (rx1Count==0) read
+                // nothing this tick, matching the original RX2 Both behaviour.
+                int want = Math.Min(audioSampleCount, sec.AudioBuf.Length);
+                int n = want > 0 ? engine.ReadAudio(secChan, sec.AudioBuf.AsSpan(0, want)) : 0;
+                _mixSlices[mixSliceCount++] = new RxAudioSlice(sec.AudioBuf, n);
+            }
+            else if (rxAudioMode == Rx2AudioMode.Rx2 && ri == 1)
+            {
+                // RX2 is the audio master in RX2-only mode: drain its ring fully.
+                rx2OnlyCount = engine.ReadAudio(secChan, sec.AudioBuf.AsSpan());
+            }
+            else
+            {
+                // Not contributing to the output — drain fully and discard so the
+                // ring can't back up.
+                engine.ReadAudio(secChan, sec.AudioBuf.AsSpan());
+            }
         }
-        audioSampleCount = SelectRxAudio(
-            state.Rx2AudioMode,
-            audioBuf,
-            audioSampleCount,
-            _secondaryRx[1].AudioBuf,
-            rx2AudioSampleCount);
+
+        if (rxAudioMode == Rx2AudioMode.Both)
+        {
+            audioSampleCount = MixRxAudioN(audioBuf, audioSampleCount, _mixSlices.AsSpan(0, mixSliceCount));
+        }
+        else if (rxAudioMode == Rx2AudioMode.Rx2 && rx2OnlyCount > 0)
+        {
+            int n = Math.Min(audioBuf.Length, rx2OnlyCount);
+            _secondaryRx[1].AudioBuf.AsSpan(0, n).CopyTo(audioBuf);
+            audioSampleCount = n;
+        }
+        // Rx1 (default): audioSampleCount unchanged — RX1 only.
         if (audioSampleCount > 0)
         {
             SanitizeAudioBuffer(audioBuf.AsSpan(0, audioSampleCount));

--- a/tests/Zeus.Server.Tests/DspPipelineRx2RoutingTests.cs
+++ b/tests/Zeus.Server.Tests/DspPipelineRx2RoutingTests.cs
@@ -118,6 +118,93 @@ public class DspPipelineRx2RoutingTests
         Assert.Equal([0.40f, -0.50f], rx1[..count]);
     }
 
+    [Fact]
+    public void MixRxAudioN_SingleSlice_MatchesLegacyHalfMix()
+    {
+        // One non-empty slice (RX2) must reproduce the old 0.5*(rx1+rx2) mix,
+        // including the diluted tail where only RX1 is present.
+        float[] rx1 = [0.10f, -0.20f, 0.30f, 0.40f];
+        float[] rx2 = [0.40f, -0.50f];
+
+        int count = DspPipelineService.MixRxAudioN(
+            rx1,
+            rx1Count: 4,
+            new[] { new DspPipelineService.RxAudioSlice(rx2, rx2.Length) });
+
+        Assert.Equal(4, count);
+        Assert.Equal(0.25f, rx1[0], 5);   // (0.10 + 0.40)/2
+        Assert.Equal(-0.35f, rx1[1], 5);  // (-0.20 - 0.50)/2
+        Assert.Equal(0.15f, rx1[2], 5);   // (0.30 + 0)/2  — tail still halved
+        Assert.Equal(0.20f, rx1[3], 5);   // (0.40 + 0)/2
+    }
+
+    [Fact]
+    public void MixRxAudioN_ThreeReceivers_AveragesAllPresent()
+    {
+        // RX1 + RX2 + RX3 all full-length → divide by 3.
+        float[] rx1 = [0.30f, 0.60f];
+        float[] rx2 = [0.30f, 0.00f];
+        float[] rx3 = [0.30f, 0.30f];
+
+        int count = DspPipelineService.MixRxAudioN(
+            rx1,
+            rx1Count: 2,
+            new[]
+            {
+                new DspPipelineService.RxAudioSlice(rx2, rx2.Length),
+                new DspPipelineService.RxAudioSlice(rx3, rx3.Length),
+            });
+
+        Assert.Equal(2, count);
+        Assert.Equal(0.30f, rx1[0], 5);   // (0.30+0.30+0.30)/3
+        Assert.Equal(0.30f, rx1[1], 5);   // (0.60+0.00+0.30)/3
+    }
+
+    [Fact]
+    public void MixRxAudioN_EmptySlicesExcludedFromDivisor()
+    {
+        // A secondary that produced no samples this tick must not dilute RX1:
+        // contributor count is 1, so RX1 passes through untouched.
+        float[] rx1 = [0.50f, -0.50f];
+
+        int count = DspPipelineService.MixRxAudioN(
+            rx1,
+            rx1Count: 2,
+            new[]
+            {
+                new DspPipelineService.RxAudioSlice(System.Array.Empty<float>(), 0),
+                new DspPipelineService.RxAudioSlice([0.10f, 0.10f], 0),
+            });
+
+        Assert.Equal(2, count);
+        Assert.Equal(0.50f, rx1[0], 5);
+        Assert.Equal(-0.50f, rx1[1], 5);
+    }
+
+    [Fact]
+    public void MixRxAudioN_Rx1Silent_PassesSecondariesThrough()
+    {
+        // RX1 produced nothing this tick (rx1Count==0); the two secondaries are
+        // averaged and passed through at the longer block length.
+        float[] rx1 = new float[3];
+        float[] rx2 = [0.40f, 0.40f, 0.40f];
+        float[] rx3 = [0.20f, 0.20f];
+
+        int count = DspPipelineService.MixRxAudioN(
+            rx1,
+            rx1Count: 0,
+            new[]
+            {
+                new DspPipelineService.RxAudioSlice(rx2, rx2.Length),
+                new DspPipelineService.RxAudioSlice(rx3, rx3.Length),
+            });
+
+        Assert.Equal(3, count);
+        Assert.Equal(0.30f, rx1[0], 5);   // (0.40+0.20)/2
+        Assert.Equal(0.30f, rx1[1], 5);   // (0.40+0.20)/2
+        Assert.Equal(0.20f, rx1[2], 5);   // (0.40 only)/2 — divisor is contributor count (2)
+    }
+
     private sealed class RecordingEngine : IDspEngine
     {
         public List<int> FeedChannels { get; } = [];


### PR DESCRIPTION
## What

Generalises the RX2 audio drain/select path to **N receivers**, so RX3+ secondary DDCs have their audio *consumed* instead of computed-and-discarded.

Follow-up to the B4-server multi-DDC work (#837): RX3+ now stream IQ losslessly on their own DDCs, but their WDSP audio rings were never drained — they backed up and tripped the `rx-ingest-health` selfcheck `rx-no-dropped-frames` warn ("audio consumer behind"). IQ ingest itself was always lossless; this is purely the audio-side consumer.

## Changes

- **Every enabled secondary RX ring is drained each `Tick`**, regardless of audio mode, so none can back up (clears the overrun warn).
- **`Rx2AudioMode` is now N-aware:**
  - `Rx1` → RX1 only (secondaries drained & discarded)
  - `Rx2` → RX2 only (RX3+ drained & discarded)
  - `Both` → RX1 + every enabled secondary **mixed**, each clocked to RX1 so the mixed stream is fed at the RX rate (the #787 over-feed fix, generalised)
- **`MixRxAudioN`** averages the contributors present per sample. With exactly one non-empty slice it is **byte-identical** to the old `0.5*(rx1+rx2)` mix, so the proven RX1/RX2 path is unchanged. Allocation-free on the hot path (preallocated slice scratch).
- Adds `MixRxAudioN` unit tests: single-slice legacy parity, 3-receiver average, empty-slice exclusion from divisor, RX1-silent passthrough.

## Live validation (real ANAN G2, P2 @ 192.168.1.25, 1536 kHz)

Connected with **3 receivers** (RX1/RX2/RX3 on DDC2/3/4, ports 1037/1038/1039 @ ~6450 pps each), `audioMode=both`:

```
activeChannels: 3
ch0 (RX1): dropped=0 queueFull=0 audioOverrun=0  headroom=88%
ch2 (RX2): dropped=0 queueFull=0 audioOverrun=0  headroom=92.8%
ch3 (RX3): dropped=0 queueFull=0 audioOverrun=0  headroom=47.4%

selfcheck worst: pass
  rx-no-dropped-frames:  PASS — "No drops or overruns across 3 active channel(s)."
  rx-worker-within-budget: PASS
```

Before this change, ch3's `audioOverrunPerWindow` climbed continuously and the selfcheck warned. Ring depths now oscillate within capacity and never overrun.

PureSignal was **off** throughout (`psAutoAttn.gate skip=PsEnabled-off`); no PS code touched.

## Scope

Server-side only. Frontend N-panadapter rendering (consume `StateDto.Receivers[]` for RX3+ `DisplayFrame`) is the remaining half of zeus-79qa and lands separately.