### PR TITLE
feat(connect): take over a Busy radio from the Discover panel

### DIFF
--- a/Zeus.Server.Hosting/RadioReclaimService.cs
+++ b/Zeus.Server.Hosting/RadioReclaimService.cs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+using System.Net;
+using System.Net.Sockets;
+using Zeus.Protocol1;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Forcibly frees an OpenHPSDR radio that discovery reports as <c>Busy</c>
+/// (status byte 0x03) — i.e. one currently streaming to another client.
+///
+/// <para>Neither HPSDR protocol authenticates the host: the radio streams to
+/// whoever last commanded it to run. To take a busy radio over we send it a
+/// <em>stop</em> command, which drops the previous owner, before connecting
+/// normally. This deliberately reverses the historical "Zeus will not fight
+/// for it" behaviour and is gated behind an explicit operator confirmation in
+/// the Connect panel — it can kick another operator off a live, possibly
+/// transmitting, radio.</para>
+///
+/// <list type="bullet">
+///   <item>Protocol 1 — Metis start/stop command <c>EF FE 04 00</c> to UDP
+///   port 1024 (the same frame <see cref="ControlFrame.BuildStartStop"/>
+///   builds with <c>start: false</c>).</item>
+///   <item>Protocol 2 — a high-priority "to radio" datagram with the run/PTT
+///   byte cleared, sent to UDP port 1027. An all-zero buffer is exactly
+///   <c>run=0, ptt=0, seq=0</c> — see Protocol2Client.SendCmdHighPriority.</item>
+/// </list>
+///
+/// Each command is sent a few times because the first UDP datagram to a
+/// freshly-ARPed host is frequently dropped (the same first-UDP-drop quirk
+/// Protocol1Client works around on start). The service is stateless and opens
+/// its own transient socket so it never disturbs an active connection.
+/// </summary>
+public sealed class RadioReclaimService
+{
+    // Fixed protocol command ports. These are NOT the data port carried in the
+    // discovery endpoint string — P1 control frames always go to 1024 and P2
+    // high-priority always to 1027, regardless of the data port.
+    private const int Protocol1CommandPort = 1024;
+    private const int Protocol2HighPriorityPort = 1027;
+
+    // Matches Protocol2Client.BufLen — the size Zeus's own high-priority
+    // sender uses on the wire.
+    private const int Protocol2HighPriorityLen = 1444;
+
+    private const int SendCount = 3;
+    private static readonly TimeSpan SettleDelay = TimeSpan.FromMilliseconds(350);
+
+    private readonly ILogger<RadioReclaimService> _log;
+
+    public RadioReclaimService(ILogger<RadioReclaimService> log) => _log = log;
+
+    /// <summary>
+    /// Sends a stop/free command to <paramref name="radioIp"/> so the radio
+    /// drops its current owner, then waits briefly for the radio to settle
+    /// before the caller re-discovers or connects.
+    /// </summary>
+    public async Task ReclaimAsync(IPAddress radioIp, bool isProtocol2, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(radioIp);
+
+        if (isProtocol2) SendProtocol2Stop(radioIp);
+        else SendProtocol1Stop(radioIp);
+
+        // Give the radio a moment to drop the previous owner and republish an
+        // idle discovery status before the caller's connect/start sequence.
+        await Task.Delay(SettleDelay, ct).ConfigureAwait(false);
+    }
+
+    private void SendProtocol1Stop(IPAddress radioIp) =>
+        SendUdp(radioIp, Protocol1CommandPort, BuildProtocol1StopFrame(), "P1");
+
+    private void SendProtocol2Stop(IPAddress radioIp) =>
+        SendUdp(radioIp, Protocol2HighPriorityPort, BuildProtocol2StopFrame(), "P2");
+
+    /// <summary>Metis stop frame (<c>EF FE 04 00</c>, 64 bytes). Internal for tests.</summary>
+    internal static byte[] BuildProtocol1StopFrame()
+    {
+        var frame = new byte[64];
+        ControlFrame.BuildStartStop(frame, start: false);
+        return frame;
+    }
+
+    /// <summary>
+    /// P2 high-priority stop: an all-zero <see cref="Protocol2HighPriorityLen"/>-byte
+    /// buffer (run/PTT cleared at byte 4, sequence 0 at bytes 0..3). Internal for tests.
+    /// </summary>
+    internal static byte[] BuildProtocol2StopFrame() => new byte[Protocol2HighPriorityLen];
+
+    private void SendUdp(IPAddress radioIp, int port, byte[] payload, string proto)
+    {
+        var target = new IPEndPoint(radioIp, port);
+        try
+        {
+            using var sock = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+            sock.Bind(new IPEndPoint(IPAddress.Any, 0));
+            for (int i = 0; i < SendCount; i++)
+            {
+                try { sock.SendTo(payload, target); }
+                catch (SocketException ex)
+                {
+                    _log.LogWarning(ex, "reclaim {Proto} stop send {I}/{N} to {Target} failed", proto, i + 1, SendCount, target);
+                }
+            }
+            _log.LogInformation("reclaim {Proto} stop sent to {Target} ({N}×)", proto, target, SendCount);
+        }
+        catch (SocketException ex)
+        {
+            _log.LogWarning(ex, "reclaim {Proto} socket setup for {Target} failed", proto, target);
+        }
+    }
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -911,6 +911,24 @@ public static class ZeusEndpoints
             }
         });
 
+        // Take over a Busy radio. Discovery reports status 0x03 when another
+        // client owns the radio; the UI normally disables Connect for those.
+        // This sends a protocol stop to the radio so it drops the current owner,
+        // freeing it for an immediate connect. Outward-facing and deliberate —
+        // the Connect panel gates it behind an explicit operator confirmation,
+        // because it can kick another (possibly transmitting) operator off.
+        app.MapPost("/api/radios/reclaim", async (ReclaimRadioRequest req, RadioReclaimService reclaim, HttpContext ctx) =>
+        {
+            if (!TryParseIpEndpoint(req.Endpoint ?? string.Empty, out var ipEndpoint))
+                return Results.BadRequest(new { error = $"Invalid endpoint '{req.Endpoint}'." });
+
+            var isP2 = string.Equals(req.Protocol, "P2", StringComparison.OrdinalIgnoreCase);
+            log.LogInformation("api.radios.reclaim ip={Ip} protocol={Proto}", ipEndpoint.Address, isP2 ? "P2" : "P1");
+
+            await reclaim.ReclaimAsync(ipEndpoint.Address, isP2, ctx.RequestAborted);
+            return Results.Ok(new { freed = true });
+        });
+
         app.MapPost("/api/connect", async (ConnectRequest req, RadioService r, WdspWisdomInitializer wisdom, HttpContext ctx) =>
         {
             log.LogInformation(
@@ -4242,6 +4260,10 @@ internal sealed record TxDutyGuidanceDto(
     double? RecommendedMaxWatts,
     bool LimitExceeded,
     string? ManualReference);
+// Body for POST /api/radios/reclaim. Endpoint is the discovered "ip:port"
+// string (port is ignored — protocol command ports are fixed); Protocol is
+// "P1" or "P2" so the server sends the correct stop frame.
+internal sealed record ReclaimRadioRequest(string? Endpoint, string? Protocol);
 internal sealed record HardwareDiagnosticsMarkerRequest(string? Label, string? Notes);
 internal sealed record WavRecordStartRequest(string? Source);
 internal sealed record WavPlayRequest(string? File);

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -230,6 +230,9 @@ public static class ZeusHost
         // PushAudioFrontEnd push. Shares zeus-prefs.db (single global row).
         builder.Services.AddSingleton<AudioSettingsStore>();
         builder.Services.AddSingleton<RadioService>();
+        // Frees a Busy radio (drops its current owner) so the operator can take
+        // it over from the Connect panel. Stateless — opens its own socket.
+        builder.Services.AddSingleton<RadioReclaimService>();
         builder.Services.AddSingleton<StreamingHub>();
         // WebRTC remote-access data plane (docs/designs/remote-access-webrtc.md).
         // Phase-0 spike service; the dev-only /api/rtc/spike/offer endpoint that

--- a/docs/manual/chapters/03-connecting.md
+++ b/docs/manual/chapters/03-connecting.md
@@ -26,7 +26,7 @@ Each radio Zeus finds appears as a row showing:
 - A **LAST** badge on the radio you most recently connected to. That radio is also floated to the top of the list for convenience.
 - The radio's network address and MAC address underneath.
 
-Press **Connect** on the row you want. If a radio shows **Busy**, another client already has it — Zeus will not fight for it. (Original-protocol radios serve one client at a time.)
+Press **Connect** on the row you want. If a radio shows **Busy**, another client already has it (HPSDR radios serve one client at a time). Use **Take over** next to the Busy badge to claim it anyway: Zeus asks you to confirm, then sends the radio a stop command that drops the current client and connects you. **This kicks the other operator off — including in the middle of a transmission — so only do it for a radio you own.**
 
 > **Tip:** If the list says "No radios found," check the radio's power and Ethernet cable, and make sure your computer is on the same subnet as the radio. Discovery uses a network broadcast, so a radio on a different VLAN or across a router will not appear — use Manual mode in that case.
 

--- a/tests/Zeus.Server.Tests/RadioReclaimServiceTests.cs
+++ b/tests/Zeus.Server.Tests/RadioReclaimServiceTests.cs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+
+using Xunit;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Pins the wire frames <see cref="RadioReclaimService"/> sends to free a
+/// Busy radio. Getting these wrong would either fail to drop the current
+/// owner or send the radio garbage, so the bytes are asserted directly.
+/// </summary>
+public class RadioReclaimServiceTests
+{
+    [Fact]
+    public void Protocol1StopFrame_IsMetisStopCommand()
+    {
+        var frame = RadioReclaimService.BuildProtocol1StopFrame();
+
+        // Metis start/stop command: EF FE 04 00 (00 = stop). 64-byte datagram.
+        Assert.Equal(64, frame.Length);
+        Assert.Equal(0xEF, frame[0]);
+        Assert.Equal(0xFE, frame[1]);
+        Assert.Equal(0x04, frame[2]);
+        Assert.Equal(0x00, frame[3]); // run bit cleared == stop
+        for (int i = 4; i < frame.Length; i++)
+            Assert.Equal(0x00, frame[i]);
+    }
+
+    [Fact]
+    public void Protocol2StopFrame_IsAllZeroHighPriorityPacket()
+    {
+        var frame = RadioReclaimService.BuildProtocol2StopFrame();
+
+        // P2 high-priority "to radio" buffer (matches Protocol2Client.BufLen).
+        // All zero == sequence 0 and run/PTT cleared at byte 4: the radio
+        // stops streaming to its current owner.
+        Assert.Equal(1444, frame.Length);
+        Assert.All(frame, b => Assert.Equal(0x00, b));
+    }
+}

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -5356,6 +5356,27 @@ export function connectP2(
   );
 }
 
+// Take over a Busy radio: ask the server to send a protocol stop so the radio
+// drops its current owner, freeing it for an immediate connect. `endpoint` is
+// the discovered "ip:port"; `protocol` is 'P1' or 'P2'. Resolves once the
+// server has sent the stop and waited for the radio to settle.
+export function reclaimRadio(
+  endpoint: string,
+  protocol: 'P1' | 'P2',
+  signal?: AbortSignal,
+): Promise<unknown> {
+  return jsonFetch(
+    '/api/radios/reclaim',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ endpoint, protocol }),
+      signal,
+    },
+    (raw) => raw,
+  );
+}
+
 export function disconnect(signal?: AbortSignal): Promise<RadioStateDto> {
   return jsonFetch(
     '/api/disconnect',

--- a/zeus-web/src/components/ConnectPanel.tsx
+++ b/zeus-web/src/components/ConnectPanel.tsx
@@ -49,6 +49,7 @@ import {
   connectP2 as apiConnectP2,
   disconnect as apiDisconnect,
   disconnectP2 as apiDisconnectP2,
+  reclaimRadio,
   fetchRadios,
   fetchState,
   listPrefsDatabases,
@@ -71,6 +72,7 @@ import { useRadioStore } from '../state/radio-store';
 import { useTxAudioProfileStore } from '../state/tx-audio-profile-store';
 import { useTxStore } from '../state/tx-store';
 import { TxAudioProfileSavePrompt } from './TxAudioProfileSavePrompt';
+import { ConfirmDialog } from '../layout/ConfirmDialog';
 import {
   useConnectStore,
   type ProtocolChoice,
@@ -436,6 +438,9 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
   // Disconnect when the loaded profile has unsaved live edits.
   const [savePrompt, setSavePrompt] = useState<{ name: string } | null>(null);
   const [savePromptBusy, setSavePromptBusy] = useState(false);
+  // Pending "take over a Busy radio" confirmation. Holds the discovered radio
+  // the operator asked to force-connect to; the dialog kicks the current owner.
+  const [pendingTakeover, setPendingTakeover] = useState<RadioInfoDto | null>(null);
 
   const [manualIp, setManualIp] = useState(manualFormDefaults.ip);
   const [manualPort, setManualPort] = useState(manualFormDefaults.port);
@@ -507,7 +512,67 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
     };
   }, [status, retryNonce]);
 
+  // Core connect sequence shared by the normal Connect button and the
+  // Busy-radio takeover flow. Caller owns the inflight/error state so both
+  // entry points can wrap it (the takeover sends a reclaim first).
+  const performConnect = useCallback(
+    async (r: RadioInfoDto) => {
+      const ep = endpointFor(r);
+      const isP2 = (r.details?.protocol ?? 'P1') === 'P2';
+      if (isP2) {
+        // Pass the discovered board byte (e.g. 0x01 = Hermes for Brick2).
+        // Without this the server falls back to OrionMkII for every P2
+        // connection — issue #171.
+        const rawBoardId = parseRawBoardId(r.details?.rawBoardId);
+        await apiConnectP2({
+          endpoint: ep,
+          sampleRate: DEFAULT_SAMPLE_RATE,
+          boardId: rawBoardId ?? undefined,
+        });
+        const fresh = await fetchState();
+        applyState(fresh);
+        hydrateTxFromState(fresh);
+      } else {
+        // Pass the discovered board byte so the server sets the correct
+        // board kind on the Protocol1Client (default is HermesLite2 —
+        // without this an ANAN-10E appears as HL2 post-connect, issue #294).
+        const rawBoardId = parseRawBoardId(r.details?.rawBoardId);
+        const next = await apiConnect({
+          endpoint: ep,
+          sampleRate: DEFAULT_SAMPLE_RATE,
+          boardId: rawBoardId ?? undefined,
+        });
+        applyState(next);
+        hydrateTxFromState(next);
+      }
+      setBoardId(r.boardId || null);
+      setConnectedProtocol(isP2 ? 'P2' : 'P1');
+      setLastConnectedEndpoint(ep || null);
+      applyPostConnectEffects();
+    },
+    [applyState, hydrateTxFromState, setBoardId, setConnectedProtocol, setLastConnectedEndpoint],
+  );
+
   const handleConnect = useCallback(
+    async (r: RadioInfoDto) => {
+      if (inflightRef.current) return;
+      setInflight(true);
+      setError(null);
+      try {
+        await performConnect(r);
+      } catch (err) {
+        setError(errorMessage(err));
+      } finally {
+        setInflight(false);
+      }
+    },
+    [performConnect, setInflight],
+  );
+
+  // Take over a Busy radio: ask the server to send a protocol stop (kicking
+  // the current owner) and then connect. Invoked from the takeover confirm
+  // dialog, never directly from the row button.
+  const handleForceConnect = useCallback(
     async (r: RadioInfoDto) => {
       if (inflightRef.current) return;
       const ep = endpointFor(r);
@@ -515,43 +580,15 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
       setInflight(true);
       setError(null);
       try {
-        if (isP2) {
-          // Pass the discovered board byte (e.g. 0x01 = Hermes for Brick2).
-          // Without this the server falls back to OrionMkII for every P2
-          // connection — issue #171.
-          const rawBoardId = parseRawBoardId(r.details?.rawBoardId);
-          await apiConnectP2({
-            endpoint: ep,
-            sampleRate: DEFAULT_SAMPLE_RATE,
-            boardId: rawBoardId ?? undefined,
-          });
-          const fresh = await fetchState();
-          applyState(fresh);
-          hydrateTxFromState(fresh);
-        } else {
-          // Pass the discovered board byte so the server sets the correct
-          // board kind on the Protocol1Client (default is HermesLite2 —
-          // without this an ANAN-10E appears as HL2 post-connect, issue #294).
-          const rawBoardId = parseRawBoardId(r.details?.rawBoardId);
-          const next = await apiConnect({
-            endpoint: ep,
-            sampleRate: DEFAULT_SAMPLE_RATE,
-            boardId: rawBoardId ?? undefined,
-          });
-          applyState(next);
-          hydrateTxFromState(next);
-        }
-        setBoardId(r.boardId || null);
-        setConnectedProtocol(isP2 ? 'P2' : 'P1');
-        setLastConnectedEndpoint(ep || null);
-        applyPostConnectEffects();
+        await reclaimRadio(ep, isP2 ? 'P2' : 'P1');
+        await performConnect(r);
       } catch (err) {
         setError(errorMessage(err));
       } finally {
         setInflight(false);
       }
     },
-    [applyState, hydrateTxFromState, setBoardId, setConnectedProtocol, setInflight, setLastConnectedEndpoint],
+    [performConnect, setInflight],
   );
 
   const handleManualConnect = useCallback(
@@ -962,25 +999,36 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
                           {ep || '—'} · {r.macAddress || '—'}
                         </span>
                       </div>
-                      <button
-                        type="button"
-                        onClick={() => handleConnect(r)}
-                        disabled={r.busy || inflight}
-                        title={
-                          r.busy
-                            ? 'Radio is busy (in use by another client)'
-                            : isP2
-                              ? 'Protocol 2 path — experimental, RX only'
-                              : undefined
-                        }
-                        className={`btn sm ${r.busy ? '' : 'active'}`}
-                      >
-                        {r.busy
-                          ? 'Busy'
-                          : inflight
-                            ? 'Connecting…'
-                            : 'Connect'}
-                      </button>
+                      {r.busy ? (
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                          <span
+                            className="label-xs"
+                            style={{ color: 'var(--tx)' }}
+                            title="In use by another client"
+                          >
+                            Busy
+                          </span>
+                          <button
+                            type="button"
+                            onClick={() => setPendingTakeover(r)}
+                            disabled={inflight}
+                            title="Take over this radio — disconnects the client currently using it"
+                            className="btn sm"
+                          >
+                            Take over
+                          </button>
+                        </div>
+                      ) : (
+                        <button
+                          type="button"
+                          onClick={() => handleConnect(r)}
+                          disabled={inflight}
+                          title={isP2 ? 'Protocol 2 path — experimental, RX only' : undefined}
+                          className="btn sm active"
+                        >
+                          {inflight ? 'Connecting…' : 'Connect'}
+                        </button>
+                      )}
                     </li>
                   );
                 })}
@@ -1023,6 +1071,28 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
         )}
       </div>
       </div>
+      {pendingTakeover && (
+        <ConfirmDialog
+          title="Take over this radio?"
+          confirmLabel="Take over"
+          cancelLabel="Cancel"
+          intent="danger"
+          onConfirm={() => {
+            const target = pendingTakeover;
+            setPendingTakeover(null);
+            void handleForceConnect(target);
+          }}
+          onCancel={() => setPendingTakeover(null)}
+        >
+          <p style={{ margin: 0 }}>
+            <strong>{pendingTakeover.boardId || 'This radio'}</strong>
+            {' '}({endpointFor(pendingTakeover) || pendingTakeover.ipAddress}) is
+            in use by another client. Taking it over sends a stop command that
+            disconnects whoever is currently using it — including an active
+            transmission — and then connects Zeus.
+          </p>
+        </ConfirmDialog>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## What

When discovery reports a radio as **Busy** (status `0x03` — another client owns it), the Connect button was simply disabled. This adds an explicit, operator-confirmed takeover so you can reclaim a radio you own.

- **`RadioReclaimService`** sends a protocol *stop* to free the radio (drops the current owner). HPSDR does not authenticate the host, so a stop frame ends/redirects the existing stream:
  - **P1** — Metis `EF FE 04 00` → UDP `:1024` (same frame as `ControlFrame.BuildStartStop(start:false)`)
  - **P2** — all-zero high-priority datagram (`run=0, ptt=0, seq=0`) → UDP `:1027`
- **`POST /api/radios/reclaim`** `{ endpoint, protocol }` wires it to the UI.
- **UI** — Busy rows now show a red **Busy** label + a **Take over** button → a danger `ConfirmDialog` (warns it disconnects the current client, *including an active transmission*) → on confirm, reclaim → settle ~350 ms → connect, in one click. Works for P1 and P2.
- Manual chapter `03-connecting.md` updated (it previously said Zeus "will not fight for it").

## Why

Reverses the prior deliberate "one client at a time, don't fight for it" default — by explicit operator request. Gated behind a confirmation because it is outward-facing: it kicks whoever currently owns the radio.

## Verification

- ✅ Web `tsc -b --noEmit`, `eslint`, full `vite build`
- ✅ `dotnet build` (hosting + solution), `RadioReclaimServiceTests` (frame bytes pinned, **2/2**)
- ✅ **Real-wire e2e (local):** ran the live `ReclaimAsync` path against loopback UDP listeners on `:1024`/`:1027` and confirmed the actual datagrams leave the socket — 64-byte `EF FE 04 00` (P1) and 1444 zero bytes (P2). (Temp test, not committed — fixed-port bind would be flaky in CI.)

## ⚠️ Not bench-tested against hardware

I could not test an actual takeover against a real radio in this environment. **P1** uses the well-established Metis stop frame. **The P2 stop (all-zero high-priority `run=0`) should be sanity-checked against a real G2 / OrionMkII before relying on it** — it matches Zeus's own stop path but hasn't been confirmed to drop another client on real hardware.