### PR TITLE
feat(g2-panel): Radio Settings card to enable + configure the front panel

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -613,6 +613,28 @@ public sealed record ExternalPttStatusDto(
 // requires a physical footswitch edge).
 public sealed record PttEnableSetRequest(bool Enabled);
 
+// State of the ANAN G2 / G2-Ultra hardware front-panel bridge — body of
+// GET/PUT /api/radio/front-panel. The Enabled/DevicePath/Baud trio are the
+// operator's stored settings (DevicePath empty + Baud 0 = auto-detect); the
+// Connected/Active*/PanelType trio is the live bridge status (Connected =
+// serial line open; PanelType 5 = a recognised G2-Ultra handshake).
+public sealed record G2PanelSettingsDto(
+    bool Enabled,
+    string? DevicePath,
+    int Baud,
+    bool Connected,
+    string? ActiveDevicePath,
+    int ActiveBaud,
+    int PanelType);
+
+// Request body for PUT /api/radio/front-panel. Every field optional — only the
+// supplied ones change. DevicePath "" clears the override (back to auto-detect);
+// Baud 0 = auto.
+public sealed record G2PanelSettingsSetRequest(
+    bool? Enabled = null,
+    string? DevicePath = null,
+    int? Baud = null);
+
 public sealed record HardwareKeyingStatusDto(
     int SchemaVersion,
     string? ActiveProtocol,

--- a/Zeus.Server.Hosting/FrontPanel/G2FrontPanelService.cs
+++ b/Zeus.Server.Hosting/FrontPanel/G2FrontPanelService.cs
@@ -18,6 +18,7 @@
 
 using System.IO.Ports;
 using System.Text;
+using Zeus.Contracts;
 
 namespace Zeus.Server.FrontPanel;
 
@@ -37,6 +38,7 @@ namespace Zeus.Server.FrontPanel;
 public sealed class G2FrontPanelService : BackgroundService
 {
     private readonly G2PanelOptions _opts;
+    private readonly G2PanelSettingsStore _store;
     private readonly RadioService _radio;
     private readonly TxService _tx;
     private readonly G2PanelActionRouter _router;
@@ -45,6 +47,15 @@ public sealed class G2FrontPanelService : BackgroundService
     private readonly AndromedaParser _parser = new();
     private readonly object _writeLock = new();
     private SerialPort? _port;
+
+    // Per-iteration linked CTS so a settings change (RequestReconnect) can break
+    // the current session/idle wait and force the loop to re-resolve the device.
+    private volatile CancellationTokenSource? _wakeCts;
+
+    // Live status for the Radio Settings card (GET /api/radio/front-panel).
+    private volatile bool _connected;
+    private volatile string? _activePath;
+    private volatile int _activeBaud;
 
     // ANDROMEDA console type announced via ZZZS. 5 = G2 Ultra (Mk2). Actions
     // are only routed for type 5; an unrecognised type is logged and ignored
@@ -58,6 +69,7 @@ public sealed class G2FrontPanelService : BackgroundService
 
     public G2FrontPanelService(
         IConfiguration config,
+        G2PanelSettingsStore store,
         RadioService radio,
         TxService tx,
         BandMemoryStore bandMemory,
@@ -66,43 +78,99 @@ public sealed class G2FrontPanelService : BackgroundService
     {
         _opts = new G2PanelOptions();
         config.GetSection(G2PanelOptions.Section).Bind(_opts);
+        _store = store;
         _radio = radio;
         _tx = tx;
         _log = log;
         _router = new G2PanelActionRouter(radio, tx, bandMemory,
             loggerFactory.CreateLogger<G2PanelActionRouter>());
+        // A Settings change re-resolves the device and reconnects without a
+        // server restart (enable toggled, COM port / baud edited).
+        _store.Changed += OnSettingsChanged;
+    }
+
+    private void OnSettingsChanged() => RequestReconnect();
+
+    /// <summary>Break the current serial session / idle wait so the run loop
+    /// re-reads settings and re-resolves the device. Safe to call from the
+    /// settings endpoint thread.</summary>
+    public void RequestReconnect()
+    {
+        try { _wakeCts?.Cancel(); }
+        catch (ObjectDisposedException) { /* loop already advanced */ }
+    }
+
+    /// <summary>Stored operator settings (Enabled / DevicePath / Baud) layered
+    /// over the G2FrontPanel config defaults, with the live bridge status.
+    /// Backs GET/PUT /api/radio/front-panel.</summary>
+    public G2PanelSettingsDto Snapshot()
+    {
+        var s = _store.Get();
+        return new G2PanelSettingsDto(
+            Enabled: s.Enabled,
+            DevicePath: s.DevicePath,
+            Baud: s.Baud,
+            Connected: _connected,
+            ActiveDevicePath: _activePath,
+            ActiveBaud: _activeBaud,
+            PanelType: _panelType);
+    }
+
+    // Stored settings layered over config: a stored value wins, else the
+    // G2FrontPanel config value, else unset (→ auto-detect / per-symlink baud).
+    private (bool Enabled, string? DevicePath, int Baud) Effective()
+    {
+        var s = _store.Get();
+        string? path = !string.IsNullOrWhiteSpace(s.DevicePath) ? s.DevicePath
+            : (!string.IsNullOrWhiteSpace(_opts.DevicePath) ? _opts.DevicePath : null);
+        int baud = s.Baud > 0 ? s.Baud : _opts.Baud;
+        return (s.Enabled, path, baud);
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        if (!_opts.Enabled)
-        {
-            _log.LogInformation("g2panel.disabled (G2FrontPanel:Enabled=false)");
-            return;
-        }
-
         while (!stoppingToken.IsCancellationRequested)
         {
-            var dev = ResolveDevice();
+            // Fresh linked CTS each pass so RequestReconnect() (settings change)
+            // can break this iteration without tearing down the service.
+            using var wake = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+            _wakeCts = wake;
+            var ct = wake.Token;
+
+            var eff = Effective();
+            if (!eff.Enabled)
+            {
+                // Disabled in Settings — wait until that changes (or shutdown),
+                // holding the port closed. RequestReconnect wakes us.
+                _log.LogInformation("g2panel.disabled (settings/config Enabled=false)");
+                await DelaySafe(Timeout.InfiniteTimeSpan, ct);
+                continue;
+            }
+
+            var dev = ResolveDevice(eff.DevicePath, eff.Baud);
             if (dev is null)
             {
                 // No panel on this host — idle and re-probe. Quiet by design.
-                await DelaySafe(TimeSpan.FromSeconds(10), stoppingToken);
+                await DelaySafe(TimeSpan.FromSeconds(10), ct);
                 continue;
             }
 
             try
             {
-                await RunPanelAsync(dev.Value.Path, dev.Value.Baud, stoppingToken);
+                await RunPanelAsync(dev.Value.Path, dev.Value.Baud, ct);
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
                 break;
             }
+            catch (OperationCanceledException)
+            {
+                // Wake from a settings change — loop and re-resolve.
+            }
             catch (Exception ex)
             {
                 _log.LogWarning(ex, "g2panel.session.error device={Dev}; reconnecting", dev.Value.Path);
-                await DelaySafe(TimeSpan.FromSeconds(5), stoppingToken);
+                await DelaySafe(TimeSpan.FromSeconds(5), ct);
             }
             finally
             {
@@ -111,15 +179,15 @@ public sealed class G2FrontPanelService : BackgroundService
         }
     }
 
-    private (string Path, int Baud)? ResolveDevice()
+    private (string Path, int Baud)? ResolveDevice(string? devicePath, int baud)
     {
-        if (!string.IsNullOrWhiteSpace(_opts.DevicePath))
-            return (_opts.DevicePath!, _opts.Baud > 0 ? _opts.Baud : 9600);
+        if (!string.IsNullOrWhiteSpace(devicePath))
+            return (devicePath!, baud > 0 ? baud : 9600);
 
         // Auto-detect the udev-published symlink (Linux / G2 Pi).
-        foreach (var (path, baud) in G2PanelOptions.KnownSymlinks)
+        foreach (var (path, symlinkBaud) in G2PanelOptions.KnownSymlinks)
         {
-            try { if (File.Exists(path)) return (path, _opts.Baud > 0 ? _opts.Baud : baud); }
+            try { if (File.Exists(path)) return (path, baud > 0 ? baud : symlinkBaud); }
             catch { /* path probing is best-effort */ }
         }
         return null;
@@ -139,6 +207,9 @@ public sealed class G2FrontPanelService : BackgroundService
         };
         port.Open();
         _port = port;
+        _activePath = path;
+        _activeBaud = baud;
+        _connected = true;
         _log.LogInformation("g2panel.open device={Dev} baud={Baud}", path, baud);
 
         // Opening the line resets Arduino-class panels into the bootloader for
@@ -254,6 +325,8 @@ public sealed class G2FrontPanelService : BackgroundService
 
     private void ClosePort()
     {
+        _connected = false;
+        _panelType = 0;
         var port = _port;
         _port = null;
         if (port is null) return;
@@ -268,6 +341,7 @@ public sealed class G2FrontPanelService : BackgroundService
 
     public override void Dispose()
     {
+        _store.Changed -= OnSettingsChanged;
         ClosePort();
         base.Dispose();
     }

--- a/Zeus.Server.Hosting/FrontPanel/G2PanelSettingsStore.cs
+++ b/Zeus.Server.Hosting/FrontPanel/G2PanelSettingsStore.cs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Per-install settings for the ANAN G2 / G2-Ultra hardware front-panel bridge:
+// the master enable, an explicit serial device (COM port / device path), and
+// the baud override. These layer OVER the G2FrontPanel config section in
+// G2FrontPanelService — a stored value wins, an unset one falls back to config
+// then to auto-detect. Surfaced in Radio Settings so an operator on a host
+// where the panel isn't a Linux by-id symlink (e.g. Windows COMx) can point the
+// bridge at the right port without editing appsettings.
+//
+// Defaults ON with no device override: byte-for-byte the historical behaviour
+// (auto-detect the g2-front symlink, idle when absent). Single-row LiteDB
+// collection ("g2_panel_settings") sharing zeus-prefs.db, mirroring
+// PttSettingsStore. Insert/Update (NOT Upsert with Id=0) avoids the LiteDB
+// Id=0-always-inserts bug (PR #387).
+
+using LiteDB;
+
+namespace Zeus.Server.FrontPanel;
+
+public sealed class G2PanelSettingsStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<G2PanelSettingsEntry> _rows;
+    private readonly ILogger<G2PanelSettingsStore> _log;
+    private readonly object _sync = new();
+
+    // Fired on any write so the front-panel service re-resolves + reconnects.
+    public event Action? Changed;
+
+    public G2PanelSettingsStore(ILogger<G2PanelSettingsStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _rows = _db.GetCollection<G2PanelSettingsEntry>("g2_panel_settings");
+
+        _log.LogInformation("G2PanelSettingsStore initialized at {Path}", dbPath);
+    }
+
+    /// <summary>Current settings. A missing row (fresh install / pre-feature DB)
+    /// returns the defaults: Enabled=true, no device override (auto-detect),
+    /// Baud=0 (auto) — identical to the historical config-only behaviour.</summary>
+    public G2PanelSettingsEntry Get()
+    {
+        lock (_sync)
+            return _rows.FindAll().FirstOrDefault() ?? new G2PanelSettingsEntry();
+    }
+
+    /// <summary>Replace the stored settings. <paramref name="devicePath"/> empty/
+    /// null = auto-detect; <paramref name="baud"/> 0 = auto. Insert-then-Update
+    /// (matching PttSettingsStore) avoids the LiteDB Id=0 upsert bug (PR #387).</summary>
+    public void Set(bool enabled, string? devicePath, int baud)
+    {
+        var normPath = string.IsNullOrWhiteSpace(devicePath) ? null : devicePath.Trim();
+        var normBaud = baud > 0 ? baud : 0;
+        lock (_sync)
+        {
+            var existing = _rows.FindAll().FirstOrDefault();
+            var nowUtc = DateTime.UtcNow;
+            if (existing is null)
+            {
+                _rows.Insert(new G2PanelSettingsEntry
+                {
+                    Enabled = enabled,
+                    DevicePath = normPath,
+                    Baud = normBaud,
+                    UpdatedUtc = nowUtc,
+                });
+            }
+            else
+            {
+                existing.Enabled = enabled;
+                existing.DevicePath = normPath;
+                existing.Baud = normBaud;
+                existing.UpdatedUtc = nowUtc;
+                _rows.Update(existing);
+            }
+        }
+        Changed?.Invoke();
+    }
+
+    public void Dispose() => _db.Dispose();
+}
+
+public sealed class G2PanelSettingsEntry
+{
+    public int Id { get; set; }
+    // Master enable. Default true — matches the historical config default, so a
+    // fresh install keeps auto-detecting the panel.
+    public bool Enabled { get; set; } = true;
+    // Explicit serial device (COM5 / /dev/ttyACM0). Null = auto-detect.
+    public string? DevicePath { get; set; }
+    // Baud override. 0 = auto (config, then per-symlink default, then 9600).
+    public int Baud { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -2163,6 +2163,33 @@ public static class ZeusEndpoints
             return Results.Ok(externalPtt.Snapshot());
         });
 
+        // ANAN G2 / G2-Ultra hardware front-panel bridge settings (per-install).
+        // GET returns the stored enable/device/baud plus live bridge status
+        // (connected + active device/baud + panel type). PUT updates the stored
+        // settings and reconnects the bridge — no server restart. DevicePath ""
+        // clears the override (auto-detect); Baud 0 = auto. On the G2 Pi the
+        // defaults auto-detect the panel; on a Windows/macOS host point it at the
+        // COM port here. Ungated — the panel is a host serial device.
+        app.MapGet("/api/radio/front-panel", (Zeus.Server.FrontPanel.G2FrontPanelService svc) =>
+        {
+            return Results.Ok(svc.Snapshot());
+        });
+
+        app.MapPut("/api/radio/front-panel",
+            (G2PanelSettingsSetRequest req,
+             Zeus.Server.FrontPanel.G2PanelSettingsStore store,
+             Zeus.Server.FrontPanel.G2FrontPanelService svc) =>
+        {
+            if (req.Baud is int b && b is not (0 or 9600 or 115200))
+                return Results.BadRequest(new { error = $"unsupported baud {b} (use 0=auto, 9600, or 115200)" });
+            var cur = store.Get();
+            store.Set(
+                enabled: req.Enabled ?? cur.Enabled,
+                devicePath: req.DevicePath ?? cur.DevicePath,
+                baud: req.Baud ?? cur.Baud);
+            return Results.Ok(svc.Snapshot());
+        });
+
         // Global (per-radio) TX-audio source (external-audio-jacks re-port). GET
         // surfaces the per-board capability gates + the RESOLVED (board-clamped)
         // source so the single-select picker shows only the jacks the connected

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -433,7 +433,13 @@ public static class ZeusHost
         // internal Pi) and routes its buttons/encoders/LEDs through the same
         // RadioService/TxService seams the web UI uses. Presence-gated: idles
         // on hosts with no panel device, so it is safe to register everywhere.
-        builder.Services.AddHostedService<Zeus.Server.FrontPanel.G2FrontPanelService>();
+        // Per-install enable / device / baud overrides live in
+        // G2PanelSettingsStore (Radio Settings card); the service is a singleton
+        // so the settings endpoint can read its live status + trigger a reconnect.
+        builder.Services.AddSingleton<Zeus.Server.FrontPanel.G2PanelSettingsStore>();
+        builder.Services.AddSingleton<Zeus.Server.FrontPanel.G2FrontPanelService>();
+        builder.Services.AddHostedService(sp =>
+            sp.GetRequiredService<Zeus.Server.FrontPanel.G2FrontPanelService>());
 
         // QRZ.com XML client. HttpClient default timeout is 100 s — cap at 10 s so a
         // hung login surfaces quickly in the UI.

--- a/tests/Zeus.Server.Tests/G2PanelSettingsStoreTests.cs
+++ b/tests/Zeus.Server.Tests/G2PanelSettingsStoreTests.cs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Server.FrontPanel;
+
+namespace Zeus.Server.Tests;
+
+// Persistence for the G2 / G2-Ultra front-panel bridge settings (enable +
+// serial device + baud override) surfaced in the Radio Settings card.
+public sealed class G2PanelSettingsStoreTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-g2panel-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+    }
+
+    private G2PanelSettingsStore NewStore() =>
+        new(NullLogger<G2PanelSettingsStore>.Instance, _dbPath);
+
+    [Fact]
+    public void Get_FreshInstall_DefaultsEnabledTrueNoOverride()
+    {
+        using var store = NewStore();
+        var s = store.Get();
+        Assert.True(s.Enabled);          // auto-detect behaviour preserved
+        Assert.Null(s.DevicePath);       // no override → auto-detect
+        Assert.Equal(0, s.Baud);         // 0 = auto
+    }
+
+    [Fact]
+    public void SetThenGet_RoundTrips()
+    {
+        using var store = NewStore();
+        store.Set(enabled: false, devicePath: "COM5", baud: 9600);
+        var s = store.Get();
+        Assert.False(s.Enabled);
+        Assert.Equal("COM5", s.DevicePath);
+        Assert.Equal(9600, s.Baud);
+    }
+
+    [Fact]
+    public void Set_NormalizesBlankPathAndNonPositiveBaud()
+    {
+        using var store = NewStore();
+        store.Set(enabled: true, devicePath: "   ", baud: -1);
+        var s = store.Get();
+        Assert.Null(s.DevicePath);  // whitespace → auto-detect
+        Assert.Equal(0, s.Baud);    // non-positive → auto
+    }
+
+    [Fact]
+    public void Set_PersistsAcrossReopen()
+    {
+        using (var store = NewStore())
+            store.Set(enabled: true, devicePath: "/dev/ttyACM0", baud: 115200);
+        using var reopened = NewStore();
+        var s = reopened.Get();
+        Assert.Equal("/dev/ttyACM0", s.DevicePath);
+        Assert.Equal(115200, s.Baud);
+    }
+
+    [Fact]
+    public void Set_FiresChanged()
+    {
+        using var store = NewStore();
+        int fired = 0;
+        store.Changed += () => fired++;
+        store.Set(enabled: false, devicePath: null, baud: 0);
+        Assert.Equal(1, fired);
+    }
+}

--- a/zeus-web/src/components/RadioSettingsPanel.tsx
+++ b/zeus-web/src/components/RadioSettingsPanel.tsx
@@ -6,7 +6,9 @@
 //
 // RADIO SETTINGS tab. Cards:
 //   1. PTT-IN → MOX enable gate, with a live PTT-IN status lamp.
-//   2. Audio Input — the single-select TX-audio SOURCE (external-audio-jacks
+//   2. Front Panel — ANAN G2 / G2-Ultra ANDROMEDA serial bridge enable +
+//      device/baud override + live connected lamp (auto-detects on the G2 Pi).
+//   3. Audio Input — the single-select TX-audio SOURCE (external-audio-jacks
 //      re-port). Board-gated off the per-board capability flags carried in the
 //      /api/radio/audio GET response, so the picker offers only the jacks the
 //      connected board has. Host is always available and is the default.
@@ -21,8 +23,9 @@
 // surfaces (tokens only, no new chrome / palette). Layout / visual specifics
 // are the maintainer's call — this stays clean and minimal.
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { usePttStore } from '../state/ptt-store';
+import { useG2PanelStore } from '../state/g2panel-store';
 import { useAudioStore, type TxAudioSource } from '../state/audio-store';
 import {
   useAntennaStore,
@@ -60,6 +63,17 @@ export function RadioSettingsPanel() {
   const loadPtt = usePttStore((s) => s.load);
   const setPttEnabled = usePttStore((s) => s.setEnabled);
 
+  const g2Enabled = useG2PanelStore((s) => s.enabled);
+  const g2DevicePath = useG2PanelStore((s) => s.devicePath);
+  const g2Baud = useG2PanelStore((s) => s.baud);
+  const g2Connected = useG2PanelStore((s) => s.connected);
+  const g2ActivePath = useG2PanelStore((s) => s.activeDevicePath);
+  const g2ActiveBaud = useG2PanelStore((s) => s.activeBaud);
+  const g2PanelType = useG2PanelStore((s) => s.panelType);
+  const g2Inflight = useG2PanelStore((s) => s.inflight);
+  const loadG2 = useG2PanelStore((s) => s.load);
+  const updateG2 = useG2PanelStore((s) => s.update);
+
   const audio = useAudioStore((s) => s.settings);
   const audioInflight = useAudioStore((s) => s.inflight);
   const loadAudio = useAudioStore((s) => s.load);
@@ -72,9 +86,25 @@ export function RadioSettingsPanel() {
 
   useEffect(() => {
     void loadPtt();
+    void loadG2();
     void loadAudio();
     void loadAntenna();
-  }, [loadPtt, loadAudio, loadAntenna]);
+  }, [loadPtt, loadG2, loadAudio, loadAntenna]);
+
+  // Poll the front-panel bridge status while this tab is mounted so the
+  // connected lamp reflects plug/unplug without a manual reload.
+  useEffect(() => {
+    const id = window.setInterval(() => void loadG2(), 3000);
+    return () => window.clearInterval(id);
+  }, [loadG2]);
+
+  // Local draft for the device-path field — commit on blur / Enter so we don't
+  // PUT on every keystroke. Re-sync when the server value changes.
+  const [g2PathDraft, setG2PathDraft] = useState(g2DevicePath);
+  useEffect(() => setG2PathDraft(g2DevicePath), [g2DevicePath]);
+  const commitG2Path = () => {
+    if (g2PathDraft.trim() !== g2DevicePath) void updateG2({ devicePath: g2PathDraft.trim() });
+  };
 
   // Per-board source-availability gates ride the /api/radio/audio response, so
   // we read them straight off the audio settings (no separate caps fetch).
@@ -175,6 +205,115 @@ export function RadioSettingsPanel() {
             <em>Release hang time — bridges CW inter-character gaps. Fixed for now.</em>
           </div>
           <span style={{ color: 'var(--fg-2)' }}>{pttHangMs} ms</span>
+        </div>
+      </div>
+
+      {/* ANAN G2 / G2-Ultra hardware front panel (ANDROMEDA serial bridge).
+          Ungated — the panel is a host serial device; on the G2 Pi it
+          auto-detects, on a Windows/macOS host point it at the COM port. */}
+      <div className="ps-card">
+        <h4>
+          <svg className="ps-ic-sm" viewBox="0 0 12 12">
+            <path d="M1.5 2.5h9v7h-9zM3 4.5h2M3 6.5h2M7 4.5h2M7 6.5h2" fill="none" />
+          </svg>
+          Front Panel
+          <span className="ps-card-hint">ANAN G2 / G2-Ultra (ANDROMEDA)</span>
+        </h4>
+
+        <div className="ps-field">
+          <div className="ps-name">
+            Status
+            <em>
+              Live bridge state. Connects automatically when the panel's serial
+              line is found; idle if no panel is wired to this host.
+            </em>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <span
+              aria-hidden
+              style={{
+                width: '0.6rem',
+                height: '0.6rem',
+                borderRadius: '50%',
+                background: g2Connected ? 'var(--accent)' : 'var(--fg-3)',
+                boxShadow: g2Connected ? '0 0 6px var(--accent)' : 'none',
+                transition: 'background 60ms linear',
+              }}
+            />
+            <span style={{ color: g2Connected ? 'var(--accent)' : 'var(--fg-2)' }}>
+              {g2Connected
+                ? `connected${g2PanelType === 5 ? ' · G2-Ultra' : g2PanelType > 0 ? ` · type ${g2PanelType}` : ''}`
+                : 'not connected'}
+            </span>
+            {g2Connected && g2ActivePath ? (
+              <span style={{ color: 'var(--fg-3)', fontSize: '0.8em' }}>
+                {g2ActivePath} @ {g2ActiveBaud}
+              </span>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="ps-field">
+          <div className="ps-name">
+            Enable
+            <em>
+              When off, the front-panel buttons / VFO / encoders are ignored
+              (the bridge never opens the port).
+            </em>
+          </div>
+          <label className="ps-check">
+            <input
+              type="checkbox"
+              checked={g2Enabled}
+              disabled={g2Inflight}
+              onChange={(e) => void updateG2({ enabled: e.target.checked })}
+            />
+            <span className="ps-check-box" />
+            <span>Front-panel bridge</span>
+          </label>
+        </div>
+
+        <div className="ps-field">
+          <div className="ps-name">
+            Serial Device
+            <em>
+              Leave blank to auto-detect (the g2-front line on the G2's Pi). On a
+              Windows / macOS host enter the panel's port, e.g. COM5 or
+              /dev/ttyACM0.
+            </em>
+          </div>
+          <input
+            className="ps-select-mini"
+            type="text"
+            placeholder="auto-detect"
+            value={g2PathDraft}
+            disabled={g2Inflight || !g2Enabled}
+            onChange={(e) => setG2PathDraft(e.target.value)}
+            onBlur={commitG2Path}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') commitG2Path();
+            }}
+          />
+        </div>
+
+        <div className="ps-field">
+          <div className="ps-name">
+            Baud
+            <em>
+              Auto picks 9600 for the 8&quot; Mk2 control front (and CM4/CM5 UART)
+              or 115200 for the RP2040 “Front V1”.
+            </em>
+          </div>
+          <select
+            className="ps-select-mini"
+            value={g2Baud}
+            disabled={g2Inflight || !g2Enabled}
+            onChange={(e) => void updateG2({ baud: Number.parseInt(e.target.value, 10) })}
+          >
+            <option value={0}>Auto</option>
+            <option value={9600}>9600</option>
+            <option value={115200}>115200</option>
+          </select>
         </div>
       </div>
 

--- a/zeus-web/src/state/g2panel-store.ts
+++ b/zeus-web/src/state/g2panel-store.ts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// ANAN G2 / G2-Ultra hardware front-panel bridge settings store. Backs the
+// Radio Settings "Front Panel" card: the master enable, an explicit serial
+// device (COM port / device path), and a baud override — plus the live bridge
+// status (connected + the device/baud actually opened + the ANDROMEDA panel
+// type). Server-authoritative: hydrates from GET /api/radio/front-panel and
+// re-syncs on every PUT, never clobbered on connect.
+//
+// On the G2's internal Pi the defaults auto-detect the panel; on a Windows /
+// macOS host the operator points the bridge at the COM port here.
+
+import { create } from 'zustand';
+
+export interface G2PanelSettings {
+  /** Master enable. Default ON server-side (auto-detects the panel). */
+  enabled: boolean;
+  /** Explicit serial device (COM5 / /dev/ttyACM0). Empty = auto-detect. */
+  devicePath: string;
+  /** Baud override; 0 = auto (9600 for the 8" Mk2 front, 115200 for V1). */
+  baud: number;
+  /** Live: the bridge has the serial line open. */
+  connected: boolean;
+  /** Live: the device path the bridge actually opened (may be auto-detected). */
+  activeDevicePath: string;
+  /** Live: the baud actually in use. */
+  activeBaud: number;
+  /** Live: ANDROMEDA console type from ZZZS (5 = G2-Ultra). 0 = not identified. */
+  panelType: number;
+}
+
+const DEFAULTS: G2PanelSettings = {
+  enabled: true,
+  devicePath: '',
+  baud: 0,
+  connected: false,
+  activeDevicePath: '',
+  activeBaud: 0,
+  panelType: 0,
+};
+
+function parse(raw: unknown): G2PanelSettings {
+  const r = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+  return {
+    enabled: typeof r.enabled === 'boolean' ? r.enabled : true,
+    devicePath: typeof r.devicePath === 'string' ? r.devicePath : '',
+    baud: typeof r.baud === 'number' ? r.baud : 0,
+    connected: typeof r.connected === 'boolean' ? r.connected : false,
+    activeDevicePath: typeof r.activeDevicePath === 'string' ? r.activeDevicePath : '',
+    activeBaud: typeof r.activeBaud === 'number' ? r.activeBaud : 0,
+    panelType: typeof r.panelType === 'number' ? r.panelType : 0,
+  };
+}
+
+export async function fetchG2PanelSettings(signal?: AbortSignal): Promise<G2PanelSettings> {
+  const res = await fetch('/api/radio/front-panel', { signal });
+  if (!res.ok) throw new Error(`GET /api/radio/front-panel → ${res.status}`);
+  return parse(await res.json());
+}
+
+export async function updateG2PanelSettings(
+  patch: { enabled?: boolean; devicePath?: string; baud?: number },
+  signal?: AbortSignal,
+): Promise<G2PanelSettings> {
+  const res = await fetch('/api/radio/front-panel', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(patch),
+    signal,
+  });
+  if (!res.ok) throw new Error(`PUT /api/radio/front-panel → ${res.status}`);
+  return parse(await res.json());
+}
+
+interface G2PanelState extends G2PanelSettings {
+  loaded: boolean;
+  inflight: boolean;
+  error: string | null;
+  /** Hydrate settings + status from the REST snapshot. */
+  load: () => Promise<void>;
+  /** Update one or more settings (optimistic, server-authoritative). */
+  update: (patch: { enabled?: boolean; devicePath?: string; baud?: number }) => Promise<void>;
+  __resetForTests: () => void;
+}
+
+export const useG2PanelStore = create<G2PanelState>((set, get) => ({
+  ...DEFAULTS,
+  loaded: false,
+  inflight: false,
+  error: null,
+
+  load: async () => {
+    set({ inflight: true, error: null });
+    try {
+      const s = await fetchG2PanelSettings();
+      set({ ...s, loaded: true, inflight: false });
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : String(err), inflight: false });
+    }
+  },
+
+  update: async (patch) => {
+    const prev: G2PanelSettings = {
+      enabled: get().enabled,
+      devicePath: get().devicePath,
+      baud: get().baud,
+      connected: get().connected,
+      activeDevicePath: get().activeDevicePath,
+      activeBaud: get().activeBaud,
+      panelType: get().panelType,
+    };
+    // Optimistic on the operator-settable fields; status fields keep prior
+    // values until the server snapshot returns.
+    set({ ...patch, inflight: true, error: null });
+    try {
+      const s = await updateG2PanelSettings(patch);
+      set({ ...s, inflight: false });
+    } catch (err) {
+      set({ ...prev, error: err instanceof Error ? err.message : String(err), inflight: false });
+    }
+  },
+
+  __resetForTests: () => set({ ...DEFAULTS, loaded: false, inflight: false, error: null }),
+}));


### PR DESCRIPTION
## Summary
The ANAN G2 / G2-Ultra ANDROMEDA front-panel bridge was **config + auto-detect only** — no web UI. On the G2's internal Pi it "just works", but on any other host (e.g. a Windows dev box where the panel is `COM5`, not a Linux `by-id` symlink) there was no way to point the bridge at the port. This adds a **Front Panel** card to **Radio Settings**.

### Card (Radio Settings)
- **Enable** toggle (master switch for the bridge).
- **Serial Device** override — blank = auto-detect; or `COM5` / `/dev/ttyACM0`.
- **Baud** — Auto / 9600 / 115200.
- **Live connected lamp** + active device/baud + ANDROMEDA panel type, polled every 3s.

### Backend
- `G2PanelSettingsStore` — single-row LiteDB store (mirrors `PttSettingsStore`). Defaults `Enabled=true` / no override, so behaviour on the G2 Pi is **unchanged**.
- `G2FrontPanelService` now layers the store **over** the `G2FrontPanel` config (stored value wins → config → auto-detect), exposes `Snapshot()`, and **reconnects on a settings change** via a per-iteration linked CTS (`RequestReconnect`) — enable/port/baud edits take effect with **no restart**. Promoted to a resolvable singleton so the endpoint can read status + trigger reconnect.
- `GET`/`PUT /api/radio/front-panel` (+ `G2PanelSettingsDto` / `G2PanelSettingsSetRequest`).

### Frontend
- `g2panel-store` (zustand, mirrors `ptt-store`); the new card in `RadioSettingsPanel`.

## Notes for review
- No behaviour change on the G2 Pi (defaults preserve auto-detect). Card is ungated (the panel is a host serial device). No PA/drive/PureSignal paths touched.
- Visual idiom reuses the existing `.ps-card` / `.ps-field` surfaces (tokens only, no new chrome) — final visual polish is the maintainer's call.

## Test plan
- `G2PanelSettingsStoreTests` 5/5 (defaults, round-trip, normalization, persist-across-reopen, `Changed` event) ✅
- All 16 `G2Panel` tests pass ✅
- `tsc -b` clean; full solution (incl. frontend) builds clean ✅