### PR TITLE
feat(web): remove Waterfall Colormap section from Display settings

### DIFF
--- a/zeus-web/src/components/DisplayPanel.tsx
+++ b/zeus-web/src/components/DisplayPanel.tsx
@@ -18,7 +18,6 @@ import { BackgroundSettingsPanel } from './BackgroundSettingsPanel';
 import { SpectrumScaleSettingsPanel } from './SpectrumScaleSettingsPanel';
 import { ThemeSettingsPanel } from './ThemeSettingsPanel';
 import { TraceColorPanel } from './TraceColorPanel';
-import { WaterfallColormapPanel } from './WaterfallColormapPanel';
 
 export function DisplayPanel() {
   return (
@@ -27,7 +26,6 @@ export function DisplayPanel() {
       <BackgroundSettingsPanel />
       <TraceColorPanel />
       <SpectrumScaleSettingsPanel />
-      <WaterfallColormapPanel />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Removes the **Waterfall Colormap** picker from the Display settings panel per request.

- Drops the `WaterfallColormapPanel` render and its import from `DisplayPanel.tsx`.
- The waterfall continues to render with the colormap currently stored in the display-settings store; this only hides the picker UI.
- `WaterfallColormapPanel.tsx` is left in the tree (no longer referenced); can be deleted in a follow-up if desired.

## Test plan
- Open Display settings → confirm the Waterfall Colormap section no longer appears.
- Waterfall continues to render normally.