### PR TITLE
fix(vst): bound the Linux editor-thread join in zvst_unload

### DIFF
--- a/native/zeus-vst-bridge/src/bridge.cpp
+++ b/native/zeus-vst-bridge/src/bridge.cpp
@@ -1222,7 +1222,24 @@ int32_t zvst_unload(zvst_handle_t handle) {
     // component teardown() below sees controller == null and won't double-free.
     if (p->editor_thread_running.load()) {
         post_editor_cmd(*p, 3, 0);
-        if (p->editor_thread.joinable()) p->editor_thread.join();
+        // Wait (bounded) for the editor thread to retire on its own. If a plug-in
+        // wedged it -- e.g. view->removed() never returns on this thread -- a plain
+        // join() would hang the host forever, so we never join unconditionally.
+        // Detach + leak instead: memory-safe, never blocks the server. Mirrors the
+        // Windows ui_thread guard above.
+        for (int i = 0; i < 500 && p->editor_thread_running.load(); ++i)
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        if (p->editor_thread.joinable()) {
+            if (!p->editor_thread_running.load()) {
+                p->editor_thread.join();
+            } else {
+                // Editor thread still wedged in the plug-in. It references *p, so
+                // freeing p would be use-after-free -- detach + leak. Rare,
+                // memory-safe, never blocks the host.
+                p->editor_thread.detach();
+                return ZVST_OK;
+            }
+        }
     }
     if (p->cmd_pipe[0] >= 0) { close(p->cmd_pipe[0]); close(p->cmd_pipe[1]); }
     teardown(*p);


### PR DESCRIPTION
## What
The Linux `zvst_unload` path joined the editor thread **unconditionally**. If a plug-in wedges that thread — e.g. `IPlugView::removed()` never returns on the editor thread during editor close — the `join()` blocks forever and **hangs the entire VST host process** (and with it the audio server).

This mirrors the existing Windows `ui_thread` guard: after posting the unload command, wait up to ~5 s for the editor thread to retire, then `join()` if it did; otherwise `detach()` and return early (intentionally leaking the still-referenced state so freeing `*p` can't become a use-after-free). Rare, memory-safe, and the host can never hang on a misbehaving plug-in editor.

## Why it's a separate, minimal PR
The fix originally lived on `feat/linux-native-vst-engine` (PR #864, squash-merged). That branch is now based on a stale develop and would revert a large amount of since-merged work if PR'd directly, so only the 1-file bridge fix is cherry-picked onto current develop here.

## Verified on real arm64 Linux hardware (Radxa CM5)
Reproduced with `DragonflyHallReverb.vst3`: the probe went from a **hung process** (editor-close deadlock on unload) to a clean unload/shutdown (exit 0).

## Related / follow-up
- Deeper root cause still open: `view->removed()` not returning on the editor thread (so `zvst_editor_is_open` stays true after close). This change makes that condition **non-fatal**; the real fix likely needs the X event loop pumped during `removed()` or a thread-affinity correction.
- Pairs with #877 (output parameter-changes queue). No realtime audio-path change; no alloc/lock added.