### PR TITLE
fix(audio): wire ANAN-10E line-in select + gain on P1 (#667)

### DIFF
--- a/Zeus.Contracts/TxAudioSource.cs
+++ b/Zeus.Contracts/TxAudioSource.cs
@@ -47,9 +47,12 @@ public enum TxAudioSource : byte
     RadioMic = 1,
 
     /// <summary>The radio's analog 3.5 mm line-in jack. Honours the per-source
-    /// 0..31 <c>LineInGain</c>. Offered on ANAN-200D and the 0x0A Saturn family
-    /// only (Zeus has no P1 radio-mic receive path in v1, so pure-P1 codec
-    /// boards do not expose it — §6 deviation note).</summary>
+    /// 0..31 <c>LineInGain</c>. Offered on ANAN-200D, the 0x0A Saturn family, and
+    /// the ANAN-10E (HermesII, issue #667) — the 10E's TLV320 codec carries
+    /// line-in on P1 via the 0x12 select bit + 0x14 gain frame (board-gated in
+    /// ControlFrame / ExternalPortEncoder). Other pure-P1 codec boards do not
+    /// expose it (Zeus has no P1 radio-mic receive path in v1 — §6 deviation
+    /// note).</summary>
     RadioLineIn = 2,
 
     /// <summary>The radio's balanced XLR microphone input. Switchable on the

--- a/Zeus.Protocol1/ControlFrame.cs
+++ b/Zeus.Protocol1/ControlFrame.cs
@@ -435,6 +435,20 @@ internal static class ControlFrame
             c14[1] |= (byte)(s.LineInGain & 0x1F);
         }
 
+        // ANAN-10E line-in (HermesII, issue #667). The 10E TLV320 codec carries
+        // its line-in gain on this SAME register-0x0a / wire-0x14 frame at
+        // C2[4:0] — identical wire layout to HL2 (Thetis networkproto1.c). Unlike
+        // HL2 the 10E does NOT carry puresignal_run here (C2[6] is HL2-only,
+        // below; ANAN-class PS lives on a different wire path) and has no
+        // mic_trs / mic_bias jack, so C1 stays 0. RadioService gates s.LineInGain
+        // to non-zero ONLY when line-in is the active source, so at default Host
+        // this emits 0 → byte-identical to today on the 10E. Board-gated to
+        // HermesII so no other Hermes / ANAN board's 0x14 frame changes.
+        if (s.Board == HpsdrBoardKind.HermesII)
+        {
+            c14[1] |= (byte)(s.LineInGain & 0x1F);
+        }
+
         // HL2 PureSignal: register 0x0a bit 22 = puresignal_run. Bit 22 lives
         // in C2 bit 6 (22 - 16 = 6) of this same C0=0x14 frame. mi0bot
         // networkproto1.c:1102 — `C2 = (line_in_gain & 0b00011111) |

--- a/Zeus.Server.Hosting/ExternalPortEncoder.cs
+++ b/Zeus.Server.Hosting/ExternalPortEncoder.cs
@@ -196,9 +196,19 @@ public sealed class Protocol1PortEncoder : IExternalPortEncoder
         => 0;
 
     public (bool MicBoost, bool MicLineIn) EncodeP1CodecAudioBits(in ExternalPortState state)
+    {
+        // ANAN-10E (HermesII, issue #667): the TLV320 codec line-in IS reachable
+        // on P1 — mic_linein select rides the 0x12 frame C2[1] and the 0..31 gain
+        // rides the 0x14 frame (board-gated in ControlFrame). Gated to HermesII
+        // here so NO other P1 codec board (e.g. ANAN-200D) changes its wire
+        // output: RadioLineIn stays a no-op select for them, exactly as before.
+        if (_board == HpsdrBoardKind.HermesII && state.Source == TxAudioSource.RadioLineIn)
+            return (MicBoost: false, MicLineIn: true);
+
         // Pure function of Source: RadioMic → mic_boost; Host / everything else
         // → all clear (no param leak).
-        => ExternalPortAudio.P1CodecAudioBits(state.Source, state.MicBoost);
+        return ExternalPortAudio.P1CodecAudioBits(state.Source, state.MicBoost);
+    }
 }
 
 /// <summary>

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -2455,12 +2455,16 @@ public sealed class RadioService : IDisposable
         // mic_trs / mic_bias / line_in_gain (HL2 0x14) stay clear in v1 (the HL2
         // mic front-end is inert plumbing), so the host pipeline is unchanged.
         var (p1Boost, p1LineIn) = encoder.EncodeP1CodecAudioBits(in portState);
+        // ANAN-10E line-in (issue #667): when the encoder selected line-in
+        // (HermesII only — p1LineIn is false on every other P1 board), forward
+        // the 0..31 gain so ControlFrame can place it on the 0x14 frame. The gain
+        // stays 0 for all other sources/boards → byte-identical to today.
         ActiveClient?.SetAudioFrontEnd(
             micBoost: p1Boost,
             micLineIn: p1LineIn,
             micTrs: false,
             micBias: false,
-            lineInGain: 0);
+            lineInGain: p1LineIn ? resolved.LineInGain : 0);
 
         // P2 (0x0A Saturn family): forward the resolved literal byte-50
         // mic_control + byte-51 line_in_gain to the live Protocol2Client via

--- a/tests/Zeus.Protocol1.Tests/ControlFrameAudioEncoderTests.cs
+++ b/tests/Zeus.Protocol1.Tests/ControlFrameAudioEncoderTests.cs
@@ -182,6 +182,45 @@ public class ControlFrameAudioEncoderTests
         Assert.Equal(0x00, cc[2] & (1 << 6));
     }
 
+    // ---- (c) ANAN-10E (HermesII) line-in — issue #667 ----------------------
+
+    private static ControlFrame.CcState Hermes2() =>
+        Hermes() with { Board = HpsdrBoardKind.HermesII };
+
+    [Fact]
+    public void DriveFilter_Anan10E_LineInSelect_LandsInC2Bit1()
+    {
+        // 10E RadioLineIn → mic_linein select on the 0x12 frame C2[1].
+        var cc = Frame(ControlFrame.CcRegister.DriveFilter, Hermes2() with { MicLineIn = true });
+        Assert.Equal(0x12, cc[0]);
+        Assert.Equal(0x02, cc[2] & 0x02);
+    }
+
+    [Theory]
+    [InlineData(0, 0x00)]
+    [InlineData(17, 0x11)]
+    [InlineData(31, 0x1F)]
+    [InlineData(63, 0x1F)] // clamps to the 5-bit field
+    public void Attenuator_Anan10E_LineInGain_LandsInC2LowFiveBits(int gain, byte expectedLow)
+    {
+        // 10E line-in gain rides the 0x14 frame C2[4:0], same layout as HL2.
+        var cc = Frame(ControlFrame.CcRegister.Attenuator, Hermes2() with { LineInGain = (byte)gain });
+        Assert.Equal(0x14, cc[0]);
+        Assert.Equal(expectedLow, (byte)(cc[2] & 0x1F));
+        // The 10E does NOT carry puresignal_run here — C2[6] stays clear.
+        Assert.Equal(0x00, cc[2] & (1 << 6));
+    }
+
+    [Fact]
+    public void Attenuator_NonAnan10E_LineInGain_IsNotEmitted()
+    {
+        // Board-gating: a pure Hermes (non-HL2, non-10E) with a stale LineInGain
+        // must NOT emit it — C2 stays zero, byte-identical to today. Proves the
+        // 0x14 gain change is confined to the 10E and never moves another board.
+        var cc = Frame(ControlFrame.CcRegister.Attenuator, Hermes() with { LineInGain = 0x1F });
+        Assert.Equal(0x00, cc[2]);
+    }
+
     // ---- CRUX: audio writes must NOT disturb PureSignal or step-atten ------
 
     [Fact]

--- a/tests/Zeus.Server.Tests/ExternalPortEncoderTests.cs
+++ b/tests/Zeus.Server.Tests/ExternalPortEncoderTests.cs
@@ -212,6 +212,30 @@ public class ExternalPortEncoderTests
     }
 
     [Fact]
+    public void P1Encoder_Anan10E_RadioLineIn_AssertsMicLineInSelect()
+    {
+        // ANAN-10E (HermesII, issue #667): RadioLineIn selects the TLV320 line-in
+        // via mic_linein (0x12 frame C2[1]); the 0..31 gain rides the 0x14 frame.
+        var encoder = ExternalPortEncoders.For(HpsdrBoardKind.HermesII);
+        var state = new ExternalPortState(Source: TxAudioSource.RadioLineIn, LineInGain: 17);
+        var (boost, lineIn) = encoder.EncodeP1CodecAudioBits(in state);
+        Assert.False(boost);
+        Assert.True(lineIn);
+    }
+
+    [Fact]
+    public void P1Encoder_RadioLineIn_IsBoardGatedToAnan10E()
+    {
+        // The line-in select is 10E-ONLY: the SAME Protocol1PortEncoder on a pure
+        // Hermes board must NOT assert mic_linein, so no other P1 codec board's
+        // wire output changes.
+        var encoder = ExternalPortEncoders.For(HpsdrBoardKind.Hermes);
+        var state = new ExternalPortState(Source: TxAudioSource.RadioLineIn, LineInGain: 17);
+        var (_, lineIn) = encoder.EncodeP1CodecAudioBits(in state);
+        Assert.False(lineIn);
+    }
+
+    [Fact]
     public void Hl2Encoder_AllAudioSurfaces_AreZero_HostOnly()
     {
         // HL2 is Host-only — no codec audio bits, no P2 bytes, ever.
@@ -246,6 +270,20 @@ public class ExternalPortEncoderTests
         var got = RadioService.ClampAudioSource(
             new AudioSourceSelection(TxAudioSource.RadioLineIn, false, false, 12), caps);
         Assert.Equal(TxAudioSource.Host, got.Source);
+    }
+
+    [Fact]
+    public void Clamp_LineIn_OnAnan10E_SurvivesWithGain()
+    {
+        // ANAN-10E (HermesII, issue #667) now exposes line-in: the persisted
+        // selection survives the clamp and keeps its 0..31 gain; mic params drop.
+        var caps = BoardCapabilitiesTable.For(HpsdrBoardKind.HermesII);
+        var got = RadioService.ClampAudioSource(
+            new AudioSourceSelection(TxAudioSource.RadioLineIn, MicBoost: true, MicBias: true, LineInGain: 21), caps);
+        Assert.Equal(TxAudioSource.RadioLineIn, got.Source);
+        Assert.Equal((byte)21, got.LineInGain);
+        Assert.False(got.MicBoost);
+        Assert.False(got.MicBias);
     }
 
     [Fact]

--- a/zeus-web/src/api/board-capabilities.ts
+++ b/zeus-web/src/api/board-capabilities.ts
@@ -52,7 +52,10 @@ export interface BoardCapabilities {
   hasOnboardCodec: boolean;
   /** Hermes-Lite 2 0x14-frame mic front-end (inert plumbing in v1). */
   hermesLite2MicFrontEnd: boolean;
-  /** Board has a switchable analog line-in jack (gates RadioLineIn). */
+  /** Board has a switchable analog line-in jack (gates RadioLineIn). True for
+   *  ANAN-200D, the 0x0A Saturn family, and the ANAN-10E (HermesII, issue #667);
+   *  false for the remaining Hermes-class P1, ANAN-G2E, Metis, HL2. Gates the
+   *  Line-In source option + its gain slider. */
   hasRadioLineIn: boolean;
   /** Board has a switchable balanced XLR mic input (G2 / G2-1K only). */
   hasBalancedXlr: boolean;


### PR DESCRIPTION
## What this does

Closes the loop on **#667 — ANAN-10E: line-in input not showing**.

The post-0.10.0 external-port re-port (#807/#810) already brought the **capability** onto develop — `BoardCapabilitiesTable` has `HermesII HasRadioLineIn=true` and `board-capabilities.ts` exposes the flag, so the web UI now *offers* the Line-In source + gain slider on a 10E. But the wiring that makes selecting it do anything on the wire was left out, so on develop today **picking Line-In on a 10E is inert**. This adds the three missing hunks (revived from the abandoned PR #668, rebased onto the current seams):

| Seam | Change |
|---|---|
| `ExternalPortEncoder.Protocol1PortEncoder` | Board-gate the `0x12` `mic_linein` select to `HermesII` → asserts on the 10E only |
| `RadioService` | Forward the 0..31 line-in gain to `SetAudioFrontEnd` only when the 10E line-in select is active |
| `ControlFrame` | Emit the 10E line-in gain on the `0x14` frame `C2[4:0]`, board-gated to `HermesII`, OR-preserving |

Plus the `TxAudioSource` / `board-capabilities.ts` doc comments.

## Wire reference
Thetis `networkproto1.c` + pihpsdr/deskhpsdr `old_protocol.c` — `0x12` `C2[1]` select; `0x14` `C2[4:0]` gain (32 steps).

## Safety / PureSignal
The `0x14` frame is the same one that carries `puresignal_run` **on HL2**. This change is **board-gated to `HermesII`**, so HL2 / G2 / 200D wire output is byte-identical — and the 10E does not carry `puresignal_run` on this frame. **No PureSignal logic, arm/disarm, persistence, or calibration is touched.** Full suite is green with the PS golden tests passing (byte-identity confirmed).

## Tests
Added 6 tests: encoder select board-gated to the 10E; clamp keeps 10E line-in + gain; `ControlFrame` `0x12` select + `0x14` gain land with the PS bit clear; a non-10E board with a stale gain field emits nothing. Full suite green — Server 1680, Protocol1 257, Protocol2 186, no failures. `dotnet build` + `npm --prefix zeus-web run build` both clean.

## Why draft
HermesII-gated and unit-verified, but it **cannot be tested locally** (maintainer runs G2 + HL2, no 10E). Needs a live **ANAN-10E** bench (Ronnie) to confirm audio actually flows before merge.