### PR TITLE
feat(remote): low-latency Opus voice-mic uplink for remote TX

### DIFF
--- a/Zeus.Server.Hosting/Remote/RemoteMicAudioPipeline.cs
+++ b/Zeus.Server.Hosting/Remote/RemoteMicAudioPipeline.cs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+
+using System.Buffers.Binary;
+using Concentus;
+
+namespace Zeus.Server.Hosting.Remote;
+
+/// <summary>
+/// Decodes the remote operator's Opus voice (the inbound WebRTC audio track)
+/// into the front-end's native TX-mic cadence: 960-sample, 20 ms, 48 kHz mono
+/// <c>f32le</c> blocks — byte-identical to what <see cref="TxAudioIngest"/>
+/// consumes from a local <c>/ws</c> 0x20 mic frame. So a remote talker's voice
+/// rides the exact same TX chain (leveler / CFC / VST / WDSP TXA) as someone
+/// sitting at the desk.
+///
+/// One instance per remote session. NOT thread-safe: SIPSorcery delivers a
+/// peer's RTP on a single receive path, and the emitted block buffer is reused,
+/// so the <c>onBlock</c> consumer must read it synchronously (TxAudioIngest copies
+/// the samples into its WDSP accumulator inside the call, satisfying this).
+///
+/// A mono Opus decoder is used deliberately: libopus/Concentus down-mixes a
+/// stereo stream and passes a mono one through, so it is robust whether the
+/// browser encodes 1 or 2 channels.
+/// </summary>
+public sealed class RemoteMicAudioPipeline
+{
+    public const int SampleRate = 48000;
+    public const int Channels = 1;
+    public const int BlockSamples = 960;          // 20 ms @ 48 kHz — matches TxAudioIngest.MicBlockSamples
+    private const int BlockBytes = BlockSamples * 4;
+    private const int MaxFrameSamples = 5760;     // 120 ms @ 48 kHz — the largest Opus frame
+
+    private readonly IOpusDecoder _decoder = OpusCodecFactory.CreateDecoder(SampleRate, Channels);
+    private readonly short[] _decoded = new short[MaxFrameSamples];
+    private readonly byte[] _block = new byte[BlockBytes];
+    private int _blockBytes;
+    private readonly Action<ReadOnlyMemory<byte>> _onBlock;
+
+    /// <param name="onBlock">
+    /// Invoked synchronously for each completed 960-sample f32le block. The buffer
+    /// is reused between calls — copy it if you retain it past the call.
+    /// </param>
+    public RemoteMicAudioPipeline(Action<ReadOnlyMemory<byte>> onBlock) => _onBlock = onBlock;
+
+    /// <summary>Decode one received Opus packet and emit any completed blocks.</summary>
+    public void Decode(ReadOnlySpan<byte> opusPayload)
+    {
+        if (opusPayload.IsEmpty) return;
+        int n;
+        // Never throw out of the RTP receive callback — a malformed packet is
+        // dropped, not fatal.
+        try { n = _decoder.Decode(opusPayload, _decoded.AsSpan(), MaxFrameSamples, false); }
+        catch { return; }
+        Emit(_decoded.AsSpan(0, n));
+    }
+
+    /// <summary>
+    /// Conceal a single lost packet via Opus PLC (decode with no input) and emit
+    /// the synthesised samples. Call once per detected sequence-number gap so a
+    /// dropped voice packet is a soft artefact, not a hard click.
+    /// </summary>
+    public void DecodeLost()
+    {
+        int n;
+        try { n = _decoder.Decode(ReadOnlySpan<byte>.Empty, _decoded.AsSpan(0, BlockSamples), BlockSamples, false); }
+        catch { return; }
+        Emit(_decoded.AsSpan(0, n));
+    }
+
+    private void Emit(ReadOnlySpan<short> samples)
+    {
+        foreach (var s in samples)
+        {
+            BinaryPrimitives.WriteSingleLittleEndian(_block.AsSpan(_blockBytes, 4), s / 32768f);
+            _blockBytes += 4;
+            if (_blockBytes == BlockBytes)
+            {
+                _onBlock(_block);
+                _blockBytes = 0;
+            }
+        }
+    }
+}

--- a/Zeus.Server.Hosting/Remote/RemoteWebRtcSession.cs
+++ b/Zeus.Server.Hosting/Remote/RemoteWebRtcSession.cs
@@ -51,6 +51,15 @@ public sealed class RemoteWebRtcSession
     private RTCDataChannel? _api;
     private RemoteFrameSink? _sink;
 
+    // Remote voice TX: the browser's mic arrives as an inbound Opus audio track.
+    // _micPipeline decodes + re-blocks it to the 960-sample f32le cadence the TX
+    // ingest expects; _lastAudioSeq drives single-packet PLC across RTP gaps.
+    // Only wired when the offer carries audio AND a hub is present (the real
+    // radio host) — RX-only clients and transport tests stay audio-free.
+    private RemoteMicAudioPipeline? _micPipeline;
+    private int _lastAudioSeq = -1;
+    private bool _audioWired;
+
     // Post-unlock binary stream-request control frames (RX monitoring, Phase A):
     //   first byte 0x22 = display request, 0x21 = audio request; byte[1] 1/0 = enable/disable.
     // We track the session's current wanted-state so a duplicate enable can't
@@ -159,6 +168,12 @@ public sealed class RemoteWebRtcSession
     /// <summary>Answer the browser's offer with a self-contained (vanilla-ICE) SDP.</summary>
     public async Task<string> CreateAnswerAsync(string offerSdp, CancellationToken ct = default)
     {
+        // If the browser offered a voice-mic audio track, attach our recvonly
+        // Opus receiver BEFORE setRemoteDescription so the answer negotiates it.
+        // Gated on the offer actually containing audio so an RX-only client
+        // (whose offer has no m=audio) is answered exactly as before.
+        MaybeWireRemoteVoice(offerSdp);
+
         var setResult = _pc.setRemoteDescription(
             new RTCSessionDescriptionInit { type = RTCSdpType.offer, sdp = offerSdp });
         if (setResult != SetDescriptionResultEnum.OK)
@@ -296,6 +311,61 @@ public sealed class RemoteWebRtcSession
                 break;
         }
     }
+
+    // -- Remote voice TX (inbound Opus audio track) --------------------------
+
+    /// <summary>
+    /// Attach the recvonly Opus audio receiver iff the browser offered a mic
+    /// track. No-op when there is no hub (transport tests), no audio in the offer
+    /// (RX-only client), or it is already wired. Decoded voice is injected into
+    /// the SAME TX-mic ingest local audio uses; MOX + source arbitration
+    /// downstream decide whether it actually reaches the air.
+    /// </summary>
+    private void MaybeWireRemoteVoice(string offerSdp)
+    {
+        if (_audioWired || _hub is null) return;
+        if (string.IsNullOrEmpty(offerSdp)
+            || offerSdp.IndexOf("m=audio", StringComparison.OrdinalIgnoreCase) < 0)
+            return;
+
+        _micPipeline = new RemoteMicAudioPipeline(OnRemoteMicBlock);
+        var audioTrack = new MediaStreamTrack(
+            SDPMediaTypesEnum.audio, false,
+            new List<SDPAudioVideoMediaFormat> { new(SDPMediaTypesEnum.audio, 111, "OPUS", 48000, 2) },
+            MediaStreamStatusEnum.RecvOnly);
+        _pc.addTrack(audioTrack);
+        _pc.OnRtpPacketReceived += OnAudioRtpReceived;
+        _audioWired = true;
+        _log.LogInformation("rtc.remote voice-mic track negotiated (Opus 48k recvonly)");
+    }
+
+    private void OnAudioRtpReceived(
+        System.Net.IPEndPoint remoteEp, SDPMediaTypesEnum media, RTPPacket pkt)
+    {
+        if (media != SDPMediaTypesEnum.audio || _micPipeline is null) return;
+        if (!_session.IsUnlocked) return; // deny-by-default: no voice before unlock
+        try
+        {
+            int seq = pkt.Header.SequenceNumber;
+            if (_lastAudioSeq >= 0)
+            {
+                // Conceal a small gap with Opus PLC; cap it so a long dropout
+                // can't spin the decoder. A reorder/duplicate (huge wrapped gap)
+                // is simply decoded in place.
+                int gap = (ushort)(seq - _lastAudioSeq - 1);
+                for (int i = 0; i < gap && i < 5; i++) _micPipeline.DecodeLost();
+            }
+            _lastAudioSeq = seq;
+            _micPipeline.Decode(pkt.Payload);
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "rtc.remote audio rtp decode failed");
+        }
+    }
+
+    /// <summary>Inject a decoded 960-sample f32le voice block into the TX-mic ingest.</summary>
+    private void OnRemoteMicBlock(ReadOnlyMemory<byte> f32leBlock) => _hub?.InjectMicPcm(f32leBlock);
 
     // -- Read-write REST tunnel ---------------------------------------------
     //

--- a/Zeus.Server.Hosting/StreamingHub.cs
+++ b/Zeus.Server.Hosting/StreamingHub.cs
@@ -387,6 +387,26 @@ public sealed class StreamingHub
     /// <summary>Remove a previously-attached remote sink.</summary>
     internal void DetachSink(Guid id) => _clients.TryRemove(id, out _);
 
+    /// <summary>
+    /// Inject a mic-PCM block (f32le samples, NO type prefix) from a non-WebSocket
+    /// source — the remote-access WebRTC audio track, after it has been Opus-
+    /// decoded and re-blocked to the front-end's 960-sample/20 ms cadence upstream
+    /// (<see cref="Remote.RemoteMicAudioPipeline"/>). Raises <see cref="MicPcmReceived"/>
+    /// exactly as a <c>/ws</c> 0x20 frame would, so a remote operator's voice
+    /// reaches <see cref="TxAudioIngest"/> through the identical path local mic
+    /// audio takes. MOX-gating + source arbitration happen downstream in the
+    /// ingest; this only delivers the samples.
+    /// </summary>
+    internal void InjectMicPcm(ReadOnlyMemory<byte> f32lePayload)
+    {
+        RecordMicInbound(f32lePayload);
+        if (RecordMicUplinkFrame(f32lePayload.Length) && MicPcmReceived is { } handler)
+        {
+            try { handler(f32lePayload); }
+            catch (Exception ex) { _log.LogWarning(ex, "MicPcmReceived (remote inject) handler threw"); }
+        }
+    }
+
     internal void DispatchInbound(ReadOnlyMemory<byte> frame)
     {
         if (frame.Length == 0)

--- a/Zeus.Server.Hosting/Zeus.Server.Hosting.csproj
+++ b/Zeus.Server.Hosting/Zeus.Server.Hosting.csproj
@@ -46,6 +46,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Concentus" Version="2.2.2" />
     <PackageReference Include="Konscious.Security.Cryptography.Argon2" Version="1.3.1" />
     <PackageReference Include="LiteDB" Version="5.0.20" />
     <PackageReference Include="QRCoder" Version="1.8.0" />

--- a/tests/Zeus.Server.Tests/RemoteMicAudioPipelineTests.cs
+++ b/tests/Zeus.Server.Tests/RemoteMicAudioPipelineTests.cs
@@ -1,0 +1,84 @@
+using System.Buffers.Binary;
+using Concentus;
+using Concentus.Enums;
+using Zeus.Server.Hosting.Remote;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// The remote voice path's decode core: Opus packets in → 960-sample, 20 ms,
+/// 48 kHz mono f32le blocks out (exactly what TxAudioIngest consumes). Round-trips
+/// real Opus through Concentus so the test exercises the actual decoder, not a
+/// stub. The SIPSorcery RTP receive + injection wiring is bench-verified live.
+/// </summary>
+public sealed class RemoteMicAudioPipelineTests
+{
+    private const int Fs = 48000;
+    private const int Frame = 960; // 20 ms
+
+    private static byte[] EncodeTone(IOpusEncoder enc, int frameIndex)
+    {
+        var pcm = new short[Frame];
+        for (int i = 0; i < Frame; i++)
+        {
+            int n = frameIndex * Frame + i;
+            pcm[i] = (short)(8000 * Math.Sin(2 * Math.PI * 440 * n / Fs));
+        }
+        var outBuf = new byte[4000];
+        int len = enc.Encode(pcm, Frame, outBuf, outBuf.Length);
+        return outBuf[..len];
+    }
+
+    [Fact]
+    public void DecodesOpusFrames_EmitsOne960SampleF32leBlockEach()
+    {
+        var enc = OpusCodecFactory.CreateEncoder(Fs, 1, OpusApplication.OPUS_APPLICATION_VOIP);
+        var blocks = new List<byte[]>();
+        var pipe = new RemoteMicAudioPipeline(b => blocks.Add(b.ToArray()));
+
+        // Three 20 ms frames → three full ingest blocks (encoder warm-up settles
+        // by the last, so the energy assertion is stable).
+        for (int f = 0; f < 3; f++)
+            pipe.Decode(EncodeTone(enc, f));
+
+        Assert.Equal(3, blocks.Count);
+        Assert.All(blocks, b => Assert.Equal(Frame * 4, b.Length));
+
+        // The last decoded block must carry the tone (Opus is lossy but preserves
+        // energy) — proves the short→f32le conversion and re-block are correct.
+        float peak = 0f;
+        var last = blocks[^1];
+        for (int i = 0; i < Frame; i++)
+        {
+            float s = BinaryPrimitives.ReadSingleLittleEndian(last.AsSpan(i * 4, 4));
+            peak = Math.Max(peak, Math.Abs(s));
+        }
+        Assert.True(peak > 0.05f, $"expected non-silent decode, peak={peak}");
+        // f32le range is normalised to [-1, 1].
+        Assert.True(peak <= 1.0f, $"sample out of range, peak={peak}");
+    }
+
+    [Fact]
+    public void EmptyPayload_EmitsNothing()
+    {
+        var blocks = new List<byte[]>();
+        var pipe = new RemoteMicAudioPipeline(b => blocks.Add(b.ToArray()));
+        pipe.Decode(ReadOnlySpan<byte>.Empty);
+        Assert.Empty(blocks);
+    }
+
+    [Fact]
+    public void DecodeLost_ConcealsWithoutThrowing_AndEmitsABlock()
+    {
+        var enc = OpusCodecFactory.CreateEncoder(Fs, 1, OpusApplication.OPUS_APPLICATION_VOIP);
+        var blocks = new List<byte[]>();
+        var pipe = new RemoteMicAudioPipeline(b => blocks.Add(b.ToArray()));
+
+        // Prime decoder state, then conceal a lost packet (PLC).
+        pipe.Decode(EncodeTone(enc, 0));
+        pipe.DecodeLost();
+
+        Assert.Equal(2, blocks.Count);
+        Assert.All(blocks, b => Assert.Equal(Frame * 4, b.Length));
+    }
+}

--- a/zeus-web/src/remote/connect.ts
+++ b/zeus-web/src/remote/connect.ts
@@ -39,6 +39,14 @@ export interface RemoteConnection {
    * over WebRTC when there is no same-origin backend — see api-tunnel.ts.
    */
   api: RTCDataChannel;
+  /**
+   * Enable/disable the voice-mic uplink (remote SSB/AM/FM TX). The first
+   * `true` lazily prompts for mic permission and swaps the live track into the
+   * pre-negotiated sendonly audio m-line (no renegotiation); subsequent calls
+   * just toggle it. Driven by MOX in remote-client.ts. Rejects if the mic is
+   * denied/unavailable — TX keying still works, just without voice audio.
+   */
+  setMicEnabled(on: boolean): Promise<void>;
   close(): void;
 }
 
@@ -110,8 +118,43 @@ async function establish(
   const pc = new RTCPeerConnection({ iceServers: opts.iceServers });
   const control = pc.createDataChannel('control'); // reliable, ordered
   const frames = pc.createDataChannel('frames', { ordered: false, maxRetransmits: 0 });
-  const api = pc.createDataChannel('api'); // reliable, ordered — read-only REST tunnel
+  const api = pc.createDataChannel('api'); // reliable, ordered — read-write REST tunnel
   if (opts.onFrame) frames.onmessage = (e: MessageEvent) => opts.onFrame!(e.data as ArrayBuffer);
+
+  // Sendonly Opus audio m-line for remote voice TX. Added up front so the offer
+  // carries m=audio (the radio answers recvonly), but getUserMedia is deferred
+  // until the operator actually keys: replaceTrack swaps the live mic into this
+  // sender with NO renegotiation, so an RX-only session never prompts for the
+  // mic. The browser encodes Opus natively — low latency, in-band FEC + PLC.
+  const audioSender = pc.addTransceiver('audio', { direction: 'sendonly' }).sender;
+  let micStream: MediaStream | null = null;
+  let micTrack: MediaStreamTrack | null = null;
+
+  const setMicEnabled = async (on: boolean): Promise<void> => {
+    if (on) {
+      if (!micTrack) {
+        // Raw mic — no browser AGC/echo-cancel/noise-suppression. The radio's TX
+        // chain (mic gain, leveler, CFC, VST, WDSP TXA) shapes the audio exactly
+        // as it does for a local operator; double-processing would muddy it.
+        micStream = await navigator.mediaDevices.getUserMedia({
+          audio: { channelCount: 1, echoCancellation: false, noiseSuppression: false, autoGainControl: false },
+        });
+        micTrack = micStream.getAudioTracks()[0] ?? null;
+        if (micTrack) await audioSender.replaceTrack(micTrack);
+      }
+      if (micTrack) micTrack.enabled = true;
+    } else if (micTrack) {
+      micTrack.enabled = false;
+    }
+  };
+
+  const stopMic = (): void => {
+    micTrack = null;
+    if (micStream) {
+      for (const t of micStream.getTracks()) t.stop();
+      micStream = null;
+    }
+  };
 
   const prover = new Spake2Plus('prover', CONTEXT, ID_PROVER, ID_VERIFIER);
   let outcome: Spake2Outcome | undefined;
@@ -161,7 +204,17 @@ async function establish(
   await pc.setRemoteDescription({ type: 'answer', sdp: answerSdp });
 
   await unlocked;
-  return { pc, frames, control, api, close: () => pc.close() };
+  return {
+    pc,
+    frames,
+    control,
+    api,
+    setMicEnabled,
+    close: () => {
+      stopMic();
+      pc.close();
+    },
+  };
 }
 
 // --- signalling transports -------------------------------------------------

--- a/zeus-web/src/remote/remote-client.ts
+++ b/zeus-web/src/remote/remote-client.ts
@@ -12,16 +12,18 @@
 // (dispatchServerFrame) — so panadapter / waterfall / meters / audio render
 // identically, just sourced over WebRTC.
 //
-// Scope: full native control. RX display + audio + meters stream over the frames
-// channel, and the read-write `/api/*` tunnel (api-tunnel.ts) carries the SPA's
-// control REST to the radio's loopback Kestrel — VFO/mode/band/filter/AGC/drive/
-// MOX/TUN, exactly as the desktop app does. The server gates the burn-zone
-// (PureSignal) + secrets and dead-man un-keys a dropped session. Voice-mic uplink
-// is the next phase (mic PCM stays WS-only for now). Deny-by-default holds:
-// nothing flows until connectViaBroker's SPAKE2+ password handshake unlocks.
+// Scope: full native control + voice TX. RX display + audio + meters stream over
+// the frames channel; the read-write `/api/*` tunnel (api-tunnel.ts) carries the
+// SPA's control REST to the radio's loopback Kestrel — VFO/mode/band/filter/AGC/
+// drive/MOX/TUN, exactly as the desktop app does; and a MOX-gated sendonly Opus
+// audio track carries the operator's mic for voice TX (see connect.ts /
+// RemoteMicAudioPipeline on the radio). The server gates the burn-zone
+// (PureSignal) + secrets and dead-man un-keys a dropped session. Deny-by-default
+// holds: nothing flows until connectViaBroker's SPAKE2+ password handshake unlocks.
 
 import { connectViaBroker, type RemoteConnection } from './connect';
 import { installApiTunnel, setApiChannel } from './api-tunnel';
+import { useTxStore } from '../state/tx-store';
 import {
   dispatchServerFrame,
   sendAudioStreamRequest,
@@ -73,10 +75,22 @@ export async function startRemoteClient(
     onFrame: (data) => dispatchServerFrame(data),
   });
 
-  // Hand the read-only API tunnel its live "api" channel so queued + future
-  // same-origin `/api/*` GETs flow to the radio's loopback Kestrel. The session
-  // is unlocked by the time connectViaBroker resolves (deny-by-default holds).
+  // Hand the read-write API tunnel its live "api" channel so queued + future
+  // same-origin `/api/*` requests (reads AND control writes) flow to the radio's
+  // loopback Kestrel. The session is unlocked by the time connectViaBroker
+  // resolves (deny-by-default holds).
   setApiChannel(conn.api);
+
+  // Voice-mic uplink: stream the operator's mic to the radio only while keyed
+  // (MOX). The first key lazily prompts for mic permission; thereafter it's an
+  // instant enable/disable. CW/RTTY/digital don't key MOX so the mic stays off.
+  // A denied/absent mic leaves TX keying fully working, just without voice audio.
+  const unsubMic = useTxStore.subscribe((s, prev) => {
+    if (s.moxOn === prev.moxOn) return;
+    void conn.setMicEnabled(s.moxOn).catch((e) => {
+      console.warn('[remote] voice mic uplink unavailable:', e);
+    });
+  });
 
   // Route the 2-byte stream-request control frames (0x21/0x22) over the WebRTC
   // control channel instead of the (absent) local websocket. Drop the override
@@ -96,6 +110,9 @@ export async function startRemoteClient(
       // Clear the tunnel channel and fail pending API requests so the UI gets a
       // network-style rejection rather than hanging on a dead session.
       setApiChannel(null);
+      // Stop driving the mic from MOX and release the capture (conn.close also
+      // stops the tracks; this unhooks the store subscription).
+      unsubMic();
     }
   });
 


### PR DESCRIPTION
## What

Phase 2 of remote operating. [#845](https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus/pull/845) gave a `?remote=<callsign>` session full control **including TX keying** (MOX/TUN/CW), but **voice** SSB/AM/FM TX had no audio path — mic PCM was WS-only. This adds a **WebRTC Opus audio track** so a remote operator's voice rides the **same TX chain** (mic gain → leveler → CFC → VST → WDSP TXA) as someone sitting at the desk.

## Browser (`connect.ts`, `remote-client.ts`)
- Adds a **sendonly Opus audio m-line** up front (offer carries `m=audio`; radio answers recvonly). `getUserMedia` is **deferred until the operator keys** — `replaceTrack` swaps the live mic in with **no renegotiation**, so an RX-only session never prompts for the mic.
- **Raw mic** (AGC / echo-cancel / noise-suppress off) so the radio's TX chain does the shaping, not the browser.
- **MOX-gated:** mic streams only while keyed; CW/RTTY/digital leave it off. A denied/absent mic leaves TX keying fully working, just without voice.

## Radio (`RemoteWebRtcSession`, `RemoteMicAudioPipeline`, `StreamingHub`)
- `MaybeWireRemoteVoice` attaches a recvonly Opus receiver **only when the offer carries audio**, so RX-only clients negotiate exactly as before (graceful).
- `RemoteMicAudioPipeline` (**Concentus**, pure-C# Opus) decodes inbound RTP to the front-end's **960-sample / 20 ms / 48 kHz mono f32le** cadence, with **single-packet PLC** across sequence gaps, and injects via `StreamingHub.InjectMicPcm` — the **same seam** a local `/ws` `0x20` mic frame uses. MOX + source arbitration downstream decide whether it reaches the air; deny-by-default holds (no audio before unlock).

## Safety
- No audio before SPAKE2+ unlock. Voice only injects post-unlock; TX still gated by MOX + the Phase 1 dead-man un-key.
- PureSignal arm remains remotely blocked (unchanged).

## Tests
- Opus round-trip decode → exactly one 960-sample f32le block per 20 ms frame, non-silent + in range; empty payload emits nothing; PLC conceals without throwing. Server suite green incl. `StreamingHub` + `TxAudioIngest`; frontend `npm run build` + `src/remote` tests green.
- ⚠️ **The live `getUserMedia` → Opus → real-radio voice path needs a bench test against hardware** (vitest/preview can't exercise mic/WebRTC). Recommend an on-air check: key SSB remotely, confirm clean audio + ALC, and that un-key/link-drop drops the carrier.

## New dependency
- `Concentus` 2.2.2 — pure-managed Opus, no native lib (cross-platform clean).