### PR TITLE
fix(dsp): stop choppy RX — keep AGC knee above noise + add MED hang

### DIFF
--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -232,10 +232,11 @@ public sealed class WdspDspEngine : IDspEngine
         public int FilterLowAbsHz = 150;
         public int FilterHighAbsHz = 2850;
         public RxaMode CurrentMode = RxaMode.USB;
-        // Thetis "AGC Top" max-gain setting in dB. 90 matches the Thetis
-        // default (radio.cs:1021 rx_agc_max_gain); the /api/agcGain endpoint can
-        // override at runtime.
-        public double AgcTopDb = 90.0;
+        // "AGC Top" max-gain setting in dB. With slope=0 (flat leveling, see
+        // ApplyAgcCore) 90 dB drops the AGC knee into the noise floor and pumps
+        // it up in speech gaps (choppy RX); 80 keeps the knee above the noise.
+        // The /api/agcGain endpoint can override at runtime up to 90.
+        public double AgcTopDb = 80.0;
         // AGC mode last applied via SetAgc / ApplyAgcDefaults. MED matches the
         // open-time default; surfaced so callers / tests can read back the mode.
         public AgcMode CurrentAgcMode = AgcMode.Med;
@@ -3485,21 +3486,34 @@ public sealed class WdspDspEngine : IDspEngine
     private static void ApplyAgcDefaults(int id)
     {
         ApplyAgcCore(id, new AgcConfig(AgcMode.Med));
-        NativeMethods.SetRXAAGCTop(id, 90.0);            // max gain, dB (Thetis radio.cs:1021 default)
+        NativeMethods.SetRXAAGCTop(id, 80.0);            // max gain, dB (keeps AGC knee above noise floor at slope=0)
     }
 
-    // Canned-mode presets, verbatim from Thetis console.cs:27958-28024. Hang/Decay
-    // in ms. HangThreshold: MED/FAST hard-set 100 (slider disabled); LONG/SLOW
-    // leave it at the Thetis slider/init default (0). Custom returns the Med
-    // baseline so a null custom field falls back somewhere sane.
+    // Canned-mode presets. Hang/Decay in ms. LONG/SLOW/FAST mirror Thetis
+    // console.cs:27958-28024 (= the native SetRXAAGCMode canned values in
+    // wcpAGC.c:354-382) verbatim.
+    //
+    // MED is a deliberate Zeus divergence: stock WDSP MED ships hangtime=0, so
+    // with our flat slope=0 leveling (ApplyAgcCore) the gain recovers over the
+    // 250 ms decay in every speech gap and pumps the noise floor up between
+    // words — audibly choppy RX. We give MED a 250 ms hang to bridge inter-
+    // syllable/word gaps so the gain holds steady through a QSO instead of
+    // pumping. The hang only engages when hang_backaverage > hang_level, and
+    // hang_level = 0.637·max_input at HangThreshold 100 — i.e. only near
+    // full-scale. So MED also drops to HangThreshold 0 (like LONG/SLOW), which
+    // lowers hang_level to ~0.637·min_volts so the hang engages across the
+    // normal signal range. This realises the project's "constant loudness, no
+    // pumping" AGC requirement on the default mode. FAST stays hang-free (snappy
+    // by design). Custom returns the Med baseline so a null custom field falls
+    // back somewhere sane.
     private static (int HangMs, int DecayMs, int HangThreshold) AgcPreset(AgcMode mode) => mode switch
     {
         AgcMode.Long => (2000, 2000, 0),
         AgcMode.Slow => (1000, 500, 0),
-        AgcMode.Med => (0, 250, 100),
+        AgcMode.Med => (250, 250, 0),
         AgcMode.Fast => (0, 50, 100),
-        AgcMode.Fixed => (0, 250, 100),
-        _ => (0, 250, 100),
+        AgcMode.Fixed => (250, 250, 0),
+        _ => (250, 250, 0),
     };
 
     // Pushes the AGC mode + custom/fixed params to WDSP. Shared by ApplyAgcDefaults

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -56,9 +56,15 @@ namespace Zeus.Server;
 public sealed class RadioService : IDisposable
 {
     private const int DefaultHpsdrPort = 1024;
-    internal const double DefaultAgcTopDb = 90.0;   // Thetis radio.cs:1021 rx_agc_max_gain default
+    // Default AGC-T baseline. With slope=0 (flat leveling — see WdspDspEngine
+    // ApplyAgcCore) the AGC knee sits at out_target/max_gain; max_gain = 10^(top/20).
+    // At 90 dB the knee sinks ~13 dB into the noise floor, so the AGC normalizes
+    // the noise itself and pumps it up in speech gaps (choppy RX). 80 keeps the
+    // knee above the noise while still normalizing real signals to one loudness.
+    // The slider ceiling stays 90 (MaxAgcTopDb) as headroom for weak bands.
+    internal const double DefaultAgcTopDb = 80.0;
     // Operator AGC-T baseline range. Below ~30 dB the RX audio is effectively
-    // muted and 90 dB is the Thetis default / loudest the AGC will drive; the
+    // muted and 90 dB is the loudest the AGC will drive; the
     // old -20..120 span (mirroring the raw Thetis slider) exposed a large dead
     // region the operator never used. The slider is linear across this window.
     // NOTE: this bounds only the manual baseline (AgcTopDb). Auto-AGC's offset

--- a/tests/Zeus.Server.Tests/RadioServiceAutoAgcTests.cs
+++ b/tests/Zeus.Server.Tests/RadioServiceAutoAgcTests.cs
@@ -35,21 +35,25 @@ public sealed class RadioServiceAutoAgcTests : IDisposable
     }
 
     [Fact]
-    public void FreshRadio_UsesWdspMediumAgcTopBaseline()
+    public void FreshRadio_UsesDefaultAgcTopBaseline()
     {
+        // Default baseline is 80 dB, not the WDSP/Thetis 90: at slope=0 (flat
+        // leveling) a 90 dB AGC top sinks the knee into the noise floor and pumps
+        // it in speech gaps. 80 keeps the knee above the noise. The slider ceiling
+        // stays 90 (RadioService.MaxAgcTopDb) as headroom for weak bands.
         using var radio = NewRadio();
 
-        Assert.Equal(90.0, radio.Snapshot().AgcTopDb);
+        Assert.Equal(80.0, radio.Snapshot().AgcTopDb);
     }
 
     [Fact]
     public void AutoAgc_LowersEffectiveBelowBaseline_OnNoisyBand()
     {
-        // Symmetric tracking (#806): default baseline AgcTopDb is 90; a noisy
+        // Symmetric tracking (#806): default baseline AgcTopDb is 80; a noisy
         // -80 dBm floor wants effective = clamp(-40-(-80)=40, 20, 100) = 40, so
-        // the offset goes NEGATIVE (40-90 = -50) — the loop lowers gain below the
+        // the offset goes NEGATIVE (40-80 = -40) — the loop lowers gain below the
         // slider baseline on a noisy band. This is the behavior the old
-        // Math.Max(0, …) clamp suppressed (making auto-AGC inaudible at the 90 dB
+        // Math.Max(0, …) clamp suppressed (making auto-AGC inaudible at the
         // default); the spectrum-floor source is exercised here explicitly.
         using var radio = NewRadio();
         radio.SetAutoAgc(true);
@@ -60,8 +64,8 @@ public sealed class RadioServiceAutoAgcTests : IDisposable
                 adcPkDbfs: double.NaN, agcGainDb: double.NaN, nowMs: i * 500);
 
         var snap = radio.Snapshot();
-        Assert.Equal(90.0, snap.AgcTopDb);
-        Assert.Equal(-50.0, snap.AgcOffsetDb);
+        Assert.Equal(80.0, snap.AgcTopDb);
+        Assert.Equal(-40.0, snap.AgcOffsetDb);
         Assert.Equal(40.0, snap.AgcTopDb + snap.AgcOffsetDb); // effective AGC-T
     }
 


### PR DESCRIPTION
## Symptom
RX audio is "super choppy" — the background noise floor swells up to full volume in every gap between words/syllables (AGC pumping).

## Root cause
The AGC runs **flat** (`slope=0`) so all signals normalize to one loudness — the intended "constant loudness" behavior. But the leveling **knee** sits at `out_target / max_gain` (`native/wdsp/wcpAGC.c:123`), where `max_gain = 10^(AgcTopDb/20)`. With the **90 dB** AGC-T default the knee sinks **~13 dB into the noise floor**, so the AGC normalizes the *noise itself* up to full output during speech gaps — then slams back down (`attack=1 ms`) on the next syllable. That swelling-between-words is the chop.

Compounding it: stock WDSP **MED** mode ships `hangtime=0` (`wcpAGC.c:368-374`), so at `slope=0` the gain recovers over the 250 ms decay in every gap with nothing to bridge it.

## Fix
- **AGC-T default 90 → 80 dB** (`RadioService.DefaultAgcTopDb`, `WdspDspEngine` `ChannelState.AgcTopDb` + `ApplyAgcDefaults`). 80 keeps the knee above the noise so gaps stay quiet; real signals still normalize to one loudness. The slider **ceiling stays 90** (`MaxAgcTopDb`) as headroom for weak bands.
- **MED gets a 250 ms hang** with `HangThreshold 0` (so the hang engages across the normal signal range — at threshold 100 `hang_level = 0.637·max_input`, i.e. only near full-scale). This bridges inter-syllable/word gaps so the gain holds steady through a QSO instead of pumping. Deliberate divergence from stock WDSP MED, in service of the project's "constant loudness, no pumping" AGC requirement. FAST stays hang-free by design.

## Why these defaults are safe to touch here
`slope=0`, `attack=1 ms`, and the LONG/SLOW hang-threshold values already shipped on `develop`; this PR only moves the **AGC-T default** and the **MED hang**, both of which an operator can still override live via AGC-T and mode selection.

## Tests
- Updated `RadioServiceAutoAgcTests` for the 80 dB baseline (effective-AGC math unchanged; clamp tests still exercise the 90 dB ceiling).
- `dotnet test` AGC suite: **24 passed, 0 failed**.

## Bench verification needed
The numeric reasoning is solid, but pumping is ultimately an ear call. Please confirm on a real radio that RX is no longer choppy on MED (default) at 80 dB. If a band still feels a touch pumpy, AGC-T is live-adjustable and SLOW/LONG remain available.