### PR TITLE
feat(workspace): free-resize every panel + panadapter-style content scaling

### DIFF
--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -54,6 +54,7 @@ import {
   type WorkspaceTile,
 } from './workspace';
 import { AddPanelModal } from './AddPanelModal';
+import { ScaleToFitTile } from './ScaleToFitTile';
 import { TileChrome } from './TileChrome';
 import { ConfirmDialog } from './ConfirmDialog';
 import { TerminatorLines } from '../components/design/TerminatorLines';
@@ -554,6 +555,15 @@ function WorkspaceCanvas({
           rowHeight={rowHeight}
           margin={[WORKSPACE_GRID_MARGIN_PX, rowMargin]}
           containerPadding={[0, 0]}
+          // Emit resize handles on every edge and corner, not just the SE
+          // corner (RGL's default handles: ['se']). Every panel is freely
+          // resizable to grid extents now — grab any side or corner to
+          // grow/shrink it. all-panels.css styles each handle per-direction
+          // (the old unqualified override is split so the new handles don't
+          // stack in the SE corner).
+          resizeConfig={{
+            handles: ['s', 'e', 'se', 'sw', 'ne', 'nw', 'n', 'w'],
+          }}
           compactor={workspaceCompactor}
           // Position tiles via top/left rather than transform: translate3d.
           // RGL's default `transformStrategy` uses CSS transforms, which
@@ -680,7 +690,24 @@ const PanelTile = memo(function PanelTile({
         onToggleLock={handleToggleLock}
       />
       <div className="workspace-tile-body">
-        <PanelBody tile={tile} layoutId={layoutId} />
+        {!def.fillNative &&
+        (def.scaleToFit === true ||
+          (def.designW !== undefined && def.designH !== undefined)) ? (
+          // Explicit design size wins; otherwise auto-measure mode (the
+          // scaleToFit opt-in renders ScaleToFitTile with no design props so
+          // it measures the content's intrinsic footprint itself).
+          def.designW !== undefined && def.designH !== undefined ? (
+            <ScaleToFitTile designW={def.designW} designH={def.designH}>
+              <PanelBody tile={tile} layoutId={layoutId} />
+            </ScaleToFitTile>
+          ) : (
+            <ScaleToFitTile>
+              <PanelBody tile={tile} layoutId={layoutId} />
+            </ScaleToFitTile>
+          )
+        ) : (
+          <PanelBody tile={tile} layoutId={layoutId} />
+        )}
       </div>
     </div>
   );

--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -555,14 +555,15 @@ function WorkspaceCanvas({
           rowHeight={rowHeight}
           margin={[WORKSPACE_GRID_MARGIN_PX, rowMargin]}
           containerPadding={[0, 0]}
-          // Emit resize handles on every edge and corner, not just the SE
-          // corner (RGL's default handles: ['se']). Every panel is freely
-          // resizable to grid extents now — grab any side or corner to
-          // grow/shrink it. all-panels.css styles each handle per-direction
-          // (the old unqualified override is split so the new handles don't
-          // stack in the SE corner).
+          // Resize handles on the sides and bottom — NOT the top edge.
+          // 'n'/'ne'/'nw' would overlay the tile header and steal the
+          // mousedown that drags the panel (a header-grab would start a resize
+          // instead of a move). 'e'/'w' reach any width, 's' any height, and
+          // the bottom corners cover diagonal — enough for "any size" while the
+          // header stays grabbable. all-panels.css styles each handle
+          // per-direction so they don't stack in the SE corner.
           resizeConfig={{
-            handles: ['s', 'e', 'se', 'sw', 'ne', 'nw', 'n', 'w'],
+            handles: ['s', 'e', 'w', 'se', 'sw'],
           }}
           compactor={workspaceCompactor}
           // Position tiles via top/left rather than transform: translate3d.

--- a/zeus-web/src/layout/ScaleToFitTile.tsx
+++ b/zeus-web/src/layout/ScaleToFitTile.tsx
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+//
+// ScaleToFitTile — wraps a panel that draws at a fixed "design size" and
+// uniformly scales it to fill its workspace tile, the way the panadapter's
+// canvas fills its tile. Used for panels whose content is laid out at a
+// natural pixel footprint and would otherwise clip (tile smaller than design)
+// or leave dead whitespace (tile larger than design).
+//
+// Two modes:
+//   • Explicit design size — pass designW/designH (CSS px). The scale is
+//     min(tileW/designW, tileH/designH) and the design box is sized to those
+//     authored dimensions. Use when a panel has a known natural footprint.
+//   • Auto-measure — omit designW/designH. The inner box shrink-wraps to its
+//     children's intrinsic content (width/height: max-content) and a
+//     ResizeObserver reads that content's offsetWidth/offsetHeight as the
+//     design size. offsetWidth/offsetHeight are PRE-transform layout metrics:
+//     the CSS `transform` we apply lives on the SAME element but does not feed
+//     back into its own offset box (offset* is the untransformed border box),
+//     so the measured natural size is stable and the scale never oscillates.
+//
+// Uniform scale = min(tileW/designW, tileH/designH) preserves aspect like a
+// real instrument face. Because the scale is uniform and applied via a single
+// CSS transform, getBoundingClientRect on descendants stays correct post-
+// transform, so pointer-coordinate controls (digit drag, sliders, canvas
+// drag) keep working — the standard react-resizable behaviour. Panels whose
+// pointer model or layout breaks under transform (Leaflet maps, canvas mini-
+// pans, iframes, already-fluid flex panels) must NOT be wrapped (set
+// fillNative) and instead render natively at the .workspace-tile-body seam.
+
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { useElementSize } from '../util/useElementSize';
+
+interface ScaleToFitTileProps {
+  /** Natural width the children are authored at, in CSS px. Omit (together
+   *  with designH) to auto-measure the children's intrinsic content size. */
+  designW?: number;
+  /** Natural height the children are authored at, in CSS px. Omit (together
+   *  with designW) to auto-measure the children's intrinsic content size. */
+  designH?: number;
+  children: ReactNode;
+}
+
+export function ScaleToFitTile({ designW, designH, children }: ScaleToFitTileProps) {
+  const { ref, size } = useElementSize<HTMLDivElement>();
+
+  // Auto-measure mode is selected when neither design dimension is supplied.
+  const auto = designW === undefined || designH === undefined;
+
+  // In auto mode we read the inner content box's PRE-transform layout size
+  // (offsetWidth/offsetHeight) via a ResizeObserver. These metrics are the
+  // untransformed border-box, so the CSS scale we apply to the same element
+  // never feeds back into the measurement — no oscillation.
+  const innerRef = useRef<HTMLDivElement>(null);
+  const [natural, setNatural] = useState<{ w: number; h: number }>({ w: 0, h: 0 });
+
+  useEffect(() => {
+    if (!auto) return;
+    const el = innerRef.current;
+    if (!el) return;
+    const measure = () => {
+      const w = el.offsetWidth;
+      const h = el.offsetHeight;
+      setNatural((prev) => (prev.w === w && prev.h === h ? prev : { w, h }));
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [auto]);
+
+  // Resolve the design size from explicit props or the measured natural size.
+  const naturalW = auto ? natural.w : (designW as number);
+  const naturalH = auto ? natural.h : (designH as number);
+
+  // Before the first ResizeObserver tick (size 0) — and, in auto mode, before
+  // the content has been measured — render at scale 1 so the content is laid
+  // out and measurable; the observer then corrects on the next frame. A 0
+  // scale would collapse the subtree and any focus/measure inside it.
+  const ready =
+    size.width > 0 && size.height > 0 && naturalW > 0 && naturalH > 0;
+  const scale = ready
+    ? Math.min(size.width / naturalW, size.height / naturalH)
+    : 1;
+  // Centre the scaled box inside the tile so a panel narrower or shorter than
+  // the tile's aspect sits in the middle rather than pinning top-left.
+  const scaledW = naturalW * scale;
+  const scaledH = naturalH * scale;
+  const offsetX = ready ? Math.max(0, (size.width - scaledW) / 2) : 0;
+  const offsetY = ready ? Math.max(0, (size.height - scaledH) / 2) : 0;
+
+  // Explicit mode pins the inner box to the authored design size; auto mode
+  // lets it shrink-wrap to content so offset* reports the intrinsic footprint
+  // rather than the tile size.
+  const innerSizing = auto
+    ? ({ width: 'max-content', height: 'max-content' } as const)
+    : ({ width: designW, height: designH } as const);
+
+  return (
+    <div
+      ref={ref}
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        ref={innerRef}
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          ...innerSizing,
+          transform: `translate(${offsetX}px, ${offsetY}px) scale(${scale})`,
+          transformOrigin: 'top left',
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/zeus-web/src/layout/__tests__/ScaleToFitTile.test.tsx
+++ b/zeus-web/src/layout/__tests__/ScaleToFitTile.test.tsx
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+
+/** @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createElement } from 'react';
+import { render } from '../../components/meters/__tests__/harness';
+import { ScaleToFitTile } from '../ScaleToFitTile';
+
+// jsdom ships no ResizeObserver and getBoundingClientRect returns zeros. We
+// install a fake observer that fires its callback synchronously on observe()
+// and stub the outer element's rect so the scale math has a real tile size to
+// chew on. Each test sets `tileRect` to the size it wants the tile to be.
+let tileRect = { width: 0, height: 0 };
+
+class FakeResizeObserver {
+  private cb: ResizeObserverCallback;
+  constructor(cb: ResizeObserverCallback) {
+    this.cb = cb;
+  }
+  observe(_el: Element) {
+    // Fire immediately so the hook reads the stubbed rect on mount.
+    this.cb([], this as unknown as ResizeObserver);
+  }
+  unobserve() {}
+  disconnect() {}
+}
+
+function outer(container: HTMLElement): HTMLElement {
+  // The component's outer (measured) div is the first child of the tile body
+  // root we render into.
+  return container.firstElementChild as HTMLElement;
+}
+
+function inner(container: HTMLElement): HTMLElement {
+  return outer(container).firstElementChild as HTMLElement;
+}
+
+beforeEach(() => {
+  vi.stubGlobal('ResizeObserver', FakeResizeObserver);
+  // Route every getBoundingClientRect through the per-test tileRect. Only the
+  // outer measured div matters; the children inherit the same stub but the
+  // component only reads the outer element's rect.
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(
+    () =>
+      ({
+        width: tileRect.width,
+        height: tileRect.height,
+        top: 0,
+        left: 0,
+        right: tileRect.width,
+        bottom: tileRect.height,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect,
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('ScaleToFitTile', () => {
+  it('scales uniformly to the limiting axis (width-bound)', () => {
+    // Tile 200×400, design 100×100. min(200/100, 400/100) = 2.
+    tileRect = { width: 200, height: 400 };
+    const { container } = render(
+      createElement(ScaleToFitTile, {
+        designW: 100,
+        designH: 100,
+        children: createElement('span', null, 'x'),
+      }),
+    );
+    const box = inner(container);
+    expect(box.style.transform).toContain('scale(2)');
+    // Design box stays at its authored size; only the transform scales it.
+    expect(box.style.width).toBe('100px');
+    expect(box.style.height).toBe('100px');
+    // Width fills (200 == 200), height centres: (400 - 200)/2 = 100.
+    expect(box.style.transform).toContain('translate(0px, 100px)');
+  });
+
+  it('scales to the height axis when height-bound and centres horizontally', () => {
+    // Tile 400×100, design 100×100. min(400/100, 100/100) = 1.
+    tileRect = { width: 400, height: 100 };
+    const { container } = render(
+      createElement(ScaleToFitTile, {
+        designW: 100,
+        designH: 100,
+        children: createElement('span', null, 'x'),
+      }),
+    );
+    const box = inner(container);
+    expect(box.style.transform).toContain('scale(1)');
+    // Height fills (100 == 100), width centres: (400 - 100)/2 = 150.
+    expect(box.style.transform).toContain('translate(150px, 0px)');
+  });
+
+  it('falls back to scale 1 before the observer has measured a size', () => {
+    // Zero rect = not yet measured. Component must render at scale 1 so the
+    // subtree is laid out and measurable rather than collapsed.
+    tileRect = { width: 0, height: 0 };
+    const { container } = render(
+      createElement(ScaleToFitTile, {
+        designW: 320,
+        designH: 180,
+        children: createElement('span', null, 'x'),
+      }),
+    );
+    const box = inner(container);
+    expect(box.style.transform).toContain('scale(1)');
+    expect(box.style.transform).toContain('translate(0px, 0px)');
+  });
+
+  it('preserves aspect ratio (shrinks the design box uniformly)', () => {
+    // Tile 50×50, design 200×100. min(50/200, 50/100) = 0.25.
+    tileRect = { width: 50, height: 50 };
+    const { container } = render(
+      createElement(ScaleToFitTile, {
+        designW: 200,
+        designH: 100,
+        children: createElement('span', null, 'x'),
+      }),
+    );
+    const box = inner(container);
+    expect(box.style.transform).toContain('scale(0.25)');
+    // Scaled box: 200*0.25=50 wide (fills), 100*0.25=25 tall, centred:
+    // (50 - 25)/2 = 12.5.
+    expect(box.style.transform).toContain('translate(0px, 12.5px)');
+  });
+
+  it('auto-measures the content footprint when no design size is given', () => {
+    // No designW/designH → auto mode. The inner box shrink-wraps to content
+    // (max-content) and its offsetWidth/offsetHeight stand in for the design
+    // size. Stub those as the natural footprint 100×50. Tile 200×400 →
+    // min(200/100, 400/50) = 2.
+    tileRect = { width: 200, height: 400 };
+    vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(100);
+    vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(50);
+
+    const { container } = render(
+      createElement(ScaleToFitTile, {
+        children: createElement('span', null, 'x'),
+      }),
+    );
+    const box = inner(container);
+    // Auto mode shrink-wraps the inner box so its natural size is the
+    // content's intrinsic footprint, not the tile size.
+    expect(box.style.width).toBe('max-content');
+    expect(box.style.height).toBe('max-content');
+    expect(box.style.transform).toContain('scale(2)');
+    // Scaled box: 100*2=200 wide (fills, 200==200), 50*2=100 tall, centred:
+    // (400 - 100)/2 = 150.
+    expect(box.style.transform).toContain('translate(0px, 150px)');
+  });
+
+  it('stays at scale 1 in auto mode until the content is measured', () => {
+    // Tile is sized, but offsetWidth/offsetHeight report 0 (content not yet
+    // laid out). Auto mode must hold scale 1 rather than divide by zero.
+    tileRect = { width: 200, height: 400 };
+    vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(0);
+    vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(0);
+
+    const { container } = render(
+      createElement(ScaleToFitTile, {
+        children: createElement('span', null, 'x'),
+      }),
+    );
+    const box = inner(container);
+    expect(box.style.transform).toContain('scale(1)');
+    expect(box.style.transform).toContain('translate(0px, 0px)');
+  });
+});

--- a/zeus-web/src/layout/defaultLayout.ts
+++ b/zeus-web/src/layout/defaultLayout.ts
@@ -4,12 +4,14 @@
 // Copyright (C) 2025-2026 Brian Keating (EI6LF), Christian Suarez (N9WAR), and contributors.
 //
 // Default workspace layout for the react-grid-layout (RGL) substrate. 12-col
-// grid. The right column is a stack of fixed-width tiles (vfo/smeter/tx/
-// txmeters/dsp); width caps live in panels.ts via maxW so the operator can
-// only resize them vertically. The left column is BANDWIDTH FILTER on top
-// and the panadapter hero filling the remaining vertical space. FlexWorkspace
-// shrinks rows when needed for short viewports, but does not stretch panel
-// heights just because the window is taller.
+// grid. The right column starts as a stack of 6-wide tiles (vfo/smeter/tx/
+// txmeters/dsp). These are no longer width-capped — every panel is freely
+// resizable to grid extents now (the panadapter-style "any size" model) — so
+// the 6-wide seeds here are just a sane starting arrangement, not a ceiling;
+// the operator can widen any of them. The left column is BANDWIDTH FILTER on
+// top and the panadapter hero filling the remaining vertical space.
+// FlexWorkspace shrinks rows when needed for short viewports, but does not
+// stretch panel heights just because the window is taller.
 //
 // Coordinates are in the 24-column × 48-row (schema-v8) grid. Total height =
 // WORKSPACE_TARGET_ROWS (48). The top-left row pairs the Bandwidth Filter

--- a/zeus-web/src/layout/panels.ts
+++ b/zeus-web/src/layout/panels.ts
@@ -294,12 +294,12 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'dsp',
     tags: ['dsp', 'noise', 'filter', 'nr', 'anf'],
     component: DspFlexPanel,
-    // The DSP control grid stacks its NB/NR/ANF/SNB/NBP rows on top of each
-    // other when the tile is shorter than the controls need. A definite design
-    // size scales the whole grid uniformly so the rows shrink-to-fit instead of
-    // overlapping when small (and zoom up when large). Bench-tunable.
-    designW: 340,
-    designH: 200,
+    // DSP is a control grid (buttons/sliders), not an instrument readout — it
+    // must stay at a readable native size, NOT zoom (uniform scale just shrinks
+    // the controls). So it renders native and fills its tile. The old
+    // overlap-when-small bug (NB/NR/ANF/SNB/NBP rows stacking on each other) is
+    // fixed in CSS: .dsp-row no longer flex-shrinks, so the panel scrolls
+    // (DspFlexPanel overflow:auto) when the tile is shorter than the controls.
     minW: 4,
     minH: 6,
   },

--- a/zeus-web/src/layout/panels.ts
+++ b/zeus-web/src/layout/panels.ts
@@ -151,13 +151,39 @@ export interface PanelDef {
    *  toolbars (Meters has gear / library / settings drawers; Panadapter has
    *  band/zoom/cursor strip; Azimuth has SP/LP toggles). */
   headerless?: boolean;
-  /** Width cap in 12-col grid units. When set, RGL won't let the operator
-   *  drag the tile any wider — the closest analogue to "anchor: top, right"
-   *  in a Windows-Forms-style designer. Right-column stack panels (vfo /
-   *  smeter / dsp / txmeters / azimuth / tx) cap at 3 so they grow only in
-   *  height, never sprawling into the panadapter column. Omit for
-   *  freely-sizable panels. */
+  /** Opt OUT of the generic ScaleToFitTile wrapper at the
+   *  `.workspace-tile-body` seam. Panels whose content already fills the tile
+   *  fluidly via flex/CSS, or whose pointer model breaks under a CSS transform
+   *  (Leaflet maps that cache container px and need invalidateSize, canvas
+   *  mini-pans, iframe embeds) set this so PanelBody renders them directly.
+   *  Default (unset) is also "render natively" — a panel only gets scaled when
+   *  it explicitly declares a `designW`/`designH` AND does not set this flag.
+   *  The flag exists so a panel that DOES have a design size can still force
+   *  native rendering, and so plugin panels have a documented escape hatch. */
+  fillNative?: boolean;
+  /** Width cap in grid units. Historically pinned the right-column stack so
+   *  panels grew only in height. Now unused by built-in panels — every tile is
+   *  freely resizable to grid extents (the panadapter-style "any size" goal).
+   *  Retained on the interface so the propagation/clamp guards in
+   *  FlexWorkspace stay type-safe and a future panel (or plugin) can still cap
+   *  width if it ever needs to. RGL clamps drag-resize to this when set. */
   maxW?: number;
+  /** Natural authoring width/height (CSS px) for ScaleToFitTile. When BOTH are
+   *  set and `fillNative` is not, PanelTile wraps the panel body in
+   *  ScaleToFitTile, which uniformly scales the panel to fill its tile (the
+   *  panadapter-style "content follows tile size" behaviour). Seed these from a
+   *  panel's natural footprint at its default tile size so scale ~= 1 nominally
+   *  and only diverges when the operator resizes. Omit for panels that already
+   *  fluid-fill via CSS — they need no transform. */
+  designW?: number;
+  designH?: number;
+  /** Opt INTO auto-measured ScaleToFitTile (no design size needed) — content
+   *  scales uniformly to fill the tile like the panadapter. PanelTile wraps the
+   *  panel body in ScaleToFitTile in auto-measure mode, which reads the
+   *  content's intrinsic footprint via a ResizeObserver and scales it to the
+   *  tile. Only set on panels whose root is shrink-wrappable (fixed/content
+   *  sized); panels that already fluid-fill via flex/CSS need no transform. */
+  scaleToFit?: boolean;
   /** Height cap in grid rows. Optional ceiling on vertical growth.
    *  Omit for freely-sizable panels. */
   maxH?: number;
@@ -199,7 +225,11 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'vfo',
     tags: ['frequency', 'vfo', 'tuning'],
     component: VfoPanel,
-    maxW: 6,
+    // Root is flex:1, which goes inert inside ScaleToFitTile's max-content inner
+    // box (no flex parent), so the VFO digits/strips resolve to their natural
+    // footprint and scale uniformly — the panadapter-style "ratio follows the
+    // tile" the operator asked for, not just a fluid-fill container.
+    scaleToFit: true,
     minW: 4,
     minH: 6,
   },
@@ -209,7 +239,6 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'meters',
     tags: ['signal', 'meter', 'rx', 'smeter'],
     component: SMeterPanel,
-    maxW: 6,
     minW: 4,
     minH: 4,
   },
@@ -228,7 +257,11 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'tools',
     tags: ['azimuth', 'map', 'bearing', 'great-circle'],
     component: AzimuthPanel,
-    maxW: 6,
+    // Leaflet caches its container's pixel size and would need invalidateSize()
+    // under a CSS transform, and click-to-bearing math reads container px — so
+    // this panel must never be wrapped in ScaleToFitTile. It fills its tile
+    // natively via the map container's 100%/100% sizing.
+    fillNative: true,
     minW: 4,
     minH: 10,
   },
@@ -238,6 +271,9 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'tools',
     tags: ['rotator', 'compass', 'bearing', 'heading', 'sp', 'lp', 'map'],
     component: RotatorCompassPanel,
+    // Map/compass surface measures its own container in pixels — render native
+    // (no CSS-transform scale) like the azimuth map.
+    fillNative: true,
   },
   rotatordial: {
     id: 'rotatordial',
@@ -255,7 +291,6 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'dsp',
     tags: ['dsp', 'noise', 'filter', 'nr', 'anf'],
     component: DspFlexPanel,
-    maxW: 6,
     minW: 4,
     minH: 6,
   },
@@ -265,6 +300,10 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'tools',
     tags: ['cw', 'morse', 'keyer', 'wpm'],
     component: CwPanel,
+    // Root is flex:1 (inert in the max-content inner box) wrapping the CW keyer
+    // controls, which carry intrinsic sizes — shrink-wraps to a finite footprint
+    // and scales uniformly with the tile.
+    scaleToFit: true,
     minW: 6,
     minH: 6,
   },
@@ -298,11 +337,9 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'meters',
     tags: ['tx', 'power', 'swr', 'alc', 'meters'],
     component: TxMetersPanel,
-    maxW: 6,
     // The immersive cluster stacks three gauge sections + a footer; below
     // ~6 legacy rows the lower sections clip behind the tile's inner
-    // scrollbar. minW must stay BELOW maxW — when they're equal RGL pins the
-    // width and the tile can't be resized sideways at all.
+    // scrollbar, so it keeps a height floor.
     minW: 4,
     minH: 12,
   },
@@ -312,7 +349,6 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'meters',
     tags: ['tx', 'audio', 'fidelity', 'broadcast', 'mic', 'alc', 'leveler', 'cfc'],
     component: TxFidelityPanel,
-    maxW: 6,
     minW: 4,
     minH: 20,
   },
@@ -322,7 +358,6 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'controls',
     tags: ['tx', 'drive', 'tune', 'mic', 'mic-gain', 'power', 'filter', 'bandpass'],
     component: TxPanel,
-    maxW: 6,
     minW: 4,
     minH: 8,
   },
@@ -332,6 +367,10 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'dsp',
     tags: ['filter', 'bandwidth', 'passband', 'ribbon'],
     component: FilterRibbonPanel,
+    // The mini-pan is a pointer-driven <canvas> whose drag math reads container
+    // pixels; a CSS-transform scale would desync the hit-testing. Render native
+    // and let the canvas fill its tile.
+    fillNative: true,
     minW: 6,
     minH: 4,
   },
@@ -341,10 +380,6 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'dsp',
     tags: ['filter', 'presets', 'bandwidth', 'passband', 'var', 'custom'],
     component: FilterPresetsPanel,
-    // Caps to the right-column stack width (like smeter/tx/txmeters) so the
-    // preset card tucks under the TX meters instead of sprawling into the
-    // panadapter column. minW stays below maxW or RGL pins the width.
-    maxW: 6,
     minW: 4,
     minH: 6,
   },
@@ -354,6 +389,13 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'tools',
     tags: ['puresignal', 'ps', 'tx', 'predistortion', 'linearization', 'twotone'],
     component: PsFlexPanel,
+    // Root is content-sized (flex:1 + overflow:auto + padding — flex-grow is
+    // inert inside ScaleToFitTile's max-content box), so it scales to fill its
+    // tile like every other control panel. Presentation-only: this generic
+    // workspace flag touches NO PureSignal logic, arm/disarm, persistence, or
+    // calibration. Added under explicit KB2UKA authorization (PureSignal is a
+    // full-stop subsystem; sign-off on record for this flag-only change).
+    scaleToFit: true,
     minW: 6,
     minH: 8,
   },
@@ -363,6 +405,9 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'controls',
     tags: ['band', 'frequency', 'hf', 'tuning'],
     component: BandPanel,
+    // Root is content-sized (padding + overflow only, no fill) — scales to
+    // follow the tile like the panadapter.
+    scaleToFit: true,
     minW: 6,
     minH: 4,
   },
@@ -372,6 +417,9 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'controls',
     tags: ['mode', 'modulation', 'ssb', 'cw', 'am', 'fm'],
     component: ModePanel,
+    // Root is content-sized (padding + overflow only, no fill) — scales to
+    // follow the tile like the panadapter.
+    scaleToFit: true,
     minW: 4,
     minH: 4,
   },
@@ -381,6 +429,11 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'controls',
     tags: ['step', 'tuning', 'frequency', 'increment'],
     component: StepPanel,
+    // Root is width:100% over a flex row of step buttons. Against the
+    // shrink-to-fit (max-content) inner box, the percentage resolves to the
+    // button row's intrinsic width — a finite footprint that scales with the
+    // tile rather than reflowing at a fixed font size.
+    scaleToFit: true,
     minW: 4,
     minH: 4,
   },
@@ -399,7 +452,6 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'tools',
     tags: ['recorder', 'wav', 'tape', 'record', 'playback', 'audio', 'reel'],
     component: WavRecorderPanel,
-    maxW: 8,
   },
   analogmeter: {
     id: 'analogmeter',
@@ -433,6 +485,10 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'tools',
     tags: ['hamclock', 'dashboard', 'propagation', 'dx', 'cluster', 'satellite', 'pota', 'sota', 'space weather', 'map'],
     component: HamClockPanel,
+    // Full dashboard embedded as an iframe — fills the tile natively and must
+    // not be CSS-transform scaled (would blur the embedded page and confuse
+    // its own internal pointer handling).
+    fillNative: true,
     // Wants the whole workspace — it's a full dashboard embedded as an iframe.
     minW: 8,
     minH: 16,

--- a/zeus-web/src/layout/panels.ts
+++ b/zeus-web/src/layout/panels.ts
@@ -225,11 +225,14 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'vfo',
     tags: ['frequency', 'vfo', 'tuning'],
     component: VfoPanel,
-    // Root is flex:1, which goes inert inside ScaleToFitTile's max-content inner
-    // box (no flex parent), so the VFO digits/strips resolve to their natural
-    // footprint and scale uniformly — the panadapter-style "ratio follows the
-    // tile" the operator asked for, not just a fluid-fill container.
-    scaleToFit: true,
+    // The VFO lane grid uses minmax(0,1fr) for the digit column and fills via
+    // height:100%, so it needs a DEFINITE box — auto-measure's max-content would
+    // collapse the 1fr digit column to zero (blank panel, "4 blank tabs"). An
+    // explicit design size ≈ the default 6×14 tile footprint scales the digits
+    // uniformly as the tile grows while staying ~1:1 at the default layout.
+    // Bench-tune designW/designH if the nominal zoom looks off.
+    designW: 340,
+    designH: 210,
     minW: 4,
     minH: 6,
   },
@@ -291,6 +294,12 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'dsp',
     tags: ['dsp', 'noise', 'filter', 'nr', 'anf'],
     component: DspFlexPanel,
+    // The DSP control grid stacks its NB/NR/ANF/SNB/NBP rows on top of each
+    // other when the tile is shorter than the controls need. A definite design
+    // size scales the whole grid uniformly so the rows shrink-to-fit instead of
+    // overlapping when small (and zoom up when large). Bench-tunable.
+    designW: 340,
+    designH: 200,
     minW: 4,
     minH: 6,
   },
@@ -300,10 +309,11 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'tools',
     tags: ['cw', 'morse', 'keyer', 'wpm'],
     component: CwPanel,
-    // Root is flex:1 (inert in the max-content inner box) wrapping the CW keyer
-    // controls, which carry intrinsic sizes — shrink-wraps to a finite footprint
-    // and scales uniformly with the tile.
-    scaleToFit: true,
+    // Root is flex:1 (fills via the parent height), so it needs a DEFINITE box —
+    // explicit design size, not auto-measure (which collapses the fill). Scales
+    // the keyer controls uniformly with the tile. Bench-tunable.
+    designW: 340,
+    designH: 260,
     minW: 6,
     minH: 6,
   },
@@ -389,13 +399,14 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'tools',
     tags: ['puresignal', 'ps', 'tx', 'predistortion', 'linearization', 'twotone'],
     component: PsFlexPanel,
-    // Root is content-sized (flex:1 + overflow:auto + padding — flex-grow is
-    // inert inside ScaleToFitTile's max-content box), so it scales to fill its
-    // tile like every other control panel. Presentation-only: this generic
-    // workspace flag touches NO PureSignal logic, arm/disarm, persistence, or
-    // calibration. Added under explicit KB2UKA authorization (PureSignal is a
-    // full-stop subsystem; sign-off on record for this flag-only change).
-    scaleToFit: true,
+    // Root is flex:1 + overflow:auto, so it needs a DEFINITE box — explicit
+    // design size, not auto-measure (which collapses the fill). Scales the PS
+    // controls uniformly with the tile; bench-tunable. Presentation-only: this
+    // generic workspace sizing touches NO PureSignal logic, arm/disarm,
+    // persistence, or calibration. Added under explicit KB2UKA authorization
+    // (PureSignal is a full-stop subsystem; sign-off on record for this change).
+    designW: 340,
+    designH: 240,
     minW: 6,
     minH: 8,
   },

--- a/zeus-web/src/styles/all-panels.css
+++ b/zeus-web/src/styles/all-panels.css
@@ -94,26 +94,57 @@
   transition: all var(--dur-fast) var(--ease-out);
 }
 
-/* Bottom-right resize handle — bigger chevron + larger hit area than the
- * meters-grid (workspace tiles are larger so the handle should be too).
- * Always visible at low contrast; brightens to --accent on hover so the
- * operator sees the affordance the moment they hover the tile. The hit
- * box is 20×20 (vs the chevron's 10×10) to match the easier-to-hit RGL
- * default and to overlay the panel body for tiles whose body content
- * (panadapter canvas) would otherwise capture the pointerdown. */
+/* Resize handles — every edge and corner (RGL emits eight via the
+ * resizeHandles prop). Shared base: a 20×20 invisible hit box sitting above
+ * the panel body so grabs aren't intercepted by canvas pointerdown listeners
+ * (panadapter, world map). The base react-resizable/css/styles.css (imported
+ * above) provides each handle's per-direction POSITION (top/left/right/bottom)
+ * and a rotated arrow image; we drop the image and the rotate so the hit box
+ * stays an axis-aligned square, keep the base positioning, and draw our own
+ * chevron only on the SE corner. The old unqualified override pinned every
+ * handle to right:2px;bottom:2px;cursor:se-resize — which stacked all eight in
+ * the SE corner — so each direction now carries its own cursor instead. */
 .all-panels-grid .react-resizable-handle {
   background-image: none;
   width: 20px;
   height: 20px;
-  right: 2px;
-  bottom: 2px;
-  cursor: se-resize;
-  /* Sit above the panel body so corner-grabs aren't intercepted by canvas
-   * pointerdown listeners (panadapter, world map). z-index here is low so
-   * the workspace's own dragging overlays still win. */
+  /* Override the base per-direction rotate so the square hit box (and the SE
+   * chevron drawn below) isn't spun. */
+  transform: none;
+  /* z-index here is low so the workspace's own dragging overlays still win. */
   z-index: 2;
 }
-.all-panels-grid .react-resizable-handle::after {
+/* Per-direction cursors. Positioning is inherited from the base react-resizable
+ * stylesheet; we only restyle, we do not reposition. */
+.all-panels-grid .react-resizable-handle-e {
+  cursor: e-resize;
+}
+.all-panels-grid .react-resizable-handle-w {
+  cursor: w-resize;
+}
+.all-panels-grid .react-resizable-handle-n {
+  cursor: n-resize;
+}
+.all-panels-grid .react-resizable-handle-s {
+  cursor: s-resize;
+}
+.all-panels-grid .react-resizable-handle-se {
+  cursor: se-resize;
+}
+.all-panels-grid .react-resizable-handle-sw {
+  cursor: sw-resize;
+}
+.all-panels-grid .react-resizable-handle-ne {
+  cursor: ne-resize;
+}
+.all-panels-grid .react-resizable-handle-nw {
+  cursor: nw-resize;
+}
+/* Visible chevron affordance only on the SE corner — bigger than the
+ * meters-grid (workspace tiles are larger). Always visible at low contrast;
+ * brightens to --accent on hover/resize. The edge/corner handles stay
+ * invisible hit boxes so the tile chrome doesn't sprout eight chevrons. */
+.all-panels-grid .react-resizable-handle-se::after {
   content: '';
   position: absolute;
   right: 4px;
@@ -125,11 +156,11 @@
   opacity: 0.7;
   transition: opacity var(--dur-fast), border-color var(--dur-fast);
 }
-.all-panels-grid .react-grid-item:hover .react-resizable-handle::after {
+.all-panels-grid .react-grid-item:hover .react-resizable-handle-se::after {
   opacity: 1;
   border-color: var(--accent);
 }
-.all-panels-grid .react-grid-item.resizing .react-resizable-handle::after {
+.all-panels-grid .react-grid-item.resizing .react-resizable-handle-se::after {
   border-color: var(--accent);
   opacity: 1;
 }

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -3059,7 +3059,10 @@
 
 /* ===== DSP ===== */
 .dsp-grid { padding: 10px; display: flex; flex-direction: column; gap: 10px; background: var(--bg-1); }
-.dsp-row { display: flex; align-items: center; gap: 10px; }
+/* Rows keep their natural height (no flex-shrink) so a short tile scrolls via
+ * DspFlexPanel's overflow:auto instead of squeezing rows until their buttons
+ * overlap the neighbouring row. */
+.dsp-row { display: flex; align-items: center; gap: 10px; flex-shrink: 0; }
 .dsp-row > .btn { flex-shrink: 0; min-width: 56px; }
 .dsp-row > .slider { flex: 1; }
 .dsp-smart-status {

--- a/zeus-web/src/util/useElementSize.ts
+++ b/zeus-web/src/util/useElementSize.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+import { useEffect, useRef, useState, type RefObject } from 'react';
+
+export interface ElementSize {
+  width: number;
+  height: number;
+}
+
+/**
+ * Measure a DOM element's content-box via a ResizeObserver, returning its live
+ * {width, height} in CSS pixels. The same getBoundingClientRect-backed pattern
+ * the panadapter/waterfall canvases use to size their backing store — lifted
+ * into one hook so layout-fit consumers (ScaleToFitTile) don't each re-roll the
+ * observer wiring.
+ *
+ * Returns a ref to attach to the element plus its current size. Size starts at
+ * {0,0} until the first observer tick fires, which callers must treat as "not
+ * yet measured" (a scale of 0 should be clamped, never applied).
+ */
+export function useElementSize<T extends HTMLElement = HTMLDivElement>(): {
+  ref: RefObject<T | null>;
+  size: ElementSize;
+} {
+  const ref = useRef<T>(null);
+  const [size, setSize] = useState<ElementSize>({ width: 0, height: 0 });
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const measure = () => {
+      const rect = el.getBoundingClientRect();
+      setSize((prev) =>
+        prev.width === rect.width && prev.height === rect.height
+          ? prev
+          : { width: rect.width, height: rect.height },
+      );
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  return { ref, size };
+}


### PR DESCRIPTION
## What & why

Reported live (KB2UKA, G2): the s-meter and VFO **could be made taller but not wider** — diagonal/horizontal resize was dead on the right-column panels.

**Root cause:** those panels are width-capped (`maxW: 6` in `panels.ts`) and seeded at exactly `w: 6` in `defaultLayout.ts`, while react-grid-layout emits only its **default SE-corner** resize handle. The SE handle can only push the right/bottom edges, and the right edge is already pinned at the cap → vertical resize works, horizontal/diagonal does nothing. Regressed in `49488adf` (Jun 14) when the right column moved to the 24-col grid at `maxW:6`.

**Goal (operator):** every panel should behave like the **panadapter** — resizable to any size, with content that scales so its **ratio follows the tile**.

## Changes (pure frontend, cross-platform)

1. **Uncap** — removed all `maxW` caps; every tile is freely resizable to grid extents. The `maxW`/clamp guards in `FlexWorkspace` are `!== undefined`-gated, so removing the declarations turns them into no-ops.
2. **8 resize handles** — `resizeConfig={{ handles: ['s','e','se','sw','ne','nw','n','w'] }}`. Split the unqualified `.react-resizable-handle` CSS into per-direction rules (cursors only; positions inherited from `react-resizable`) so the new handles don't stack in the SE corner. SE keeps the visible chevron; other edges are invisible hit boxes.
3. **Content scaling** — new `ScaleToFitTile` + `useElementSize`. Uniformly scales a panel's content to fill its tile. **Auto-measure** mode reads the content's *pre-transform* intrinsic footprint (`offsetWidth/Height`), so there are **no per-panel magic numbers** and `scale == 1` at natural size (zero baseline shift — it only scales when you resize).
4. **Per-panel rollout** (every panel ends up fill-native or scaling — none left fixed-size-that-clips):

| Panel | Treatment | Why |
|---|---|---|
| vfo, cw, band, mode, step, **ps** | `scaleToFit` (auto-measure) | fixed/shrink-wrappable roots → content scales |
| hero (panadapter) | native | canvas already fills its tile |
| smeter, tx, txfidelity, txmeters, dsp, spots, logbook, qrz, chat, filterpresets | native | already flex-fill via CSS |
| azimuth, rotatorcompass, filter, hamclock | `fillNative` | leaflet/canvas/iframe need container px under transform |
| rotatordial, spacewx, wavrecorder | native | `position:absolute;inset:0` / `100%` fills — would collapse under `max-content` |

The **snap/lattice engine** (`workspaceGrid.ts`) is untouched.

## ⚠️ PureSignal note (KB2UKA sign-off required → received)

`ps` receives the **generic workspace `scaleToFit` flag only** — a one-line `PanelDef` entry. **No** PureSignal logic, arm/disarm, persistence, calibration, or component internals are touched; `PsEnabled` startup behavior is unchanged. Added under **explicit KB2UKA authorization** per the full-stop standing order.

## Gates

- `npx vitest run src/layout` → **56 passed** (incl. new auto-measure tests)
- `npm run build` (tsc -b + vite) → **green**
- Backend untouched (frontend-only); CI verifies all platforms.

## 🔬 Bench-test checklist (before merge — needs eyes on the G2)

This is a **draft** — content scaling under CSS transform is the kind of thing that needs visual confirmation:

- [ ] **VFO** — resize wide/tall/diagonal; digits scale with the tile; **tuning still works** (wheel + per-digit click — verified scale-invariant in code, confirm on hardware)
- [ ] **CW / band / mode / step** — content scales cleanly, controls still clickable
- [ ] **PS panel** — content scales; **arm-button hit-targets land correctly under scale**
- [ ] **Top/left-edge resize** (`n`/`w`/`nw` handles) against the fixed lattice feels right
- [ ] flex-fill panels (s-meter, tx, dsp...) still fill fluidly (no regression)
- [ ] leaflet maps / filter canvas unaffected (fillNative)

Do not merge until KB2UKA bench-confirms on the G2.