### PR TITLE
feat(vst): native Linux VST3 engine — in-process hosting, cross-platform scan, X11 editors

### DIFF
--- a/Zeus.Plugins.Host/Audio/IVstBridgeNative.cs
+++ b/Zeus.Plugins.Host/Audio/IVstBridgeNative.cs
@@ -50,7 +50,30 @@ public interface IVstBridgeNative
 
     /// <summary>True if the plugin's editor window is currently open.</summary>
     bool EditorIsOpen(nint handle);
+
+    /// <summary>
+    /// Enumerate the audio-effect classes in a VST3 file/bundle WITHOUT
+    /// activating them — the in-process plugin scanner. On <see cref="VstBridgeStatus.Ok"/>,
+    /// <paramref name="json"/> is a UTF-8 JSON array of
+    /// <c>{uid,name,category,vendor}</c> objects (empty array when the file
+    /// has no audio-effect class). Other status codes match <c>zvst_status_t</c>.
+    /// Defaulted so existing test fakes need no change; the production bridge
+    /// overrides it via <c>zvst_describe</c>.
+    /// </summary>
+    int Describe(string path, out string json)
+    {
+        json = "[]";
+        return VstBridgeStatus.NotImplemented;
+    }
 }
+
+/// <summary>
+/// One audio-effect class enumerated from a VST3 file by
+/// <see cref="IVstBridgeNative.Describe"/>. <see cref="Uid"/> is the class
+/// TUID string — the identifier that selects this exact sub-plugin when a
+/// single file (a "shell") hosts several.
+/// </summary>
+public sealed record VstPluginDescriptor(string Uid, string Name, string Category, string Vendor);
 
 /// <summary>
 /// Status codes returned by <see cref="IVstBridgeNative"/>. Mirror

--- a/Zeus.Plugins.Host/Audio/VstBridgeNative.cs
+++ b/Zeus.Plugins.Host/Audio/VstBridgeNative.cs
@@ -57,6 +57,48 @@ public sealed partial class VstBridgeNative : IVstBridgeNative
 
     public bool EditorIsOpen(nint handle) => zvst_editor_is_open(handle) != 0;
 
+    public int Describe(string path, out string json)
+    {
+        // 64 KiB holds a large shell file's worth of plugin metadata; the
+        // native side reports the full length so a rare overflow grows once.
+        var buf = new byte[64 * 1024];
+        int status = zvst_describe(path, buf, buf.Length, out int len);
+        if (status != VstBridgeStatus.Ok) { json = "[]"; return status; }
+        if (len > buf.Length)
+        {
+            buf = new byte[len + 1];
+            status = zvst_describe(path, buf, buf.Length, out len);
+            if (status != VstBridgeStatus.Ok) { json = "[]"; return status; }
+        }
+        int n = Math.Min(len, buf.Length);
+        json = System.Text.Encoding.UTF8.GetString(buf, 0, n);
+        return VstBridgeStatus.Ok;
+    }
+
+    /// <summary>
+    /// Convenience scan: <see cref="Describe"/> + JSON parse. Returns an empty
+    /// list on any failure (unloadable file, non-VST3, malformed JSON) so a
+    /// directory walk can skip a bad file without throwing.
+    /// </summary>
+    public static IReadOnlyList<VstPluginDescriptor> Scan(IVstBridgeNative bridge, string path)
+    {
+        try
+        {
+            if (bridge.Describe(path, out var json) != VstBridgeStatus.Ok) return [];
+            return System.Text.Json.JsonSerializer
+                       .Deserialize<List<VstPluginDescriptor>>(json, ScanJsonOpts) ?? [];
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    // JSON from the native scanner uses lower-case keys (uid/name/category/
+    // vendor); match them to the PascalCase record positionally, case-insensitive.
+    private static readonly System.Text.Json.JsonSerializerOptions ScanJsonOpts =
+        new() { PropertyNameCaseInsensitive = true };
+
     // --- P/Invoke imports ---------------------------------------------------
 
     [LibraryImport(LibraryName, EntryPoint = "zvst_init")]
@@ -85,4 +127,7 @@ public sealed partial class VstBridgeNative : IVstBridgeNative
 
     [LibraryImport(LibraryName, EntryPoint = "zvst_editor_is_open")]
     private static partial int zvst_editor_is_open(nint handle);
+
+    [LibraryImport(LibraryName, EntryPoint = "zvst_describe", StringMarshalling = StringMarshalling.Utf8)]
+    private static partial int zvst_describe(string path, [Out] byte[] outJson, int outCap, out int outLen);
 }

--- a/Zeus.Plugins.Host/VstDirectoryScanService.cs
+++ b/Zeus.Plugins.Host/VstDirectoryScanService.cs
@@ -298,37 +298,49 @@ public sealed class VstDirectoryScanService
     }
 
     /// <summary>
-    /// Hostable plugin candidates for one <c>.vst3</c> entry. With the in-process
-    /// bridge available (the normal runtime case) this asks the bridge to describe
-    /// the file — accepting it cross-platform and reading the real plugin name; an
-    /// empty result means the file can't be hosted HERE (wrong arch / not a VST3)
-    /// and is recorded as a skip. Without the bridge it falls back to the static
-    /// Windows-PE heuristic + filename. The in-process loader instantiates the
-    /// first audio-effect class, so a file yields one candidate (uid left null =
-    /// "load the first class"; shell sub-plugin selection awaits a load-by-uid ABI).
+    /// Hostable plugin candidates for one <c>.vst3</c> entry. Two layered checks:
+    /// the cheap static Windows-PE heuristic accepts a 64-bit Windows VST3 without
+    /// loading anything (and gives the skip reason for incompatible Windows files);
+    /// when it rejects a binary — which it always does for a Linux ELF / macOS
+    /// dylib VST3 — the in-process bridge (the actual host) is asked to describe
+    /// the file, and a non-empty result both confirms it is hostable on THIS
+    /// platform/arch and yields the real plugin name. The bridge also enriches the
+    /// display name on the Windows path when it can introspect the file. The
+    /// in-process loader instantiates the first audio-effect class, so a file
+    /// yields one candidate (uid null = "load the first class"; shell sub-plugin
+    /// selection awaits a load-by-uid ABI).
     /// </summary>
     private IReadOnlyList<VstCandidate> EnumerateVstCandidates(
         string entry, IVstBridgeNative? bridge, List<ScanError> errors, string fileName)
     {
         var vst3Abs = Path.GetFullPath(entry);
+
+        if (IsLoadableVst3(entry, out var reason))
+        {
+            var name = fileName;
+            if (bridge is not null)
+            {
+                var d = VstBridgeNative.Scan(bridge, vst3Abs);
+                if (d.Count > 0 && !string.IsNullOrWhiteSpace(d[0].Name)) name = d[0].Name;
+            }
+            return [new VstCandidate(vst3Abs, name, null)];
+        }
+
+        // PE heuristic rejected it — but it may be a Linux/macOS VST3 the bridge
+        // can host. The bridge IS what loads it in Native mode, so its verdict is
+        // authoritative for non-Windows binaries.
         if (bridge is not null)
         {
             var descs = VstBridgeNative.Scan(bridge, vst3Abs);
-            if (descs.Count == 0)
+            if (descs.Count > 0)
             {
-                errors.Add(new ScanError(entry, "skipped (not a hostable VST3 on this platform)"));
-                return [];
+                var name = string.IsNullOrWhiteSpace(descs[0].Name) ? fileName : descs[0].Name;
+                return [new VstCandidate(vst3Abs, name, null)];
             }
-            var d = descs[0];
-            var name = string.IsNullOrWhiteSpace(d.Name) ? fileName : d.Name;
-            return [new VstCandidate(vst3Abs, name, null)];
         }
-        if (!IsLoadableVst3(entry, out var reason))
-        {
-            errors.Add(new ScanError(entry, $"skipped (incompatible): {reason}"));
-            return [];
-        }
-        return [new VstCandidate(vst3Abs, fileName, null)];
+
+        errors.Add(new ScanError(entry, $"skipped (incompatible): {reason}"));
+        return [];
     }
 
     /// <summary>

--- a/Zeus.Plugins.Host/VstDirectoryScanService.cs
+++ b/Zeus.Plugins.Host/VstDirectoryScanService.cs
@@ -213,42 +213,43 @@ public sealed class VstDirectoryScanService
         var activeIds = new HashSet<string>(
             _manager.Active.Select(p => p.Loaded.Manifest.Id), StringComparer.Ordinal);
 
+        // The in-process bridge is the authoritative loadability check + metadata
+        // source on EVERY platform — it is exactly what hosts the plugin in Native
+        // mode. describe() loads the module and reads the factory, so it accepts a
+        // Linux ELF .vst3 / correct-arch bundle (which the Windows-PE heuristic
+        // below rejects) and yields the real plugin name. Falls back to the static
+        // PE heuristic only when the native bridge can't initialise (e.g. the
+        // library isn't staged in a CI/test layout).
+        var bridge = TryCreateScanBridge();
+
         foreach (var entry in entries)
         {
             ct.ThrowIfCancellationRequested();
-            var name = Path.GetFileNameWithoutExtension(entry.TrimEnd(
+            var fileName = Path.GetFileNameWithoutExtension(entry.TrimEnd(
                 Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
             try
             {
-                // Reject VSTs the engine can't host BEFORE registering them, so
-                // incompatible files never become dead "Bad Image" entries in the
-                // rack. Static check only — no plugin code is executed.
-                if (!IsLoadableVst3(entry, out var incompatReason))
+                var candidates = EnumerateVstCandidates(entry, bridge, errors, fileName);
+                if (candidates.Count == 0)
                 {
-                    errors.Add(new ScanError(entry, $"skipped (incompatible): {incompatReason}"));
-                    _log.LogInformation("Skipped incompatible VST '{Name}': {Reason}", name, incompatReason);
+                    _log.LogInformation("Skipped VST '{Name}' (not hostable on this platform)", fileName);
                     continue;
                 }
 
                 // Reference the VST in place — do NOT copy it. Many plugins ship
-                // as a thin .vst3 stub beside sibling payload DLLs / resources in
-                // their install dir (e.g. Clear.vst3 + Clear.dll + Clear.bin).
-                // Copying only the .vst3 strips those siblings, so LoadLibrary
-                // can't resolve the payload and the module fails to load
-                // (status=3 NotAVst3) even though the plugin is fine in a host
-                // that loads it from its install dir. We therefore store the
-                // ORIGINAL absolute path in the manifest; both the engine's
-                // load_chain and the in-process bridge honour a rooted vst3Path.
-                // Trade-off: if the operator moves/deletes the original file, the
-                // plugin stops loading — acceptable vs. silently breaking every
-                // stub-based plugin.
-                var vst3Abs = Path.GetFullPath(entry);
-
+                // as a thin .vst3 stub beside sibling payload libraries / resources
+                // in their install dir; copying only the .vst3 strips those siblings
+                // and the module then fails to load. The manifest carries the
+                // ORIGINAL absolute path; both the engine's load_chain and the
+                // in-process bridge honour a rooted vst3Path. Trade-off: moving or
+                // deleting the original breaks the plugin — acceptable vs. silently
+                // breaking every stub-based plugin.
+                foreach (var cand in candidates)
                 foreach (var routeInfo in routes)
                 {
-                    var routeName = routeInfo.DisplaySuffix is null ? name : $"{name} {routeInfo.DisplaySuffix}";
-                    var slot = ResolveSlot(routeInfo, name, vst3Abs);
-                    var id = UniqueId(name, usedIds, ResolveIdPrefix(routeInfo, slot));
+                    var routeName = routeInfo.DisplaySuffix is null ? cand.Name : $"{cand.Name} {routeInfo.DisplaySuffix}";
+                    var slot = ResolveSlot(routeInfo, cand.Name, cand.Vst3Abs);
+                    var id = UniqueId(cand.Name, usedIds, ResolveIdPrefix(routeInfo, slot));
                     usedIds.Add(id);
 
                     if (activeIds.Contains(id))
@@ -263,7 +264,7 @@ public sealed class VstDirectoryScanService
                     WriteStubAssembly(Path.Combine(pluginDir, StubAssemblyFile));
                     await File.WriteAllTextAsync(
                         Path.Combine(pluginDir, "plugin.json"),
-                        BuildManifestJson(id, routeName, vst3Abs, null, slot),
+                        BuildManifestJson(id, routeName, cand.Vst3Abs, cand.Uid, slot),
                         ct).ConfigureAwait(false);
 
                     await _manager.ActivateAsync(pluginDir, ct).ConfigureAwait(false);
@@ -279,6 +280,55 @@ public sealed class VstDirectoryScanService
         }
 
         return new ScanResult(directory, registered, skipped, errors);
+    }
+
+    private sealed record VstCandidate(string Vst3Abs, string Name, string? Uid);
+
+    private static IVstBridgeNative? TryCreateScanBridge()
+    {
+        try
+        {
+            var b = new VstBridgeNative();
+            return b.Init(VstBridgeAbi.Current) == VstBridgeStatus.Ok ? b : null;
+        }
+        catch
+        {
+            return null; // native lib absent (CI / unsupported layout) — use the heuristic
+        }
+    }
+
+    /// <summary>
+    /// Hostable plugin candidates for one <c>.vst3</c> entry. With the in-process
+    /// bridge available (the normal runtime case) this asks the bridge to describe
+    /// the file — accepting it cross-platform and reading the real plugin name; an
+    /// empty result means the file can't be hosted HERE (wrong arch / not a VST3)
+    /// and is recorded as a skip. Without the bridge it falls back to the static
+    /// Windows-PE heuristic + filename. The in-process loader instantiates the
+    /// first audio-effect class, so a file yields one candidate (uid left null =
+    /// "load the first class"; shell sub-plugin selection awaits a load-by-uid ABI).
+    /// </summary>
+    private IReadOnlyList<VstCandidate> EnumerateVstCandidates(
+        string entry, IVstBridgeNative? bridge, List<ScanError> errors, string fileName)
+    {
+        var vst3Abs = Path.GetFullPath(entry);
+        if (bridge is not null)
+        {
+            var descs = VstBridgeNative.Scan(bridge, vst3Abs);
+            if (descs.Count == 0)
+            {
+                errors.Add(new ScanError(entry, "skipped (not a hostable VST3 on this platform)"));
+                return [];
+            }
+            var d = descs[0];
+            var name = string.IsNullOrWhiteSpace(d.Name) ? fileName : d.Name;
+            return [new VstCandidate(vst3Abs, name, null)];
+        }
+        if (!IsLoadableVst3(entry, out var reason))
+        {
+            errors.Add(new ScanError(entry, $"skipped (incompatible): {reason}"));
+            return [];
+        }
+        return [new VstCandidate(vst3Abs, fileName, null)];
     }
 
     /// <summary>

--- a/Zeus.Server.Hosting/CapabilitiesService.cs
+++ b/Zeus.Server.Hosting/CapabilitiesService.cs
@@ -46,7 +46,7 @@ public sealed class CapabilitiesService
             Architecture: architecture,
             Version: version,
             LanHttpsUrls: lanHttpsUrls,
-            Features: new FeatureMatrix());
+            Features: new FeatureMatrix(Vst: VstSupported(), VstEditor: VstEditorSupported()));
 
         _shareOverLan = options.HostMode == ZeusHostMode.Desktop && options.ShareOverLan;
     }
@@ -79,6 +79,28 @@ public sealed class CapabilitiesService
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return "windows";
         return "unknown";
     }
+
+    // In-process VST3 hosting (libzeus-vst-bridge) ships for Windows, Linux and
+    // macOS — the realtime chain is platform-agnostic, so VST audio is available
+    // wherever the native bridge loads. The frontend uses this to expose the
+    // Audio Suite VST affordances instead of treating VST as Windows-only.
+    private static bool VstSupported()
+        => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+        || RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+        || RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+
+    // Plugin editors are native GUI windows: always available on Windows/macOS;
+    // on Linux only when a display server is reachable (the bridge opens an X11
+    // window — headless has nowhere to show it).
+    private static bool VstEditorSupported()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return true;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return true;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DISPLAY"))
+                || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WAYLAND_DISPLAY"));
+        return false;
+    }
 }
 
 // JSON shape returned by /api/capabilities. Property names land lower-case
@@ -93,4 +115,4 @@ public sealed record CapabilitiesSnapshot(
     IReadOnlyList<string> LanHttpsUrls,
     FeatureMatrix Features);
 
-public sealed record FeatureMatrix();
+public sealed record FeatureMatrix(bool Vst = false, bool VstEditor = false);

--- a/native/build.sh
+++ b/native/build.sh
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
-# native/build.sh — build libwdsp + libminiaudio and stage them for .NET.
+# native/build.sh — build libwdsp + libminiaudio + the VST3 host bridge and
+# stage them for .NET.
 #
 # Usage:
-#   ./native/build.sh                 # Release, auto-detect RID
+#   ./native/build.sh                 # Release, all targets, auto-detect RID
 #   ./native/build.sh Debug           # pass build type as arg
-#   ./native/build.sh Release wdsp    # build only WDSP (skip miniaudio)
-#   ./native/build.sh Release miniaudio # build only miniaudio (skip WDSP)
+#   ./native/build.sh Release wdsp    # build only WDSP
+#   ./native/build.sh Release miniaudio # build only miniaudio
+#   ./native/build.sh Release vstbridge # build only the VST3 host bridge
 #
-# Run from the repo root. Output goes to Zeus.Dsp/runtimes/<rid>/native/ so
-# `dotnet publish` / `NativeLibrary.Load("wdsp"|"miniaudio")` picks it up
-# automatically (no extra runtime config — same convention for both libs).
+# Run from the repo root. libwdsp / libminiaudio stage to
+# Zeus.Dsp/runtimes/<rid>/native/; the VST3 bridge stages to
+# Zeus.Plugins.Host/runtimes/<rid>/native/. NativeLibrary.Load picks each up
+# from its RID path automatically (no extra runtime config).
 
 set -euo pipefail
 
@@ -28,6 +31,7 @@ case "$(uname -s)" in
         esac
         WDSP_LIB="libwdsp.dylib"
         MA_LIB="libminiaudio.dylib"
+        VST_LIB="libzeus-vst-bridge.dylib"
         ;;
     Linux)
         case "$(uname -m)" in
@@ -37,6 +41,7 @@ case "$(uname -s)" in
         esac
         WDSP_LIB="libwdsp.so"
         MA_LIB="libminiaudio.so"
+        VST_LIB="libzeus-vst-bridge.so"
         ;;
     *)
         echo "Unsupported host OS: $(uname -s). Use cmake directly on Windows." >&2
@@ -46,6 +51,10 @@ esac
 
 DEST_DIR="${REPO_ROOT}/Zeus.Dsp/runtimes/${RID}/native"
 mkdir -p "${DEST_DIR}"
+
+# The VST3 host bridge stages next to the .NET plugin host (its loader,
+# VstBridgeNativeLoader, probes Zeus.Plugins.Host/runtimes/<rid>/native first).
+VST_DEST_DIR="${REPO_ROOT}/Zeus.Plugins.Host/runtimes/${RID}/native"
 
 build_wdsp() {
     local src="${SCRIPT_DIR}/wdsp"
@@ -71,10 +80,31 @@ build_miniaudio() {
     ls -lh "${DEST_DIR}/${MA_LIB}"
 }
 
+build_vstbridge() {
+    local src="${SCRIPT_DIR}/zeus-vst-bridge"
+    local build="${src}/build"
+    if [ ! -f "${src}/third_party/vst3sdk/pluginterfaces/vst/ivstcomponent.h" ]; then
+        echo "==> [vst-bridge] NOTE: vst3sdk submodule not initialised — CMake will"
+        echo "    build a STUB (loads, but hosts no real VST3). For real hosting run:"
+        echo "      git submodule update --init native/zeus-vst-bridge/third_party/vst3sdk"
+        echo "      git -C native/zeus-vst-bridge/third_party/vst3sdk \\"
+        echo "          submodule update --init base pluginterfaces public.sdk cmake"
+    fi
+    echo "==> [vst-bridge] Configuring (${BUILD_TYPE}, ${RID})"
+    cmake -S "${src}" -B "${build}" -DCMAKE_BUILD_TYPE="${BUILD_TYPE}"
+    echo "==> [vst-bridge] Building"
+    cmake --build "${build}" --config "${BUILD_TYPE}" --parallel
+    echo "==> [vst-bridge] Staging ${VST_LIB} -> ${VST_DEST_DIR}"
+    mkdir -p "${VST_DEST_DIR}"
+    cp "${build}/${VST_LIB}" "${VST_DEST_DIR}/${VST_LIB}"
+    ls -lh "${VST_DEST_DIR}/${VST_LIB}"
+}
+
 case "${WHICH}" in
     all)
         build_wdsp
         build_miniaudio
+        build_vstbridge
         ;;
     wdsp)
         build_wdsp
@@ -82,8 +112,11 @@ case "${WHICH}" in
     miniaudio|ma)
         build_miniaudio
         ;;
+    vstbridge|vst)
+        build_vstbridge
+        ;;
     *)
-        echo "Unknown target '${WHICH}'. Use: all | wdsp | miniaudio" >&2
+        echo "Unknown target '${WHICH}'. Use: all | wdsp | miniaudio | vstbridge" >&2
         exit 1
         ;;
 esac

--- a/native/zeus-vst-bridge/CMakeLists.txt
+++ b/native/zeus-vst-bridge/CMakeLists.txt
@@ -94,7 +94,11 @@ if(ZEUS_USE_VST3SDK)
             ${VST3SDK_DIR}/public.sdk/source/vst/hosting/module_mac.mm
             PROPERTIES COMPILE_FLAGS "-fobjc-arc")
     elseif(UNIX AND NOT APPLE)
-        target_link_libraries(zeus-vst-bridge PRIVATE dl pthread)
+        # X11 hosts the plug-in editor window + run loop on Linux (bridge.cpp,
+        # __linux__ path). find_package surfaces include dirs/libs portably.
+        find_package(X11 REQUIRED)
+        target_include_directories(zeus-vst-bridge PRIVATE ${X11_INCLUDE_DIR})
+        target_link_libraries(zeus-vst-bridge PRIVATE dl pthread ${X11_LIBRARIES})
     endif()
 
     if(WIN32)

--- a/native/zeus-vst-bridge/include/zvst.h
+++ b/native/zeus-vst-bridge/include/zvst.h
@@ -117,6 +117,27 @@ ZVST_EXPORT int32_t zvst_unload(zvst_handle_t handle);
  */
 ZVST_EXPORT int32_t zvst_shutdown(void);
 
+/*
+ * Enumerate the audio-effect classes inside a VST3 file/bundle WITHOUT
+ * activating them — the in-process engine's plugin scanner. `path` is a
+ * UTF-8 absolute path to a .vst3 bundle or flat file. On success writes a
+ * UTF-8 JSON array into `out_json` (always NUL-terminated, truncated to
+ * `out_cap - 1` bytes), and sets *out_len (if non-NULL) to the FULL length
+ * the JSON needed — so a caller that got truncated can re-call with a
+ * bigger buffer. Each element is an object:
+ *   {"uid":"...","name":"...","category":"...","vendor":"..."}
+ * where `uid` is the class TUID string (the identifier to pass back to
+ * load that exact sub-plugin from a shell file). Returns ZVST_OK even when
+ * the file has zero audio-effect classes (empty array), or a load error
+ * (ZVST_FILE_NOT_FOUND / ZVST_NOT_A_VST3). Forward-compatible addition
+ * under ABI v2 — a new entry point only; no existing signature changed.
+ */
+ZVST_EXPORT int32_t zvst_describe(
+    const char* path,
+    char* out_json,
+    int32_t out_cap,
+    int32_t* out_len);
+
 /* --- Editor (plug-in GUI) — ABI v2 -----------------------------------
  *
  * Open the plug-in's native editor (IPlugView) in a dedicated UI thread

--- a/native/zeus-vst-bridge/src/bridge.cpp
+++ b/native/zeus-vst-bridge/src/bridge.cpp
@@ -54,6 +54,22 @@
 #  include <ole2.h>    // OleInitialize / OleUninitialize (VSTGUI needs OLE)
 #endif
 
+// Editor (IPlugView) hosting on Linux — the plug-in GUI is embedded into an
+// X11 window we own, driven by a Steinberg Linux::IRunLoop the plug-in uses to
+// register its event-handler fds + timers (the X11 GUI contract). Runs on a
+// dedicated editor thread per plug-in so the window + run loop never touch the
+// realtime audio thread.
+#if defined(__linux__)
+#  include <X11/Xlib.h>
+#  include <X11/Xutil.h>
+#  include <poll.h>
+#  include <unistd.h>
+#  include <condition_variable>
+#  include <chrono>
+#  include <ctime>
+#  include <vector>
+#endif
+
 namespace vst = Steinberg::Vst;
 
 namespace {
@@ -79,12 +95,12 @@ std::atomic<int> g_init_count{0};
 struct LoadedPlugin;
 static void zvst_push_param_edit(LoadedPlugin* p, uint32_t param_id, double normalized);
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__linux__)
 // ---------------------------------------------------------------------
-// Editor (plug-in GUI) host support — Windows. Both helper objects have
-// *inert* reference counting (addRef/release return a constant): their
-// lifetime is owned by us (value members of LoadedPlugin that outlive the
-// view), not the plug-in.
+// Editor (plug-in GUI) host support — Windows + Linux. The component
+// handler has *inert* reference counting (addRef/release return a
+// constant): its lifetime is owned by us (a member of LoadedPlugin that
+// outlives the view), not the plug-in.
 // ---------------------------------------------------------------------
 
 // Component handler: the plug-in calls performEdit() on the UI thread
@@ -116,7 +132,9 @@ public:
     Steinberg::uint32 PLUGIN_API addRef() SMTG_OVERRIDE { return 1000; }
     Steinberg::uint32 PLUGIN_API release() SMTG_OVERRIDE { return 1000; }
 };
+#endif // _WIN32 || __linux__
 
+#ifdef _WIN32
 // Per-editor plug frame. Lets the plug-in ask the host to resize its
 // window (IPlugFrame::resizeView). Stored by value on LoadedPlugin.
 class ZeusPlugFrame : public Steinberg::IPlugFrame {
@@ -152,6 +170,83 @@ public:
     Steinberg::uint32 PLUGIN_API release() SMTG_OVERRIDE { return 1000; }
 };
 #endif // _WIN32
+
+#ifdef __linux__
+// Combined plug frame + Linux run loop. On Linux the plug-in queries the frame
+// for IRunLoop (the X11 GUI contract) and registers its own event-handler file
+// descriptors + timers here; the editor thread's poll loop services them. All
+// methods run on the editor thread, so the handler/timer vectors need no lock.
+// Inert refcount — owned by LoadedPlugin, outlives the view.
+class ZeusLinuxFrame : public Steinberg::IPlugFrame, public Steinberg::Linux::IRunLoop {
+public:
+    Display* display{nullptr};
+    Window   window{0};
+
+    struct EH { Steinberg::Linux::IEventHandler* h; int fd; };
+    struct TH { Steinberg::Linux::ITimerHandler* h; uint64_t intervalMs; uint64_t nextMs; };
+    std::vector<EH> handlers;
+    std::vector<TH> timers;
+
+    static uint64_t now_ms() {
+        struct timespec ts;
+        clock_gettime(CLOCK_MONOTONIC, &ts);
+        return static_cast<uint64_t>(ts.tv_sec) * 1000ull + static_cast<uint64_t>(ts.tv_nsec / 1000000ull);
+    }
+
+    // IPlugFrame: the plug-in asks us to resize its embedded window.
+    Steinberg::tresult PLUGIN_API resizeView(Steinberg::IPlugView* view,
+                                             Steinberg::ViewRect* r) SMTG_OVERRIDE {
+        if (!view || !r || !display || !window) return Steinberg::kResultFalse;
+        XResizeWindow(display, window,
+                      static_cast<unsigned>(std::max(1, r->getWidth())),
+                      static_cast<unsigned>(std::max(1, r->getHeight())));
+        XFlush(display);
+        view->onSize(r);
+        return Steinberg::kResultTrue;
+    }
+
+    // IRunLoop: the plug-in registers the fds + timers driving its own GUI.
+    Steinberg::tresult PLUGIN_API registerEventHandler(Steinberg::Linux::IEventHandler* h,
+                                                       Steinberg::Linux::FileDescriptor fd) SMTG_OVERRIDE {
+        if (!h) return Steinberg::kInvalidArgument;
+        handlers.push_back({h, fd});
+        return Steinberg::kResultOk;
+    }
+    Steinberg::tresult PLUGIN_API unregisterEventHandler(Steinberg::Linux::IEventHandler* h) SMTG_OVERRIDE {
+        for (auto it = handlers.begin(); it != handlers.end();)
+            it = (it->h == h) ? handlers.erase(it) : it + 1;
+        return Steinberg::kResultOk;
+    }
+    Steinberg::tresult PLUGIN_API registerTimer(Steinberg::Linux::ITimerHandler* h,
+                                                Steinberg::Linux::TimerInterval ms) SMTG_OVERRIDE {
+        if (!h) return Steinberg::kInvalidArgument;
+        if (ms == 0) ms = 1;
+        timers.push_back({h, ms, now_ms() + ms});
+        return Steinberg::kResultOk;
+    }
+    Steinberg::tresult PLUGIN_API unregisterTimer(Steinberg::Linux::ITimerHandler* h) SMTG_OVERRIDE {
+        for (auto it = timers.begin(); it != timers.end();)
+            it = (it->h == h) ? timers.erase(it) : it + 1;
+        return Steinberg::kResultOk;
+    }
+
+    Steinberg::tresult PLUGIN_API queryInterface(const Steinberg::TUID iid, void** obj) SMTG_OVERRIDE {
+        if (Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::FUnknown::iid) ||
+            Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::IPlugFrame::iid)) {
+            *obj = static_cast<Steinberg::IPlugFrame*>(this);
+            return Steinberg::kResultOk;
+        }
+        if (Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::Linux::IRunLoop::iid)) {
+            *obj = static_cast<Steinberg::Linux::IRunLoop*>(this);
+            return Steinberg::kResultOk;
+        }
+        *obj = nullptr;
+        return Steinberg::kNoInterface;
+    }
+    Steinberg::uint32 PLUGIN_API addRef() SMTG_OVERRIDE { return 1000; }
+    Steinberg::uint32 PLUGIN_API release() SMTG_OVERRIDE { return 1000; }
+};
+#endif // __linux__
 
 // Per-handle state. Owns one IComponent + IAudioProcessor, plus the
 // scratch ProcessData buffers sized at load time so the realtime path
@@ -220,6 +315,27 @@ struct LoadedPlugin {
     Steinberg::IPtr<Steinberg::IPlugView> view;
     ZeusPlugFrame                         plug_frame;
     ZeusComponentHandler                  component_handler;
+#elif defined(__linux__)
+    // The editor runs on a dedicated thread (lazily spawned on first open) so the
+    // X11 window + run loop never touch the realtime audio thread; the audio
+    // component stays loaded on the caller thread and process() is unaffected.
+    std::thread                           editor_thread;
+    std::atomic<bool>                     editor_thread_running{false};
+    std::atomic<bool>                     editor_open_flag{false};
+    std::string                           editor_title;
+    int                                   cmd_pipe[2]{-1, -1}; // wake the editor loop
+    std::mutex                            editor_cmd_mtx;
+    std::condition_variable               editor_cmd_cv;
+    int                                   editor_cmd{0};       // 1 open, 2 close, 3 unload
+    bool                                  editor_cmd_done{false};
+    int                                   editor_cmd_result{0};
+    ZeusComponentHandler                  component_handler;
+    // X11 + view state — touched only on the editor thread.
+    Display*                              x_display{nullptr};
+    Window                                x_window{0};
+    Atom                                  wm_delete{0};
+    Steinberg::IPtr<Steinberg::IPlugView> view;
+    ZeusLinuxFrame                        linux_frame;
 #endif
 };
 
@@ -709,6 +825,240 @@ static void ui_thread_main(LoadedPlugin* p) {
 }
 #endif // _WIN32
 
+#if defined(__linux__)
+// ---------------------------------------------------------------------
+// Editor (plug-in GUI) host support — Linux / X11. The plug-in's editor view
+// embeds in an X11 window we own, driven by ZeusLinuxFrame's IRunLoop. The
+// controller, view, window and run loop all live on a dedicated per-plugin
+// editor thread (lazily spawned on first open), so none of it ever touches the
+// realtime audio thread; audio still calls the processor directly.
+// ---------------------------------------------------------------------
+
+#define ZEDL_LOG(...) do { std::fprintf(stderr, "[zvst-editor:linux] " __VA_ARGS__); std::fprintf(stderr, "\n"); std::fflush(stderr); } while (0)
+
+// Connect component<->controller + push component state into the controller.
+// Parity with the Windows path; many plug-ins need this before createView()
+// succeeds. Only used on the separate-controller (2-object) path.
+static void linux_connect_and_sync(LoadedPlugin& p) {
+    using namespace Steinberg;
+    FUnknownPtr<vst::IConnectionPoint> ccp(p.component);
+    FUnknownPtr<vst::IConnectionPoint> ecp(p.controller);
+    if (ccp && ecp) { ccp->connect(ecp); ecp->connect(ccp); }
+    MemoryStream stream;
+    if (p.component->getState(&stream) == kResultOk) {
+        stream.seek(0, IBStream::kIBSeekSet, nullptr);
+        p.controller->setComponentState(&stream);
+    }
+}
+
+// Lazily create (or adopt) the edit controller — prefer the dedicated
+// controller class, fall back to a single-component effect.
+static bool linux_ensure_controller(LoadedPlugin& p) {
+    using namespace Steinberg;
+    if (p.controller) return true;
+    TUID cid;
+    if (p.component->getControllerClassId(cid) == kResultOk) {
+        auto& factory = p.module->getFactory();
+        auto ctrl = factory.createInstance<vst::IEditController>(VST3::UID::fromTUID(cid));
+        if (ctrl && ctrl->initialize(&GlobalHost::instance()) == kResultOk) {
+            p.controller = ctrl;
+            p.controller_is_separate = true;
+            linux_connect_and_sync(p);
+            return true;
+        }
+    }
+    vst::IEditController* raw = nullptr;
+    if (p.component->queryInterface(vst::IEditController::iid, reinterpret_cast<void**>(&raw)) == kResultOk && raw) {
+        p.controller = owned(raw);
+        p.controller_is_separate = false;
+        return true;
+    }
+    return false;
+}
+
+static void editor_close_on_thread(LoadedPlugin& p) {
+    if (!p.editor_open_flag.load() && !p.x_window && !p.view) return;
+    if (p.view) { p.view->setFrame(nullptr); p.view->removed(); p.view = nullptr; }
+    p.linux_frame.handlers.clear();
+    p.linux_frame.timers.clear();
+    p.linux_frame.window = 0;
+    if (p.x_window && p.x_display) { XDestroyWindow(p.x_display, p.x_window); XFlush(p.x_display); }
+    p.x_window = 0;
+    p.editor_open_flag.store(false);
+    ZEDL_LOG("editor closed");
+}
+
+static int editor_open_on_thread(LoadedPlugin& p) {
+    using namespace Steinberg;
+    if (p.editor_open_flag.load()) return 1;
+    if (!linux_ensure_controller(p)) { ZEDL_LOG("ensure_controller FAILED"); return 0; }
+    p.component_handler.owner = &p;
+    p.controller->setComponentHandler(&p.component_handler);
+
+    IPlugView* raw = p.controller->createView(vst::ViewType::kEditor);
+    if (!raw) { ZEDL_LOG("createView returned null"); return 0; }
+    p.view = owned(raw);
+    if (p.view->isPlatformTypeSupported(kPlatformTypeX11EmbedWindowID) != kResultTrue) {
+        ZEDL_LOG("plug-in does not support X11 embedding");
+        p.view = nullptr;
+        return 0;
+    }
+
+    ViewRect rect{};
+    p.view->getSize(&rect);
+    int w = rect.getWidth()  > 0 ? rect.getWidth()  : 800;
+    int h = rect.getHeight() > 0 ? rect.getHeight() : 600;
+
+    int screen = DefaultScreen(p.x_display);
+    Window root = RootWindow(p.x_display, screen);
+    p.x_window = XCreateSimpleWindow(p.x_display, root, 0, 0,
+                                     static_cast<unsigned>(w), static_cast<unsigned>(h), 0,
+                                     BlackPixel(p.x_display, screen), BlackPixel(p.x_display, screen));
+    if (!p.x_window) { p.view = nullptr; return 0; }
+    if (!p.editor_title.empty()) XStoreName(p.x_display, p.x_window, p.editor_title.c_str());
+    p.wm_delete = XInternAtom(p.x_display, "WM_DELETE_WINDOW", False);
+    XSetWMProtocols(p.x_display, p.x_window, &p.wm_delete, 1);
+    XSelectInput(p.x_display, p.x_window, StructureNotifyMask);
+
+    p.linux_frame.display = p.x_display;
+    p.linux_frame.window  = p.x_window;
+    p.view->setFrame(&p.linux_frame);
+
+    XMapWindow(p.x_display, p.x_window);
+    XFlush(p.x_display);
+
+    tresult att = p.view->attached(reinterpret_cast<void*>(static_cast<uintptr_t>(p.x_window)),
+                                   kPlatformTypeX11EmbedWindowID);
+    ZEDL_LOG("attached res=%d win=%lu %dx%d", static_cast<int>(att), static_cast<unsigned long>(p.x_window), w, h);
+    if (att != kResultOk) {
+        p.view->setFrame(nullptr);
+        XDestroyWindow(p.x_display, p.x_window);
+        p.x_window = 0; p.linux_frame.window = 0;
+        p.view = nullptr;
+        return 0;
+    }
+
+    // The plug-in may have resized itself during attached().
+    ViewRect cur{};
+    if (p.view->getSize(&cur) == kResultOk && cur.getWidth() > 0 && cur.getHeight() > 0)
+        XResizeWindow(p.x_display, p.x_window,
+                      static_cast<unsigned>(cur.getWidth()), static_cast<unsigned>(cur.getHeight()));
+    XFlush(p.x_display);
+    p.editor_open_flag.store(true);
+    ZEDL_LOG("editor shown");
+    return 1;
+}
+
+static void editor_teardown_on_thread(LoadedPlugin& p) {
+    editor_close_on_thread(p);
+    if (p.controller && p.controller_is_separate) {
+        p.controller->setComponentHandler(nullptr);
+        p.controller->terminate();
+    }
+    p.controller = nullptr;
+}
+
+// The persistent per-plugin editor thread: owns the X11 connection, services
+// open/close/unload commands, and pumps X events + the plug-in's registered
+// run-loop fds and timers.
+static void editor_thread_main(LoadedPlugin* p) {
+    p->x_display = XOpenDisplay(nullptr);
+    if (!p->x_display) {
+        ZEDL_LOG("XOpenDisplay failed (no DISPLAY?) — editor unavailable");
+        std::lock_guard<std::mutex> lk(p->editor_cmd_mtx);
+        p->editor_cmd_done = true;
+        p->editor_cmd_result = 0;
+        p->editor_cmd_cv.notify_all();
+        p->editor_thread_running.store(false);
+        return;
+    }
+    int xfd = ConnectionNumber(p->x_display);
+
+    for (;;) {
+        int cmd = 0;
+        { std::lock_guard<std::mutex> lk(p->editor_cmd_mtx); cmd = p->editor_cmd; p->editor_cmd = 0; }
+        if (cmd == 3) break; // unload
+        if (cmd == 1) {
+            int r = editor_open_on_thread(*p);
+            std::lock_guard<std::mutex> lk(p->editor_cmd_mtx);
+            p->editor_cmd_result = r; p->editor_cmd_done = true; p->editor_cmd_cv.notify_all();
+        } else if (cmd == 2) {
+            editor_close_on_thread(*p);
+            std::lock_guard<std::mutex> lk(p->editor_cmd_mtx);
+            p->editor_cmd_result = 1; p->editor_cmd_done = true; p->editor_cmd_cv.notify_all();
+        }
+
+        std::vector<struct pollfd> pfds;
+        pfds.push_back({p->cmd_pipe[0], POLLIN, 0});
+        pfds.push_back({xfd, POLLIN, 0});
+        for (auto& eh : p->linux_frame.handlers) pfds.push_back({eh.fd, POLLIN, 0});
+
+        int timeout = 1000;
+        uint64_t nowms = ZeusLinuxFrame::now_ms();
+        for (auto& t : p->linux_frame.timers) {
+            long d = static_cast<long>(t.nextMs - nowms);
+            if (d < 0) d = 0;
+            if (d < timeout) timeout = static_cast<int>(d);
+        }
+
+        poll(pfds.data(), static_cast<nfds_t>(pfds.size()), timeout);
+
+        if (pfds[0].revents & POLLIN) {
+            char b[64];
+            while (read(p->cmd_pipe[0], b, sizeof b) > 0) { }
+            continue; // re-read the command at the loop top
+        }
+
+        while (XPending(p->x_display)) {
+            XEvent ev; XNextEvent(p->x_display, &ev);
+            if (ev.type == ClientMessage &&
+                static_cast<Atom>(ev.xclient.data.l[0]) == p->wm_delete) {
+                editor_close_on_thread(*p);
+            }
+        }
+        for (size_t i = 2; i < pfds.size(); ++i) {
+            if (pfds[i].revents & POLLIN) {
+                int fd = pfds[i].fd;
+                for (auto& eh : p->linux_frame.handlers)
+                    if (eh.fd == fd) { eh.h->onFDIsSet(fd); break; }
+            }
+        }
+        nowms = ZeusLinuxFrame::now_ms();
+        for (auto& t : p->linux_frame.timers)
+            if (static_cast<long>(t.nextMs - nowms) <= 0) { t.h->onTimer(); t.nextMs = nowms + t.intervalMs; }
+    }
+
+    editor_teardown_on_thread(*p);
+    if (p->x_display) { XCloseDisplay(p->x_display); p->x_display = nullptr; }
+    p->editor_thread_running.store(false);
+}
+
+// Post a command to the editor thread and (except for unload) wait for it. Spawns
+// the thread on the first 'open'. Returns the command result (open: 1 shown / 0
+// failed). Control thread only.
+static int post_editor_cmd(LoadedPlugin& p, int cmd, int timeoutMs) {
+    if (!p.editor_thread_running.load()) {
+        if (cmd != 1) return 0; // only 'open' starts the thread
+        if (pipe(p.cmd_pipe) != 0) return 0;
+        p.editor_thread_running.store(true);
+        try { p.editor_thread = std::thread(editor_thread_main, &p); }
+        catch (...) {
+            p.editor_thread_running.store(false);
+            close(p.cmd_pipe[0]); close(p.cmd_pipe[1]);
+            p.cmd_pipe[0] = p.cmd_pipe[1] = -1;
+            return 0;
+        }
+    }
+    std::unique_lock<std::mutex> lk(p.editor_cmd_mtx);
+    p.editor_cmd = cmd; p.editor_cmd_done = false; p.editor_cmd_result = 0;
+    if (p.cmd_pipe[1] >= 0) { char c = 1; ssize_t n = write(p.cmd_pipe[1], &c, 1); (void)n; }
+    if (cmd == 3) return 1; // unload: the join in zvst_unload waits for exit
+    bool ok = p.editor_cmd_cv.wait_for(lk, std::chrono::milliseconds(timeoutMs),
+                                       [&] { return p.editor_cmd_done; });
+    return ok ? p.editor_cmd_result : 0;
+}
+#endif // __linux__
+
 } // namespace
 
 extern "C" {
@@ -858,6 +1208,18 @@ int32_t zvst_unload(zvst_handle_t handle) {
     if (p->ready_evt) { CloseHandle(p->ready_evt); p->ready_evt = nullptr; }
     delete p; // teardown() already ran on the UI thread
     return ZVST_OK;
+#elif defined(__linux__)
+    // Stop the editor thread first: it owns the controller + X11 window and
+    // terminates the controller itself (editor_teardown_on_thread), so the
+    // component teardown() below sees controller == null and won't double-free.
+    if (p->editor_thread_running.load()) {
+        post_editor_cmd(*p, 3, 0);
+        if (p->editor_thread.joinable()) p->editor_thread.join();
+    }
+    if (p->cmd_pipe[0] >= 0) { close(p->cmd_pipe[0]); close(p->cmd_pipe[1]); }
+    teardown(*p);
+    delete p;
+    return ZVST_OK;
 #else
     teardown(*p);
     delete p;
@@ -920,6 +1282,13 @@ int32_t zvst_editor_open(zvst_handle_t handle, const char* title) {
                                      0, 0, SMTO_NORMAL, 20000, &res);
     if (!ok) return ZVST_OTHER;            // timed out / UI thread hung
     return res ? ZVST_OK : ZVST_OTHER;     // res = editor_open_on_ui() result
+#elif defined(__linux__)
+    if (!handle) return ZVST_INVALID_HANDLE;
+    auto* p = static_cast<LoadedPlugin*>(handle);
+    p->editor_title = title ? title : "";
+    // Open synchronously on the editor thread (spawned on first call). 20 s budget
+    // mirrors the Windows path; a plug-in without a display or X11 support returns 0.
+    return post_editor_cmd(*p, 1, 20000) ? ZVST_OK : ZVST_OTHER;
 #else
     (void)handle; (void)title;
     return ZVST_NOT_IMPLEMENTED;
@@ -936,6 +1305,11 @@ int32_t zvst_editor_close(zvst_handle_t handle) {
                             SMTO_ABORTIFHUNG, 5000, &res);
     }
     return ZVST_OK;
+#elif defined(__linux__)
+    if (!handle) return ZVST_OK;
+    auto* p = static_cast<LoadedPlugin*>(handle);
+    if (p->editor_thread_running.load()) post_editor_cmd(*p, 2, 5000);
+    return ZVST_OK;
 #else
     (void)handle;
     return ZVST_OK;
@@ -947,6 +1321,9 @@ int32_t zvst_editor_is_open(zvst_handle_t handle) {
     if (!handle) return 0;
     auto* p = static_cast<LoadedPlugin*>(handle);
     return p->editor_open_flag.load() ? 1 : 0;
+#elif defined(__linux__)
+    if (!handle) return 0;
+    return static_cast<LoadedPlugin*>(handle)->editor_open_flag.load() ? 1 : 0;
 #else
     (void)handle;
     return 0;

--- a/native/zeus-vst-bridge/src/bridge.cpp
+++ b/native/zeus-vst-bridge/src/bridge.cpp
@@ -38,6 +38,7 @@
 #include <vector>
 #include <cstring>
 #include <cstdio>
+#include <algorithm>
 
 // Editor (IPlugView) hosting is Windows-only for now — the plug-in GUI
 // is a native window we create + message-pump on a dedicated thread.
@@ -231,6 +232,29 @@ static void zvst_push_param_edit(LoadedPlugin* p, uint32_t param_id, double norm
     std::lock_guard<std::mutex> lk(p->param_mtx);
     if (p->param_count < LoadedPlugin::kParamCap)
         p->param_buf[p->param_count++] = { param_id, normalized };
+}
+
+// Append `s` to `out` as a JSON string body (no surrounding quotes),
+// escaping the characters JSON requires. Used by zvst_describe to emit a
+// plugin-metadata array the .NET scanner parses.
+static void json_escape(const std::string& s, std::string& out) {
+    for (char c : s) {
+        switch (c) {
+            case '"':  out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\n': out += "\\n";  break;
+            case '\r': out += "\\r";  break;
+            case '\t': out += "\\t";  break;
+            default:
+                if (static_cast<unsigned char>(c) < 0x20) {
+                    char b[8];
+                    std::snprintf(b, sizeof b, "\\u%04x", static_cast<unsigned>(static_cast<unsigned char>(c)));
+                    out += b;
+                } else {
+                    out += c;
+                }
+        }
+    }
 }
 
 // Look up the first kVstAudioEffectClass in the factory.
@@ -843,6 +867,42 @@ int32_t zvst_unload(zvst_handle_t handle) {
 
 int32_t zvst_shutdown(void) {
     if (g_init_count.load() > 0) g_init_count.fetch_sub(1);
+    return ZVST_OK;
+}
+
+int32_t zvst_describe(const char* path, char* out_json, int32_t out_cap, int32_t* out_len) {
+    if (out_len) *out_len = 0;
+    if (!path || !out_json || out_cap < 1) return ZVST_INVALID_ARGUMENTS;
+
+    std::string err;
+    auto module = VST3::Hosting::Module::create(path, err);
+    if (!module) {
+        // Mirror do_load's distinction: a readable file that isn't a valid
+        // VST3 is NOT_A_VST3; an unreadable path is FILE_NOT_FOUND.
+        FILE* probe = std::fopen(path, "rb");
+        if (probe) { std::fclose(probe); return ZVST_NOT_A_VST3; }
+        return ZVST_FILE_NOT_FOUND;
+    }
+
+    std::string json = "[";
+    bool first = true;
+    for (const auto& ci : module->getFactory().classInfos()) {
+        if (ci.category() != kVstAudioEffectClass) continue; // hosts effects only
+        if (!first) json += ",";
+        first = false;
+        std::string esc;
+        json += "{\"uid\":\"";      esc.clear(); json_escape(ci.ID().toString(), esc);    json += esc;
+        json += "\",\"name\":\"";   esc.clear(); json_escape(ci.name(), esc);             json += esc;
+        json += "\",\"category\":\""; esc.clear(); json_escape(ci.subCategoriesString(), esc); json += esc;
+        json += "\",\"vendor\":\"";  esc.clear(); json_escape(ci.vendor(), esc);           json += esc;
+        json += "\"}";
+    }
+    json += "]";
+
+    if (out_len) *out_len = static_cast<int32_t>(json.size());
+    int32_t n = static_cast<int32_t>(std::min<size_t>(json.size(), static_cast<size_t>(out_cap) - 1));
+    std::memcpy(out_json, json.data(), static_cast<size_t>(n));
+    out_json[n] = '\0';
     return ZVST_OK;
 }
 


### PR DESCRIPTION
## What

Makes Zeus host **VST3 plugins natively on Linux** (verified on a Radxa CM5 / aarch64), building on the in-process bridge (`libzeus-vst-bridge.so`) rather than the Windows-only out-of-process engine (`VSTHostEngine.exe`, which stays Windows-only). In-process = lowest latency, no IPC — the performant path.

## Stages (each built + tested on arm64)

1. **`zvst_describe`** native scan entry point — enumerates a `.vst3`'s audio-effect classes (uid/name/category/vendor) without activating them. Forward-compatible ABI v2 addition.
2. **P/Invoke + `Scan()`** in `VstBridgeNative` (default interface method so test fakes are unaffected).
3. **Cross-platform scan**: `VstDirectoryScanService` keeps the Windows-PE static check as the fast path and consults the in-process bridge's `describe` to additionally accept **Linux ELF / macOS dylib** VST3s and enrich plugin names. `CapabilitiesService` now reports `features.vst` (in-process hosting, all desktop OSes) and `features.vstEditor` (Windows/macOS always; Linux when a display server is present).
4. **Linux X11 editor** in the native bridge: `zvst_editor_open/close/is_open` embed the plug-in's `IPlugView` in a host-owned X11 window driven by a Steinberg `Linux::IRunLoop` (`ZeusLinuxFrame`) that services the plug-in's registered fds + timers and pumps X events. Runs on a lazily-spawned per-plugin editor thread so the realtime audio path is untouched. CMake links X11.
5. **Reproducible build**: `native/build.sh` now builds + stages the bridge into `Zeus.Plugins.Host/runtimes/<rid>/native`.

## Verification (Radxa CM5, aarch64, .NET 10)

- Native bridge builds real (with vst3sdk) on arm64; all `zvst_*` symbols exported.
- `Zeus.slnx` builds clean (0 errors).
- `Zeus.Plugins.Host.Tests` VST filter: **34 passed**, 7 skipped, 0 failed.
- `Zeus.Server.Tests` capabilities/VST/editor filter: **96 passed**, 0 failed.
- Headless server: `/api/capabilities` → `features.vst=true`, `vstEditor=false` (no DISPLAY headless — correct; true on the panel's X session). `libzeus-vst-bridge.so` loads.

## Not yet verified / follow-ups

- **No real arm64 Linux VST3 plug-in was available on the test box**, so the full runtime scan→load→process→**editor** flow (especially the X11 GUI on the panel's display) is **compiled + unit-verified but not exercised against a real plug-in**. Needs a GUI VST3 on a graphical session to confirm.
- The in-process loader instantiates a file's first audio-effect class; shell sub-plugin selection by uid awaits a load-by-uid ABI addition.
- Frontend already shows VST UI cross-platform (no platform gate); it doesn't yet *consume* the new `features.vst*` fields (capabilities parser drops the matrix by design until the plugin system lands).

In-process hosting trades crash isolation for latency: a misbehaving plug-in can take down the server. This was the chosen model (max performance).