### PR TITLE
fix(web): FreeDV mode no longer reverts to USB on state round-trip

### DIFF
--- a/zeus-web/src/api/client.test.ts
+++ b/zeus-web/src/api/client.test.ts
@@ -144,6 +144,16 @@ describe('normalizeMode', () => {
     expect(normalizeMode(1)).toBe('USB');
     expect(normalizeMode(4)).toBe('AM');
     expect(normalizeMode(9)).toBe('DIGU');
+    expect(normalizeMode(10)).toBe('FREEDV');
+  });
+  it('matches the server enum name case-insensitively (FreeDv → FREEDV)', () => {
+    // The server serialises RxMode by its C# enum name: all-caps for every mode
+    // except FreeDv (PascalCase). Without case-insensitive matching, "FreeDv"
+    // missed MODE_ORDER and normalizeMode fell back to USB, making FreeDV mode
+    // silently revert to USB on the next state round-trip.
+    expect(normalizeMode('FreeDv')).toBe('FREEDV');
+    expect(normalizeMode('FREEDV')).toBe('FREEDV');
+    expect(normalizeMode('usb')).toBe('USB');
   });
   it('falls back to USB on garbage', () => {
     expect(normalizeMode('nope')).toBe('USB');

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -2048,8 +2048,15 @@ export function normalizeStatus(v: unknown): ConnectionStatus {
 
 function modeFromWire(v: unknown): RxMode | null {
   if (typeof v === 'string') {
-    return (MODE_ORDER as readonly string[]).includes(v)
-      ? (v as RxMode)
+    // The server serialises RxMode by its C# enum NAME. Every name is all-caps
+    // (USB, CWL, …) EXCEPT FreeDv (PascalCase), while our RxMode literals are
+    // all-caps ('FREEDV'). Match case-insensitively so "FreeDv" resolves to
+    // 'FREEDV' instead of falling through to the 'USB' default in normalizeMode
+    // — that miss is what made FreeDV mode silently revert to USB on the next
+    // state round-trip.
+    const upper = v.toUpperCase();
+    return (MODE_ORDER as readonly string[]).includes(upper)
+      ? (upper as RxMode)
       : null;
   }
   if (typeof v === 'number' && Number.isInteger(v)) {


### PR DESCRIPTION
## Symptom

Selecting **FreeDV** did nothing and the mode snapped straight back to USB — the modem/panel never engaged because the mode never stuck.

## Root cause

The server serialises `RxMode` by its **C# enum name**. Every name is all-caps (`USB`, `CWL`, `DIGU`…) **except `FreeDv`** (PascalCase), while the frontend `RxMode` literal is `'FREEDV'`. `modeFromWire` matched `MODE_ORDER` **case-sensitively**, so the incoming `"FreeDv"` missed `'FREEDV'` and `normalizeMode` fell through to its **`'USB'` default**.

Since `normalizeMode` runs on every state parse (`normalizeState` → `mode`/`modeB`), the `setMode` response *and* the 1 Hz state poll both rewrote the store back to USB — so FreeDV could never persist.

Confirmed against the live backend: `POST /api/mode {mode:10}` → `HTTP 200, "mode":"FreeDv"` (server is correct); the frontend then normalised `"FreeDv"` → `'USB'`.

## Fix

Match the wire mode name **case-insensitively** in `modeFromWire` (upper-case before the `MODE_ORDER` membership check). All other names are already all-caps, so it's a no-op for them; `"FreeDv"` now resolves to `'FREEDV'` and the mode sticks.

## Tests

`normalizeMode` regression cases: `'FreeDv' → 'FREEDV'`, `'FREEDV' → 'FREEDV'`, ordinal `10 → 'FREEDV'`. Full client suite **107 pass**; `tsc -b --force` + `eslint` clean.

## Notes

This is the blocker behind the earlier 'clicking FreeDV does nothing' reports — independent of, and complementary to, the panel auto-show (#885) and the codec2 install button (#888).