### PR TITLE
fix(tx-display): TX panadapter auto-range only for voice MOX/PTT (clean TUNE/two-tone carrier)

### DIFF
--- a/zeus-web/src/components/Panadapter.tsx
+++ b/zeus-web/src/components/Panadapter.tsx
@@ -53,7 +53,7 @@ import {
 import { planForFrame } from '../gl/frame-plan';
 import { cancelDrawBusFrame, requestDrawBusFrame } from '../realtime/draw-bus';
 import { registerFrameConsumer, selectDisplaySlice, useDisplayStore } from '../state/display-store';
-import { useDisplaySettingsStore } from '../state/display-settings-store';
+import { useDisplaySettingsStore, shouldTxAutoRange } from '../state/display-settings-store';
 import { useConnectionStore } from '../state/connection-store';
 import { enhanceInto, useSignalEnhanceStore } from '../dsp/signal-estimator';
 import { normalizeStitchedBins, stitchFloorShiftDb } from '../dsp/stitch-normalizer';
@@ -339,14 +339,17 @@ export function Panadapter({
         }
       }
 
-      // While keyed, fit the TX display windows to the live transmitted signal
-      // (no-op when TX auto-range is off). The panadapter is the always-present
-      // TX surface, so it drives the fit regardless of which waterfall renderer
-      // is active. Receiver A only — that's the slice the server feeds TX
-      // pixels into; RX2 (receiver B) keeps its own RX window during TX.
+      // While transmitting voice (MOX/PTT), fit the TX display windows to the
+      // live signal. TUNE and two-tone are excluded — see shouldTxAutoRange();
+      // their narrow carrier would collapse the fit onto the noise floor. The
+      // panadapter is the always-present TX surface, so it drives the fit
+      // regardless of which waterfall renderer is active. Receiver A only —
+      // that's the slice the server feeds TX pixels into; RX2 (receiver B)
+      // keeps its own RX window during TX.
       if (receiver === 'A' && slice.panValid && slice.panDb) {
-        const { moxOn, tunOn } = useTxStore.getState();
-        if (moxOn || tunOn) useDisplaySettingsStore.getState().updateTxAutoRange(slice.panDb);
+        const tx = useTxStore.getState();
+        const ds = useDisplaySettingsStore.getState();
+        if (shouldTxAutoRange(tx, ds.txAutoRange)) ds.updateTxAutoRange(slice.panDb);
       }
 
       requestRedraw();
@@ -408,7 +411,17 @@ export function Panadapter({
     // 50 Hz from the worklet, RxDbm at 5 Hz, PaTempC at 2 Hz, etc.), which
     // raises the floor on the redraw rate above the spectrum-tick rate.
     const unsubTx = useTxStore.subscribe((state, prev) => {
-      if (state.moxOn !== prev.moxOn || state.tunOn !== prev.tunOn) {
+      if (
+        state.moxOn !== prev.moxOn ||
+        state.tunOn !== prev.tunOn ||
+        state.twoToneOn !== prev.twoToneOn
+      ) {
+        // When auto-range isn't engaging for this TX type (TUNE / two-tone, or
+        // master off), snap the TX window back to the fixed/saved range so a
+        // carrier left narrow by a prior voice-MOX fit renders clean. Voice MOX
+        // lets the per-frame fit drive it instead.
+        const ds = useDisplaySettingsStore.getState();
+        if (!shouldTxAutoRange(state, ds.txAutoRange)) ds.restoreSavedTxWindows();
         // buildAnchor gates Pop off while keyed, so rebuild from the last raw
         // trace on the MOX/TUN edge to avoid a one-frame enhanced-vs-TX-range
         // mismap before the first TX frame adopts.

--- a/zeus-web/src/state/display-settings-store.test.ts
+++ b/zeus-web/src/state/display-settings-store.test.ts
@@ -58,6 +58,7 @@ import {
   WATERFALL_SCROLL_SPEED_MIN,
   TX_FIXED_DB_MAX,
   TX_FIXED_DB_MIN,
+  shouldTxAutoRange,
   useDisplaySettingsStore,
 } from './display-settings-store';
 
@@ -273,6 +274,16 @@ describe('TX display analyzer params', () => {
 describe('TX auto-range', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({}) })));
+    // In-memory localStorage so saved-range round-trips are deterministic and
+    // isolated per test, regardless of the runtime env (local node has no
+    // localStorage; CI jsdom does — direct global access isn't portable).
+    const store = new Map<string, string>();
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+      setItem: (k: string, v: string) => void store.set(k, v),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => store.clear(),
+    });
     useDisplaySettingsStore.setState({
       txAutoRange: true,
       txDbMin: -80,
@@ -320,5 +331,75 @@ describe('TX auto-range', () => {
   it('a manual TX window edit switches auto-range off', () => {
     useDisplaySettingsStore.getState().setTxDbRange(-76, 14);
     expect(useDisplaySettingsStore.getState().txAutoRange).toBe(false);
+  });
+
+  describe('shouldTxAutoRange — engages only for voice MOX/PTT', () => {
+    const tx = (over: Partial<{ moxOn: boolean; tunOn: boolean; twoToneOn: boolean }> = {}) => ({
+      moxOn: false,
+      tunOn: false,
+      twoToneOn: false,
+      ...over,
+    });
+
+    it('engages for voice MOX when master enable is on', () => {
+      expect(shouldTxAutoRange(tx({ moxOn: true }), true)).toBe(true);
+    });
+
+    it('does NOT engage for TUNE', () => {
+      expect(shouldTxAutoRange(tx({ tunOn: true }), true)).toBe(false);
+    });
+
+    it('does NOT engage for two-tone, even if MOX is also keyed', () => {
+      expect(shouldTxAutoRange(tx({ twoToneOn: true }), true)).toBe(false);
+      expect(shouldTxAutoRange(tx({ moxOn: true, twoToneOn: true }), true)).toBe(false);
+    });
+
+    it('does NOT engage when the master enable is off', () => {
+      expect(shouldTxAutoRange(tx({ moxOn: true }), false)).toBe(false);
+    });
+
+    it('does NOT engage when not transmitting', () => {
+      expect(shouldTxAutoRange(tx(), true)).toBe(false);
+    });
+  });
+
+  it('restoreSavedTxWindows falls back to the fixed range when nothing is saved', () => {
+    // Deterministic regardless of test order — clear any persisted range first.
+    localStorage.removeItem('zeus.display.txDbRange');
+    localStorage.removeItem('zeus.display.wfTxDbRange');
+    // Simulate a window left narrow by a prior voice-MOX auto-fit.
+    useDisplaySettingsStore.setState({
+      txDbMin: -64,
+      txDbMax: -52,
+      wfTxDbMin: -64,
+      wfTxDbMax: -52,
+    });
+    useDisplaySettingsStore.getState().restoreSavedTxWindows();
+    const r = useDisplaySettingsStore.getState();
+    expect(r.txDbMin).toBe(TX_FIXED_DB_MIN);
+    expect(r.txDbMax).toBe(TX_FIXED_DB_MAX);
+    expect(r.wfTxDbMin).toBe(TX_FIXED_DB_MIN);
+    expect(r.wfTxDbMax).toBe(TX_FIXED_DB_MAX);
+    // The auto-range master flag is independent — restore must not touch it.
+    expect(r.txAutoRange).toBe(true);
+  });
+
+  it('restoreSavedTxWindows snaps a narrowed window back to the operator-saved range', () => {
+    localStorage.setItem('zeus.display.txDbRange', JSON.stringify({ txDbMin: -70, txDbMax: 10 }));
+    localStorage.setItem('zeus.display.wfTxDbRange', JSON.stringify({ wfTxDbMin: -70, wfTxDbMax: 10 }));
+    useDisplaySettingsStore.setState({
+      txDbMin: -64,
+      txDbMax: -52,
+      wfTxDbMin: -64,
+      wfTxDbMax: -52,
+    });
+    useDisplaySettingsStore.getState().restoreSavedTxWindows();
+    const r = useDisplaySettingsStore.getState();
+    expect(r.txDbMin).toBe(-70);
+    expect(r.txDbMax).toBe(10);
+    expect(r.wfTxDbMin).toBe(-70);
+    expect(r.wfTxDbMax).toBe(10);
+    localStorage.removeItem('zeus.display.txDbRange');
+    localStorage.removeItem('zeus.display.wfTxDbRange');
   });
 });

--- a/zeus-web/src/state/display-settings-store.ts
+++ b/zeus-web/src/state/display-settings-store.ts
@@ -381,6 +381,23 @@ const TX_AUTO_PEAK_PCT = 0.995;
 // Guard against degenerate ranges (e.g. silent input producing p5==p95).
 const MIN_SPAN_DB = 20;
 
+/**
+ * Whether the TX display auto-fit should engage for the current TX state.
+ *
+ * Auto-range is only meaningful for a wide modulated signal (voice MOX/PTT),
+ * where the high-percentile "peak" lands on real signal. A TUNE carrier (a
+ * few-bin spike) or a two-tone test (twin spikes) defeats the percentile fit —
+ * the "peak" falls in the noise floor and the window collapses onto it,
+ * rendering the clean carrier as "grass". Those transmit types keep the fixed
+ * window. Two-tone arms independently of MOX, so it is excluded explicitly.
+ */
+export function shouldTxAutoRange(
+  tx: { moxOn: boolean; tunOn: boolean; twoToneOn: boolean },
+  txAutoRange: boolean,
+): boolean {
+  return txAutoRange && tx.moxOn && !tx.tunOn && !tx.twoToneOn;
+}
+
 export type DisplaySettingsState = {
   autoRange: boolean;
   // Panadapter dB window. Driven by the DbScale gesture (manual) and/or
@@ -468,6 +485,10 @@ export type DisplaySettingsState = {
   // Fit the TX windows to a frame of live TX pixels (no-op when off / empty).
   // Driven from the waterfall ingest while keyed.
   updateTxAutoRange: (pixels: Float32Array) => void;
+  // Snap the TX windows back to the operator's saved (or fixed -80..+20) range.
+  // Used when auto-range disengages — turned off, or a non-voice TX type (TUNE /
+  // two-tone) where the auto-fit would collapse onto the noise floor.
+  restoreSavedTxWindows: () => void;
   resetDbRanges: () => void;
   updateAutoRange: (wfDb: Float32Array) => void;
   // Shift dbMin and dbMax together by `deltaDb`. Used by the draggable dB
@@ -538,6 +559,12 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
   txDisplayFftSize: DEFAULT_TX_DISPLAY_FFT_SIZE,
   txDisplayWindow: DEFAULT_TX_DISPLAY_WINDOW,
   txDisplayAvgTauMs: DEFAULT_TX_DISPLAY_AVG_TAU_MS,
+  // Master enable for the TX display auto-fit. ON by default, but it only
+  // actually engages for voice MOX/PTT — see shouldTxAutoRange(). TUNE and
+  // two-tone are deliberately excluded: their narrow carrier / twin-tone fools
+  // the percentile fit into collapsing the dB window onto the noise floor,
+  // rendering the clean carrier as "grass". Those fall back to the Thetis-parity
+  // fixed TX_FIXED_DB_MIN/MAX (-80..+20) window via restoreSavedTxWindows().
   txAutoRange: true,
   colormap: 'blue',
   waterfallScrollSpeed: initialWaterfallScrollSpeed,
@@ -718,16 +745,29 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
       set({ txAutoRange: true });
     } else {
       // Off restores the operator's saved TX windows (mirrors setAutoRange).
-      const tx = readSavedTxRange();
-      const wf = readSavedWfTxRange();
-      set({
-        txAutoRange: false,
-        txDbMin: tx.txDbMin,
-        txDbMax: tx.txDbMax,
-        wfTxDbMin: wf.wfTxDbMin,
-        wfTxDbMax: wf.wfTxDbMax,
-      });
+      set({ txAutoRange: false });
+      get().restoreSavedTxWindows();
     }
+  },
+  restoreSavedTxWindows: () => {
+    const tx = readSavedTxRange();
+    const wf = readSavedWfTxRange();
+    const { txDbMin, txDbMax, wfTxDbMin, wfTxDbMax } = get();
+    // Avoid a redundant set() (and render) when the windows are already there.
+    if (
+      txDbMin === tx.txDbMin &&
+      txDbMax === tx.txDbMax &&
+      wfTxDbMin === wf.wfTxDbMin &&
+      wfTxDbMax === wf.wfTxDbMax
+    ) {
+      return;
+    }
+    set({
+      txDbMin: tx.txDbMin,
+      txDbMax: tx.txDbMax,
+      wfTxDbMin: wf.wfTxDbMin,
+      wfTxDbMax: wf.wfTxDbMax,
+    });
   },
   updateTxAutoRange: (pixels) => {
     if (!get().txAutoRange || pixels.length === 0) return;


### PR DESCRIPTION
## What

The TUNE carrier (and two-tone test) render as a messy "grass" signal on the TX panadapter instead of the clean spikes they should be. **Transmitted RF is clean — this is purely a display vertical-scale issue.**

## Root cause

Commit `e9cad293` (*"fix(tx-display): auto-range the TX panadapter + waterfall"*, 2026-06-20) added a TX display auto-range that runs for **any** keyed state. The per-frame fit takes the **99.5th-percentile** FFT bin as the window "peak." That's correct for a wide modulated voice signal, but a TUNE carrier is a 1–5 bin spike and a two-tone is twin spikes — so the percentile lands in the **noise floor**, the window collapses to a ~20 dB band on the floor, and the floor's natural variance fills the pane as "grass" while the carrier clips off the top.

## Fix — gate auto-range on TX type

Auto-range is only meaningful for a wide voice signal, so engage it only there:

| TX type | Auto-range | Result |
|---|---|---|
| **MOX / PTT** (voice) | **ON** | percentile fit valid — signal fills the window |
| **TUNE** | **OFF** | fixed −80..+20 window — clean carrier spike |
| **two-tone** | **OFF** | fixed window — clean twin tones |

- New pure helper `shouldTxAutoRange(tx, txAutoRange)` = `txAutoRange && moxOn && !tunOn && !twoToneOn`, used at both the fit-drive site and the TX-state subscriber in `Panadapter.tsx`. Two-tone arms independently of MOX, so it's excluded explicitly.
- For the excluded types, the TX window snaps back to the fixed/saved range via `restoreSavedTxWindows()` (extracted and shared with the existing "auto off" path) — so a window left narrow by a prior voice-MOX fit doesn't bleed into the next TUNE.
- The master **"Auto-range TX"** toggle still gates everything and stays **ON** by default; turning it off disables auto-range even for voice MOX.

## Scope / safety

- **Display-only.** No TX power, drive, PA, AGC, filter, or WDSP analyzer (FFT/window/tau) path is touched. Transmitted carrier is byte-for-byte unchanged.
- `txAutoRange` is not persisted/hydrated/localStorage-mirrored, so the gating takes effect for every operator on every load.

## Verification

- `tsc --noEmit` clean; `vite build` succeeds.
- `display-settings-store.test.ts` — **25/25 pass** (6 new: `shouldTxAutoRange` truth table for MOX/TUNE/two-tone/master-off/idle, plus `restoreSavedTxWindows`).
- Pre-existing unrelated test failures on the rebased develop base (SmartNR / DspPanel / tx-store / audio-device / mic-pcm) reproduce without this change and are not touched by it.

> ⚠️ Draft — bench-confirm on G2/HL2: TUNE and two-tone render as clean spikes, voice MOX still auto-ranges. Default-behavior change → needs Brian/Doug sign-off before merge.