### PR TITLE
fix(chat): rehydrate friend graph before roster broadcast on socket close

### DIFF
--- a/cloud/zeuschat-relay/src/chat-room.ts
+++ b/cloud/zeuschat-relay/src/chat-room.ts
@@ -251,10 +251,15 @@ export class ChatRoom extends DurableObject<Env> {
 
   override async webSocketClose(ws: WebSocket, code: number, reason: string): Promise<void> {
     try { ws.close(code, reason); } catch { /* already closing */ }
+    // A close can wake a hibernated DO with an empty in-memory graph; rehydrate
+    // before broadcasting or rosterFor() would strip every friend's freq.
+    await this.ensureLoaded();
     this.broadcastRoster();
   }
 
   override async webSocketError(): Promise<void> {
+    // Same hibernation guard as webSocketClose — never broadcast an unloaded graph.
+    await this.ensureLoaded();
     this.broadcastRoster();
   }
 


### PR DESCRIPTION
## Problem

Operators reported **not seeing some friends' frequencies in realtime**, even after a friend accepted the invite and hadn't hidden their freq.

## Root cause

The ZeusChat relay Durable Object uses the WebSocket Hibernation API. The in-memory friend graph (`this.friends`) is rehydrated lazily by `ensureLoaded()`.

- `webSocketMessage` calls `ensureLoaded()` before any roster work. ✅
- `webSocketClose` and `webSocketError` called `broadcastRoster()` **directly**, with no `ensureLoaded()`. ❌

After the DO hibernates (memory evicted, `loaded = false`, `friends` empty) and is recreated, a socket **close or heartbeat timeout** broadcasts a roster computed against the **empty** graph. `rosterFor()` then finds no mutual friendship for any viewer and strips `freq` from every operator:

```js
const canSeeFreq =
  att.callsign === viewer ||
  (att.freqPublic !== false && (fset?.has(att.callsign) ?? false)); // fset undefined → false
```

Clients replace their roster wholesale, so friends' frequencies disappear. It only self-heals on the next *real* `webSocketMessage` that reloads the graph — and idle clients send only auto-answered pings (which never wake the DO), so it can stay broken indefinitely. That intermittence matches the "some friends, sometimes" symptom.

## Fix

Guard both hibernation-path handlers with `await this.ensureLoaded()` before `broadcastRoster()`, so the roster is never computed against an unloaded graph.

## Notes

- Relay-only change (`cloud/zeuschat-relay`). **Requires a Worker redeploy** (`wrangler deploy`) to take effect on `chat.openhpsdrzeus.com`.
- `tsc --noEmit` passes.
- No change to the friend-consent model, freq-privacy semantics, or the eye toggle — only *when* the graph is loaded before a broadcast.