### PR TITLE
feat(web): render RX3+ live monitor panes from Receivers[] (multi-DDC)

### DIFF
--- a/zeus-web/src/components/MultiRxMonitorStrip.test.tsx
+++ b/zeus-web/src/components/MultiRxMonitorStrip.test.tsx
@@ -1,0 +1,85 @@
+/** @vitest-environment jsdom */
+
+import { createElement } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ReceiverDto } from '../api/client';
+import { useConnectionStore } from '../state/connection-store';
+import { render } from './meters/__tests__/harness';
+import { MultiRxMonitorStrip } from './MultiRxMonitorStrip';
+
+function rx(index: number, enabled: boolean): ReceiverDto {
+  return {
+    index,
+    enabled,
+    adcSource: 0,
+    vfoHz: 14_200_000 + index * 1_000_000,
+    mode: 'USB',
+    filterLowHz: 100,
+    filterHighHz: 2850,
+    filterPresetName: 'VAR1',
+    afGainDb: 0,
+    sampleRateHz: 192_000,
+  };
+}
+
+function setup(opts: { protocol?: 'P1' | 'P2' | null; receivers?: ReceiverDto[] }) {
+  useConnectionStore.setState({
+    status: 'Connected',
+    connectedProtocol: opts.protocol ?? 'P2',
+    receivers: opts.receivers ?? [rx(0, true)],
+  });
+}
+
+describe('MultiRxMonitorStrip', () => {
+  beforeEach(() => {
+    // jsdom has no WebGL2 — RxMonitorPane logs and bails out of renderer setup.
+    // Suppress the expected console.error so it doesn't pollute test output.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders nothing on a non-P2 connection even with RX3 enabled', () => {
+    setup({ protocol: 'P1', receivers: [rx(0, true), rx(1, true), rx(2, true)] });
+    const { container, unmount } = render(createElement(MultiRxMonitorStrip));
+    expect(container.querySelector('[data-multi-rx-strip]')).toBeNull();
+    unmount();
+  });
+
+  it('renders nothing when only RX1/RX2 are enabled', () => {
+    setup({ protocol: 'P2', receivers: [rx(0, true), rx(1, true)] });
+    const { container, unmount } = render(createElement(MultiRxMonitorStrip));
+    expect(container.querySelector('[data-multi-rx-strip]')).toBeNull();
+    unmount();
+  });
+
+  it('renders one monitor pane per enabled RX3+ receiver', () => {
+    setup({
+      protocol: 'P2',
+      receivers: [rx(0, true), rx(1, true), rx(2, true), rx(3, true)],
+    });
+    const { container, unmount } = render(createElement(MultiRxMonitorStrip));
+
+    const strip = container.querySelector('[data-multi-rx-strip]');
+    expect(strip).not.toBeNull();
+    // One pane (canvas) each for RX3 and RX4; RX1/RX2 live in HeroPanel, not here.
+    expect(container.querySelectorAll('canvas').length).toBe(2);
+    expect(container.textContent).toContain('RX3');
+    expect(container.textContent).toContain('RX4');
+    unmount();
+  });
+
+  it('skips a disabled extra receiver (contiguity gap is not rendered)', () => {
+    setup({
+      protocol: 'P2',
+      receivers: [rx(0, true), rx(1, true), rx(2, true), rx(3, false)],
+    });
+    const { container, unmount } = render(createElement(MultiRxMonitorStrip));
+    expect(container.querySelectorAll('canvas').length).toBe(1);
+    expect(container.textContent).toContain('RX3');
+    expect(container.textContent).not.toContain('RX4');
+    unmount();
+  });
+});

--- a/zeus-web/src/components/MultiRxMonitorStrip.tsx
+++ b/zeus-web/src/components/MultiRxMonitorStrip.tsx
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Strip of read-only live monitor panes for the multi-DDC RX3+ receivers. RX1
+// and RX2 keep their full interactive panadapter/waterfall in HeroPanel; this
+// strip appears only once the operator exposes a third receiver (Settings ->
+// RECEIVERS), and renders one RxMonitorPane per contiguous enabled RX3+.
+// Multi-DDC is a Protocol-2 feature, so the strip self-gates on a live P2 link.
+
+import { useConnectionStore } from '../state/connection-store';
+import { RxMonitorPane } from './RxMonitorPane';
+
+export function MultiRxMonitorStrip() {
+  const receivers = useConnectionStore((s) => s.receivers);
+  const status = useConnectionStore((s) => s.status);
+  const connectedProtocol = useConnectionStore((s) => s.connectedProtocol);
+
+  const connected = status === 'Connected';
+  const isP2 = connectedProtocol === 'P2';
+  // RX3+ = receiver index >= 2 that is enabled. RX1/RX2 render in HeroPanel.
+  const extraReceivers = receivers.filter((r) => r.index >= 2 && r.enabled);
+
+  if (!connected || !isP2 || extraReceivers.length === 0) return null;
+
+  return (
+    <div
+      data-multi-rx-strip
+      style={{
+        display: 'grid',
+        gridTemplateColumns: `repeat(${extraReceivers.length}, minmax(0, 1fr))`,
+        gap: 2,
+        width: '100%',
+        height: '100%',
+        minHeight: 0,
+      }}
+    >
+      {extraReceivers.map((r) => (
+        <div key={r.index} style={{ minWidth: 0, minHeight: 0 }}>
+          <RxMonitorPane rxIndex={r.index} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/zeus-web/src/components/RxMonitorPane.tsx
+++ b/zeus-web/src/components/RxMonitorPane.tsx
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Read-only live spectrum pane for a multi-DDC RX3+ receiver (rxId >= 2). It
+// reuses the proven WebGL pan renderer (gl/panadapter.ts) but with a stripped
+// draw path: the server frame's own trace is drawn anchored at its own centre,
+// with no view-centre glide, no zoom tween, no stitch normalisation, and no
+// tuning gestures or filter/passband overlays. Those all belong to the VFO-A/B
+// model that RX1/RX2 own; keeping RX3+ panes isolated means this component
+// cannot perturb the primary receivers' rendering in any way.
+//
+// Interactive tuning/filters for RX3+ are a follow-up; today these panes are
+// live monitors driven from StateDto.Receivers[] + the display store's `extra`
+// slices (selectDisplaySliceByRxId).
+
+import { useEffect, useRef, type CSSProperties } from 'react';
+import {
+  cancelPendingPanContextLoss,
+  createPanRenderer,
+  hexToRgbFloats,
+  schedulePanContextLoss,
+} from '../gl/panadapter';
+import { cancelDrawBusFrame, requestDrawBusFrame } from '../realtime/draw-bus';
+import {
+  registerFrameConsumer,
+  selectDisplaySliceByRxId,
+  useDisplayStore,
+} from '../state/display-store';
+import { useDisplaySettingsStore } from '../state/display-settings-store';
+import { useConnectionStore } from '../state/connection-store';
+
+type RxMonitorPaneProps = {
+  // 0-based receiver index. Intended for RX3+ (index >= 2); the rxId on the wire
+  // is the same value, so the display slice is selectDisplaySliceByRxId(state, rxIndex).
+  rxIndex: number;
+};
+
+export function RxMonitorPane({ rxIndex }: RxMonitorPaneProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  const receiver = useConnectionStore((s) =>
+    s.receivers.find((r) => r.index === rxIndex),
+  );
+  const vfoHz = receiver?.vfoHz ?? 0;
+  const mode = receiver?.mode ?? '';
+  const adcSource = receiver?.adcSource ?? 0;
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const container = containerRef.current;
+    if (!canvas || !container) return;
+
+    // Cancel any deferred context loss scheduled by a previous unmount so a
+    // quick remount reuses the canvas instead of tearing down a live context
+    // (mirrors Panadapter.tsx, #629).
+    cancelPendingPanContextLoss(canvas);
+
+    const gl = canvas.getContext('webgl2', {
+      antialias: true,
+      alpha: true,
+      premultipliedAlpha: true,
+    });
+    if (!gl) {
+      console.error('WebGL2 not available');
+      return;
+    }
+
+    // Tell the realtime client decoded spectrum frames are needed — ws-client
+    // skips decodeDisplayFrame entirely when no consumer is registered.
+    const releaseFrameConsumer = registerFrameConsumer();
+    const renderer = createPanRenderer(gl);
+
+    // The adopted trace is simply the latest server frame for this rxId. No
+    // anchor offset/scale: a monitor pane shows the captured spectrum centred,
+    // it does not glide or zoom with an animated view-centre.
+    let anchorPan: Float32Array | null = null;
+
+    let inViewport = true;
+    let pageVisible = !document.hidden;
+    const isActive = () => inViewport && pageVisible;
+
+    const redraw = () => {
+      if (!isActive() || !anchorPan) return;
+      const s = useDisplaySettingsStore.getState();
+      const { r, g, b } = hexToRgbFloats(s.rxTraceColor);
+      renderer.setTraceColor(r, g, b);
+      renderer.setPopMode(false, 0);
+      renderer.draw(anchorPan, s.dbMin, s.dbMax, 0, 1);
+    };
+    const requestRedraw = () => {
+      if (!isActive()) return;
+      requestDrawBusFrame(redraw);
+    };
+
+    const resize = () => {
+      const { width, height } = container.getBoundingClientRect();
+      // Clamp the backing store at DPR=1 — see Panadapter.tsx resize() for why
+      // sub-pixel AA on a single-pixel trace isn't worth the GPU cost.
+      const dpr = Math.min(1, window.devicePixelRatio || 1);
+      const w = Math.max(1, Math.round(width * dpr));
+      const h = Math.max(1, Math.round(height * dpr));
+      canvas.width = w;
+      canvas.height = h;
+      renderer.resize(w, h);
+      requestRedraw();
+    };
+
+    const ro = new ResizeObserver(resize);
+    ro.observe(container);
+    resize();
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) inViewport = e.isIntersecting;
+        if (isActive()) requestRedraw();
+      },
+      { threshold: 0 },
+    );
+    io.observe(container);
+    const onVisibilityChange = () => {
+      pageVisible = !document.hidden;
+      if (isActive()) requestRedraw();
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    let lastSeqDrawn = -1;
+    const unsub = useDisplayStore.subscribe((state) => {
+      const slice = selectDisplaySliceByRxId(state, rxIndex);
+      if (slice.lastSeq === 0 || slice.lastSeq === lastSeqDrawn) return;
+      lastSeqDrawn = slice.lastSeq;
+      if (slice.panValid && slice.panDb) anchorPan = slice.panDb;
+      requestRedraw();
+    });
+
+    // Repaint on dB-range / trace-colour changes without waiting for a frame.
+    const unsubSettings = useDisplaySettingsStore.subscribe((state, prev) => {
+      if (
+        state.dbMin !== prev.dbMin ||
+        state.dbMax !== prev.dbMax ||
+        state.rxTraceColor !== prev.rxTraceColor
+      ) {
+        requestRedraw();
+      }
+    });
+
+    return () => {
+      unsub();
+      unsubSettings();
+      ro.disconnect();
+      io.disconnect();
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      cancelDrawBusFrame(redraw);
+      renderer.dispose();
+      schedulePanContextLoss(canvas, gl);
+      releaseFrameConsumer();
+    };
+  }, [rxIndex]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="spectrum-canvas"
+      style={
+        {
+          position: 'relative',
+          minHeight: 0,
+          width: '100%',
+          height: '100%',
+          background: 'var(--spec-bg)',
+        } as CSSProperties
+      }
+    >
+      <canvas
+        ref={canvasRef}
+        style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }}
+      />
+      <div
+        className="pointer-events-none absolute z-[25] rounded-sm px-2 py-0.5 font-mono text-[10px]"
+        style={{
+          top: 6,
+          left: 8,
+          background: 'rgba(8, 10, 14, 0.78)',
+          color: 'var(--accent, #4a9eff)',
+          border: '1px solid rgba(255,255,255,0.16)',
+        }}
+      >
+        {`RX${rxIndex + 1}`}
+        {mode ? ` · ${mode}` : ''} · {(vfoHz / 1e6).toFixed(6)} · ADC{adcSource}
+      </div>
+    </div>
+  );
+}

--- a/zeus-web/src/layout/panels/HeroPanel.tsx
+++ b/zeus-web/src/layout/panels/HeroPanel.tsx
@@ -48,6 +48,7 @@ import type { MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent }
 import { GripVertical, X } from 'lucide-react';
 import { Panadapter } from '../../components/Panadapter';
 import { WaterfallSurface } from '../../components/WaterfallSurface';
+import { MultiRxMonitorStrip } from '../../components/MultiRxMonitorStrip';
 import { ZoomControl } from '../../components/ZoomControl';
 import { WaterfallSpeedControl } from '../../components/WaterfallSpeedControl';
 import { SpectrumControls } from '../../components/SpectrumControls';
@@ -126,6 +127,11 @@ export function HeroPanel({
   const connected = useConnectionStore((s) => s.status === 'Connected');
   const applyState = useConnectionStore((s) => s.applyState);
   const rx2Enabled = useConnectionStore((s) => s.rx2Enabled);
+  // Multi-DDC RX3+ (receiver index >= 2). When any are exposed, a strip of
+  // read-only monitor panes renders below the RX1/RX2 panadapter/waterfall.
+  const hasExtraRx = useConnectionStore((s) =>
+    s.receivers.some((r) => r.index >= 2 && r.enabled),
+  );
   const rx2AudioMode = useConnectionStore((s) => s.rx2AudioMode);
   const rxFocus = useConnectionStore((s) => s.rxFocus);
   const setRxFocus = useConnectionStore((s) => s.setRxFocus);
@@ -445,7 +451,9 @@ export function HeroPanel({
             position: 'absolute',
             inset: 0,
             display: 'grid',
-            gridTemplateRows: `${split}fr 8px ${1 - split}fr`,
+            gridTemplateRows: hasExtraRx
+              ? `${split}fr 8px ${1 - split}fr minmax(96px, 26%)`
+              : `${split}fr 8px ${1 - split}fr`,
             zIndex: 1,
           }}
         >
@@ -518,6 +526,11 @@ export function HeroPanel({
             ) : (
               <WaterfallSurface transparent={bgActive} />
             )
+          )}
+          {connected && hasExtraRx && (
+            <div style={{ minWidth: 0, minHeight: 0, overflow: 'hidden' }}>
+              <MultiRxMonitorStrip />
+            </div>
           )}
         </div>
       </div>


### PR DESCRIPTION
## What

Surfaces the multi-DDC RX3+ receivers on screen — the last piece of zeus-79qa. When the operator exposes a third receiver (Settings → RECEIVERS), a strip of **read-only live spectrum panes** appears below the RX1/RX2 panadapter/waterfall in HeroPanel, one pane per contiguous enabled RX3+, gated on a live Protocol-2 connection.

## Design — isolated, can't touch RX1/RX2

The `receiver: 'A'|'B'` model (VFO A/B) is woven through ~30 files (viewCenter, planner, stitch-normalizer, tuning gestures, filter/passband overlays). Rather than refactor all of that blind, RX3+ render through a **dedicated, isolated path**:

- **`RxMonitorPane`** reuses the proven WebGL pan renderer (`gl/panadapter`) with a stripped draw: the server frame for that `rxId` is drawn anchored at its own centre — no view-centre glide, no zoom tween, no stitch normalisation, no tuning gestures, no filter/passband overlays. Reads the display store's `extra` slices via `selectDisplaySliceByRxId` (from #850) and per-receiver VFO/mode/ADC from `StateDto.Receivers[]`.
- **`MultiRxMonitorStrip`** lays the panes out in a row and self-gates (P2 + connected + any RX3+ enabled). RX1/RX2-only layouts are byte-unchanged.
- **HeroPanel** adds a conditional bottom grid row only when RX3+ are exposed; the existing RX1/RX2 stitched grid path is otherwise untouched (`rxIndex` never enters it).

Interactive tuning/filters for RX3+ are a deliberate follow-up — today these are live monitors.

## Verification

- `npm run build` (tsc -b + vite) green; `eslint` clean on all changed files.
- 4 strip tests: non-P2 renders nothing, RX1/RX2-only renders nothing, one pane per enabled RX3+, disabled extra is skipped.
- The data path is already proven end-to-end except the final pixels: server emits RX3+ `DisplayFrame` (`RxId>=2`, verified live on the G2 in #848's session), ws-client decodes, `pushFrame` routes to `extra[]` (#850, unit-tested), and `RxMonitorPane` reads it.

⚠️ **Needs a real-browser eyeball:** the headless preview here can't render canvas/WebGL, so I could not visually confirm the trace draws or the strip layout looks right. Everything verifiable by build/lint/tests/live-API is green; the on-screen result is the one thing I couldn't check.

Completes the multi-DDC B4-UI series: #837 (server N-DDC) → #848 (RX3+ audio) → #850 (display-store routing) → this (RX3+ rendering).