### PR TITLE
fix(p2): bind ephemeral local port when 1025 is taken (co-located radio)

### DIFF
--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -531,7 +531,30 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         var localBind = FindLocalAddressForSubnet(radioEndpoint.Address) ?? IPAddress.Any;
         // Matched port convention — PC binds 1025, radio sends back with source
         // ports 1025/1026/1027/1035.. which we demux by fromaddr.
-        sock.Bind(new IPEndPoint(localBind, 1025));
+        //
+        // Fall back to an ephemeral local port if 1025 is already taken. This
+        // happens when Zeus runs on the SAME host as the radio's network app —
+        // e.g. a Saturn/ANAN-G2 all-in-one where the on-board p2app already
+        // owns UDP 1025 — and the hard-coded bind would otherwise fail the
+        // whole P2 connect with EADDRINUSE (issue: 500 on /api/connect/p2,
+        // co-located radio). Every openHPSDR P2 radio streams its data back to
+        // the client's *source* port (p2app sets reply_addr.sin_port =
+        // sender's port and never overrides it per stream), so any local port
+        // works — we don't need 1025 to receive, only to send from. Separate-
+        // host setups keep 1025 and behave exactly as before.
+        int localPort = 1025;
+        try
+        {
+            sock.Bind(new IPEndPoint(localBind, 1025));
+        }
+        catch (SocketException ex) when (ex.SocketErrorCode == SocketError.AddressAlreadyInUse)
+        {
+            sock.Bind(new IPEndPoint(localBind, 0));
+            localPort = ((IPEndPoint)sock.LocalEndPoint!).Port;
+            _log.LogInformation(
+                "p2.connect local UDP 1025 in use (co-located radio app?) — bound ephemeral port {Port}",
+                localPort);
+        }
         // 4 MiB RX socket buffer. At 1536 kHz a single DDC pushes ~9.3 MB/s, and
         // with several DDCs streaming concurrently the kernel buffer must absorb
         // scheduling jitter without dropping datagrams. 4 MiB ≈ 110 ms of one
@@ -541,9 +564,10 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         catch (SocketException) { sock.ReceiveBufferSize = 1 << 20; }
         _sock = sock;
         _log.LogInformation(
-            "p2.connect radio={Radio} localBind={Local} localPort=1025",
+            "p2.connect radio={Radio} localBind={Local} localPort={Port}",
             radioEndpoint.Address,
-            localBind.Equals(IPAddress.Any) ? "ANY (no subnet match)" : localBind.ToString());
+            localBind.Equals(IPAddress.Any) ? "ANY (no subnet match)" : localBind.ToString(),
+            localPort);
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
## Problem

On a Saturn/ANAN-G2 **all-in-one** (the radio's own SBC runs both the on-board `p2app` *and* the Zeus client), `p2app` already binds UDP **1025**. Zeus's P2 client hard-coded `Bind(localBind, 1025)`, so the bind failed with `SocketException (98): Address already in use` → **HTTP 500 on `POST /api/connect/p2`**, with nothing usable in the browser console.

This was hit live on a Saturn Radxa-CM5 running `p2app` + Zeus desktop on one host.

## Fix

Try `1025` first (unchanged for the normal separate-host case); on `AddressAlreadyInUse`, fall back to an **ephemeral local port** (`Bind(localBind, 0)`).

This is safe because every openHPSDR P2 radio streams its data back to the **client's source port** — `p2app` sets `reply_addr.sin_port = addr_from.sin_port` and the `Out*.c` threads copy `reply_addr` verbatim with no per-stream port override. Zeus uses one socket for send+receive, so binding any port works; it never needed 1025 to *receive*, only to *send from*. Separate-host setups bind 1025 exactly as before — the fallback only triggers when 1025 is occupied.

Scope is limited to the RX control-socket bind; no TX / PA / PureSignal path is touched.

## Verification

On the Saturn Radxa-CM5 all-in-one (`p2app` holding 1024/1025):
- `POST /api/connect/p2` → **200** (was 500)
- Zeus binds an ephemeral local port (e.g. `…:38947`)
- **~2 MB/s of 192 kHz DDC IQ** flows from the co-located `p2app` to that port (measured via `/proc/net/dev` loopback delta; drops to idle on disconnect)

`dotnet build Zeus.Protocol2` clean (0 warnings/errors).