### PR TITLE
feat(freedv): one-click in-app install of the codec2 modem

### DIFF
--- a/Zeus.Dsp.FreeDv/FreeDvNativeLoader.cs
+++ b/Zeus.Dsp.FreeDv/FreeDvNativeLoader.cs
@@ -11,13 +11,21 @@
 // with the WDSP resolver in Zeus.Dsp. The codec2 binary ships under
 // Zeus.Dsp/runtimes/{rid}/native and lands in the shared output directory, so
 // both the assembly-relative and BaseDirectory probes find it at runtime.
+//
+// It is ALSO resolvable from a writable per-user "managed" directory
+// (LocalApplicationData/Zeus/freedv) that the in-app FreeDV installer
+// (FreeDvNativeInstaller) stages into when the bundled binary is missing — e.g.
+// an older build that predates the committed lib, or a platform whose binary
+// wasn't shipped. The managed path is probed FIRST so a freshly-installed lib
+// wins, and TryProbe()'s cached result can be invalidated via ResetProbe() so
+// an install takes effect without restarting the host.
 
 using System.Reflection;
 using System.Runtime.InteropServices;
 
 namespace Zeus.Dsp.FreeDv;
 
-internal static class FreeDvNativeLoader
+public static class FreeDvNativeLoader
 {
     private static readonly object Gate = new();
     private static bool _registered;
@@ -57,6 +65,20 @@ internal static class FreeDvNativeLoader
         }
     }
 
+    /// <summary>
+    /// Drop the cached <see cref="TryProbe"/> result so the next probe re-scans
+    /// the candidate paths. Called after the in-app installer stages a new
+    /// codec2 binary so FreeDV can go live without restarting the host.
+    /// </summary>
+    public static void ResetProbe()
+    {
+        lock (Gate)
+        {
+            _probedLoadable = false;
+            _loadable = false;
+        }
+    }
+
     private static IntPtr Resolve(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
     {
         if (libraryName != FreeDvNativeMethods.LibraryName) return IntPtr.Zero;
@@ -77,6 +99,12 @@ internal static class FreeDvNativeLoader
     {
         string rid = CurrentRid();
         string fileName = NativeFileName();
+
+        // Writable per-user install location first: a binary staged by the
+        // in-app installer should win over (and back-fill) a missing bundled one.
+        string? managed = ManagedLibraryPath();
+        if (managed is not null) yield return managed;
+
         string? asmDir = Path.GetDirectoryName(assembly.Location);
         if (!string.IsNullOrEmpty(asmDir))
         {
@@ -89,7 +117,30 @@ internal static class FreeDvNativeLoader
         yield return Path.Combine(baseDir, fileName);
     }
 
-    private static string CurrentRid()
+    /// <summary>
+    /// The writable per-user directory the in-app installer stages the codec2
+    /// binary into (LocalApplicationData/Zeus/freedv). Cross-platform via
+    /// <see cref="Environment.SpecialFolder.LocalApplicationData"/>:
+    /// %LOCALAPPDATA%\Zeus\freedv on Windows, ~/.local/share/Zeus/freedv on
+    /// Linux, ~/Library/Application Support/Zeus/freedv on macOS. Null only when
+    /// the platform exposes no local-app-data location.
+    /// </summary>
+    public static string? ManagedLibraryDir()
+    {
+        string baseDir = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (string.IsNullOrEmpty(baseDir)) return null;
+        return Path.Combine(baseDir, "Zeus", "freedv");
+    }
+
+    /// <summary>Full path the codec2 binary is staged at for the current platform.</summary>
+    public static string? ManagedLibraryPath()
+    {
+        string? dir = ManagedLibraryDir();
+        return dir is null ? null : Path.Combine(dir, NativeFileName());
+    }
+
+    /// <summary>Runtime identifier (os-arch) used to resolve the bundled binary, e.g. "win-x64".</summary>
+    public static string CurrentRid()
     {
         string arch = RuntimeInformation.ProcessArchitecture switch
         {
@@ -104,7 +155,8 @@ internal static class FreeDvNativeLoader
         return $"unknown-{arch}";
     }
 
-    private static string NativeFileName()
+    /// <summary>Platform shared-library filename for codec2 (codec2.dll / libcodec2.so / libcodec2.dylib).</summary>
+    public static string NativeFileName()
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return "libcodec2.dylib";
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return "libcodec2.so";

--- a/Zeus.Server.Hosting/FreeDvNativeInstaller.cs
+++ b/Zeus.Server.Hosting/FreeDvNativeInstaller.cs
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// FreeDvNativeInstaller — the in-app "Install FreeDV" provisioning flow for the
+// codec2 modem library, modelled on VstEngineInstaller.
+//
+// codec2 cannot be built on a stock operator machine (its OFDM code is C99
+// _Complex, which MSVC can't compile — Windows needs a MinGW-w64 toolchain) and
+// upstream drowe67/codec2 publishes no prebuilt shared libraries. Zeus itself
+// builds the per-platform binary in CI (.github/workflows/build-native-libs.yml)
+// and commits it under Zeus.Dsp/runtimes/{rid}/native/. A normal Zeus build
+// therefore already carries FreeDV; the panel only reports "not installed" on an
+// OLDER build that predates the committed binary, or a platform whose binary was
+// never shipped (e.g. win-arm64, tracked as a follow-up).
+//
+// This installer back-fills exactly that case without a full app update: it
+// downloads the committed binary for the running platform straight from the Zeus
+// repo (raw GitHub, pinned ref), stages it into the writable managed path
+// (FreeDvNativeLoader.ManagedLibraryPath), then asks FreeDvService to reload the
+// modem so NativeAvailable flips true live — no restart. Nothing is built on the
+// user's machine and no extra hosting is required.
+
+using System.Net;
+using Zeus.Dsp.FreeDv;
+
+namespace Zeus.Server;
+
+/// <summary>Backs the in-app "Install FreeDV" action: downloads the prebuilt
+/// codec2 library Zeus committed for the running platform and stages it at the
+/// Zeus-managed path, then reloads the modem. Registered as a singleton in
+/// <c>ZeusHost</c>.</summary>
+public sealed class FreeDvNativeInstaller
+{
+    // Where the committed binary lives. The default points at the Zeus repo's
+    // runtimes/ tree; both the ref and the base are overridable for staging and
+    // tests. raw.githubusercontent serves the committed file with no auth (the
+    // repo is public), no toolchain, and no extra hosting.
+    internal const string DefaultBaseUrl =
+        "https://raw.githubusercontent.com/OpenHPSDR-Zeus-org/openhpsdr-zeus";
+    internal const string DefaultRef = "develop";
+
+    public enum Phase { Idle, Downloading, Staging, Done, Failed }
+
+    /// <summary>Coarse install progress for the polling frontend.</summary>
+    public sealed record Status(Phase Phase, int Percent, string? Message)
+    {
+        public bool InProgress => Phase is Phase.Downloading or Phase.Staging;
+    }
+
+    private readonly ILogger<FreeDvNativeInstaller> _log;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly FreeDvService _freeDv;
+    private readonly object _lock = new();
+    private Status _status = new(Phase.Idle, 0, null);
+    private Task? _running;
+
+    public FreeDvNativeInstaller(
+        ILogger<FreeDvNativeInstaller> log,
+        IHttpClientFactory httpClientFactory,
+        FreeDvService freeDv)
+    {
+        _log = log;
+        _httpClientFactory = httpClientFactory;
+        _freeDv = freeDv;
+    }
+
+    /// <summary>True when the codec2 library is already loadable — the install
+    /// affordance is unnecessary.</summary>
+    public bool Installed => _freeDv.NativeAvailable;
+
+    /// <summary>Snapshot of the current install state for the status endpoint.</summary>
+    public Status Current
+    {
+        get { lock (_lock) return _status; }
+    }
+
+    /// <summary>Kick off a background install if one isn't already running and the
+    /// library isn't already present. Returns the (possibly unchanged) status
+    /// immediately — the frontend polls <see cref="Current"/> for progress.</summary>
+    public Status Start(CancellationToken ct = default)
+    {
+        lock (_lock)
+        {
+            if (_running is { IsCompleted: false })
+                return _status; // already running
+
+            if (Installed)
+            {
+                _status = new Status(Phase.Done, 100, "FreeDV is already installed.");
+                return _status;
+            }
+
+            if (FreeDvNativeLoader.ManagedLibraryPath() is null)
+            {
+                _status = new Status(Phase.Failed, 0,
+                    "No writable install location on this platform.");
+                return _status;
+            }
+
+            _status = new Status(Phase.Downloading, 0, "Contacting the download server…");
+            _running = Task.Run(() => RunAsync(ct), CancellationToken.None);
+            return _status;
+        }
+    }
+
+    private void SetStatus(Phase phase, int percent, string? message)
+    {
+        lock (_lock) _status = new Status(phase, Math.Clamp(percent, 0, 100), message);
+    }
+
+    private async Task RunAsync(CancellationToken ct)
+    {
+        string? tempFile = null;
+        try
+        {
+            string rid = FreeDvNativeLoader.CurrentRid();
+            string fileName = FreeDvNativeLoader.NativeFileName();
+            string destPath = FreeDvNativeLoader.ManagedLibraryPath()
+                ?? throw new InvalidOperationException("No managed install path on this platform.");
+            string destDir = Path.GetDirectoryName(destPath)!;
+            string url = BuildLibraryUrl(BaseUrl(), Ref(), rid, fileName);
+
+            SetStatus(Phase.Downloading, 3, $"Downloading the FreeDV modem for {rid}…");
+            var http = _httpClientFactory.CreateClient("ZeusFreeDvNative");
+
+            // Download to a temp file alongside the managed dir so the final move
+            // is atomic on the same volume (and never leaves a half-written DLL
+            // where the loader would try to open it).
+            Directory.CreateDirectory(destDir);
+            tempFile = Path.Combine(destDir, $".codec2-download-{Guid.NewGuid():N}.tmp");
+            await DownloadAsync(http, url, tempFile, rid, ct).ConfigureAwait(false);
+
+            // Stage (85..95%): move into place, replacing any stale copy.
+            SetStatus(Phase.Staging, 88, "Installing the FreeDV modem…");
+            File.Move(tempFile, destPath, overwrite: true);
+            tempFile = null;
+
+            // Reload (95..100%): re-probe + swap in a fresh modem so FreeDV can go
+            // live without a restart.
+            SetStatus(Phase.Staging, 95, "Loading the FreeDV modem…");
+            bool ok = _freeDv.ReloadNative();
+            if (ok)
+            {
+                SetStatus(Phase.Done, 100, "FreeDV installed. Select FreeDV mode to use it.");
+                _log.LogInformation("FreeDV codec2 staged at {Path} from {Url}", destPath, url);
+            }
+            else
+            {
+                SetStatus(Phase.Failed, 0,
+                    "Downloaded the FreeDV modem, but the codec2 library still won't load on this system.");
+                _log.LogWarning("FreeDV codec2 staged at {Path} but did not load", destPath);
+            }
+        }
+        catch (PlatformUnavailableException ex)
+        {
+            SetStatus(Phase.Failed, 0, ex.Message);
+            _log.LogWarning("FreeDV install unavailable: {Message}", ex.Message);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            SetStatus(Phase.Failed, 0, "FreeDV install was cancelled.");
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "FreeDV install failed");
+            SetStatus(Phase.Failed, 0, $"FreeDV install failed: {Trunc(ex.Message)}");
+        }
+        finally
+        {
+            TryDelete(tempFile);
+        }
+    }
+
+    private async Task DownloadAsync(HttpClient http, string url, string destPath, string rid, CancellationToken ct)
+    {
+        using var response = await http
+            .GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct)
+            .ConfigureAwait(false);
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+            throw new PlatformUnavailableException(
+                $"FreeDV isn't published for this platform yet ({rid}). "
+                + "The codec2 modem ships for win-x64, linux-x64, linux-arm64 and osx-arm64.");
+        response.EnsureSuccessStatusCode();
+
+        long total = response.Content.Headers.ContentLength ?? 0;
+        await using var src = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        await using var dst = new FileStream(destPath, FileMode.Create, FileAccess.Write, FileShare.None);
+
+        var buffer = new byte[81920];
+        long read = 0;
+        int n;
+        while ((n = await src.ReadAsync(buffer, ct).ConfigureAwait(false)) > 0)
+        {
+            await dst.WriteAsync(buffer.AsMemory(0, n), ct).ConfigureAwait(false);
+            read += n;
+            if (total > 0)
+            {
+                // Map download to the 3..85% band.
+                int pct = 3 + (int)(read * 82 / total);
+                SetStatus(Phase.Downloading, pct, "Downloading the FreeDV modem…");
+            }
+        }
+    }
+
+    /// <summary>Build the raw-GitHub URL for the committed codec2 binary. Pure +
+    /// internal so the RID/path mapping is unit-testable without a network call.</summary>
+    internal static string BuildLibraryUrl(string baseUrl, string gitRef, string rid, string fileName)
+        => $"{baseUrl.TrimEnd('/')}/{gitRef}/Zeus.Dsp/runtimes/{rid}/native/{fileName}";
+
+    private static string BaseUrl()
+    {
+        var env = Environment.GetEnvironmentVariable("ZEUS_FREEDV_NATIVE_BASE_URL");
+        return string.IsNullOrWhiteSpace(env) ? DefaultBaseUrl : env.Trim();
+    }
+
+    private static string Ref()
+    {
+        var env = Environment.GetEnvironmentVariable("ZEUS_FREEDV_NATIVE_REF");
+        return string.IsNullOrWhiteSpace(env) ? DefaultRef : env.Trim();
+    }
+
+    private static string Trunc(string s, int max = 200)
+        => s.Length <= max ? s : s[..max] + "…";
+
+    private static void TryDelete(string? path)
+    {
+        if (path is null) return;
+        try { if (File.Exists(path)) File.Delete(path); } catch { /* best effort */ }
+    }
+
+    /// <summary>The committed binary doesn't exist for the running platform (a 404
+    /// on the repo path) — surfaced as a clear operator message, not a stack dump.</summary>
+    private sealed class PlatformUnavailableException(string message) : Exception(message);
+}

--- a/Zeus.Server.Hosting/FreeDvService.cs
+++ b/Zeus.Server.Hosting/FreeDvService.cs
@@ -21,18 +21,46 @@ namespace Zeus.Server;
 
 public sealed class FreeDvService : IDisposable
 {
-    private readonly FreeDvModem _modem;
+    private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<FreeDvService> _log;
+    private FreeDvModem _modem;
     private volatile string? _txText;
 
     public FreeDvService(ILoggerFactory loggerFactory)
     {
+        _loggerFactory = loggerFactory;
         _log = loggerFactory.CreateLogger<FreeDvService>();
         _modem = new FreeDvModem(loggerFactory.CreateLogger<FreeDvModem>());
     }
 
     /// <summary>True when FreeDV is engaged and the modem is processing audio.</summary>
     public bool Active => _modem.Active;
+
+    /// <summary>True when the codec2 native library is loadable and FreeDV can run.</summary>
+    public bool NativeAvailable => _modem.NativeAvailable;
+
+    /// <summary>
+    /// Re-evaluate codec2 availability after the in-app installer stages a new
+    /// binary, swapping in a fresh modem so <see cref="NativeAvailable"/> can
+    /// flip true without restarting the host. The operator's submode + squelch
+    /// selection carries over. Safe against the DSP hot path: the swap is a
+    /// single reference assignment, and the retired modem only ever passes audio
+    /// through once disposed. Returns the post-reload availability.
+    /// </summary>
+    public bool ReloadNative()
+    {
+        FreeDvNativeLoader.ResetProbe();
+        var fresh = new FreeDvModem(_loggerFactory.CreateLogger<FreeDvModem>());
+        fresh.SetSubmode(_modem.Submode);
+        fresh.SetSquelch(_modem.SquelchEnabled, _modem.SnrSquelchThreshDb);
+        var old = _modem;
+        _modem = fresh;
+        old.Dispose();
+        _log.LogInformation(
+            "FreeDV: native reload — codec2 {State}",
+            fresh.NativeAvailable ? "available" : "still unavailable");
+        return fresh.NativeAvailable;
+    }
 
     /// <summary>
     /// Reconcile the modem's active state with the live RX0 mode. Called from

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -1257,6 +1257,32 @@ public static class ZeusEndpoints
             return Results.Ok(fd.ApplyConfig(req));
         });
 
+        // FreeDV codec2 library install. codec2 can't be built on an operator's
+        // machine, so when the bundled binary is missing this fetches the prebuilt
+        // lib Zeus committed for the running platform from the repo and stages it,
+        // reloading the modem live (see FreeDvNativeInstaller). GET reports install
+        // progress + whether codec2 is already present; POST starts a background
+        // download (idempotent — no-op if already installed/running). The panel
+        // polls GET until phase is "done" / "failed".
+        static object FreeDvInstallDto(FreeDvNativeInstaller installer)
+        {
+            var s = installer.Current;
+            return new
+            {
+                phase = s.Phase.ToString().ToLowerInvariant(),
+                percent = s.Percent,
+                message = s.Message,
+                installed = installer.Installed,
+            };
+        }
+        app.MapGet("/api/freedv/install", (FreeDvNativeInstaller installer) =>
+            Results.Ok(FreeDvInstallDto(installer)));
+        app.MapPost("/api/freedv/install", (FreeDvNativeInstaller installer) =>
+        {
+            installer.Start();
+            return Results.Ok(FreeDvInstallDto(installer));
+        });
+
         // TX bandpass filter — signed Hz pair (LSB negative, DSB symmetric). Per-mode
         // family memory is managed in RadioService, identical shape to the RX filter.
         // Operator-editable via Settings → TX Filter panel.

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -370,6 +370,18 @@ public static class ZeusHost
         // and TxAudioIngest taps TX (pre-WDSP), both gated on FreeDV being the
         // active RX0 mode. No-op when the codec2 native library is absent.
         builder.Services.AddSingleton<FreeDvService>();
+        // FreeDvNativeInstaller — the in-app "Install FreeDV" downloader. codec2
+        // can't be built on a stock operator machine, so when the bundled binary
+        // is missing (older build / unshipped platform) this fetches the prebuilt
+        // lib Zeus committed for the running platform straight from the repo and
+        // stages it at the managed path, then reloads the modem live. The named
+        // HttpClient carries a User-Agent and a generous timeout.
+        builder.Services.AddHttpClient("ZeusFreeDvNative", c =>
+        {
+            c.Timeout = TimeSpan.FromMinutes(5);
+            c.DefaultRequestHeaders.UserAgent.ParseAdd("OpenHPSDR-Zeus");
+        });
+        builder.Services.AddSingleton<FreeDvNativeInstaller>();
         builder.Services.AddSingleton<TxService>();
         builder.Services.AddSingleton<TxAudioIngest>();
         // Resolve at startup so the MicPcmReceived subscription attaches before the

--- a/tests/Zeus.Dsp.FreeDv.Tests/FreeDvNativeLoaderTests.cs
+++ b/tests/Zeus.Dsp.FreeDv.Tests/FreeDvNativeLoaderTests.cs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// FreeDvNativeLoader — platform resolution + the writable managed install path
+// the in-app installer stages into. These are environment-independent: the RID
+// shape, the platform filename, and that the managed path sits under
+// Zeus/freedv and is named for the current platform.
+
+using Zeus.Dsp.FreeDv;
+
+namespace Zeus.Dsp.FreeDv.Tests;
+
+public class FreeDvNativeLoaderTests
+{
+    [Fact]
+    public void NativeFileName_matches_the_running_platform()
+    {
+        var name = FreeDvNativeLoader.NativeFileName();
+        if (OperatingSystem.IsWindows()) Assert.Equal("codec2.dll", name);
+        else if (OperatingSystem.IsMacOS()) Assert.Equal("libcodec2.dylib", name);
+        else if (OperatingSystem.IsLinux()) Assert.Equal("libcodec2.so", name);
+    }
+
+    [Fact]
+    public void CurrentRid_is_os_dash_arch()
+    {
+        Assert.Matches(@"^(win|linux|osx|unknown)-(x64|arm64|x86)$", FreeDvNativeLoader.CurrentRid());
+    }
+
+    [Fact]
+    public void ManagedLibraryPath_sits_under_Zeus_freedv_named_for_the_platform()
+    {
+        var path = FreeDvNativeLoader.ManagedLibraryPath();
+        Assert.NotNull(path);
+        Assert.EndsWith(FreeDvNativeLoader.NativeFileName(), path);
+        Assert.Contains(Path.Combine("Zeus", "freedv"), path!);
+        Assert.Equal(FreeDvNativeLoader.ManagedLibraryDir(), Path.GetDirectoryName(path));
+    }
+
+    [Fact]
+    public void ResetProbe_is_safe_to_call_repeatedly()
+    {
+        // Probe availability is environment-dependent (the lib may or may not be
+        // present on the test host); the contract here is only that invalidating
+        // the cached probe never throws and is idempotent.
+        FreeDvNativeLoader.ResetProbe();
+        FreeDvNativeLoader.ResetProbe();
+    }
+}

--- a/tests/Zeus.Server.Tests/FreeDvNativeInstallerTests.cs
+++ b/tests/Zeus.Server.Tests/FreeDvNativeInstallerTests.cs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// FreeDvNativeInstaller — the URL/path mapping core (no network). The installer
+// fetches the prebuilt codec2 binary Zeus committed for the running platform
+// from the repo's runtimes/ tree; BuildLibraryUrl must compose that raw-GitHub
+// path correctly for every shipped RID and tolerate a trailing slash on the base.
+
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class FreeDvNativeInstallerTests
+{
+    [Fact]
+    public void BuildLibraryUrl_composes_repo_raw_path()
+    {
+        var url = FreeDvNativeInstaller.BuildLibraryUrl(
+            "https://raw.githubusercontent.com/OpenHPSDR-Zeus-org/openhpsdr-zeus",
+            "develop",
+            "win-x64",
+            "codec2.dll");
+
+        Assert.Equal(
+            "https://raw.githubusercontent.com/OpenHPSDR-Zeus-org/openhpsdr-zeus/develop/Zeus.Dsp/runtimes/win-x64/native/codec2.dll",
+            url);
+    }
+
+    [Theory]
+    [InlineData("win-x64", "codec2.dll")]
+    [InlineData("linux-x64", "libcodec2.so")]
+    [InlineData("linux-arm64", "libcodec2.so")]
+    [InlineData("osx-arm64", "libcodec2.dylib")]
+    public void BuildLibraryUrl_maps_each_shipped_platform(string rid, string file)
+    {
+        var url = FreeDvNativeInstaller.BuildLibraryUrl("https://host/repo", "main", rid, file);
+        Assert.Equal($"https://host/repo/main/Zeus.Dsp/runtimes/{rid}/native/{file}", url);
+    }
+
+    [Fact]
+    public void BuildLibraryUrl_trims_a_trailing_slash_on_the_base()
+    {
+        var url = FreeDvNativeInstaller.BuildLibraryUrl(
+            "https://host/repo/", "develop", "win-x64", "codec2.dll");
+        Assert.Equal("https://host/repo/develop/Zeus.Dsp/runtimes/win-x64/native/codec2.dll", url);
+    }
+}

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -6768,3 +6768,47 @@ export function setFreeDvConfig(
     normalizeFreeDvStatus,
   );
 }
+
+// FreeDV codec2-library install (GET status / POST start). Mirrors the server
+// FreeDvInstallDto. codec2 can't be built on an operator's machine, so when the
+// bundled binary is missing the backend downloads the prebuilt one Zeus
+// committed for this platform and reloads the modem live. The panel polls the
+// GET while installing until `phase` is 'done' or 'failed'.
+export type FreeDvInstallPhase = 'idle' | 'downloading' | 'staging' | 'done' | 'failed';
+
+export type FreeDvInstallStatusDto = {
+  phase: FreeDvInstallPhase;
+  percent: number;
+  message: string | null;
+  installed: boolean;
+};
+
+const FREEDV_INSTALL_PHASES: readonly FreeDvInstallPhase[] = [
+  'idle',
+  'downloading',
+  'staging',
+  'done',
+  'failed',
+];
+
+function normalizeFreeDvInstallStatus(raw: unknown): FreeDvInstallStatusDto {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  const phase =
+    typeof r.phase === 'string' && (FREEDV_INSTALL_PHASES as readonly string[]).includes(r.phase)
+      ? (r.phase as FreeDvInstallPhase)
+      : 'idle';
+  return {
+    phase,
+    percent: typeof r.percent === 'number' ? r.percent : 0,
+    message: typeof r.message === 'string' ? r.message : null,
+    installed: r.installed === true,
+  };
+}
+
+export function getFreeDvInstallStatus(signal?: AbortSignal): Promise<FreeDvInstallStatusDto> {
+  return jsonFetch('/api/freedv/install', { signal }, normalizeFreeDvInstallStatus);
+}
+
+export function startFreeDvInstall(signal?: AbortSignal): Promise<FreeDvInstallStatusDto> {
+  return jsonFetch('/api/freedv/install', { method: 'POST', signal }, normalizeFreeDvInstallStatus);
+}

--- a/zeus-web/src/layout/panels/FreeDvPanel.tsx
+++ b/zeus-web/src/layout/panels/FreeDvPanel.tsx
@@ -25,10 +25,13 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   getFreeDvStatus,
   setFreeDvConfig,
+  getFreeDvInstallStatus,
+  startFreeDvInstall,
   FREEDV_SUBMODES,
   type FreeDvStatusDto,
   type FreeDvSubmode,
   type FreeDvConfigRequest,
+  type FreeDvInstallStatusDto,
 } from '../../api/client';
 import { useConnectionStore } from '../../state/connection-store';
 import { useQrzStore } from '../../state/qrz-store';
@@ -124,7 +127,7 @@ export function FreeDvPanel() {
     sendConfig({ txText: ownCallsign });
   }, [ownCallsign, status, sendConfig]);
 
-  // Library missing — show the clear unavailable state instead of dead controls.
+  // Library missing — offer the one-click install instead of dead controls.
   if (status && !status.nativeAvailable) {
     return (
       <div className="dsp-cfg" style={{ gap: 8 }}>
@@ -140,11 +143,10 @@ export function FreeDvPanel() {
             lineHeight: 1.5,
           }}
         >
-          FreeDV library not installed / building — telemetry unavailable. The
-          codec2 modem isn't present in this build, so digital-voice decode and
-          encode can't run yet.
-          {status.libraryVersion ? ` (${status.libraryVersion})` : ''}
+          The codec2 modem isn't installed yet, so FreeDV decode/encode can't run.
+          Install it once and FreeDV works every time you pick the mode.
         </div>
+        <FreeDvInstallSection />
       </div>
     );
   }
@@ -406,6 +408,135 @@ function FreeDvHeader({
               : 'idle'}
         {status?.libraryVersion ? ` · ${status.libraryVersion}` : ''}
       </span>
+    </div>
+  );
+}
+
+// One-click codec2 install. The backend downloads the prebuilt modem Zeus
+// committed for this platform and reloads it live (see FreeDvNativeInstaller);
+// once it reports installed, the panel's status poll flips nativeAvailable and
+// this whole branch is replaced by the live controls — so the "done" state here
+// is only ever momentary.
+function FreeDvInstallSection() {
+  const [install, setInstall] = useState<FreeDvInstallStatusDto | null>(null);
+  const timerRef = useRef<number | null>(null);
+  const pollAbort = useRef<AbortController | null>(null);
+
+  const phase = install?.phase ?? 'idle';
+  const busy = phase === 'downloading' || phase === 'staging';
+  const failed = phase === 'failed';
+  const done = phase === 'done';
+
+  const stopTimer = useCallback(() => {
+    if (timerRef.current != null) {
+      window.clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const poll = useCallback(() => {
+    pollAbort.current?.abort();
+    const ac = new AbortController();
+    pollAbort.current = ac;
+    getFreeDvInstallStatus(ac.signal)
+      .then((s) => {
+        if (ac.signal.aborted) return;
+        setInstall(s);
+        // Terminal phase (or already installed) — stop polling.
+        if (s.installed || (s.phase !== 'downloading' && s.phase !== 'staging')) stopTimer();
+      })
+      .catch(() => {
+        /* next tick retries */
+      });
+  }, [stopTimer]);
+
+  const start = useCallback(() => {
+    startFreeDvInstall()
+      .then((s) => {
+        setInstall(s);
+        if (s.phase === 'downloading' || s.phase === 'staging') {
+          stopTimer();
+          timerRef.current = window.setInterval(poll, 500);
+        }
+      })
+      .catch(() => setInstall({ phase: 'failed', percent: 0, message: 'Could not reach the install service.', installed: false }));
+  }, [poll, stopTimer]);
+
+  useEffect(
+    () => () => {
+      stopTimer();
+      pollAbort.current?.abort();
+    },
+    [stopTimer],
+  );
+
+  const label = busy
+    ? `Installing… ${install?.percent ?? 0}%`
+    : failed
+      ? 'Retry install'
+      : done
+        ? 'Starting modem…'
+        : 'Install FreeDV';
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <button
+        type="button"
+        className="btn sm active"
+        disabled={busy || done}
+        onClick={() => {
+          if (!busy && !done) start();
+        }}
+        title="Download the FreeDV (codec2) modem for this platform and enable it"
+        style={{ whiteSpace: 'nowrap', alignSelf: 'flex-start' }}
+      >
+        {label}
+      </button>
+
+      {(busy || failed) && (
+        <div
+          role="status"
+          aria-live="polite"
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 6,
+            padding: '8px 10px',
+            background: 'var(--bg-1)',
+            border: '1px solid var(--line)',
+            borderRadius: 'var(--r-sm)',
+          }}
+        >
+          {busy && (
+            <div
+              aria-hidden
+              style={{
+                height: 4,
+                borderRadius: 2,
+                background: 'var(--bg-2)',
+                overflow: 'hidden',
+              }}
+            >
+              <div
+                style={{
+                  height: '100%',
+                  width: `${install?.percent ?? 0}%`,
+                  background: 'var(--accent)',
+                  transition: 'width 0.2s ease',
+                }}
+              />
+            </div>
+          )}
+          {install?.message && (
+            <div
+              className="label-xs"
+              style={{ color: failed ? 'var(--tx)' : 'var(--fg-2)', lineHeight: 1.4 }}
+            >
+              {install.message}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## What

The FreeDV panel showed *"library not installed / building — telemetry unavailable"* with no way forward whenever the running build had no codec2 binary (an older build that predates the committed lib, or a platform whose binary wasn't shipped). This adds a one-click **Install** button to that state.

## Why fetch (not build) — and from the repo

- **codec2 can't be built on a stock operator machine.** Its OFDM code is C99 `_Complex`, which MSVC can't compile — Windows needs a MinGW-w64 toolchain. A typical operator has no compiler.
- **drowe67/codec2 publishes no prebuilt shared libraries** — only source tarballs.
- **Zeus already builds + commits the prebuilt lib** (`build-native-libs.yml` → `Zeus.Dsp/runtimes/{rid}/native/`). So the only seamless install is to fetch *that* binary. No toolchain, no new hosting.

## How it works

1. Panel's not-installed state shows **Install FreeDV** + a progress bar.
2. `POST /api/freedv/install` downloads the committed lib for the running RID straight from the repo (`raw.githubusercontent.com/.../{ref}/Zeus.Dsp/runtimes/{rid}/native/{file}`).
3. It's staged into a writable managed path (`LocalApplicationData/Zeus/freedv`) that the loader now probes **first**.
4. `FreeDvService.ReloadNative()` resets the cached probe and swaps in a fresh modem (carrying the operator's submode/squelch), so `nativeAvailable` flips true **live — no restart**.
5. win-arm64 (no committed lib yet) returns a clear *"not available for this platform"* message.

`ref`/base URL are overridable via `ZEUS_FREEDV_NATIVE_REF` / `ZEUS_FREEDV_NATIVE_BASE_URL` for staging/tests.

## Files

- `FreeDvNativeLoader` — public surface + managed-path candidate (probed first) + `ResetProbe()`.
- `FreeDvService.ReloadNative()` — passthrough-safe modem swap vs the DSP hot path.
- `FreeDvNativeInstaller` + `GET/POST /api/freedv/install` — mirrors the VST-engine installer.
- Panel Install button/progress + client API (`getFreeDvInstallStatus` / `startFreeDvInstall`).

## Verification

End-to-end **headless** against a simulated old build (bundled dll moved aside):

| Step | Result |
|---|---|
| before | `nativeAvailable: false`, `libraryVersion: null` |
| POST install | `phase: downloading` |
| poll | `phase: done`, `installed: true` |
| after | `nativeAvailable: true`, `libraryVersion: "codec2 1.2.0 (FreeDV)"` |
| managed path | `codec2.dll` staged, 1,512,448 B (exact match to the repo download) |

Tests: FreeDv loader **23 pass / 1 skip**, installer URL **6 pass**, client **106 pass**; `tsc -b --force` + `eslint` clean; Hosting builds clean.

## Notes

- Builds on the merged FreeDV mode (#881) and panel auto-show (#885).
- Default `ref` is `develop` (where the committed lib lives); pin to a release tag once FreeDV ships in one.