### PR TITLE
docs(g2-panel): document hardware PTT / rear-panel I/O mapping

### DIFF
--- a/docs/lessons/g2-front-panel.md
+++ b/docs/lessons/g2-front-panel.md
@@ -51,6 +51,41 @@ The G2-Ultra panel has **no PS push-button** (only a status LED), so the router
 has *no* code path that arms PureSignal. The KB2UKA no-auto-arm invariant is
 preserved structurally — `SetPs` is never reachable from panel input.
 
+## Hardware PTT / footswitch & rear-panel I/O (NOT the front panel)
+
+A footswitch, mic PTT, or grounded rear KEY jack is **not** an ANDROMEDA panel
+event — it is wired into the *radio*, which echoes the level back to the host.
+This path is independent of `G2FrontPanelService` and already complete:
+
+- **Protocol 1** — `Protocol1Client` reads the EP6 `C0[0]` bit-0 echo
+  (`PacketParser.ExtractHardwarePtt`) and raises `HardwarePttChanged`. The shaped
+  CW keyer output (`C0[2]`) is read separately (`ExtractCwKeyDown`) to drive the
+  local sidetone per dit/dah.
+- **Protocol 2** (G2 / G2-Ultra / OrionMkII family) — `Protocol2Client` decodes
+  the UDP-1025 hi-priority status byte 0 (bit 0 PTT-IN, bit 1 Dot, bit 2 Dash;
+  offsets mirror Thetis `network.c:689-716`) and raises `TelemetryReceived`.
+- **`ExternalPttService`** promotes either edge to MOX as `MoxSource.Hardware`
+  with a 250 ms CW hang, and drives the PTT-IN status lamp regardless of the
+  enable gate. `RadioSettingsPanel` exposes the live KEYED lamp, the
+  **Hardware PTT → MOX** opt-in toggle (`PttSettingsStore`, persisted), and the
+  hang readout.
+
+The enable gate **defaults OFF** (opt-in) — unlike Thetis, where the footswitch
+always keys. This is the deliberate floating-connector PTT-hang guard: a fresh
+install leaves the footswitch inert until the operator enables it in Radio
+Settings. A persisted ON flag only *arms* the gate across restarts; it never
+auto-keys (promotion is edge-triggered, never on connect).
+
+**User I/O (J16 / accessory lines)** is decoded read-only: the P2 hi-priority
+user ADCs (`UserAdc0..3`) and digital input byte are surfaced at
+`/api/radio/user-io/labels` and `/api/radio/dig-in` (G2 TX-disable = IO5,
+active-low). The **output / automation** side — driving open-collector outputs to
+key an external amp/sequencer on TX, or actually *blocking* TX on the Dig-In
+line — is intentionally **unarmed** (`ActionBindingsConfigured: false`,
+`TxInhibitBehaviorArmed: false`). That surface touches real PA-keying and TX
+interlocks, so it stays read-only until an explicit hardware-inhibit policy is
+enabled. See the follow-up issue rather than arming it from here.
+
 ## Mapped controls (full G2-Ultra parity)
 
 Default assignments follow Thetis's `MakeNewG2PanelDataset`.


### PR DESCRIPTION
Follow-up to #861. Documents the verified hardware-PTT / accessory-I/O mapping in the G2 front-panel lesson, answering "make sure the PTT and I/O ports are correctly mapped so we can use the hardware PTT button like Thetis."

## Finding (verified, no code change needed for the input path)

The footswitch / mic-PTT / rear KEY is wired into the **radio**, not the ANDROMEDA front panel — and the input path was already complete on develop:

| Path | Source |
|---|---|
| P1 hardware PTT | `Protocol1Client` reads EP6 `C0[0]` bit 0 (`PacketParser.ExtractHardwarePtt`) → `HardwarePttChanged` |
| P2 (G2-Ultra / OrionMkII) | `Protocol2Client` decodes UDP-1025 hi-pri byte 0 bit 0 `PttIn` (offsets mirror Thetis `network.c:689-716`) → `TelemetryReceived` |
| Promotion to MOX | `ExternalPttService` → `MoxSource.Hardware`, 250 ms CW hang, live PTT-IN lamp |
| UI | `RadioSettingsPanel` PTT-IN card: KEYED lamp + **Hardware PTT → MOX** opt-in toggle + hang readout |
| User I/O | `/api/radio/user-io/labels`, `/api/radio/dig-in` (G2 TX-disable = IO5, active-low) — read-only |

Difference from Thetis: the enable gate **defaults OFF** (opt-in) — the deliberate floating-connector PTT-hang guard. The operator enables it once in Radio Settings; it persists.

## Verified
- `Zeus.Protocol1.Tests` hardware-PTT: **7/7**
- `Zeus.Server.Tests` PTT / UserIO / HardwareKeying / MoxSource / DigIn: **34/34**

## Out of scope (flagged, not built)
The User-I/O **output/automation** side — driving open-collector outputs to key an external amp/sequencer on TX, and actually blocking TX on the Dig-In line — is intentionally unarmed (`ActionBindingsConfigured: false`, `TxInhibitBehaviorArmed: false`). Those touch real PA keying / TX interlocks, so they stay read-only pending an explicit hardware-inhibit policy. Tracked as zeus-aa56.