### PR TITLE
feat(nr): fix NR2 Trained T2 default + add opt-in NR3 (RNNoise)

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -83,12 +83,14 @@ public enum BandpassWindow : byte { Soft = 0, Normal = 1, Sharp = 2 }
 public enum ConnectionStatus { Disconnected, Connecting, Connected, Error }
 
 // Thetis NR-button state: Off = no NR, Anr = NR1 (time-domain LMS),
-// Emnr = NR2 (Ephraim-Malah), Sbnr = NR4 (libspecbleach, issue #79).
-// NR3 (RNNR) is intentionally absent: training data for the bundled RNNoise
-// model is voice-corpus-only and underperforms on HF noise. All modes are
-// mutually exclusive in WDSP, so the button carries them in one enum. Byte
-// order is fixed — appending only — because persisted DspSettingsStore rows
-// would mis-deserialize on a reorder.
+// Emnr = NR2 (Ephraim-Malah), Sbnr = NR4 (libspecbleach, issue #79),
+// Rnnr = NR3 (RNNoise). NR3 ships with NO bundled model — the operator
+// installs an RNNoise weights file via the DSP menu, and NR3 only becomes
+// selectable once a model is present (Zeus serves no default model; the
+// stock RNNoise voice corpus underperforms on HF, so bring-your-own). All
+// modes are mutually exclusive in WDSP, so the button carries them in one
+// enum. Byte order is fixed — appending only — because persisted
+// DspSettingsStore rows would mis-deserialize on a reorder.
 [JsonConverter(typeof(NrModeJsonConverter))]
 public enum NrMode : byte
 {
@@ -96,6 +98,7 @@ public enum NrMode : byte
     Anr,
     Emnr,
     Sbnr = 3,
+    Rnnr = 4,
 }
 
 public sealed class NrModeJsonConverter : JsonConverter<NrMode>
@@ -103,7 +106,7 @@ public sealed class NrModeJsonConverter : JsonConverter<NrMode>
     public override NrMode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         if (reader.TokenType == JsonTokenType.Number && reader.TryGetByte(out var numericValue))
-            return numericValue <= (byte)NrMode.Sbnr ? (NrMode)numericValue : NrMode.Off;
+            return numericValue <= (byte)NrMode.Rnnr ? (NrMode)numericValue : NrMode.Off;
 
         if (reader.TokenType == JsonTokenType.String)
         {
@@ -111,6 +114,7 @@ public sealed class NrModeJsonConverter : JsonConverter<NrMode>
             if (string.Equals(stringValue, nameof(NrMode.Anr), StringComparison.OrdinalIgnoreCase)) return NrMode.Anr;
             if (string.Equals(stringValue, nameof(NrMode.Emnr), StringComparison.OrdinalIgnoreCase)) return NrMode.Emnr;
             if (string.Equals(stringValue, nameof(NrMode.Sbnr), StringComparison.OrdinalIgnoreCase)) return NrMode.Sbnr;
+            if (string.Equals(stringValue, nameof(NrMode.Rnnr), StringComparison.OrdinalIgnoreCase)) return NrMode.Rnnr;
         }
 
         return NrMode.Off;
@@ -123,6 +127,7 @@ public sealed class NrModeJsonConverter : JsonConverter<NrMode>
             NrMode.Anr => nameof(NrMode.Anr),
             NrMode.Emnr => nameof(NrMode.Emnr),
             NrMode.Sbnr => nameof(NrMode.Sbnr),
+            NrMode.Rnnr => nameof(NrMode.Rnnr),
             _ => nameof(NrMode.Off),
         });
     }
@@ -1242,7 +1247,17 @@ public sealed record StateDto(
     // Null = diversity off (default), byte-identical to today's single-ADC RX
     // path. See DiversityConfig. Ephemeral — re-armed each session (like PS),
     // never auto-armed on restart.
-    DiversityConfig? Diversity = null);
+    DiversityConfig? Diversity = null,
+
+    // ---- NR3 (RNNoise) availability + installed model ----
+    // WdspNr3RnnrAvailable: the loaded libwdsp exports the RNNR symbols
+    // (SetRXARNNRRun / SetRXARNNRPosition / RNNRloadModel). False on builds
+    // compiled with WDSP_WITH_NR3=OFF — NR3 is then hidden in the UI.
+    // Nr3ModelName: file name of the operator-installed RNNoise weights file,
+    // or null when none is installed. NR3 only becomes selectable when the
+    // native symbols are present AND a model is installed (Zeus ships none).
+    bool WdspNr3RnnrAvailable = false,
+    string? Nr3ModelName = null);
 
 /// <summary>Canonical CW constants shared between backend and wire DTOs.
 /// Single source of truth — CwOffset (server-side) and StateDto both
@@ -1562,6 +1577,11 @@ public sealed record TxPreKeyDelaySetRequest(int DelayMs);
 public sealed record TuneDriveSetRequest(int Percent);
 
 public sealed record NrSetRequest(NrConfig Nr);
+
+// NR3 (RNNoise) model install-from-URL request. The operator pastes a URL to a
+// compatible RNNoise weights file; the server fetches and installs it. Uploads
+// use multipart/form-data instead (no DTO). Zeus hosts no model of its own.
+public sealed record Nr3ModelDownloadRequest(string Url);
 
 // AGC mode + custom-params set request. Replace-style (the whole AgcConfig is
 // posted on every change), matching NrSetRequest. The separate AGC max-gain

--- a/Zeus.Dsp/IDspEngine.cs
+++ b/Zeus.Dsp/IDspEngine.cs
@@ -151,6 +151,13 @@ public interface IDspEngine : IDisposable
 
     void SetNoiseReduction(int channelId, NrConfig cfg);
 
+    /// <summary>Load (or, with a null/empty path, clear) the process-global
+    /// RNNoise (NR3) model shared by every RNNR channel. Returns false when the
+    /// loaded libwdsp lacks NR3 support (built with WDSP_WITH_NR3=OFF) so the
+    /// caller can report "NR3 unavailable on this build". No-op returning false
+    /// on Synthetic.</summary>
+    bool LoadNr3Model(string? modelFilePath);
+
     /// <summary>
     /// Replace the full manual-notch (MNF) set applied to the RX audio. Notch
     /// centre/width are absolute RF Hz; the engine rewrites the WDSP notch

--- a/Zeus.Dsp/SyntheticDspEngine.cs
+++ b/Zeus.Dsp/SyntheticDspEngine.cs
@@ -143,6 +143,10 @@ public sealed class SyntheticDspEngine : IDspEngine
         if (!Enum.IsDefined(cfg.NbMode)) throw new ArgumentException($"unknown NbMode {cfg.NbMode}", nameof(cfg));
     }
 
+    // No RNNoise backend in the synthetic engine — report "unavailable" so the
+    // server surfaces NR3 as off rather than pretending a model loaded.
+    public bool LoadNr3Model(string? modelFilePath) => false;
+
     // Manual notch filters have no audio effect in the synthetic engine; accept
     // and ignore so dev/CI exercises the full plumbing without a WDSP backend.
     public void SetNotches(IReadOnlyList<NotchDto> notches) => ArgumentNullException.ThrowIfNull(notches);

--- a/Zeus.Dsp/Wdsp/NativeMethods.cs
+++ b/Zeus.Dsp/Wdsp/NativeMethods.cs
@@ -470,6 +470,28 @@ internal static partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial void SetRXASBNRnoiseScalingType(int channel, int noise_scaling_type);
 
+    // RNNR (NR3) — RNNoise recurrent-network denoiser. Symbols defined in
+    // native/wdsp/rnnr.c, gated by WDSP_WITH_NR3 (OFF until xiph/rnnoise is
+    // vendored — see native/rnnoise/VENDORING.md). Builds without NR3 compile
+    // stubs/nr3/rnnr_stub.c, which does NOT export these symbols, so calls here
+    // fail with EntryPointNotFoundException; the engine guards on
+    // Nr3RnnrAvailable before invoking. RNNRloadModel is process-global (loads
+    // the model used by every RNNR channel); the path is the operator-installed
+    // RNNoise weights file. A NULL/empty path reverts to the baked-in model —
+    // but Zeus builds rnnoise WITHOUT a default model, so NR3 stays inert until
+    // a model is loaded.
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetRXARNNRRun(int channel, int run);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SetRXARNNRPosition(int channel, int position);
+
+    [LibraryImport(LibraryName, StringMarshalling = StringMarshalling.Utf8)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void RNNRloadModel(string filePath);
+
     [LibraryImport(LibraryName)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial void SetRXASNBARun(int channel, int run);

--- a/Zeus.Dsp/Wdsp/WdspDspEngine.cs
+++ b/Zeus.Dsp/Wdsp/WdspDspEngine.cs
@@ -137,6 +137,13 @@ public sealed class WdspDspEngine : IDspEngine
         nameof(NativeMethods.SetRXASBNRnoiseScalingType),
     ];
 
+    private static readonly string[] Nr3RnnrRequiredExports =
+    [
+        nameof(NativeMethods.SetRXARNNRRun),
+        nameof(NativeMethods.SetRXARNNRPosition),
+        nameof(NativeMethods.RNNRloadModel),
+    ];
+
     private static bool AllNativeExportsAvailable(string[] symbolNames)
     {
         if (!WdspNativeLoader.TryProbe()) return false;
@@ -153,6 +160,8 @@ public sealed class WdspDspEngine : IDspEngine
     public static bool EmnrPost2Available => AllNativeExportsAvailable(EmnrPost2RequiredExports);
 
     public static bool Nr4SbnrAvailable => AllNativeExportsAvailable(SbnrRequiredExports);
+
+    public static bool Nr3RnnrAvailable => AllNativeExportsAvailable(Nr3RnnrRequiredExports);
 
     private static double FiniteOrZero(double value) =>
         double.IsFinite(value) ? value : 0.0;
@@ -931,6 +940,7 @@ public sealed class WdspDspEngine : IDspEngine
             case NrMode.Anr:
                 NativeMethods.SetRXAEMNRRun(channelId, 0);
                 TrySetSbnrRun(channelId, 0);
+                TrySetRnnrRun(channelId, 0);
                 NativeMethods.SetRXAANRVals(channelId, NrDefaults.AnrTaps, NrDefaults.AnrDelay, NrDefaults.AnrGain, NrDefaults.AnrLeakage);
                 NativeMethods.SetRXAANRPosition(channelId, NrDefaults.Position);
                 NativeMethods.SetRXAANRRun(channelId, 1);
@@ -938,6 +948,7 @@ public sealed class WdspDspEngine : IDspEngine
             case NrMode.Emnr:
                 NativeMethods.SetRXAANRRun(channelId, 0);
                 TrySetSbnrRun(channelId, 0);
+                TrySetRnnrRun(channelId, 0);
                 // Core EMNR algorithm selectors (gain method, NPE method, AE
                 // filter) plus the optional Trained-method T1/T2 tuning. All
                 // operator-tunable; null fields fall back to NrDefaults so the
@@ -960,13 +971,31 @@ public sealed class WdspDspEngine : IDspEngine
                 NativeMethods.SetRXAANRRun(channelId, 0);
                 TrySetEmnrPost2Run(channelId, 0);
                 NativeMethods.SetRXAEMNRRun(channelId, 0);
+                TrySetRnnrRun(channelId, 0);
                 ApplyNr4Sbnr(channelId, cfg);
+                break;
+            case NrMode.Rnnr:
+                // NR3 — RNNoise. Disable the other post-RXA NR paths, then
+                // enable RNNR. The model is loaded process-globally via
+                // RNNRloadModel at install/startup (LoadNr3Model), NOT here —
+                // a per-channel call would thrash the shared model. Guarded by
+                // TrySetRnnr* so a libwdsp without NR3 exports (WDSP_WITH_NR3
+                // OFF) leaves the channel NR-off instead of crashing. If no
+                // model is loaded, rnnr.c's create_rnnr left rnnoise_create
+                // NULL, so xrnnr passes audio through untouched — inert, safe.
+                NativeMethods.SetRXAANRRun(channelId, 0);
+                TrySetEmnrPost2Run(channelId, 0);
+                NativeMethods.SetRXAEMNRRun(channelId, 0);
+                TrySetSbnrRun(channelId, 0);
+                TrySetRnnrPosition(channelId, NrDefaults.Position);
+                TrySetRnnrRun(channelId, 1);
                 break;
             default:
                 NativeMethods.SetRXAANRRun(channelId, 0);
                 TrySetEmnrPost2Run(channelId, 0);
                 NativeMethods.SetRXAEMNRRun(channelId, 0);
                 TrySetSbnrRun(channelId, 0);
+                TrySetRnnrRun(channelId, 0);
                 break;
         }
         state.CurrentNrMode = cfg.NrMode;
@@ -1201,6 +1230,48 @@ public sealed class WdspDspEngine : IDspEngine
         catch (EntryPointNotFoundException) { /* libwdsp lacks post2; nothing to turn off */ }
     }
 
+    // NR3 (RNNoise) Run/Position guards — same shape as the SBNR ones. A
+    // libwdsp built with WDSP_WITH_NR3=OFF (the stub) does not export RNNR
+    // symbols, so every call is wrapped: NR3 then behaves as a no-op rather
+    // than crashing the worker.
+    private void TrySetRnnrRun(int channelId, int run)
+    {
+        try { NativeMethods.SetRXARNNRRun(channelId, run); }
+        catch (EntryPointNotFoundException) { /* libwdsp lacks NR3; nothing to toggle */ }
+    }
+
+    private void TrySetRnnrPosition(int channelId, int position)
+    {
+        try { NativeMethods.SetRXARNNRPosition(channelId, position); }
+        catch (EntryPointNotFoundException) { /* libwdsp lacks NR3; position is moot */ }
+    }
+
+    // Loads (or, with a null/empty path, clears) the process-global RNNoise
+    // model used by every RNNR channel. Called by the server when the operator
+    // installs/removes a model and once at startup if one is already installed.
+    // Returns false when libwdsp lacks NR3 support so the caller can surface
+    // "NR3 unavailable on this build" instead of silently succeeding. Zeus
+    // builds rnnoise without a baked-in model, so clearing the path leaves NR3
+    // inert (audio passes through) rather than falling back to a stock model.
+    public bool LoadNr3Model(string? modelFilePath)
+    {
+        try
+        {
+            NativeMethods.RNNRloadModel(modelFilePath ?? string.Empty);
+            _log.LogInformation(
+                "wdsp.rnnr.loadModel path=\"{Path}\"",
+                string.IsNullOrEmpty(modelFilePath) ? "(none — NR3 inert)" : modelFilePath);
+            return true;
+        }
+        catch (EntryPointNotFoundException ex)
+        {
+            _log.LogWarning(
+                "wdsp.rnnr.unavailable reason=\"libwdsp build does not export RNNR symbols (WDSP_WITH_NR3=OFF — xiph/rnnoise not vendored)\" detail={Msg}",
+                ex.Message);
+            return false;
+        }
+    }
+
     // Post-RXA NR defaults — sourced from Thetis setup.designer.cs + radio.cs.
     // UI-space scaling (gain × 1e-6, leakage × 1e-3) is already resolved: these
     // are the post-scale values WDSP actually receives. See docs/prd/10-noise-reduction.md.
@@ -1219,11 +1290,16 @@ public sealed class WdspDspEngine : IDspEngine
         public const int EmnrAeRun = 1;
         public const int Position = 1;
 
-        // Thetis Setup → DSP "Trained" T1/T2 NUDs (setup.designer.cs:43244,
-        // 43276). Defaults match Thetis exactly; only consulted by WDSP when
+        // Thetis Setup → DSP "Trained" T1/T2 NUDs (setup.designer.cs:43330 /
+        // 43298). Pushed raw via SetRXAEMNRtrainZetaThresh / SetRXAEMNRtrainT2
+        // (setup.cs:29384 / 32308). Only consulted by WDSP when
         // EmnrGainMethod=3 (Trained gain method).
+        //   T1: udDSPNR2trainThresh.Value = -0.5  (range -5..5, step 0.1)
+        //   T2: udDSPNR2trainT2.Value     =  0.2  (range 0.02..0.3, step 0.01)
+        // NB: Thetis packs the T2 NUD as decimal{2,0,0,scale=1} = 0.2 — earlier
+        // Zeus read it as 2.0 (a 10× error). It is 0.2.
         public const double EmnrTrainT1 = -0.5;
-        public const double EmnrTrainT2 = 2.0;
+        public const double EmnrTrainT2 = 0.2;
 
         // post2 defaults sourced from Thetis radio.cs:2103/2122/2160 (raw
         // NumericUpDown values 0..100, default 15/15/12). The /100 scaling
@@ -1232,6 +1308,13 @@ public sealed class WdspDspEngine : IDspEngine
         // ends up storing. (post2Rate has no /100 in WDSP, so 5.0 is correct
         // as-is.) Earlier Zeus defaults of 0.15 were 100× too small once WDSP
         // divided again, leaving comfort-noise effectively silent.
+        //
+        // Run defaults ON — this is a DELIBERATE Zeus divergence, not Thetis
+        // parity: Thetis's "Noise post proc" checkbox ships OFF
+        // (setup.designer.cs chkNR2PostProc_enable_rx1, no Checked=true). Zeus
+        // enables post2 by default because the comfort-noise injection masks
+        // the musical-warble artifacts of frequency-domain EMNR, which the
+        // maintainers consider an improvement over the Thetis baseline.
         public const int EmnrPost2Run = 1;
         public const double EmnrPost2Factor = 15.0;
         public const double EmnrPost2Nlevel = 15.0;

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -1112,7 +1112,8 @@ public class DspPipelineService : BackgroundService,
         FrontendDspSceneDiagnosticsService? frontendDspScene = null,
         DisplaySettingsStore? displaySettings = null,
         FreeDvService? freeDv = null,
-        Func<TxAudioIngest?>? txIngestFactory = null)
+        Func<TxAudioIngest?>? txIngestFactory = null,
+        Nr3ModelStore? nr3ModelStore = null)
     {
         _radio = radio;
         _hub = hub;
@@ -1132,6 +1133,38 @@ public class DspPipelineService : BackgroundService,
         _secondaryRx = new SecondaryRx[MaxReceivers];
         for (int i = 1; i < MaxReceivers; i++)
             _secondaryRx[i] = new SecondaryRx();
+
+        _nr3ModelStore = nr3ModelStore;
+        if (_nr3ModelStore is not null)
+        {
+            // NR3 (RNNoise) model is process-global in libwdsp. Re-push the
+            // operator's installed model whenever a fresh engine spins up
+            // (reconnect / WDSP↔synthetic swap) and whenever the operator
+            // installs/removes a model. Both funnel through LoadNr3ModelInto so
+            // the engine-lock discipline lives in one place.
+            EngineChanged += LoadNr3ModelInto;
+            _nr3ModelStore.Changed += _ => ReloadNr3ModelToCurrentEngine();
+        }
+    }
+
+    // Operator-installed RNNoise (NR3) model store. Optional so test
+    // constructions keep working; when null, NR3 model loading is skipped
+    // entirely (NR3 stays inert).
+    private readonly Nr3ModelStore? _nr3ModelStore;
+
+    // Push the active NR3 model path into the given engine under the engine
+    // lock. A null/empty path clears the model (NR3 inert) — we always call so
+    // a reused process never keeps a stale model after a remove.
+    private void LoadNr3ModelInto(IDspEngine engine)
+    {
+        var path = _nr3ModelStore?.GetActiveModelPath();
+        lock (_engineLock) { engine.LoadNr3Model(path); }
+    }
+
+    private void ReloadNr3ModelToCurrentEngine()
+    {
+        var engine = Volatile.Read(ref _engine);
+        if (engine is not null) LoadNr3ModelInto(engine);
     }
 
     // Lazily resolve TxAudioIngest (DI cycle avoidance — see field comment) and

--- a/Zeus.Server.Hosting/DspSettingsStore.cs
+++ b/Zeus.Server.Hosting/DspSettingsStore.cs
@@ -572,8 +572,11 @@ public sealed class DspSettingsStore : IDisposable
         e.CfcBand10Freq = c.Bands[9].FreqHz; e.CfcBand10Comp = c.Bands[9].CompLevelDb; e.CfcBand10Post = c.Bands[9].PostGainDb;
     }
 
+    // Keep this in lock-step with RadioService.IsSupportedNrMode — the store
+    // must persist every mode RadioService treats as supported, or the live
+    // selection (e.g. NR3 / Rnnr) is silently dropped to Off on the next read.
     private static NrMode NormalizeNrMode(NrMode mode) =>
-        mode is NrMode.Off or NrMode.Anr or NrMode.Emnr or NrMode.Sbnr
+        mode is NrMode.Off or NrMode.Anr or NrMode.Emnr or NrMode.Sbnr or NrMode.Rnnr
             ? mode
             : NrMode.Off;
 

--- a/Zeus.Server.Hosting/Nr3ModelStore.cs
+++ b/Zeus.Server.Hosting/Nr3ModelStore.cs
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using Microsoft.Extensions.Logging;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Stores the operator-installed RNNoise (NR3) model file on disk and tracks
+/// which one is active. Zeus ships NO bundled model — NR3 stays inert until the
+/// operator installs an RNNoise weights file (upload or URL download via the DSP
+/// menu). One model at a time: installing replaces the previous one.
+///
+/// The file lives under <c>%LOCALAPPDATA%/Zeus/nr3-models/</c>
+/// (cross-platform <see cref="Environment.SpecialFolder.LocalApplicationData"/>:
+/// <c>~/.local/share/Zeus</c> on Linux, <c>~/Library/Application Support/Zeus</c>
+/// on macOS). The file itself is the persistence — no LiteDB row — so a model
+/// survives restarts and the active model is simply "the one file in the dir".
+///
+/// The native loader (<c>RNNRloadModel</c>, native/wdsp/rnnr.c) takes a path and
+/// is process-global, so <see cref="DspPipelineService"/> calls
+/// <c>IDspEngine.LoadNr3Model</c> with <see cref="GetActiveModelPath"/> on engine
+/// (re)creation and whenever <see cref="Changed"/> fires.
+/// </summary>
+public sealed class Nr3ModelStore
+{
+    // RNNoise weight dumps are tiny (the stock xiph model is well under 1 MiB),
+    // but custom/experimental models vary. 64 MiB is a generous ceiling that
+    // still rejects an accidental upload of the wrong (huge) file.
+    private const long MaxModelBytes = 64L * 1024 * 1024;
+
+    private readonly ILogger<Nr3ModelStore> _log;
+    private readonly string _dir;
+    private readonly object _gate = new();
+
+    /// <summary>Raised after the active model changes (install or remove) so the
+    /// DSP pipeline can re-push it to the engine. Argument is the new active
+    /// model path, or null when the model was removed.</summary>
+    public event Action<string?>? Changed;
+
+    public Nr3ModelStore(ILogger<Nr3ModelStore> log)
+    {
+        _log = log;
+        var appData = Environment.GetFolderPath(
+            Environment.SpecialFolder.LocalApplicationData,
+            Environment.SpecialFolderOption.Create);
+        _dir = Path.Combine(appData, "Zeus", "nr3-models");
+    }
+
+    // Test/host override so xUnit (parallel WebApplicationFactory) and headless
+    // runs can point at an isolated throw-away directory.
+    public Nr3ModelStore(ILogger<Nr3ModelStore> log, string directory)
+    {
+        _log = log;
+        _dir = directory;
+    }
+
+    /// <summary>Absolute path of the installed model file, or null when none is
+    /// installed. The active model is the single file in the models dir.</summary>
+    public string? GetActiveModelPath()
+    {
+        lock (_gate)
+        {
+            if (!Directory.Exists(_dir)) return null;
+            // First (and by contract only) file in the dir is the active model.
+            foreach (var path in Directory.EnumerateFiles(_dir))
+                return path;
+            return null;
+        }
+    }
+
+    /// <summary>File name of the installed model, or null when none is
+    /// installed. Surfaced to the UI via StateDto.Nr3ModelName.</summary>
+    public string? GetActiveModelName()
+    {
+        var path = GetActiveModelPath();
+        return path is null ? null : Path.GetFileName(path);
+    }
+
+    /// <summary>
+    /// Install (replacing any prior model) the given bytes under a sanitized
+    /// copy of <paramref name="originalName"/>. Returns the absolute path the
+    /// file was written to. Throws <see cref="ArgumentException"/> on an empty
+    /// payload or one over <see cref="MaxModelBytes"/>. Raises
+    /// <see cref="Changed"/> with the new path.
+    /// </summary>
+    public string Install(ReadOnlySpan<byte> content, string originalName)
+    {
+        if (content.Length == 0)
+            throw new ArgumentException("NR3 model file is empty.", nameof(content));
+        if (content.Length > MaxModelBytes)
+            throw new ArgumentException(
+                $"NR3 model file is {content.Length} bytes, over the {MaxModelBytes}-byte limit.",
+                nameof(content));
+
+        var safeName = SanitizeFileName(originalName);
+        string destPath;
+        lock (_gate)
+        {
+            Directory.CreateDirectory(_dir);
+            // One model at a time — clear any previous file(s) so GetActiveModelPath
+            // is unambiguous.
+            foreach (var existing in Directory.EnumerateFiles(_dir))
+                TryDelete(existing);
+
+            destPath = Path.Combine(_dir, safeName);
+            File.WriteAllBytes(destPath, content.ToArray());
+        }
+
+        _log.LogInformation(
+            "nr3.model.installed name=\"{Name}\" bytes={Bytes} path=\"{Path}\"",
+            safeName, content.Length, destPath);
+        Changed?.Invoke(destPath);
+        return destPath;
+    }
+
+    /// <summary>Remove the installed model. Returns true if a model existed and
+    /// was removed. Raises <see cref="Changed"/> (null) when something was
+    /// removed so the engine clears its loaded model.</summary>
+    public bool Remove()
+    {
+        bool removed = false;
+        lock (_gate)
+        {
+            if (Directory.Exists(_dir))
+            {
+                foreach (var path in Directory.EnumerateFiles(_dir))
+                {
+                    TryDelete(path);
+                    removed = true;
+                }
+            }
+        }
+
+        if (removed)
+        {
+            _log.LogInformation("nr3.model.removed");
+            Changed?.Invoke(null);
+        }
+        return removed;
+    }
+
+    // Strip any directory component (defends against "../" path traversal in an
+    // uploaded filename) and fall back to a stable name when the result is empty.
+    private static string SanitizeFileName(string originalName)
+    {
+        var name = Path.GetFileName(originalName ?? string.Empty);
+        if (string.IsNullOrWhiteSpace(name))
+            name = "model.rnnn";
+        // Replace any remaining invalid chars defensively.
+        foreach (var bad in Path.GetInvalidFileNameChars())
+            name = name.Replace(bad, '_');
+        return name;
+    }
+
+    private void TryDelete(string path)
+    {
+        try { File.Delete(path); }
+        catch (IOException ex) { _log.LogWarning("nr3.model.delete.failed path=\"{Path}\" detail={Msg}", path, ex.Message); }
+        catch (UnauthorizedAccessException ex) { _log.LogWarning("nr3.model.delete.denied path=\"{Path}\" detail={Msg}", path, ex.Message); }
+    }
+}

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -71,6 +71,9 @@ public sealed class RadioService : IDisposable
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<RadioService> _log;
     private readonly DspSettingsStore _dspSettingsStore;
+    // NR3 (RNNoise) operator-installed model store. Optional (null in older test
+    // constructions); when null, NR3 reports no installed model.
+    private readonly Nr3ModelStore? _nr3ModelStore;
     private readonly PaSettingsStore _paStore;
     // Per-band external-antenna selection (external-ports plan — antenna slice,
     // #804). Optional so existing constructions (tests) stay valid; null → the
@@ -313,11 +316,12 @@ public sealed class RadioService : IDisposable
     // to its internal test-tone generator (dev / tests without a hub).
     private readonly Zeus.Protocol1.ITxIqSource? _txIqSource;
 
-    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, FilterPresetStore? filterPresetStore = null, Zeus.Protocol1.ITxIqSource? txIqSource = null, PreferredRadioStore? preferredRadioStore = null, PsSettingsStore? psStore = null, RadioStateStore? radioStateStore = null, CwSettingsStore? cwSettingsStore = null, TxAudioProfileStore? txAudioProfileStore = null, AntennaSettingsStore? antennaStore = null, AudioSettingsStore? audioStore = null)
+    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, FilterPresetStore? filterPresetStore = null, Zeus.Protocol1.ITxIqSource? txIqSource = null, PreferredRadioStore? preferredRadioStore = null, PsSettingsStore? psStore = null, RadioStateStore? radioStateStore = null, CwSettingsStore? cwSettingsStore = null, TxAudioProfileStore? txAudioProfileStore = null, AntennaSettingsStore? antennaStore = null, AudioSettingsStore? audioStore = null, Nr3ModelStore? nr3ModelStore = null)
     {
         _loggerFactory = loggerFactory;
         _log = loggerFactory.CreateLogger<RadioService>();
         _dspSettingsStore = dspSettingsStore;
+        _nr3ModelStore = nr3ModelStore;
         _paStore = paStore;
         _antennaStore = antennaStore;
         _preferredRadioStore = preferredRadioStore;
@@ -492,6 +496,12 @@ public sealed class RadioService : IDisposable
             TxLeveling: persistedTxLeveling,
             AttenDb: rsSnap?.AttenDb ?? 0,
             Nr: persistedNr,
+            // NR3 (RNNoise): native availability is a static probe of the loaded
+            // libwdsp's RNNR exports; the installed-model name comes from the
+            // operator's model store. The frontend reveals NR3 only when both
+            // are present (symbols available AND a model installed).
+            WdspNr3RnnrAvailable: Zeus.Dsp.Wdsp.WdspDspEngine.Nr3RnnrAvailable,
+            Nr3ModelName: _nr3ModelStore?.GetActiveModelName(),
             ZoomLevel: rsSnap?.ZoomLevel ?? 1,
             AutoAttEnabled: _adcProtection.Enabled,
             AttOffsetDb: 0,         // always reset — control-loop accumulator
@@ -2869,11 +2879,41 @@ public sealed class RadioService : IDisposable
         return Snapshot();
     }
 
+    // ---- NR3 (RNNoise) model management ----
+    // The operator installs an RNNoise weights file (Zeus ships none). The model
+    // store persists the file to disk and raises Changed, which the DSP pipeline
+    // observes to (re)load it into libwdsp (process-global RNNRloadModel). We
+    // mirror the active model name into StateDto so the UI can reveal NR3 once a
+    // model is present.
+    public StateDto InstallNr3Model(byte[] content, string fileName)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        if (_nr3ModelStore is null)
+            throw new InvalidOperationException("NR3 model store is not configured.");
+        _nr3ModelStore.Install(content, fileName);
+        var name = _nr3ModelStore.GetActiveModelName();
+        Mutate(s => s with { Nr3ModelName = name });
+        return Snapshot();
+    }
+
+    public StateDto RemoveNr3Model()
+    {
+        if (_nr3ModelStore is null || !_nr3ModelStore.Remove())
+            return Snapshot();
+        Mutate(s => s with { Nr3ModelName = null });
+        // If NR3 was the active mode, fall back to Off (persisted via SetNr) so
+        // the operator isn't stranded on a now-model-less, inert NR3.
+        var cur = Snapshot().Nr;
+        if (cur?.NrMode == NrMode.Rnnr)
+            return SetNr(cur with { NrMode = NrMode.Off });
+        return Snapshot();
+    }
+
     private static NrConfig NormalizeNrConfig(NrConfig cfg) =>
         IsSupportedNrMode(cfg.NrMode) ? cfg : cfg with { NrMode = NrMode.Off };
 
     private static bool IsSupportedNrMode(NrMode mode) =>
-        mode is NrMode.Off or NrMode.Anr or NrMode.Emnr or NrMode.Sbnr;
+        mode is NrMode.Off or NrMode.Anr or NrMode.Emnr or NrMode.Sbnr or NrMode.Rnnr;
 
     // AGC mode + custom/fixed params. Replace-style like SetNr; the engine apply
     // happens in DspPipelineService via the _appliedAgc latch. The separate AGC

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -1812,6 +1812,68 @@ public static class ZeusEndpoints
             return Results.Ok(r.SetNr4(req));
         });
 
+        // ---- NR3 (RNNoise) model management (issue #79 follow-up) ----
+        // Zeus ships no model; NR3 stays hidden in the UI until the operator
+        // installs an RNNoise weights file here — either a multipart upload or a
+        // server-side fetch from a URL. Native availability + the installed
+        // model name also ride StateDto, so the GET is a convenience for the
+        // install panel.
+        app.MapGet("/api/rx/nr3/model", (RadioService r) =>
+        {
+            var s = r.Snapshot();
+            return Results.Ok(new { available = s.WdspNr3RnnrAvailable, modelName = s.Nr3ModelName });
+        });
+
+        app.MapPost("/api/rx/nr3/model", async (HttpRequest http, RadioService r) =>
+        {
+            if (!http.HasFormContentType || http.Form.Files.Count == 0)
+                return Results.BadRequest(new { error = "expected multipart/form-data with a 'file' field" });
+            var file = http.Form.Files["file"] ?? http.Form.Files[0];
+            if (file.Length == 0)
+                return Results.BadRequest(new { error = "uploaded model file is empty" });
+            using var ms = new MemoryStream();
+            await file.CopyToAsync(ms);
+            try
+            {
+                var state = r.InstallNr3Model(ms.ToArray(), file.FileName);
+                log.LogInformation("api.rx.nr3.model.install name=\"{Name}\" bytes={Bytes}", file.FileName, ms.Length);
+                return Results.Ok(state);
+            }
+            catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
+            catch (InvalidOperationException ex) { return Results.Problem(ex.Message); }
+        });
+
+        app.MapPost("/api/rx/nr3/model/download", async (Nr3ModelDownloadRequest req, RadioService r, IHttpClientFactory httpFactory) =>
+        {
+            if (string.IsNullOrWhiteSpace(req.Url) ||
+                !Uri.TryCreate(req.Url, UriKind.Absolute, out var uri) ||
+                (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+                return Results.BadRequest(new { error = "url must be an absolute http(s) URL" });
+            try
+            {
+                var client = httpFactory.CreateClient();
+                client.Timeout = TimeSpan.FromSeconds(60);
+                // Cap the buffered response so a wrong (huge) URL can't OOM the
+                // host; the model store enforces its own 64 MiB ceiling too.
+                client.MaxResponseContentBufferSize = 80L * 1024 * 1024;
+                var bytes = await client.GetByteArrayAsync(uri);
+                var name = Path.GetFileName(uri.LocalPath);
+                if (string.IsNullOrWhiteSpace(name)) name = "model.rnnn";
+                var state = r.InstallNr3Model(bytes, name);
+                log.LogInformation("api.rx.nr3.model.download url=\"{Url}\" bytes={Bytes}", req.Url, bytes.Length);
+                return Results.Ok(state);
+            }
+            catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
+            catch (HttpRequestException ex) { return Results.BadRequest(new { error = $"download failed: {ex.Message}" }); }
+            catch (TaskCanceledException) { return Results.BadRequest(new { error = "download timed out" }); }
+        });
+
+        app.MapDelete("/api/rx/nr3/model", (RadioService r) =>
+        {
+            log.LogInformation("api.rx.nr3.model.remove");
+            return Results.Ok(r.RemoveNr3Model());
+        });
+
         // Manual notch filters (MNF) — the client posts the full notch list on
         // every change (and on connect). GET returns the current set so a fresh
         // client (or a reconnect) can hydrate. Notches kill EMF/birdies in the

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -500,6 +500,9 @@ public static class ZeusHost
         builder.Services.AddSingleton<DiagnosticReportBuilder>();
 
         builder.Services.AddSingleton<DspSettingsStore>();
+        // NR3 (RNNoise) operator-installed model store. Auto-injected into
+        // RadioService + DspPipelineService (both have an optional param).
+        builder.Services.AddSingleton<Nr3ModelStore>();
         builder.Services.AddSingleton<CfcPresetStore>();
         builder.Services.AddSingleton<PaSettingsStore>();
         builder.Services.AddSingleton<PreferredRadioStore>();

--- a/native/rnnoise/VENDORING.md
+++ b/native/rnnoise/VENDORING.md
@@ -1,0 +1,85 @@
+# librnnoise (NR3 / RNNoise) — vendoring notes
+
+This directory holds an in-tree copy of **RNNoise** (xiph), the recurrent-neural
+denoiser that WDSP's `rnnr.c` (NR3) links against. It is **not yet populated** —
+NR3 is gated `OFF` in `native/wdsp/CMakeLists.txt` (`WDSP_WITH_NR3`) until the
+source is vendored here. The C#/TypeScript side of NR3 is already wired; this is
+the one remaining step to make NR3 functional, and it must run on the CI native
+runners (cross-platform) — see "CI" below.
+
+## Provenance
+
+Upstream: <https://gitlab.xiph.org/xiph/rnnoise> (mirror:
+<https://github.com/xiph/rnnoise>). License: **BSD-3-Clause** — compatible with
+Zeus's GPL-2.0-or-later distribution (BSD → GPL is one-way compatible). Preserve
+the upstream `COPYING` / `LICENSE` verbatim when vendoring.
+
+`rnnr.c` itself (the ringbuffer + AGC wrapper around RNNoise) is MW0LGE's Thetis
+code, already in `native/wdsp/rnnr.c`. Only the RNNoise library proper is
+vendored here.
+
+## Re-vendoring
+
+Pin a specific upstream tag/commit (record it here when you do):
+
+```sh
+RNNOISE_REF=<tag-or-commit>      # e.g. a release tag; record it in this file
+git clone https://github.com/xiph/rnnoise /tmp/rnnoise
+git -C /tmp/rnnoise checkout "$RNNOISE_REF"
+rm -rf native/rnnoise/src native/rnnoise/include
+mkdir -p native/rnnoise/src native/rnnoise/include
+cp /tmp/rnnoise/src/*.c native/rnnoise/src/
+cp /tmp/rnnoise/src/*.h native/rnnoise/src/   2>/dev/null || true
+cp /tmp/rnnoise/include/rnnoise.h native/rnnoise/include/
+cp /tmp/rnnoise/COPYING native/rnnoise/COPYING
+# keep this VENDORING.md
+```
+
+The CMake glob (`native/wdsp/CMakeLists.txt`, `WDSP_WITH_NR3` block) compiles
+`native/rnnoise/src/*.c` as a STATIC sub-target and links it into `libwdsp`.
+
+## No bundled model (deliberate)
+
+Zeus ships **no** RNNoise model. NR3 stays inert until the operator installs a
+weights file via the DSP menu (which calls `RNNRloadModel` →
+`rnnoise_model_from_filename`). To guarantee that, the library is compiled
+**without the default model**, matching xiph's `--disable-default-model`:
+
+- The CMake block **excludes** the default-weights translation unit
+  (`*rnnoise_data*.c`) from the source glob.
+- It defines `USE_WEIGHTS_FILE`, which gates off the stock-model code path so
+  `rnnoise_create(NULL)` returns an inert denoiser (audio passes through) rather
+  than referencing the excluded weights.
+
+Verify against the pinned tag: if upstream's macro/filenames differ, adjust the
+`EXCLUDE REGEX` and `target_compile_definitions` in the CMake block to match.
+The acceptance check is: `libwdsp` links with no undefined `rnnoise_*` symbols,
+and with no model loaded NR3 is a clean pass-through.
+
+## Enabling the build
+
+```sh
+cmake -S native/wdsp -B build -DWDSP_WITH_NR3=ON     # plus the usual FFTW flags
+```
+
+`rnnr.c` is then compiled instead of `stubs/nr3/rnnr_stub.c`, and `libwdsp`
+exports `SetRXARNNRRun`, `SetRXARNNRPosition`, and `RNNRloadModel`. The managed
+side detects these via `WdspDspEngine.Nr3RnnrAvailable` and reveals NR3 in the UI
+once a model is also installed.
+
+## CI
+
+Flip `-DWDSP_WITH_NR3=ON` in `.github/workflows/build-native-libs.yml` and
+`release.yml` alongside the existing `WDSP_WITH_NR4=ON`, so the shipped
+per-platform `libwdsp` binaries (macOS arm64/x64, Linux x64/arm64, Windows x64)
+carry the RNNR exports. Until those binaries are rebuilt, `Nr3RnnrAvailable` is
+false and NR3 stays hidden — by design, not a regression.
+
+A loader smoke test mirroring `Zeus.Dsp.Tests/WdspNativeLoaderTests` (which
+asserts the NR4/SBNR exports) should assert the RNNR exports once NR3 ships.
+
+## Models for operators
+
+Zeus links to documentation rather than hosting a model. Operators supply their
+own RNNoise weights file (e.g. a community HF-tuned model, or one trained per the
+upstream training pipeline) and install it from the DSP menu (upload or URL).

--- a/native/wdsp/CMakeLists.txt
+++ b/native/wdsp/CMakeLists.txt
@@ -15,7 +15,10 @@
 # because libspecbleach is single-precision.
 #
 # NR3 (RNNoise) and NR4 (libspecbleach / SBNR) are gated by separate flags:
-#   * WDSP_WITH_NR3 — OFF by default. librnnoise is not yet vendored.
+#   * WDSP_WITH_NR3 — OFF by default. Turn ON after vendoring xiph/rnnoise under
+#                    native/rnnoise/ (see native/rnnoise/VENDORING.md). Built
+#                    without the default model — NR3 needs an operator-installed
+#                    model at runtime.
 #   * WDSP_WITH_NR4 — ON  by default. libspecbleach is vendored under
 #                    native/libspecbleach/ (see Phase 1a of #162).
 
@@ -307,6 +310,48 @@ if(WDSP_WITH_NR4)
     endif()
 
     target_link_libraries(wdsp PRIVATE specbleach)
+endif()
+
+# -----------------------------------------------------------------------------
+# librnnoise (NR3 / RNNoise) — vendored at native/rnnoise/, built inline as a
+# STATIC sub-target so it embeds into libwdsp (same pattern as libspecbleach).
+#
+# Built WITHOUT the baked-in default model: Zeus requires the operator to
+# install a model (RNNRloadModel / rnnoise_model_from_filename), so the large
+# default-weights translation unit is excluded and the "stock model" path is
+# gated off (xiph's --disable-default-model equivalent). NR3 is then inert until
+# a model file is loaded. See native/rnnoise/VENDORING.md for the vendor step
+# and the pinned upstream tag.
+# -----------------------------------------------------------------------------
+if(WDSP_WITH_NR3)
+    set(RNNOISE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../rnnoise)
+    if(NOT EXISTS ${RNNOISE_DIR}/include/rnnoise.h)
+        message(FATAL_ERROR "WDSP_WITH_NR3=ON but native/rnnoise/ is missing or incomplete. See native/rnnoise/VENDORING.md.")
+    endif()
+
+    # Drop the compiled-in default-model data unit(s) so no stock weights ship.
+    file(GLOB_RECURSE RNNOISE_SRCS "${RNNOISE_DIR}/src/*.c")
+    list(FILTER RNNOISE_SRCS EXCLUDE REGEX ".*rnnoise_data.*\\.c$")
+    add_library(rnnoise STATIC ${RNNOISE_SRCS})
+    set_target_properties(rnnoise PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+        C_VISIBILITY_PRESET hidden
+        C_STANDARD 99
+    )
+    target_include_directories(rnnoise PUBLIC ${RNNOISE_DIR}/include PRIVATE ${RNNOISE_DIR}/src)
+    # USE_WEIGHTS_FILE gates off the stock-model code path (matches xiph's
+    # --disable-default-model), so rnnoise_create(NULL) yields an inert denoiser
+    # until RNNRloadModel installs a model.
+    target_compile_definitions(rnnoise PRIVATE USE_WEIGHTS_FILE)
+    if(NOT MSVC)
+        target_compile_options(rnnoise PRIVATE
+            -Wno-unused-variable -Wno-unused-function -Wno-unused-but-set-variable)
+    endif()
+
+    # rnnr.c does #include "rnnoise.h" — point it at the vendored header (the
+    # stub include dir is intentionally NOT added when WDSP_WITH_NR3 is ON).
+    target_include_directories(wdsp PRIVATE ${RNNOISE_DIR}/include)
+    target_link_libraries(wdsp PRIVATE rnnoise)
 endif()
 
 # -----------------------------------------------------------------------------

--- a/tests/Zeus.Server.Tests/DspPipelineRx2RoutingTests.cs
+++ b/tests/Zeus.Server.Tests/DspPipelineRx2RoutingTests.cs
@@ -235,6 +235,7 @@ public class DspPipelineRx2RoutingTests
         public void SetRxDisplayFastAttack(int channelId, bool fast) { }
         public void SetRxAfGainDb(int channelId, double db) { }
         public void SetNoiseReduction(int channelId, NrConfig cfg) { }
+        public bool LoadNr3Model(string? modelFilePath) => false;
         public void SetNotches(IReadOnlyList<NotchDto> notches) { }
         public void SetNotchTuneFrequencyHz(double loHz) { }
         public void SetZoom(int channelId, int level) { }

--- a/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/MicGainEndpointTests.cs
@@ -183,6 +183,7 @@ public class MicGainEndpointTests : IClassFixture<MicGainEndpointTests.Factory>
     public void SetRxDisplayFastAttack(int channelId, bool fast) { }
         public void SetRxAfGainDb(int channelId, double db) { }
         public void SetNoiseReduction(int channelId, NrConfig cfg) { }
+        public bool LoadNr3Model(string? modelFilePath) => false;
         public void SetNotches(IReadOnlyList<NotchDto> notches) { }
         public void SetNotchTuneFrequencyHz(double loHz) { }
         public void SetZoom(int channelId, int level) { }

--- a/tests/Zeus.Server.Tests/NrModeRemovalTests.cs
+++ b/tests/Zeus.Server.Tests/NrModeRemovalTests.cs
@@ -26,7 +26,9 @@ public sealed class NrModeRemovalTests : IDisposable
         using var dspStore = NewDspStore();
         using var radio = NewRadio(dspStore);
 
-        var snapshot = radio.SetNr(new NrConfig(NrMode: (NrMode)4));
+        // 5 is one past the last defined mode (Rnnr = 4) — a corrupt/legacy
+        // DB value that must normalize to Off rather than be honored.
+        var snapshot = radio.SetNr(new NrConfig(NrMode: (NrMode)5));
 
         Assert.Equal(NrMode.Off, snapshot.Nr?.NrMode);
         Assert.Equal(NrMode.Off, dspStore.Get()?.NrMode);
@@ -36,11 +38,34 @@ public sealed class NrModeRemovalTests : IDisposable
     public void Constructor_NormalizesPersistedUnsupportedModeToOff()
     {
         using var dspStore = NewDspStore();
-        dspStore.Upsert(new NrConfig(NrMode: (NrMode)4));
+        // 5 is one past the last defined mode (Rnnr = 4): a stale persisted
+        // value from an older schema must be clamped to Off on load.
+        dspStore.Upsert(new NrConfig(NrMode: (NrMode)5));
 
         using var radio = NewRadio(dspStore);
 
         Assert.Equal(NrMode.Off, radio.Snapshot().Nr?.NrMode);
+    }
+
+    // Regression: the store's NormalizeNrMode must accept every mode
+    // RadioService.IsSupportedNrMode accepts. NR3 (Rnnr) was added to the
+    // RadioService allow-list but not the store's, so SetNr(Rnnr) was silently
+    // persisted as Off and the operator's NR3 selection never survived a
+    // restart. Keep the two allow-lists in lock-step.
+    [Fact]
+    public void SetNr_PersistsRnnrModeAcrossReload()
+    {
+        using var dspStore = NewDspStore();
+        using (var radio = NewRadio(dspStore))
+        {
+            var snapshot = radio.SetNr(new NrConfig(NrMode: NrMode.Rnnr));
+            Assert.Equal(NrMode.Rnnr, snapshot.Nr?.NrMode);
+        }
+
+        Assert.Equal(NrMode.Rnnr, dspStore.Get()?.NrMode);
+
+        using var reloaded = NewRadio(dspStore);
+        Assert.Equal(NrMode.Rnnr, reloaded.Snapshot().Nr?.NrMode);
     }
 
     private RadioService NewRadio(DspSettingsStore dspStore)

--- a/tests/Zeus.Server.Tests/RadioMicReceiverTests.cs
+++ b/tests/Zeus.Server.Tests/RadioMicReceiverTests.cs
@@ -159,6 +159,7 @@ public class RadioMicReceiverTests
         public void SetRxDisplayFastAttack(int channelId, bool fast) { }
         public void SetRxAfGainDb(int channelId, double db) { }
         public void SetNoiseReduction(int channelId, NrConfig cfg) { }
+        public bool LoadNr3Model(string? modelFilePath) => false;
         public void SetZoom(int channelId, int level) { }
         public int ReadAudio(int channelId, Span<float> output) => 0;
         public bool TryGetDisplayPixels(int channelId, DisplayPixout which, Span<float> dbOut) => false;

--- a/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
+++ b/tests/Zeus.Server.Tests/TxAudioIngestTests.cs
@@ -100,6 +100,7 @@ public class TxAudioIngestTests
     public void SetRxDisplayFastAttack(int channelId, bool fast) { }
         public void SetRxAfGainDb(int channelId, double db) { }
         public void SetNoiseReduction(int channelId, NrConfig cfg) { }
+        public bool LoadNr3Model(string? modelFilePath) => false;
         public void SetNotches(IReadOnlyList<NotchDto> notches) { }
         public void SetNotchTuneFrequencyHz(double loHz) { }
         public void SetZoom(int channelId, int level) { }

--- a/zeus-web/src/api/client.test.ts
+++ b/zeus-web/src/api/client.test.ts
@@ -349,7 +349,10 @@ describe('normalizeNrMode / normalizeNbMode', () => {
     expect(normalizeNrMode(0)).toBe('Off');
     expect(normalizeNrMode(1)).toBe('Anr');
     expect(normalizeNrMode(2)).toBe('Emnr');
-    expect(normalizeNrMode(4)).toBe('Off');
+    expect(normalizeNrMode(3)).toBe('Sbnr');
+    expect(normalizeNrMode(4)).toBe('Rnnr');
+    // 5 is past the last defined ordinal (Rnnr = 4) → Off.
+    expect(normalizeNrMode(5)).toBe('Off');
     expect(normalizeNbMode(2)).toBe('Nb2');
   });
   it('falls back to Off on garbage', () => {

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -71,7 +71,7 @@ export type RxMode =
 export type Rx2AudioMode = 'both' | 'rx1' | 'rx2';
 export type TxVfo = 'A' | 'B';
 
-export type NrMode = 'Off' | 'Anr' | 'Emnr' | 'Sbnr';
+export type NrMode = 'Off' | 'Anr' | 'Emnr' | 'Sbnr' | 'Rnnr';
 export type NbMode = 'Off' | 'Nb1' | 'Nb2';
 
 // SSB bandpass "rectangularity" (issue #871). 'Soft' = WDSP fir.c
@@ -212,7 +212,7 @@ export const NR2_CORE_DEFAULTS = {
   npeMethod: 0 as 0 | 1 | 2,         // OSMS
   aeRun: true,
   trainT1: -0.5,
-  trainT2: 2.0,
+  trainT2: 0.2, // Thetis udDSPNR2trainT2 NUD default (range 0.02..0.3)
 } as const;
 
 export const GAIN_METHOD_LABELS = ['Linear', 'Log', 'Gamma', 'Trained'] as const;
@@ -331,6 +331,12 @@ export type RadioStateDto = {
   adcOverloadWarning: boolean;
   preampOn: boolean;
   nr: NrConfigDto;
+  // NR3 (RNNoise): native availability (libwdsp RNNR exports present) plus the
+  // operator-installed model file name (null = none installed). NR3 is revealed
+  // in the NR cycle only when available AND a model is installed — Zeus ships no
+  // model, so the operator installs one via the DSP menu.
+  wdspNr3RnnrAvailable: boolean;
+  nr3ModelName: string | null;
   zoomLevel: ZoomLevel;
   // PureSignal persisted settings — server is the source of truth, hydrated
   // into tx-store on connect so a fresh browser (no localStorage) sees the
@@ -2031,7 +2037,7 @@ const MODE_ORDER: readonly RxMode[] = [
 ];
 
 const RX2_AUDIO_MODE_ORDER: readonly Rx2AudioMode[] = ['both', 'rx1', 'rx2'];
-const NR_MODE_ORDER: readonly NrMode[] = ['Off', 'Anr', 'Emnr', 'Sbnr'];
+const NR_MODE_ORDER: readonly NrMode[] = ['Off', 'Anr', 'Emnr', 'Sbnr', 'Rnnr'];
 const NB_MODE_ORDER: readonly NbMode[] = ['Off', 'Nb1', 'Nb2'];
 
 export function normalizeStatus(v: unknown): ConnectionStatus {
@@ -2399,6 +2405,8 @@ export function normalizeState(raw: unknown): RadioStateDto {
     // StateDto.Nr is nullable on the server (older clients) — fall back to
     // the engine's declared defaults so the UI has something to render.
     nr: normalizeNr(r.nr),
+    wdspNr3RnnrAvailable: Boolean(r.wdspNr3RnnrAvailable),
+    nr3ModelName: typeof r.nr3ModelName === 'string' ? r.nr3ModelName : null,
     zoomLevel: normalizeZoomLevel(r.zoomLevel),
     // PureSignal persisted settings. Defaults match RadioService.cs init and
     // PsSettingsEntry — older servers without the fields fall back cleanly.
@@ -6145,6 +6153,50 @@ export function setNr4(
     },
     normalizeState,
   );
+}
+
+// ---- NR3 (RNNoise) model management ----
+// Zeus ships no model; the operator installs an RNNoise weights file (upload or
+// URL fetch) via the DSP menu. `available` reflects whether libwdsp exports the
+// RNNR symbols; `modelName` is the installed file name (null = none).
+export type Nr3ModelStatus = { available: boolean; modelName: string | null };
+
+export function getNr3ModelStatus(signal?: AbortSignal): Promise<Nr3ModelStatus> {
+  return jsonFetch(
+    '/api/rx/nr3/model',
+    { signal },
+    (raw) => {
+      const r = (raw ?? {}) as Record<string, unknown>;
+      return {
+        available: Boolean(r.available),
+        modelName: typeof r.modelName === 'string' ? r.modelName : null,
+      };
+    },
+  );
+}
+
+export function uploadNr3Model(file: File, signal?: AbortSignal): Promise<RadioStateDto> {
+  const form = new FormData();
+  form.append('file', file, file.name);
+  // No content-type header: the browser sets multipart/form-data + boundary.
+  return jsonFetch('/api/rx/nr3/model', { method: 'POST', body: form, signal }, normalizeState);
+}
+
+export function downloadNr3Model(url: string, signal?: AbortSignal): Promise<RadioStateDto> {
+  return jsonFetch(
+    '/api/rx/nr3/model/download',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ url }),
+      signal,
+    },
+    normalizeState,
+  );
+}
+
+export function removeNr3Model(signal?: AbortSignal): Promise<RadioStateDto> {
+  return jsonFetch('/api/rx/nr3/model', { method: 'DELETE', signal }, normalizeState);
 }
 
 // MOX endpoint returns {moxOn} — not a full StateDto — because MOX is

--- a/zeus-web/src/components/DspPanel.tsx
+++ b/zeus-web/src/components/DspPanel.tsx
@@ -55,18 +55,26 @@ import { useSmartNrStore } from '../state/smart-nr-store';
 import { useAudioSuiteStore } from '../state/audio-suite-store';
 import { Slider } from './design/Slider';
 import { NrSettingsSection, type NrSettingsMode } from './nr/NrSettingsSection';
+import { Nr3ModelPanel } from './nr/Nr3ModelPanel';
 
 // Leveler max-gain moved to TxFilterPanel (alongside DRV/TUN/MIC) — it's
 // a TX-only stage and lives with the other TX controls now.
 
-// Mirrors NrControls.tsx. NR3 (RNNR) is intentionally skipped, and removed
-// NR modes are not exposed in the normal operator cycle.
-const NR_CYCLE: readonly NrMode[] = ['Off', 'Anr', 'Emnr', 'Sbnr'];
+// Mirrors NrControls.tsx. NR3 (RNNR / RNNoise) joins the cycle only when
+// libwdsp exports RNNR AND the operator has installed a model (Zeus ships none;
+// install it from the NR3 panel below). Removed NR modes are not exposed.
+const NR_CYCLE_BASE: readonly NrMode[] = ['Off', 'Anr', 'Emnr', 'Sbnr'];
+
+function nrCycleFor(nr3Ready: boolean): readonly NrMode[] {
+  return nr3Ready ? [...NR_CYCLE_BASE, 'Rnnr'] : NR_CYCLE_BASE;
+}
+
 const NR_LABEL: Record<NrMode, string> = {
   Off: 'NR',
   Anr: 'NR',
   Emnr: 'NR2',
   Sbnr: 'NR4',
+  Rnnr: 'NR3',
 };
 
 function nrButtonTitle(mode: NrMode): string {
@@ -75,6 +83,7 @@ function nrButtonTitle(mode: NrMode): string {
     case 'Anr': return 'NR1 (ANR, time-domain LMS) — right-click for tunables';
     case 'Emnr': return 'NR2 (EMNR, spectral) — right-click for tunables';
     case 'Sbnr': return 'NR4 (SBNR, libspecbleach) — right-click for tunables';
+    case 'Rnnr': return 'NR3 (RNNoise, neural)';
   }
 }
 
@@ -136,12 +145,17 @@ export function DspPanel() {
     [setLocalNr, applyState],
   );
 
+  const nr3Available = useConnectionStore((s) => s.wdspNr3RnnrAvailable);
+  const nr3ModelName = useConnectionStore((s) => s.nr3ModelName);
+  const nr3Ready = nr3Available && !!nr3ModelName;
+
   const cycleNr = useCallback(() => {
     if (!connected) return;
-    const idx = NR_CYCLE.indexOf(nr.nrMode);
-    const nextIdx = (idx < 0 ? 0 : idx + 1) % NR_CYCLE.length;
-    send({ ...nr, nrMode: NR_CYCLE[nextIdx]! });
-  }, [nr, send, connected]);
+    const cycle = nrCycleFor(nr3Ready);
+    const idx = cycle.indexOf(nr.nrMode);
+    const nextIdx = (idx < 0 ? 0 : idx + 1) % cycle.length;
+    send({ ...nr, nrMode: cycle[nextIdx]! });
+  }, [nr, send, connected, nr3Ready]);
 
   const cycleNb = useCallback(() => {
     const idx = NB_CYCLE.indexOf(nr.nbMode);
@@ -320,6 +334,9 @@ export function DspPanel() {
       {hasNrSettings(nr.nrMode) && (
         <NrSettingsSection mode={settingsModeFor(nr.nrMode)} />
       )}
+      {/* NR3 (RNNoise) model install lives in the DSP menu so the operator can
+          install a model even while NR3 is hidden from the cycle. */}
+      <Nr3ModelPanel />
     </div>
   );
 }

--- a/zeus-web/src/components/NrControls.tsx
+++ b/zeus-web/src/components/NrControls.tsx
@@ -55,14 +55,24 @@ import { NrSettingsSection, type NrSettingsMode } from './nr/NrSettingsSection';
 
 // NR-button cycle mirrors the proven operator NR paths: Off -> NR1 (ANR,
 // time-domain LMS) -> NR2 (EMNR, Ephraim-Malah spectral) -> NR4 (SBNR,
-// libspecbleach). NR3 (RNNR) is intentionally skipped; see issue #79. Removed
-// NR modes are not part of the normal cycle.
-const NR_CYCLE: readonly NrMode[] = ['Off', 'Anr', 'Emnr', 'Sbnr'];
+// libspecbleach) -> NR3 (RNNR, RNNoise). NR3 is appended to the cycle only when
+// libwdsp exports RNNR AND the operator has installed a model (Zeus ships none;
+// install it from the DSP menu) — see nrCycleFor(). Removed NR modes are not
+// part of the normal cycle.
+const NR_CYCLE_BASE: readonly NrMode[] = ['Off', 'Anr', 'Emnr', 'Sbnr'];
+
+// NR3 stays out of the cycle until both the native symbols are present and a
+// model is installed, so the operator never lands on an inert NR3.
+function nrCycleFor(nr3Ready: boolean): readonly NrMode[] {
+  return nr3Ready ? [...NR_CYCLE_BASE, 'Rnnr'] : NR_CYCLE_BASE;
+}
+
 const NR_LABEL: Record<NrMode, string> = {
   Off: 'NR',
   Anr: 'NR',
   Emnr: 'NR2',
   Sbnr: 'NR4',
+  Rnnr: 'NR3',
 };
 
 const NB_CYCLE: readonly NbMode[] = ['Off', 'Nb1', 'Nb2'];
@@ -82,6 +92,7 @@ function nrButtonTitle(mode: NrMode): string {
     case 'Anr': return 'NR1 (ANR, time-domain LMS)';
     case 'Emnr': return 'NR2 (EMNR, spectral)';
     case 'Sbnr': return 'NR4 (SBNR, libspecbleach)';
+    case 'Rnnr': return 'NR3 (RNNoise, neural)';
   }
 }
 
@@ -129,12 +140,17 @@ export function NrControls() {
     [setLocalNr, applyState],
   );
 
+  const nr3Available = useConnectionStore((s) => s.wdspNr3RnnrAvailable);
+  const nr3ModelName = useConnectionStore((s) => s.nr3ModelName);
+  const nr3Ready = nr3Available && !!nr3ModelName;
+
   const cycleNr = useCallback(() => {
     if (!connected) return;
-    const idx = NR_CYCLE.indexOf(nr.nrMode);
-    const nextIdx = (idx < 0 ? 0 : idx + 1) % NR_CYCLE.length;
-    send({ ...nr, nrMode: NR_CYCLE[nextIdx]! });
-  }, [nr, send, connected]);
+    const cycle = nrCycleFor(nr3Ready);
+    const idx = cycle.indexOf(nr.nrMode);
+    const nextIdx = (idx < 0 ? 0 : idx + 1) % cycle.length;
+    send({ ...nr, nrMode: cycle[nextIdx]! });
+  }, [nr, send, connected, nr3Ready]);
 
   const cycleNb = useCallback(() => {
     const idx = NB_CYCLE.indexOf(nr.nbMode);

--- a/zeus-web/src/components/SmartNrController.test.tsx
+++ b/zeus-web/src/components/SmartNrController.test.tsx
@@ -109,6 +109,8 @@ function mockState(nr: NrConfigDto): RadioStateDto {
     adcOverloadWarning: false,
     preampOn: false,
     nr,
+    wdspNr3RnnrAvailable: false,
+    nr3ModelName: null,
     zoomLevel: 1,
     psEnabled: false,
     psAuto: true,

--- a/zeus-web/src/components/nr/Nr3ModelPanel.tsx
+++ b/zeus-web/src/components/nr/Nr3ModelPanel.tsx
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+//
+// NR3 (RNNoise) model install panel. Lives in the DSP menu. Zeus ships no
+// model — NR3 stays hidden from the NR cycle until the operator installs an
+// RNNoise weights file here (local upload or fetch-from-URL). Once a model is
+// installed and libwdsp exports the RNNR symbols, NR3 appears in the NR button
+// cycle. See NrControls / DspPanel nrCycleFor().
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  downloadNr3Model,
+  removeNr3Model,
+  uploadNr3Model,
+  type RadioStateDto,
+} from '../../api/client';
+import { useConnectionStore } from '../../state/connection-store';
+
+export function Nr3ModelPanel() {
+  const available = useConnectionStore((s) => s.wdspNr3RnnrAvailable);
+  const modelName = useConnectionStore((s) => s.nr3ModelName);
+  const applyState = useConnectionStore((s) => s.applyState);
+
+  const [url, setUrl] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const fileInput = useRef<HTMLInputElement | null>(null);
+  const inflight = useRef<AbortController | null>(null);
+
+  useEffect(() => () => inflight.current?.abort(), []);
+
+  // Runs an install/remove action, funnelling the returned StateDto through
+  // applyState so the NR cycle reveals/hides NR3 immediately.
+  const run = useCallback(
+    async (action: (signal: AbortSignal) => Promise<RadioStateDto>) => {
+      inflight.current?.abort();
+      const ac = new AbortController();
+      inflight.current = ac;
+      setBusy(true);
+      setError(null);
+      try {
+        const state = await action(ac.signal);
+        if (!ac.signal.aborted) applyState(state);
+      } catch (e) {
+        if (!ac.signal.aborted) setError(e instanceof Error ? e.message : 'NR3 model operation failed');
+      } finally {
+        if (!ac.signal.aborted) setBusy(false);
+      }
+    },
+    [applyState],
+  );
+
+  const onFilePicked = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      // Reset the input so picking the same file again re-fires onChange.
+      e.target.value = '';
+      if (file) void run((signal) => uploadNr3Model(file, signal));
+    },
+    [run],
+  );
+
+  const onDownload = useCallback(() => {
+    const trimmed = url.trim();
+    if (!trimmed) return;
+    void run((signal) => downloadNr3Model(trimmed, signal)).then(() => setUrl(''));
+  }, [url, run]);
+
+  const onRemove = useCallback(() => {
+    void run((signal) => removeNr3Model(signal));
+  }, [run]);
+
+  if (!available) {
+    return (
+      <div className="nr-settings" role="region" aria-label="NR3 model">
+        <h4 className="nr-settings__subhdr">NR3 — RNNoise model</h4>
+        <p className="nr-settings__hint">
+          NR3 (RNNoise) is not available in this build — the loaded WDSP library
+          was compiled without RNNoise support.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="nr-settings" role="region" aria-label="NR3 model">
+      <h4 className="nr-settings__subhdr">NR3 — RNNoise model</h4>
+
+      <p className="nr-settings__hint">
+        {modelName
+          ? `Installed model: ${modelName}. NR3 is now in the NR cycle.`
+          : 'No model installed — NR3 is hidden until you install an RNNoise weights file. Zeus ships no model; bring your own.'}
+      </p>
+
+      <div className="nr-settings__row">
+        <span className="nr-settings__label">File</span>
+        <input
+          ref={fileInput}
+          type="file"
+          accept=".rnnn,.bin,.txt,application/octet-stream"
+          style={{ display: 'none' }}
+          onChange={onFilePicked}
+        />
+        <button
+          type="button"
+          className="btn sm"
+          disabled={busy}
+          onClick={() => fileInput.current?.click()}
+          title="Upload an RNNoise model file from this device"
+        >
+          {busy ? '…' : 'Upload…'}
+        </button>
+      </div>
+
+      <div className="nr-settings__row">
+        <span className="nr-settings__label">URL</span>
+        <input
+          type="url"
+          className="nr-settings__url-input"
+          placeholder="https://…/model.rnnn"
+          value={url}
+          disabled={busy}
+          onChange={(e) => setUrl(e.target.value)}
+        />
+        <button
+          type="button"
+          className="btn sm"
+          disabled={busy || !url.trim()}
+          onClick={onDownload}
+          title="Download and install an RNNoise model from a URL"
+        >
+          Get
+        </button>
+      </div>
+
+      {modelName && (
+        <div className="nr-settings__buttons">
+          <button
+            type="button"
+            className="nr-settings__button"
+            disabled={busy}
+            onClick={onRemove}
+            title="Remove the installed NR3 model (NR3 reverts to off + hidden)"
+          >
+            Remove model
+          </button>
+        </div>
+      )}
+
+      {error && (
+        <p className="nr-settings__hint" role="alert" style={{ color: 'var(--tx)' }}>
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/zeus-web/src/components/nr/NrSettingsSection.tsx
+++ b/zeus-web/src/components/nr/NrSettingsSection.tsx
@@ -322,7 +322,10 @@ function Nr2Panel() {
     persistPost2({ post2Taper: r });
   };
 
-  // Resets BOTH groups to Thetis-parity factory state. Two endpoints fire;
+  // Resets BOTH groups to Zeus factory state. Method/Trained values track
+  // Thetis exactly; Post-Process defaults to ON (a deliberate Zeus
+  // improvement over the Thetis baseline, which ships post-proc OFF). Two
+  // endpoints fire;
   // each response reconciles independently via applyState (last write wins,
   // and both servers' merged states agree on the reset values).
   const resetDefaults = () => {
@@ -428,7 +431,7 @@ function Nr2Panel() {
             label="T2"
             value={trainT2}
             min={0.02}
-            max={3.5}
+            max={0.3}
             step={0.01}
             decimals={2}
             onChange={onTrainT2Change}

--- a/zeus-web/src/state/connection-store.ts
+++ b/zeus-web/src/state/connection-store.ts
@@ -135,6 +135,11 @@ export type ConnectionState = {
   radioLoHz: number;
   cwPitchHz: number;
   nr: NrConfigDto;
+  // NR3 (RNNoise): native availability (libwdsp RNNR exports) + the operator-
+  // installed model name (null = none). NR3 appears in the NR cycle only when
+  // available AND a model is installed.
+  wdspNr3RnnrAvailable: boolean;
+  nr3ModelName: string | null;
   zoomLevel: ZoomLevel;
   inflight: boolean;
   // Endpoint of the most recently successful /api/connect. Survives a
@@ -213,6 +218,8 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
   radioLoHz: 14_200_000,
   cwPitchHz: 600,
   nr: { ...NR_CONFIG_DEFAULT },
+  wdspNr3RnnrAvailable: false,
+  nr3ModelName: null,
   zoomLevel: 1,
   inflight: false,
   lastConnectedEndpoint: null,
@@ -271,6 +278,8 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
         radioLoHz: s.radioLoHz,
         cwPitchHz: s.cwPitchHz,
         nr: s.nr,
+        wdspNr3RnnrAvailable: s.wdspNr3RnnrAvailable,
+        nr3ModelName: s.nr3ModelName,
         zoomLevel: s.zoomLevel,
       };
     }),


### PR DESCRIPTION
## NR-Thetis parity audit + NR3

### NR parity fixes
- **NR2 Trained gain-method `T2` default was 10× off** — Zeus used `2.0`, but Thetis's `udDSPNR2trainT2` NUD packs to **`0.2`** (range `0.02..0.3`, pushed raw via `SetRXAEMNRtrainT2`). The original author cited the right designer line but misread the packed `decimal` scale byte. Fixed the default in `WdspDspEngine` + `client.ts` and tightened the UI gauge range. Only affects the non-default *Trained* gain method.
- Corrected comments that mislabeled **NR2 post2-on** as "Thetis parity" — post2-on is a deliberate Zeus improvement (Thetis ships the "Noise post proc" checkbox **off**); kept ON per maintainer direction ("be better than Thetis").
- Verified everything else (ANR taps/delay/gain/leak, EMNR gain/NPE method + AE + position + T1, SBNR params, enum orderings) already matches Thetis's **effective** defaults.

### NR3 (RNNoise) — opt-in, bring-your-own model
Thetis has NR3; Zeus had dropped it (issue #79). Re-added as an opt-in feature with **no bundled model** — the operator installs an RNNoise weights file from the DSP menu, and NR3 only appears in the NR cycle once a model is installed **and** the native symbols are present.

- **Contract**: `NrMode.Rnnr` (append-only); `StateDto.WdspNr3RnnrAvailable` + `Nr3ModelName`.
- **Engine**: P/Invoke `SetRXARNNRRun`/`SetRXARNNRPosition`/`RNNRloadModel`; `Nr3RnnrAvailable` native probe; mutually-exclusive `Rnnr` apply case; `IDspEngine.LoadNr3Model` (synthetic/stubs no-op).
- **Server**: `Nr3ModelStore` (disk-backed, one model under `%LOCALAPPDATA%/Zeus/nr3-models/`); `RadioService.InstallNr3Model`/`RemoveNr3Model`; `DspPipelineService` loads the process-global model on engine-create + on model change; endpoints `GET`/`POST`(upload)/`DELETE /api/rx/nr3/model` + `POST .../download`.
- **Frontend**: NR3 joins the cycle only when available + model installed; `Nr3ModelPanel` (upload / URL / remove) in the DSP menu.
- **Native**: CMake `WDSP_WITH_NR3` builds vendored xiph/rnnoise (no default model) as a static sub-target; `native/rnnoise/VENDORING.md` documents the vendor + CI step.

### Verification
- All .NET projects compile (Contracts, Dsp, Hosting, Dsp.Tests) — 0 errors.
- Frontend `tsc -b` — 0 errors.

### Maintainer / CI follow-ups (required for NR3 to function)
- [ ] Vendor xiph/rnnoise source into `native/rnnoise/` (see `VENDORING.md`).
- [ ] Set `WDSP_WITH_NR3=ON` in `build-native-libs.yml` + `release.yml` and rebuild the per-platform `libwdsp` binaries. Until then `Nr3RnnrAvailable` is false and NR3 stays hidden — by design.

NR3 is purely additive and inert until a model is installed; the NR-parity `T2` fix is the only behavioral change to existing modes.
