### PR TITLE
fix(web): route RX3+ display frames to per-receiver slices (multi-DDC)

### DIFF
--- a/zeus-web/src/state/display-store.test.ts
+++ b/zeus-web/src/state/display-store.test.ts
@@ -13,6 +13,7 @@ import {
   registerFrameConsumer,
   sanitizeDisplayBins,
   selectDisplaySlice,
+  selectDisplaySliceByRxId,
   subscribeFrameConsumerPresence,
   useDisplayStore,
 } from './display-store';
@@ -33,6 +34,7 @@ afterEach(() => {
     wfFloorDb: null,
     lastSeq: 0,
     rx2: createEmptyDisplaySlice(),
+    extra: [],
   });
 });
 
@@ -190,6 +192,61 @@ describe('display frame bin sanitizer', () => {
       centerHz: 7_200_000n,
       panDb: rx2Pan,
     });
+  });
+
+  it('routes RX3+ frames into the extra array without clobbering RX1 or RX2', () => {
+    const rx1Pan = new Float32Array([-90, -88, -87, -86]);
+    useDisplayStore.getState().pushFrame({
+      msgType: 0x01,
+      headerFlags: 0,
+      seq: 21,
+      tsUnixMs: 1_700_000_000_000,
+      rxId: 0,
+      bodyFlags: 0x03,
+      panValid: true,
+      wfValid: true,
+      width: 4,
+      centerHz: 14_200_000n,
+      hzPerPixel: 93.75,
+      panDb: rx1Pan,
+      wfDb: rx1Pan,
+    });
+
+    // RX3 = rxId 2 → extra[0].
+    const rx3Pan = new Float32Array([-130, -128, -127, -126]);
+    useDisplayStore.getState().pushFrame({
+      msgType: 0x01,
+      headerFlags: 0,
+      seq: 22,
+      tsUnixMs: 1_700_000_000_002,
+      rxId: 2,
+      bodyFlags: 0x03,
+      panValid: true,
+      wfValid: true,
+      width: 4,
+      centerHz: 7_100_000n,
+      hzPerPixel: 93.75,
+      panDb: rx3Pan,
+      wfDb: rx3Pan,
+    });
+
+    const state = useDisplayStore.getState();
+    // RX1 primary slice untouched by the RX3 frame.
+    expect(state.lastSeq).toBe(21);
+    expect(state.centerHz).toBe(14_200_000n);
+    expect(state.panDb).toBe(rx1Pan);
+    // RX2 still empty (never fed).
+    expect(selectDisplaySliceByRxId(state, 1).lastSeq).toBe(0);
+    // RX3 lands in extra[0] and is reachable by rxId.
+    expect(state.extra[0]).toMatchObject({
+      lastSeq: 22,
+      centerHz: 7_100_000n,
+      panDb: rx3Pan,
+    });
+    expect(selectDisplaySliceByRxId(state, 2)).toBe(state.extra[0]);
+    // An unseen RX4 returns the shared empty slice, not undefined.
+    expect(selectDisplaySliceByRxId(state, 3).lastSeq).toBe(0);
+    expect(selectDisplaySliceByRxId(state, 3).panDb).toBeNull();
   });
 
   it('marks a valid-bit payload invalid when its bin count does not match frame width', () => {

--- a/zeus-web/src/state/display-store.ts
+++ b/zeus-web/src/state/display-store.ts
@@ -77,6 +77,11 @@ export type DisplayState = {
   wfFloorDb: number | null;
   lastSeq: number;
   rx2: ReceiverDisplaySlice;
+  // Display slices for RX3+ (multi-DDC). Indexed by rxId - 2, so extra[0] is
+  // RX3 (rxId 2), extra[1] is RX4, etc. RX1 lives in the root fields and RX2 in
+  // `rx2`; keeping those untouched preserves the VFO-A/B ('A'/'B') consumers
+  // while RX3+ frames land here instead of clobbering the primary slice.
+  extra: ReceiverDisplaySlice[];
   setConnected: (c: boolean) => void;
   pushFrame: (f: DecodedFrame) => void;
 };
@@ -204,6 +209,24 @@ export function selectDisplaySlice(
   };
 }
 
+// Shared empty slice for not-yet-seen RX3+ receivers. Slices are treated as
+// read-only snapshots, so a single frozen instance avoids per-render allocation
+// and keeps reference identity stable until the first frame arrives.
+const EMPTY_DISPLAY_SLICE: ReceiverDisplaySlice = createEmptyDisplaySlice();
+
+// Select a display slice by raw rxId (0 = RX1 / VFO A, 1 = RX2 / VFO B, >=2 =
+// RX3+ from the multi-DDC `extra` array). This is the N-receiver accessor used
+// by RX3+ panadapter/waterfall surfaces; the binary 'A'/'B' selectDisplaySlice
+// above still serves the VFO-A/B UI unchanged.
+export function selectDisplaySliceByRxId(
+  state: DisplayState,
+  rxId: number,
+): ReceiverDisplaySlice {
+  if (rxId <= 0) return selectDisplaySlice(state, 'A');
+  if (rxId === 1) return state.rx2;
+  return state.extra[rxId - 2] ?? EMPTY_DISPLAY_SLICE;
+}
+
 export const useDisplayStore = create<DisplayState>((set) => ({
   connected: false,
   width: 0,
@@ -217,14 +240,27 @@ export const useDisplayStore = create<DisplayState>((set) => ({
   wfFloorDb: null,
   lastSeq: 0,
   rx2: createEmptyDisplaySlice(),
+  extra: [],
   setConnected: (connected) => set({ connected }),
   pushFrame: (f) => {
     const clean = cleanFrame(f);
-    const receiver = receiverFromRxId(clean.rxId);
     const nextSlice = sliceFromFrame(clean);
+    const rxId = clean.rxId;
 
-    if (receiver === 'B') {
+    if (rxId === 1) {
       set({ rx2: nextSlice });
+      return;
+    }
+
+    // RX3+ (multi-DDC): land in the `extra` array keyed by rxId - 2 instead of
+    // falling through to the primary slice. Before this, receiverFromRxId mapped
+    // any rxId != 1 to 'A', so RX3 frames overwrote RX1's display.
+    if (rxId >= 2) {
+      set((state) => {
+        const extra = state.extra.slice();
+        extra[rxId - 2] = nextSlice;
+        return { extra };
+      });
       return;
     }
 


### PR DESCRIPTION
## What

Fixes a latent multi-DDC display bug and lays the store foundation for rendering RX3+ panadapters.

The display store keyed spectrum frames by a binary `receiverFromRxId()`: `rxId === 1 → 'B'` (RX2), **anything else → 'A'** (RX1). With the B4-server work, RX3+ now emit their own `DisplayFrame`s (`RxId >= 2`) — which mapped to `'A'` and **overwrote RX1's** panadapter/waterfall slice.

## Changes

- Add an `extra: ReceiverDisplaySlice[]` array (indexed `rxId - 2`, so `extra[0]` is RX3) to `DisplayState`. `pushFrame` routes `rxId >= 2` there instead of falling through to the primary slice.
- RX1 root fields and the RX2 `rx2` slice are **untouched**, so all the VFO-A/B (`'A'`/`'B'`) consumers (~30 files: filters, tuning gestures, band/mode memory) keep working exactly as before.
- Add `selectDisplaySliceByRxId(state, rxId)` — the N-receiver accessor (`0 → RX1`, `1 → RX2`, `>=2 → extra[]`), returning a shared empty slice for not-yet-seen receivers.
- Store test: an RX3 (`rxId 2`) frame populates `extra[0]` and is reachable via `selectDisplaySliceByRxId`, without disturbing the RX1 primary slice or RX2.

## Verification

`vitest run src/state/display-store.test.ts` → 13/13 pass. `npm run build` (tsc -b + vite) green.

## Scope / follow-up

Store-layer only — no RX1/RX2 behavioural change. The remaining half of zeus-79qa is the **workspace rendering**: laying out an RX3+ panadapter/waterfall per `StateDto.Receivers[]` and wiring per-receiver VFO/tuning. That's a larger UX change (the `receiver: 'A'|'B'` prop is deeply tied to the VFO-A/B model across ~30 files) and is best done with visual iteration in a real browser — tracked under zeus-79qa.

Pairs with #848 (server-side RX3+ audio routing), which is live-validated on the G2.