### PR TITLE
fix(rx): improve auto-ATT — sustained-overload gate + release hold-off

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -1600,10 +1600,12 @@ public sealed record AutoAttSetRequest(bool Enabled);
 // RX ADC protection policy. This is the operator-facing superset of the
 // legacy Auto-ATT toggle: existing /api/auto-att still maps to Enabled, while
 // /api/rx/adc-protection exposes the ramp timing, step size, maximum automatic
-// offset, warning threshold, and optional Protocol-2 max-magnitude soft limit.
-// Defaults preserve the original Thetis-style loop: 100 ms windows, 1 dB
-// attack/release steps, 31 dB maximum offset, warning when overload level > 3,
-// and no magnitude-only attack unless the operator explicitly sets a limit.
+// offset, warning threshold, release hold-off, and optional Protocol-2
+// max-magnitude soft limit. Defaults mirror Thetis' handleOverload loop:
+// 100 ms windows, 1 dB attack/release steps, 31 dB maximum offset, attenuation
+// and the warning lamp both gated on a sustained overload (level > 3), a 2 s
+// hold before the offset unwinds (Thetis' nudAutoAttHold), and no
+// magnitude-only attack unless the operator explicitly sets a limit.
 public sealed record AdcProtectionConfig(
     bool Enabled = true,
     int AttackMs = 100,
@@ -1612,7 +1614,8 @@ public sealed record AdcProtectionConfig(
     int ReleaseStepDb = 1,
     int MaxOffsetDb = 31,
     int WarningThreshold = 3,
-    int MagnitudeSoftLimit = 0);
+    int MagnitudeSoftLimit = 0,
+    int ReleaseHoldMs = 2000);
 
 public sealed record AdcProtectionSetRequest(
     bool? Enabled = null,
@@ -1622,7 +1625,8 @@ public sealed record AdcProtectionSetRequest(
     int? ReleaseStepDb = null,
     int? MaxOffsetDb = null,
     int? WarningThreshold = null,
-    int? MagnitudeSoftLimit = null);
+    int? MagnitudeSoftLimit = null,
+    int? ReleaseHoldMs = null);
 
 public sealed record AdcProtectionStatusDto(
     AdcProtectionConfig Config,

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -206,6 +206,7 @@ public sealed class RadioService : IDisposable
     private DateTimeOffset? _lastAdcTelemetryUtc;
     private AdcProtectionConfig _adcProtection = new();
     private long _lastTickMs = long.MinValue;
+    private long _lastOverloadMs = long.MinValue;   // wall-clock of the last overload window (release hold-off)
     private int _lastAppliedEffectiveDb = -1;   // so the first send always fires
 
     // Auto-AGC control-loop state. Tracks the band noise floor and places the
@@ -433,7 +434,8 @@ public sealed class RadioService : IDisposable
             ReleaseStepDb: rsSnap?.AdcProtectionReleaseStepDb ?? 1,
             MaxOffsetDb: rsSnap?.AdcProtectionMaxOffsetDb ?? 31,
             WarningThreshold: rsSnap?.AdcProtectionWarningThreshold ?? 3,
-            MagnitudeSoftLimit: rsSnap?.AdcProtectionMagnitudeSoftLimit ?? 0));
+            MagnitudeSoftLimit: rsSnap?.AdcProtectionMagnitudeSoftLimit ?? 0,
+            ReleaseHoldMs: rsSnap?.AdcProtectionReleaseHoldMs ?? 2000));
 
         // Restore per-mode-family filter memory from snapshot if available so
         // an AM→USB mode-switch at startup recalls the last SSB width, not the
@@ -815,6 +817,7 @@ public sealed class RadioService : IDisposable
             _adcOverloadLevel = 0;
             _overloadSeenInWindow = false;
             _lastTickMs = long.MinValue;
+            _lastOverloadMs = long.MinValue;
             _lastAppliedEffectiveDb = -1;
         }
         StateChanged?.Invoke(Snapshot());
@@ -1928,6 +1931,7 @@ public sealed class RadioService : IDisposable
                 _attOffsetDb = 0;
                 _adcOverloadLevel = 0;
                 _overloadSeenInWindow = false;
+                _lastOverloadMs = long.MinValue;
                 _state = _state with { AttOffsetDb = 0, AdcOverloadWarning = false };
                 int baseline = _atten.ClampedDb;
                 if (_lastAppliedEffectiveDb != baseline)
@@ -1972,7 +1976,8 @@ public sealed class RadioService : IDisposable
                 ReleaseStepDb: req.ReleaseStepDb ?? _adcProtection.ReleaseStepDb,
                 MaxOffsetDb: req.MaxOffsetDb ?? _adcProtection.MaxOffsetDb,
                 WarningThreshold: req.WarningThreshold ?? _adcProtection.WarningThreshold,
-                MagnitudeSoftLimit: req.MagnitudeSoftLimit ?? _adcProtection.MagnitudeSoftLimit));
+                MagnitudeSoftLimit: req.MagnitudeSoftLimit ?? _adcProtection.MagnitudeSoftLimit,
+                ReleaseHoldMs: req.ReleaseHoldMs ?? _adcProtection.ReleaseHoldMs));
 
             if (next != _adcProtection)
             {
@@ -1993,6 +1998,7 @@ public sealed class RadioService : IDisposable
                 _attOffsetDb = 0;
                 _adcOverloadLevel = 0;
                 _overloadSeenInWindow = false;
+                _lastOverloadMs = long.MinValue;
                 if (_state.AttOffsetDb != 0 || _state.AdcOverloadWarning)
                 {
                     _state = _state with { AttOffsetDb = 0, AdcOverloadWarning = false };
@@ -2053,8 +2059,11 @@ public sealed class RadioService : IDisposable
         AttackStepDb = Math.Clamp(config.AttackStepDb, 1, 6),
         ReleaseStepDb = Math.Clamp(config.ReleaseStepDb, 1, 6),
         MaxOffsetDb = Math.Clamp(config.MaxOffsetDb, HpsdrAtten.MinDb, HpsdrAtten.MaxDb),
-        WarningThreshold = Math.Clamp(config.WarningThreshold, 0, 5),
+        // The overload counter caps at 5, so the gate (level > threshold) must
+        // stay reachable — clamp to 4 so it can never silently disable the ramp.
+        WarningThreshold = Math.Clamp(config.WarningThreshold, 0, 4),
         MagnitudeSoftLimit = Math.Clamp(config.MagnitudeSoftLimit, 0, ushort.MaxValue),
+        ReleaseHoldMs = Math.Clamp(config.ReleaseHoldMs, 0, 10_000),
     };
 
     public StateDto SetAutoAgc(bool enabled)
@@ -3389,6 +3398,7 @@ public sealed class RadioService : IDisposable
                 AdcProtectionMaxOffsetDb = adcProtection.MaxOffsetDb,
                 AdcProtectionWarningThreshold = adcProtection.WarningThreshold,
                 AdcProtectionMagnitudeSoftLimit = adcProtection.MagnitudeSoftLimit,
+                AdcProtectionReleaseHoldMs = adcProtection.ReleaseHoldMs,
                 AttenDb = snap.AttenDb,
                 AutoAgcEnabled = snap.AutoAgcEnabled,
                 PreampOn = snap.PreampOn,
@@ -3460,6 +3470,7 @@ public sealed class RadioService : IDisposable
             _adcOverloadLevel = 0;
             _overloadSeenInWindow = false;
             _lastTickMs = long.MinValue;
+            _lastOverloadMs = long.MinValue;
             _lastAppliedEffectiveDb = -1;
             _lastAdcOverloadBits = 0;
             _lastAdc0MaxMagnitude = null;
@@ -3500,6 +3511,7 @@ public sealed class RadioService : IDisposable
             _adcOverloadLevel = 0;
             _overloadSeenInWindow = false;
             _lastTickMs = long.MinValue;
+            _lastOverloadMs = long.MinValue;
             _lastAppliedEffectiveDb = -1;
         }
         if (previous is not null) previous.TelemetryReceived -= OnP2Telemetry;
@@ -3680,15 +3692,32 @@ public sealed class RadioService : IDisposable
 
             if (seen)
             {
-                if (_attOffsetDb < cfg.MaxOffsetDb)
+                _lastOverloadMs = nowMs;
+                // Thetis counts +1 per overload poll (console.cs:22107), capped
+                // at 5, and decays -1 per clean poll. _adcOverloadLevel mirrors
+                // that counter exactly so the gate below matches its >3 timing.
+                _adcOverloadLevel = Math.Min(5, _adcOverloadLevel + 1);
+
+                // Gate the ramp on a *sustained* overload — Thetis only touches
+                // the attenuator once _adc_overload_level[i] > 3 (console.cs:
+                // 21518), the same threshold that turns the lamp red. A single
+                // transient spike no longer pulls in attenuation.
+                if (_adcOverloadLevel > cfg.WarningThreshold && _attOffsetDb < cfg.MaxOffsetDb)
                     _attOffsetDb = Math.Min(cfg.MaxOffsetDb, _attOffsetDb + cfg.AttackStepDb);
-                _adcOverloadLevel = Math.Min(5, _adcOverloadLevel + 2);
             }
             else
             {
-                if (_attOffsetDb > 0)
-                    _attOffsetDb = Math.Max(0, _attOffsetDb - cfg.ReleaseStepDb);
                 if (_adcOverloadLevel > 0) _adcOverloadLevel--;
+
+                // Hold the applied attenuation for ReleaseHoldMs after the last
+                // overload before unwinding — Thetis' nudAutoAttHold delay
+                // (console.cs:21569). This stops the offset pumping up and down
+                // on a signal that hovers right at the ADC ceiling. The level
+                // counter still decays above so the lamp clears on schedule.
+                bool holdElapsed = _lastOverloadMs == long.MinValue
+                    || (nowMs - _lastOverloadMs) >= cfg.ReleaseHoldMs;
+                if (holdElapsed && _attOffsetDb > 0)
+                    _attOffsetDb = Math.Max(0, _attOffsetDb - cfg.ReleaseStepDb);
             }
 
             int effective = Math.Clamp(_atten.ClampedDb + _attOffsetDb, HpsdrAtten.MinDb, HpsdrAtten.MaxDb);

--- a/Zeus.Server.Hosting/RadioStateStore.cs
+++ b/Zeus.Server.Hosting/RadioStateStore.cs
@@ -154,6 +154,7 @@ public sealed class RadioStateEntry
     public int AdcProtectionMaxOffsetDb { get; set; } = 31;
     public int AdcProtectionWarningThreshold { get; set; } = 3;
     public int AdcProtectionMagnitudeSoftLimit { get; set; }
+    public int AdcProtectionReleaseHoldMs { get; set; } = 2000;
     public int AttenDb { get; set; }
     public bool AutoAgcEnabled { get; set; }
     // RX preamp toggle (PRE). Not part of older rows; default false matches

--- a/tests/Zeus.Contracts.Tests/AutoAttControlLoopTests.cs
+++ b/tests/Zeus.Contracts.Tests/AutoAttControlLoopTests.cs
@@ -103,6 +103,9 @@ public class AutoAttControlLoopTests : IDisposable
     public void OverloadRepeated_RampsOneStepPerTickWindow()
     {
         var r = MakeService();
+        // Disable the sustained-overload gate so this exercises pure ramp
+        // mechanics (gate behaviour has its own test below).
+        r.SetAdcProtection(new AdcProtectionSetRequest(WarningThreshold: 0));
 
         // First event is a free "baseline" — no step applied (throttle rule).
         r.HandleAdcOverload(Overload, nowMs: 0);
@@ -116,6 +119,26 @@ public class AutoAttControlLoopTests : IDisposable
         // Another window crossing.
         r.HandleAdcOverload(Overload, nowMs: 210);
         Assert.Equal(2, r.Snapshot().AttOffsetDb);
+    }
+
+    [Fact]
+    public void SustainedOverloadGate_NoRampUntilCounterExceedsThreshold()
+    {
+        var r = MakeService();  // default WarningThreshold = 3
+
+        // Establish the tick baseline, then ramp the counter one step per
+        // window. Thetis only touches the attenuator once the counter > 3, so
+        // the first three sustained windows must leave the offset at zero.
+        r.HandleAdcOverload(Overload, nowMs: 0);    // baseline
+        r.HandleAdcOverload(Overload, nowMs: 105);  // level 1
+        r.HandleAdcOverload(Overload, nowMs: 210);  // level 2
+        r.HandleAdcOverload(Overload, nowMs: 315);  // level 3
+        Assert.Equal(0, r.Snapshot().AttOffsetDb);
+
+        // Fourth sustained window crosses the gate (level 4 > 3) → first step.
+        r.HandleAdcOverload(Overload, nowMs: 420);
+        Assert.Equal(1, r.Snapshot().AttOffsetDb);
+        Assert.True(r.Snapshot().AdcOverloadWarning);
     }
 
     [Fact]
@@ -135,6 +158,9 @@ public class AutoAttControlLoopTests : IDisposable
     public void ClearAfterRamp_DecaysToZero()
     {
         var r = MakeService();
+        // No gate, no release hold — pure decay mechanics.
+        r.SetAdcProtection(new AdcProtectionSetRequest(WarningThreshold: 0, ReleaseHoldMs: 0));
+
         r.HandleAdcOverload(Overload, nowMs: 0);
         // Ramp to 5 dB offset.
         for (int i = 1; i <= 5; i++)
@@ -152,9 +178,36 @@ public class AutoAttControlLoopTests : IDisposable
     }
 
     [Fact]
+    public void ReleaseHoldOff_HoldsOffsetThenUnwinds()
+    {
+        var r = MakeService();
+        // No gate so the ramp is simple; 1 s release hold so we can watch it.
+        r.SetAdcProtection(new AdcProtectionSetRequest(WarningThreshold: 0, ReleaseHoldMs: 1_000));
+
+        r.HandleAdcOverload(Overload, nowMs: 0);     // baseline
+        r.HandleAdcOverload(Overload, nowMs: 105);   // offset 1
+        r.HandleAdcOverload(Overload, nowMs: 210);   // offset 2
+        Assert.Equal(2, r.Snapshot().AttOffsetDb);
+
+        // Clean windows arrive but the 1 s hold has not elapsed since the last
+        // overload (t=210): the offset is held, not unwound.
+        r.HandleAdcOverload(Clean, nowMs: 400);
+        r.HandleAdcOverload(Clean, nowMs: 800);
+        r.HandleAdcOverload(Clean, nowMs: 1_100);
+        Assert.Equal(2, r.Snapshot().AttOffsetDb);
+
+        // Past the hold (t >= 210 + 1000): the offset unwinds one step per window.
+        r.HandleAdcOverload(Clean, nowMs: 1_300);
+        Assert.Equal(1, r.Snapshot().AttOffsetDb);
+        r.HandleAdcOverload(Clean, nowMs: 1_500);
+        Assert.Equal(0, r.Snapshot().AttOffsetDb);
+    }
+
+    [Fact]
     public void OverloadBurstsWithinWindow_CountAsOneStep()
     {
         var r = MakeService();
+        r.SetAdcProtection(new AdcProtectionSetRequest(WarningThreshold: 0));
         r.HandleAdcOverload(Clean, nowMs: 0);    // baseline tick
         // Many events in one 100ms window.
         for (int i = 1; i <= 50; i++)
@@ -169,12 +222,16 @@ public class AutoAttControlLoopTests : IDisposable
     {
         var r = MakeService();
         r.HandleAdcOverload(Overload, nowMs: 0);   // baseline
-        // Each overload tick adds +2 to the counter, clamped to 5. Red lamp on
-        // counter>3 means 2 overload ticks are enough.
+        // Each overload tick adds +1 to the counter (Thetis analog), clamped to
+        // 5. Red lamp on counter>3 means four sustained ticks (~400 ms).
         r.HandleAdcOverload(Overload, nowMs: 105);
-        Assert.False(r.Snapshot().AdcOverloadWarning); // counter=2 after 1 tick
+        Assert.False(r.Snapshot().AdcOverloadWarning); // counter=1
         r.HandleAdcOverload(Overload, nowMs: 210);
-        Assert.True(r.Snapshot().AdcOverloadWarning);  // counter=4 after 2 ticks
+        Assert.False(r.Snapshot().AdcOverloadWarning); // counter=2
+        r.HandleAdcOverload(Overload, nowMs: 315);
+        Assert.False(r.Snapshot().AdcOverloadWarning); // counter=3
+        r.HandleAdcOverload(Overload, nowMs: 420);
+        Assert.True(r.Snapshot().AdcOverloadWarning);  // counter=4 → red
     }
 
     [Fact]
@@ -182,12 +239,12 @@ public class AutoAttControlLoopTests : IDisposable
     {
         var r = MakeService();
         r.HandleAdcOverload(Overload, nowMs: 0);
-        r.HandleAdcOverload(Overload, nowMs: 105);
-        r.HandleAdcOverload(Overload, nowMs: 210);
+        for (int i = 1; i <= 4; i++)
+            r.HandleAdcOverload(Overload, nowMs: i * 100 + 5);
         Assert.True(r.Snapshot().AdcOverloadWarning); // counter=4
 
         // Each clean tick decrements by 1. After 1 clean tick counter=3 → !warn.
-        r.HandleAdcOverload(Clean, nowMs: 315);
+        r.HandleAdcOverload(Clean, nowMs: 525);
         Assert.False(r.Snapshot().AdcOverloadWarning);
     }
 
@@ -211,6 +268,7 @@ public class AutoAttControlLoopTests : IDisposable
     public void MoxOn_SuspendsControlLoop()
     {
         var r = MakeService();
+        r.SetAdcProtection(new AdcProtectionSetRequest(WarningThreshold: 0));
         r.HandleAdcOverload(Overload, nowMs: 0);
         r.HandleAdcOverload(Overload, nowMs: 105);
         Assert.Equal(1, r.Snapshot().AttOffsetDb);
@@ -236,6 +294,7 @@ public class AutoAttControlLoopTests : IDisposable
     public void TurningAutoAttOff_ResetsOffsetAndWarning()
     {
         var r = MakeService();
+        r.SetAdcProtection(new AdcProtectionSetRequest(WarningThreshold: 0));
         r.HandleAdcOverload(Overload, nowMs: 0);
         for (int i = 1; i <= 4; i++)
             r.HandleAdcOverload(Overload, nowMs: i * 100 + 5);
@@ -288,15 +347,18 @@ public class AutoAttControlLoopTests : IDisposable
             ReleaseStepDb: 99,
             MaxOffsetDb: 99,
             WarningThreshold: 99,
-            MagnitudeSoftLimit: 99_999));
+            MagnitudeSoftLimit: 99_999,
+            ReleaseHoldMs: 99_999));
 
         Assert.Equal(25, status.Config.AttackMs);
         Assert.Equal(5_000, status.Config.ReleaseMs);
         Assert.Equal(6, status.Config.AttackStepDb);
         Assert.Equal(6, status.Config.ReleaseStepDb);
         Assert.Equal(31, status.Config.MaxOffsetDb);
-        Assert.Equal(5, status.Config.WarningThreshold);
+        // Capped at 4 (not 5) so the gate stays reachable against the level-5 cap.
+        Assert.Equal(4, status.Config.WarningThreshold);
         Assert.Equal((int)ushort.MaxValue, status.Config.MagnitudeSoftLimit);
+        Assert.Equal(10_000, status.Config.ReleaseHoldMs);
     }
 
     [Fact]
@@ -309,6 +371,7 @@ public class AutoAttControlLoopTests : IDisposable
             AttackStepDb: 2,
             ReleaseStepDb: 1,
             MaxOffsetDb: 4,
+            WarningThreshold: 0,   // isolate the magnitude-soft-limit ramp from the gate
             MagnitudeSoftLimit: 1_000));
 
         var hot = new P2TelemetryReading(

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -242,6 +242,7 @@ export type AdcProtectionConfigDto = {
   maxOffsetDb: number;
   warningThreshold: number;
   magnitudeSoftLimit: number;
+  releaseHoldMs: number;
 };
 
 export const ADC_PROTECTION_CONFIG_DEFAULT: AdcProtectionConfigDto = {
@@ -253,6 +254,7 @@ export const ADC_PROTECTION_CONFIG_DEFAULT: AdcProtectionConfigDto = {
   maxOffsetDb: 31,
   warningThreshold: 3,
   magnitudeSoftLimit: 0,
+  releaseHoldMs: 2000,
 };
 
 export type AdcProtectionStatusDto = {
@@ -2270,6 +2272,10 @@ function normalizeAdcProtectionConfig(raw: unknown): AdcProtectionConfigDto {
       typeof r.magnitudeSoftLimit === 'number'
         ? r.magnitudeSoftLimit
         : ADC_PROTECTION_CONFIG_DEFAULT.magnitudeSoftLimit,
+    releaseHoldMs:
+      typeof r.releaseHoldMs === 'number'
+        ? r.releaseHoldMs
+        : ADC_PROTECTION_CONFIG_DEFAULT.releaseHoldMs,
   };
 }
 

--- a/zeus-web/src/components/AdcProtectionSettingsSection.tsx
+++ b/zeus-web/src/components/AdcProtectionSettingsSection.tsx
@@ -260,10 +260,19 @@ export function AdcProtectionSettingsSection() {
           label="Warn Level"
           value={draft.warningThreshold}
           min={0}
-          max={5}
+          max={4}
           disabled={!draft.enabled}
-          onChange={(v) => update({ warningThreshold: clampInt(v, 0, 5) })}
+          onChange={(v) => update({ warningThreshold: clampInt(v, 0, 4) })}
           formatValue={(v) => `${Math.round(v)}`}
+        />
+        <Slider
+          label="Release Hold"
+          value={draft.releaseHoldMs}
+          min={0}
+          max={10000}
+          disabled={!draft.enabled}
+          onChange={(v) => update({ releaseHoldMs: clampInt(v, 0, 10000) })}
+          formatValue={(v) => `${Math.round(v)} ms`}
         />
       </div>
 


### PR DESCRIPTION
## What

Brings the RX ADC-overload **auto-attenuator** in line with Thetis' `handleOverload` (`console.cs`). The Zeus loop was wired end-to-end (P1/P2 overload bits → `RadioService.HandleAdcProtection` → `SetAttenuator`, with config endpoints, persistence, UI, tests) but the control *law* diverged from the reference in two operator-felt ways.

## Changes

1. **Sustained-overload attack gate.** The overload counter is now a faithful Thetis analog (`+1/-1` per window, capped at 5). The offset ramps **only once the counter exceeds `WarningThreshold`** — the same `> 3` gate Thetis uses to also turn the lamp red. A single-packet transient no longer pulls in attenuation. `WarningThreshold` is clamped to `0..4` so the gate can never sit above the level-5 cap and silently disable the ramp.
2. **Release hold-off** (new `ReleaseHoldMs`, default **2000 ms** — Thetis' `nudAutoAttHold`, shortened from its 5 s). After overload clears the offset is held before unwinding, killing the up/down pumping on a signal hovering at the ADC ceiling. The level counter still decays so the warning lamp clears on schedule.

Plumbed through `AdcProtectionConfig`, `RadioStateStore` persistence, normalisation (clamp `0..10000`), the client DTO/default/normaliser, and a new **Release Hold** UI slider (Warn Level slider max corrected to 4).

## Scope / safety

- **TX / PureSignal auto-att is intentionally untouched** (burn-zone, KB2UKA full-stop). The loop still bails on `_mox`.
- Known follow-ups left out: per-band attenuation history, per-ADC RX1/RX2 separation on dual-ADC boards, and preamp-mode stepping for boards without a step attenuator.

## Verification

- `17/17` auto-ATT control-loop tests pass against `develop` (incl. 2 new tests: sustained-overload gate, release hold-off).
- Full host build (incl. frontend bundle) green; frontend `tsc` typecheck green.

Target: develop