### PR TITLE
feat(about): in-app "User Manual" link in the About panel

### DIFF
--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -42,6 +42,21 @@ public static class ZeusEndpoints
             return Results.Ok(new { version });
         });
 
+        // Operator manual. The PDF is built fresh from docs/manual each release
+        // and bundled next to the host binary (release.yml `build-manual` job),
+        // so it resolves under AppContext.BaseDirectory on every platform —
+        // including inside the macOS .app bundle and the Linux AppImage, where
+        // it is otherwise unreachable. Served inline (no download disposition)
+        // so the About-panel link opens it in a new tab. Dev builds don't carry
+        // the PDF, so this 404s locally — the link simply does nothing then.
+        app.MapGet("/manual", () =>
+        {
+            var path = System.IO.Path.Combine(AppContext.BaseDirectory, "Zeus-Operator-Manual.pdf");
+            return System.IO.File.Exists(path)
+                ? Results.File(path, "application/pdf", enableRangeProcessing: true)
+                : Results.NotFound("Operator manual is not bundled in this build.");
+        });
+
         // Self-diagnostic "Report a problem" feature. The picker fetches the
         // symptom list; submitting a symptom + free text returns a redacted,
         // paste-ready report (Markdown + last-100 log lines) plus a prefilled

--- a/tests/Zeus.Server.Tests/ManualEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/ManualEndpointTests.cs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+//
+// Pins the GET /manual contract: the operator-manual PDF is built + bundled
+// only at release time (release.yml `build-manual` job), so it is absent from
+// the test host's base directory. The endpoint must 404 cleanly rather than
+// throw — the About-panel link relies on that graceful absence in dev builds.
+
+using System.Net;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Zeus.Server.Tests;
+
+public class ManualEndpointTests : IClassFixture<ManualEndpointTests.Factory>
+{
+    private readonly Factory _factory;
+    public ManualEndpointTests(Factory factory) => _factory = factory;
+
+    [Fact]
+    public async Task Manual_WhenPdfNotBundled_Returns404()
+    {
+        using var client = _factory.CreateClient();
+        var resp = await client.GetAsync("/manual");
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    public sealed class Factory : IsolatedPrefsFactory { }
+}

--- a/zeus-web/src/components/AboutPanel.tsx
+++ b/zeus-web/src/components/AboutPanel.tsx
@@ -203,6 +203,20 @@ export function AboutPanel() {
 
       <div style={{ marginBottom: 20, paddingTop: 20, borderTop: '1px solid var(--panel-border)' }}>
         <p style={{ margin: '0 0 12px 0', lineHeight: 1.6, color: 'var(--fg-1)' }}>
+          📖{' '}
+          {/* The manual PDF ships inside every installer; the backend serves it
+              at /manual (see ZeusEndpoints). Opens in a new tab — and is a no-op
+              in dev builds that don't bundle the PDF. */}
+          <a
+            href="/manual"
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: 'var(--accent)', textDecoration: 'underline', fontWeight: 600 }}
+          >
+            Open the User Manual (PDF)
+          </a>
+        </p>
+        <p style={{ margin: '0 0 12px 0', lineHeight: 1.6, color: 'var(--fg-1)' }}>
           OpenHPSDR Zeus is a cross-platform SDR client for OpenHPSDR Protocol-1 and Protocol-2 radios.
         </p>
         <p style={{ margin: '0 0 12px 0', lineHeight: 1.6, color: 'var(--fg-2)' }}>

--- a/zeus-web/vite.config.ts
+++ b/zeus-web/vite.config.ts
@@ -147,6 +147,10 @@ export default defineConfig({
     proxy: {
       '/api': `http://${backendHost}:${backendPort}`,
       '/ws': { target: `ws://${backendHost}:${backendPort}`, ws: true },
+      // Operator manual PDF (About panel → /manual). Same-origin in the real
+      // app/desktop builds; proxied here so the link also works under the Vite
+      // dev server.
+      '/manual': `http://${backendHost}:${backendPort}`,
     },
   },
   build: {


### PR DESCRIPTION
The operator manual PDF already ships in every v0.10.0 installer (release.yml bundles it next to the host binary), but users cannot realistically find it — it is buried inside the macOS `.app` bundle and the Linux AppImage, and has no Start-Menu shortcut on Windows. There was no in-app entry point.

## What this does
- Backend serves the bundled PDF at `GET /manual` from `AppContext.BaseDirectory` (resolves to the binary directory on every platform, incl. inside the `.app`/AppImage). Inline disposition so it opens in a new tab; **404s gracefully** in dev builds that do not carry the PDF.
- Adds an **"Open the User Manual (PDF)"** link to **Settings → About** (per KB2UKA request for placement).
- No `release.yml` change needed — packaging already copies the PDF into the publish dir, which is exactly `AppContext.BaseDirectory`.

## Tests / gates
- New `ManualEndpointTests`: `GET /manual` 404s cleanly when the PDF is absent (dev/test). Passing.
- `dotnet` build + frontend typecheck + build all green. PWA precache unchanged (PDF is not a Vite asset, so the service worker does not bloat).

Placement/styling is a maintainer-visual call — wired per the requested "About section" location; styling matches the existing About-panel links/tokens.