### PR TITLE
feat(web): gate WDSP Filter Architecture 

### DIFF
--- a/zeus-web/src/components/DspSettingsPanel.tsx
+++ b/zeus-web/src/components/DspSettingsPanel.tsx
@@ -24,12 +24,18 @@ import { SquelchSettingsSection } from './SquelchSettingsSection';
 import { SignalIntelligenceSettingsSection } from './SignalIntelligenceSettingsSection';
 import { SmartNrSettingsSection } from './SmartNrSettingsSection';
 import { TxLevelingSettingsSection } from './TxLevelingSettingsSection';
+import { useEasterEggStore } from '../state/easter-egg-store';
 
 // Verbose DSP editor. The control strip carries quick controls (AGC dropdown,
 // SQL toggle); this tab is the full editor exposing every wired parameter, and
 // both drive the same store + endpoints so they stay in sync. One ps-card per
 // control family, mirroring Thetis's Setup ▸ DSP layout.
 export function DspSettingsPanel() {
+  // WDSP Filter Architecture (which also exposes the Active RXA/TXA Filter
+  // readouts) is a hidden diagnostics surface, gated behind the same
+  // header-bolt easter egg as the HARDWARE settings folder. Locked by default;
+  // re-locks every launch.
+  const hardwareUnlocked = useEasterEggStore((s) => s.hardwareUnlocked);
   return (
     <div className="ps-shell">
       <div className="ps-card">
@@ -39,13 +45,15 @@ export function DspSettingsPanel() {
         </h4>
         <BandwidthSettingsSection />
       </div>
-      <div className="ps-card">
-        <h4>
-          WDSP Filter Architecture
-          <span className="ps-card-hint">buffers / taps / window / cache</span>
-        </h4>
-        <DspFilterArchitectureSection />
-      </div>
+      {hardwareUnlocked && (
+        <div className="ps-card">
+          <h4>
+            WDSP Filter Architecture
+            <span className="ps-card-hint">buffers / taps / window / cache</span>
+          </h4>
+          <DspFilterArchitectureSection />
+        </div>
+      )}
       <div className="ps-card">
         <h4>
           SSB Filter Shape


### PR DESCRIPTION
## What

Hides the **WDSP Filter Architecture** settings card (in the DSP settings tab) behind the same in-memory easter-egg gate that already hides the **HARDWARE** diagnostics folder — i.e. it only appears once the operator taps the header brand-mark lightning bolt `HARDWARE_UNLOCK_CLICKS` (4) times.

## Why

That card is a deep WDSP diagnostics surface (IQ/DSP buffer sizes, tap counts, FFTW wisdom cache, the Thetis filter matrix) rather than an everyday operator control. It belongs with the other hidden hardware diagnostics, not in the default DSP settings view.

## Active RXA Filter

The **Active RXA Filter** (and Active TXA Filter) readout lives *inside* `DspFilterArchitectureSection`, which is the body of this card — so it's covered by the same gate automatically; no separate change was needed.

## How

- `DspSettingsPanel` now reads `hardwareUnlocked` from `useEasterEggStore` (the same store `SettingsMenu` uses to reveal the HARDWARE folder).
- The WDSP Filter Architecture `ps-card` is wrapped in `{hardwareUnlocked && (…)}`.
- State is in-memory only, so the card re-locks on every launch — consistent with the existing HARDWARE folder behaviour.

## Notes

- Pure visibility gate — no DSP/protocol/default behaviour changes; nothing in the burn-zone or red-light areas.
- Frontend `tsc --noEmit` passes; no tests asserted the card's unconditional presence.