### PR TITLE
feat(multi-ddc): TX on any receiver, VFO master-detail, ≤4-stitch waterfall grid

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -1214,6 +1214,14 @@ public sealed record StateDto(
     bool Rx1Muted = false,
     bool Rx2Muted = false,
 
+    // ---- Multi-DDC TX target ----
+    // Authoritative transmit target as a receiver index (0 = RX1/VFO A, 1 = RX2/
+    // VFO B, >= 2 = an extra DDC). TxVfo stays the legacy A/B projection;
+    // RadioService.TxFrequencyHz resolves the carrier from this index so TX can
+    // key on any receiver's VFO. Ephemeral — resets to RX1 each session (never
+    // auto-transmit on a receiver the operator can't see after a restart).
+    int TxReceiverIndex = 0,
+
     // ---- Diversity combiner (Thetis DiversityForm / WDSP xdivEXT) ----
     // Two phase-synchronous ADC streams combined with a per-source complex
     // rotation (gain magnitude + phase) to null an interferer or peak a signal.
@@ -1526,6 +1534,11 @@ public sealed record AttenuatorSetRequest(int Db);
 public sealed record MoxSetRequest(bool On);
 
 public sealed record TxVfoSetRequest(TxVfo TxVfo);
+
+/// <summary>Body of <c>POST /api/tx/receiver</c> — select the transmit target by
+/// receiver index (0 = RX1, 1 = RX2, >= 2 = an extra DDC). Generalises
+/// <see cref="TxVfoSetRequest"/> beyond the A/B pair.</summary>
+public sealed record TxReceiverSetRequest(int Index);
 
 public sealed record DriveSetRequest(int Percent);
 

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -839,7 +839,15 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
             return;
         double factor = BitConverter.Int64BitsToDouble(Interlocked.Read(ref _freqCorrectionBits));
         long corrected = (long)Math.Round(hz * factor, MidpointRounding.AwayFromZero);
-        _extraRxFreqHz[receiverIndex] = (uint)Math.Clamp(corrected, 0L, uint.MaxValue);
+        uint next = (uint)Math.Clamp(corrected, 0L, uint.MaxValue);
+        // Idempotent — a no-op when this DDC's NCO is unchanged. OnRadioStateChanged
+        // re-pushes every extra receiver's frequency on EVERY state broadcast, and
+        // those fire continuously during steady RX. Without this guard each one
+        // re-sent the high-priority packet, re-latching the alex/OC band relays —
+        // which chattered the relays the moment RX3 was exposed. Mirrors the same
+        // idempotency the RX2 DDC path (SetRx2Enabled / SetExtraReceivers) relies on.
+        if (_extraRxFreqHz[receiverIndex] == next) return;
+        _extraRxFreqHz[receiverIndex] = next;
         if (_rxTask is not null) SendCmdHighPriority(run: true);
     }
 

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -952,7 +952,7 @@ public sealed class RadioService : IDisposable
         long clamped = Math.Clamp(hz, 0L, 60_000_000L);
         lock (_sync) { if (_state.VfoLocked) return Snapshot(); }
         long previousTx;
-        lock (_sync) previousTx = TxFrequencyHz(_state);
+        lock (_sync) previousTx = TxFrequencyHzLocked(_state);
         Mutate(s => s with { VfoBHz = clamped });
         if (BandUtils.FreqToBand(previousTx) != BandUtils.FreqToBand(TxFrequencyHz(Snapshot())))
         {
@@ -1024,8 +1024,21 @@ public sealed class RadioService : IDisposable
         }
         // Re-project + broadcast (StateChanged → DspPipelineService opens channels
         // and pushes SetExtraReceivers/SetExtraReceiverFreqHz to the radio).
-        // Enabling an extra DDC requires RX2 (no DDC gap), so turn it on.
-        Mutate(s => enabling && !s.Rx2Enabled ? s with { Rx2Enabled = true } : s);
+        // Enabling an extra DDC requires RX2 (no DDC gap), so turn it on. If the
+        // disable cascade just removed the receiver the operator was transmitting
+        // on, fall the TX target back to RX1 (never key a receiver that stopped
+        // streaming).
+        Mutate(s =>
+        {
+            var next = enabling && !s.Rx2Enabled ? s with { Rx2Enabled = true } : s;
+            if (next.TxReceiverIndex >= 2 &&
+                (next.TxReceiverIndex >= _extraReceivers.Length
+                 || _extraReceivers[next.TxReceiverIndex] is not { Enabled: true }))
+            {
+                next = next with { TxReceiverIndex = 0, TxVfo = TxVfo.A };
+            }
+            return next;
+        });
         return Snapshot();
     }
 
@@ -1033,7 +1046,7 @@ public sealed class RadioService : IDisposable
     {
         ArgumentNullException.ThrowIfNull(req);
         long previousTx;
-        lock (_sync) previousTx = TxFrequencyHz(_state);
+        lock (_sync) previousTx = TxFrequencyHzLocked(_state);
         Mutate(s =>
         {
             long nextVfoB = req.VfoBHz.HasValue
@@ -1065,9 +1078,29 @@ public sealed class RadioService : IDisposable
     {
         if (!Enum.IsDefined(txVfo))
             throw new ArgumentOutOfRangeException(nameof(txVfo), txVfo, "Unknown TX VFO");
+        // Legacy A/B endpoint — funnel through the index-based setter so TxVfo and
+        // TxReceiverIndex never diverge.
+        return SetTxReceiver(txVfo == TxVfo.B ? 1 : 0);
+    }
+
+    /// <summary>Select the transmit target by receiver index (0 = RX1/VFO A,
+    /// 1 = RX2/VFO B, >= 2 = an extra DDC). The independent TX DUC and CW/CTUN LO
+    /// alignment read <see cref="TxFrequencyHz"/>, so the carrier moves to the
+    /// chosen receiver's VFO. An out-of-range or not-exposed index clamps to RX1
+    /// (never transmit on a receiver the operator can't see).</summary>
+    public StateDto SetTxReceiver(int index)
+    {
         long previousTx;
-        lock (_sync) previousTx = TxFrequencyHz(_state);
-        Mutate(s => s.TxVfo == txVfo ? s : s with { TxVfo = txVfo });
+        lock (_sync)
+        {
+            index = ClampTxReceiverIndexUnderLock(index);
+            previousTx = TxFrequencyHzLocked(_state);
+        }
+        // TxVfo stays as the legacy A/B projection (index 1 -> B, else A) so
+        // pre-multi-DDC consumers keep working; TxReceiverIndex is authoritative.
+        Mutate(s => s.TxReceiverIndex == index
+            ? s
+            : s with { TxReceiverIndex = index, TxVfo = index == 1 ? TxVfo.B : TxVfo.A });
         var snap = Snapshot();
         if (BandUtils.FreqToBand(previousTx) != BandUtils.FreqToBand(TxFrequencyHz(snap)))
         {
@@ -1076,8 +1109,38 @@ public sealed class RadioService : IDisposable
         return snap;
     }
 
-    public static long TxFrequencyHz(StateDto state) =>
-        state.TxVfo == TxVfo.B ? state.VfoBHz : state.VfoHz;
+    // Caller holds _sync. RX1/RX2 are always valid TX targets; an extra DDC
+    // (>= 2) is valid only while exposed/enabled — otherwise fall back to RX1 so
+    // TX never points at a receiver that isn't streaming.
+    private int ClampTxReceiverIndexUnderLock(int index)
+    {
+        if (index <= 0) return 0;
+        if (index == 1) return 1;
+        if (index >= _extraReceivers.Length) return 0;
+        return _extraReceivers[index] is { Enabled: true } ? index : 0;
+    }
+
+    // Authoritative TX carrier frequency for the selected TX target. Index 0 =
+    // RX1 (VFO A), 1 = RX2 (VFO B), >= 2 = an extra DDC read from the projected
+    // Receivers[] array. Use this static form on a SNAPSHOT (Receivers
+    // populated); internal callers holding _sync on the un-projected _state must
+    // use TxFrequencyHzLocked, which resolves >= 2 from _extraReceivers.
+    public static long TxFrequencyHz(StateDto state) => state.TxReceiverIndex switch
+    {
+        <= 0 => state.VfoHz,
+        1 => state.VfoBHz,
+        int i => state.Receivers is { } rs && i < rs.Count ? rs[i].VfoHz : state.VfoHz,
+    };
+
+    // Caller holds _sync. Like TxFrequencyHz but resolves an extra-DDC TX target
+    // (index >= 2) from _extraReceivers, which the internal _state can't carry
+    // (its Receivers list is null until ProjectReceivers runs at Snapshot time).
+    private long TxFrequencyHzLocked(StateDto state) => state.TxReceiverIndex switch
+    {
+        <= 0 => state.VfoHz,
+        1 => state.VfoBHz,
+        int i => i < _extraReceivers.Length && _extraReceivers[i] is { } e ? e.VfoHz : state.VfoHz,
+    };
 
     /// <summary>TX carrier frequency including any active XIT offset. The
     /// displayed VFO is unchanged; only the transmitted carrier moves (Thetis
@@ -1095,7 +1158,7 @@ public sealed class RadioService : IDisposable
         RxMode mode = RxMode.USB;
         Mutate(s =>
         {
-            previousTx = TxFrequencyHz(s);
+            previousTx = TxFrequencyHzLocked(s);
             newA = Math.Clamp(s.VfoBHz, 0L, 60_000_000L);
             mode = s.Mode;
             return s with
@@ -1259,7 +1322,7 @@ public sealed class RadioService : IDisposable
         // XIT (CTUN off, VFO A) also drags the shared LO to dial+XIT for TX, so
         // the pre-TX RX centre must be remembered for RestoreLoAfterTx to put
         // back on un-key — otherwise RX would stay off by the XIT offset.
-        if ((_state.CtunEnabled || _state.TxVfo == TxVfo.B || _state.XitEnabled)
+        if ((_state.CtunEnabled || _state.TxReceiverIndex >= 1 || _state.XitEnabled)
             && _ctunPreTxLoHz == long.MinValue)
             _ctunPreTxLoHz = _state.RadioLoHz;
     }
@@ -1310,12 +1373,12 @@ public sealed class RadioService : IDisposable
             // the tune carrier showed on BOTH receivers (the two-carrier bug).
             // Skip the drag for this case; CTUN and P1 split still drag (P1 has
             // no independent DUC, and CTUN must move the shared LO).
-            if (_state.TxVfo == TxVfo.B && _state.Rx2Enabled
+            if (_state.TxReceiverIndex >= 1 && _state.Rx2Enabled
                 && ConnectedBoardKind == HpsdrBoardKind.OrionMkII)
                 return false;
             // XIT moves the carrier even with CTUN off on VFO A, so align then
             // too (RememberFrozenLoUnderLock captured the RX centre to restore).
-            if (!_state.CtunEnabled && _state.TxVfo != TxVfo.B && !_state.XitEnabled) return false;
+            if (!_state.CtunEnabled && _state.TxReceiverIndex < 1 && !_state.XitEnabled) return false;
             vfo = TxCarrierHz(_state);
             mode = _state.Mode;
             currentLo = _state.RadioLoHz;

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -1203,6 +1203,17 @@ public static class ZeusEndpoints
             return Results.Ok(r.SetTxVfo(req.TxVfo));
         });
 
+        // Select the transmit target by receiver index (0=RX1, 1=RX2, >=2 extra
+        // DDC). Generalises /api/tx/vfo beyond the A/B pair; an out-of-range or
+        // not-exposed index clamps to RX1 server-side.
+        app.MapPost("/api/tx/receiver", (TxReceiverSetRequest req, RadioService r) =>
+        {
+            if (req.Index < 0 || req.Index >= Zeus.Contracts.WireContract.MaxReceivers)
+                return Results.BadRequest(new { error = $"tx receiver index out of range (0..{Zeus.Contracts.WireContract.MaxReceivers - 1})" });
+            log.LogInformation("api.tx.receiver index={Index}", req.Index);
+            return Results.Ok(r.SetTxReceiver(req.Index));
+        });
+
         // Set the radio's hardware NCO (LO) frequency directly. Does not
         // move VfoHz — used by the panadapter pure-pan gesture when a drag
         // would carry the viewport outside the IQ capture window.

--- a/docs/designs/multi-ddc-tx-and-audio.md
+++ b/docs/designs/multi-ddc-tx-and-audio.md
@@ -1,0 +1,133 @@
+# Multi-DDC TX target + per-receiver audio mixer
+
+Status: PR against develop (branch feat/multi-ddc-tx-audio).
+Owners: N9WAR (impl). TX-on-RX3+ is operator-felt — flagged for KB2UKA / EI6LF
+bench review before merge.
+
+> **Reconciliation with develop (read first).** This branch was rebuilt onto
+> develop after develop independently shipped a per-RX **mute** feature
+> (`ReceiverDto.Muted` / `StateDto.Rx1Muted`/`Rx2Muted` / `RadioService.
+> SetReceiverMuted` / `POST /api/receivers/{i}/mute`). So the per-RX audio
+> *backend* described below as a new `Audible` field is **not** added here — the
+> UI mixer/VFO-panel mute toggles drive develop's existing `Muted` instead. What
+> this PR actually lands:
+> 1. **Receivers-menu fix** — `normalizeState` now carries `receivers[]` /
+>    `maxReceivers` / `wireVersion` (develop still dropped them, so the exposed-
+>    receiver control + multi-DDC panels never saw RX2+).
+> 2. **TX-on-any-RX** — `StateDto.TxReceiverIndex`, `SetTxReceiver`,
+>    `POST /api/tx/receiver`, generalized `TxFrequencyHz`.
+> 3. **RX3+ relay-chatter fix** — idempotent `SetExtraReceiverFreqHz`.
+> 4. **UI** — VFO master-detail panel, movable RX mixer popout, and the ≤4-stitch
+>    waterfall grid (`RxWaterfallPane`), with mute wired to develop's `Muted`.
+>
+> The `Audible`-based audio-mix sections below are retained as the original design
+> record; develop's `Muted` model supersedes them.
+
+## Goal
+
+Make the two dual-receiver UI surfaces first-class for **all** exposed DDC
+receivers (RX1..RXN, N ≤ `WireContract.MaxReceivers`), not just the RX1/RX2
+(VFO A/B) pair:
+
+1. **`vfo-dual-panel` (VfoPanel)** — one lane per exposed receiver, each with
+   live frequency display + click-to-type + per-digit wheel tuning, band
+   readout, focus, **and TX-select** (transmit on any receiver's VFO).
+2. **`hero-rx-audio-switch` (HeroPanel)** — a per-RX listen/mute mixer: the
+   operator chooses which receivers they hear, replacing the RX1/Both/RX2
+   tri-state with N independent hear/mute toggles.
+
+## Why this needed a contract change
+
+The old model is binary and woven through the stack:
+
+- TX target is `TxVfo {A,B}` — `RadioService.TxFrequencyHz` returns `VfoBHz`
+  for B else `VfoHz`. There is no way to point TX at an RX3+ VFO.
+- Audio routing is `Rx2AudioMode {Rx1,Both,Rx2}` — an RX1/RX2-only tri-state.
+  The DSP mix (`DspPipelineService.Tick`) switches on it.
+
+Both are extended (not replaced) so legacy callers keep working.
+
+## Contract (`Zeus.Contracts/Dtos.cs`)
+
+- `StateDto.TxReceiverIndex : int = 0` — **authoritative** TX target (0=RX1,
+  1=RX2, ≥2=extra DDC). `TxVfo` stays as a back-compat projection
+  (`index==1 ? B : A`); `TxFrequencyHz` now resolves off `TxReceiverIndex`.
+- `ReceiverDto.Audible : bool` — whether this receiver is mixed into the
+  monitor output. Projected from `RadioService._audible[]` (default all true).
+  `Rx2AudioMode` is retained and projected from `audible[0]/audible[1]`
+  (`rx1`=only RX1, `rx2`=only RX2, `both`=both) so legacy consumers and the
+  `/api/rx2/audio` endpoint keep working.
+- New request DTO `TxReceiverSetRequest(int Index)` for `POST /api/tx/receiver`.
+  `ReceiverSetRequest` gains `bool? Audible`.
+
+## Server
+
+### TX target — `RadioService`
+- `TxFrequencyHz(StateDto)`: index 0→VfoHz, 1→VfoBHz, ≥2→`Receivers[i].VfoHz`
+  (snapshot path) / `_extraReceivers[i].VfoHz` (internal `_state` path via an
+  instance overload, since `_state.Receivers` is null until projected).
+- `SetTxReceiver(int index)`: clamps to an enabled receiver, sets
+  `TxReceiverIndex` + projected `TxVfo`, recomputes PA on band change.
+- The independent TX DUC (`OnRadioStateChanged → SetTxDucFrequency`) and CW/CTUN
+  LO alignment all read `TxFrequencyHz`, so they follow automatically. The
+  OrionMkII split-TX DUC guard (`AlignLoForTx`) generalizes from
+  `TxVfo==B` to `TxReceiverIndex>=1`.
+
+### Audio mixer — `DspPipelineService.Tick`
+- Replace the `Rx2AudioMode` switch with a per-RX audible model:
+  - RX1 (index 0) remains the audio **clock master** — always drained at full
+    rate so the output ring is fed at exactly the RX sample rate (the #787
+    constraint). "Muting RX1" means it contributes nothing to the mix, not that
+    it stops clocking.
+  - Every enabled+audible secondary contributes (read ≤ rx1Count, remainder
+    buffered) exactly as the old `Both` path.
+  - Mix via `MixRxAudioN(audioBuf, rx1Audible ? rx1Count : 0, audibleSlices)` —
+    with `rx1Count==0` the existing averager already excludes RX1 and writes the
+    secondary-only average into the output buffer. Hot path stays lock-free /
+    zero-alloc (reuses `_mixSlices`).
+
+## Frontend
+
+- `connection-store`: widen focus from `rxFocus: 'A'|'B'` to a receiver index
+  (`focusedRxIndex: number`), with `'A'/'B'` kept as derived helpers during the
+  migration so the 31-file A/B blast radius (Panadapter/Waterfall/Filter/Mode/
+  Band/keyboard tuning) flips incrementally. RX1/RX2 keep stitched-view identity.
+- `VfoDisplay`: accept an optional `rxIndex` for ≥2 — reads
+  `receivers[i].vfoHz`, posts `setReceiver(i,{vfoHz})`. A/B unchanged.
+- `VfoPanel`: revamped to a **master-detail** — a compact chip rail (one chip per
+  exposed receiver: id, freq, band, TX/mute dots) + a single active-receiver
+  detail (full digits, listen/mute, TX-select, per-RX AF, A↔B copy/swap). Fixed
+  footprint regardless of receiver count.
+- `HeroPanel`: per-RX hear/mute + focus mixer, surfaced as a small **movable
+  popout** (`RX MIX` trigger) instead of an inline header strip.
+
+### Multi-DDC spectrum grid (waterfall stitching)
+
+The hero panadapter and waterfall regions are a shared grid: **≤4 receivers
+stitched across one row; beyond that the grid wraps so the last receivers stack
+into a second row** (8 RX = two rows of 4). RX1/RX2 keep the interactive A/B
+`Panadapter`/`WaterfallSurface`; RX3+ render read-only live panes —
+`RxMonitorPane` (trace) and the new `RxWaterfallPane` (scrolling waterfall via
+`createWfRenderer` + a per-rxId `planForFrame` key). While keyed the waterfall
+collapses to the single full-width TX panafall (unchanged).
+
+**Scaling note:** each pane owns a WebGL2 context, so 8 receivers = up to 16
+contexts (8 trace + 8 waterfall) plus the chrome — near the browser's ~16-context
+ceiling. The panes already handle context loss, but a future optimisation is a
+shared/pooled renderer if 8-RX panafall proves context-starved on weak GPUs.
+
+## Test plan
+
+- Contract: `normalizeState` carries `txReceiverIndex` + `receivers[].audible`.
+- Server: `TxFrequencyHz` index resolution; `SetTxReceiver` band/PA recompute;
+  `MixRxAudioN` per-RX audible (RX1-muted → secondary-only average; all-muted →
+  silence; single audible → passthrough).
+- Frontend: VfoPanel renders a lane per exposed RX and tunes RX3+; HeroPanel
+  mixer toggles audible per RX.
+
+## Safety / bench notes (KB2UKA / EI6LF)
+
+- TX-on-RX3+ reuses the existing single TX DUC/DUC-frequency mechanism; no new
+  TX amplitude/drive path. Still: verify on HL2 + a P2 board that selecting TX
+  on RX3 places the carrier on RX3's VFO and that un-key restores the RX LO.
+- No change to PureSignal arm/disarm, drive bytes, or PA gain. Untouched.

--- a/tests/Zeus.Server.Tests/RadioServiceMultiDdcTxAudioTests.cs
+++ b/tests/Zeus.Server.Tests/RadioServiceMultiDdcTxAudioTests.cs
@@ -1,0 +1,133 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+// Multi-DDC TX target: SetTxReceiver / TxFrequencyHz index resolution, plus the
+// interaction with develop's per-RX mute (SetReceiverMuted). See
+// docs/designs/multi-ddc-tx-and-audio.md.
+public sealed class RadioServiceMultiDdcTxAudioTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-multiddc-{Guid.NewGuid():N}.db");
+    private readonly PaSettingsStore _paStore;
+    private readonly DspSettingsStore _dspStore;
+
+    public RadioServiceMultiDdcTxAudioTests()
+    {
+        _paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance, _dbPath + ".pa");
+        _dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance, _dbPath + ".dsp");
+    }
+
+    public void Dispose()
+    {
+        _paStore.Dispose();
+        _dspStore.Dispose();
+        foreach (var suffix in new[] { "", ".pa", ".dsp" })
+        {
+            try { if (File.Exists(_dbPath + suffix)) File.Delete(_dbPath + suffix); } catch { }
+        }
+    }
+
+    private RadioService BuildRadio() => new(NullLoggerFactory.Instance, _dspStore, _paStore);
+
+    private static ReceiverDto Rx(StateDto s, int index) =>
+        s.Receivers!.Single(r => r.Index == index);
+
+    [Fact]
+    public void TxFrequency_DefaultsToRx1()
+    {
+        using var radio = BuildRadio();
+        radio.SetVfo(14_200_000);
+
+        var s = radio.Snapshot();
+        Assert.Equal(0, s.TxReceiverIndex);
+        Assert.Equal(TxVfo.A, s.TxVfo);
+        Assert.Equal(14_200_000, RadioService.TxFrequencyHz(s));
+    }
+
+    [Fact]
+    public void SetTxReceiver_Rx2_TransmitsOnVfoB()
+    {
+        using var radio = BuildRadio();
+        radio.SetVfo(14_200_000);
+        radio.SetRx2(new Rx2SetRequest(Enabled: true, VfoBHz: 7_100_000));
+
+        var s = radio.SetTxReceiver(1);
+
+        Assert.Equal(1, s.TxReceiverIndex);
+        Assert.Equal(TxVfo.B, s.TxVfo); // legacy A/B projection stays consistent
+        Assert.Equal(7_100_000, RadioService.TxFrequencyHz(s));
+    }
+
+    [Fact]
+    public void SetTxReceiver_ExtraDdc_TransmitsOnThatReceiverVfo()
+    {
+        using var radio = BuildRadio();
+        radio.SetVfo(14_200_000);
+        radio.SetReceiver(2, enabled: true, vfoHz: 21_050_000);
+
+        var s = radio.SetTxReceiver(2);
+
+        Assert.Equal(2, s.TxReceiverIndex);
+        Assert.Equal(TxVfo.A, s.TxVfo); // RX3+ projects to A for legacy consumers
+        Assert.Equal(21_050_000, RadioService.TxFrequencyHz(s));
+    }
+
+    [Fact]
+    public void SetTxReceiver_UnexposedExtra_ClampsToRx1()
+    {
+        using var radio = BuildRadio();
+        radio.SetVfo(14_200_000);
+
+        // RX3 not exposed -> must not transmit on a receiver that isn't streaming.
+        var s = radio.SetTxReceiver(2);
+
+        Assert.Equal(0, s.TxReceiverIndex);
+        Assert.Equal(14_200_000, RadioService.TxFrequencyHz(s));
+    }
+
+    [Fact]
+    public void DisablingTxTargetReceiver_FallsBackToRx1()
+    {
+        using var radio = BuildRadio();
+        radio.SetReceiver(2, enabled: true, vfoHz: 21_050_000);
+        radio.SetTxReceiver(2);
+
+        // Disabling RX3 (the TX target) must drop TX back to RX1.
+        var s = radio.SetReceiver(2, enabled: false);
+
+        Assert.Equal(0, s.TxReceiverIndex);
+        Assert.Equal(TxVfo.A, s.TxVfo);
+    }
+
+    [Fact]
+    public void SetTxVfo_LegacyEndpointStaysConsistentWithIndex()
+    {
+        using var radio = BuildRadio();
+        radio.SetRx2(new Rx2SetRequest(Enabled: true, VfoBHz: 7_100_000));
+
+        var s = radio.SetTxVfo(TxVfo.B);
+        Assert.Equal(1, s.TxReceiverIndex);
+        Assert.Equal(TxVfo.B, s.TxVfo);
+
+        s = radio.SetTxVfo(TxVfo.A);
+        Assert.Equal(0, s.TxReceiverIndex);
+        Assert.Equal(TxVfo.A, s.TxVfo);
+    }
+
+    [Fact]
+    public void PerRxMute_ExtraDdc_RoundTrips()
+    {
+        using var radio = BuildRadio();
+        radio.SetReceiver(2, enabled: true, vfoHz: 21_050_000);
+
+        var s = radio.SetReceiverMuted(2, true);
+        Assert.True(Rx(s, 2).Muted);
+        Assert.False(Rx(s, 0).Muted);
+
+        s = radio.SetReceiverMuted(2, false);
+        Assert.False(Rx(s, 2).Muted);
+    }
+}

--- a/zeus-web/src/api/client.test.ts
+++ b/zeus-web/src/api/client.test.ts
@@ -245,6 +245,32 @@ describe('normalizeState', () => {
     expect(s.nr).toEqual(NR_CONFIG_DEFAULT);
     expect(s.zoomLevel).toBe(1);
   });
+  it('carries the multi-DDC receivers[] array and ceiling (wire v2)', () => {
+    // Regression: normalizeState used to drop receivers/maxReceivers/wireVersion,
+    // so applyState's `s.receivers ?? prev.receivers` kept the empty default and
+    // the "exposed receivers" control was frozen at RX1 (>2 did nothing).
+    const s = normalizeState({
+      wireVersion: 2,
+      maxReceivers: 8,
+      receivers: [
+        { index: 0, enabled: true, adcSource: 0, vfoHz: 7_100_000, mode: 'LSB' },
+        { index: 1, enabled: true, adcSource: 0, vfoHz: 7_150_000, mode: 'USB' },
+        { index: 2, enabled: true, adcSource: 1, vfoHz: 14_200_000, mode: 'USB' },
+      ],
+    });
+    expect(s.wireVersion).toBe(2);
+    expect(s.maxReceivers).toBe(8);
+    expect(s.receivers).toHaveLength(3);
+    expect(s.receivers?.[2]).toMatchObject({ index: 2, enabled: true, adcSource: 1, mode: 'USB' });
+  });
+  it('leaves receivers/maxReceivers undefined when a v1 server omits them', () => {
+    // Undefined (not []/0) lets applyState keep the store's prior values rather
+    // than collapsing the exposed-receiver control.
+    const s = normalizeState({});
+    expect(s.receivers).toBeUndefined();
+    expect(s.maxReceivers).toBeUndefined();
+    expect(s.wireVersion).toBeUndefined();
+  });
   it('reads zoomLevel from the server', () => {
     expect(normalizeState({ zoomLevel: 3 }).zoomLevel).toBe(3);
     expect(normalizeState({ zoomLevel: 4 }).zoomLevel).toBe(4);

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -281,6 +281,10 @@ export type RadioStateDto = {
   rx2AudioMode: Rx2AudioMode;
   rx2AfGainDb: number;
   txVfo: TxVfo;
+  // Authoritative TX target as a receiver index (0=RX1/VFO A, 1=RX2/VFO B,
+  // >=2 extra DDC). txVfo stays the legacy A/B projection. Optional until a v2
+  // server reports it.
+  txReceiverIndex?: number;
   mode: RxMode;
   modeB: RxMode;
   filterLowHz: number;
@@ -409,6 +413,9 @@ export type ReceiverDto = {
   filterPresetName: string | null;
   afGainDb: number;
   sampleRateHz: number;
+  // Per-receiver audio mute (Thetis chkMUT/chkRX2Mute). The hero mixer + VFO
+  // panel drive this via POST /api/receivers/{index}/mute.
+  muted: boolean;
 };
 
 // CFC mirrors Zeus.Contracts.CfcConfig. Bands array is fixed at 10 entries
@@ -2301,6 +2308,26 @@ export function normalizeAdcProtectionStatus(raw: unknown): AdcProtectionStatusD
   };
 }
 
+// Normalise one wire ReceiverDto (mirrors Zeus.Contracts.ReceiverDto). A
+// malformed entry falls back to safe defaults rather than dropping the whole
+// array, so a single bad receiver can't blank the multi-DDC UI.
+function normalizeReceiver(raw: unknown, fallbackIndex: number): ReceiverDto {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  return {
+    index: typeof r.index === 'number' ? r.index : fallbackIndex,
+    enabled: typeof r.enabled === 'boolean' ? r.enabled : false,
+    adcSource: typeof r.adcSource === 'number' ? r.adcSource : 0,
+    vfoHz: typeof r.vfoHz === 'number' ? r.vfoHz : 0,
+    mode: normalizeMode(r.mode),
+    filterLowHz: typeof r.filterLowHz === 'number' ? r.filterLowHz : 0,
+    filterHighHz: typeof r.filterHighHz === 'number' ? r.filterHighHz : 0,
+    filterPresetName: typeof r.filterPresetName === 'string' ? r.filterPresetName : null,
+    afGainDb: typeof r.afGainDb === 'number' ? r.afGainDb : 0,
+    sampleRateHz: typeof r.sampleRateHz === 'number' ? r.sampleRateHz : 0,
+    muted: typeof r.muted === 'boolean' ? r.muted : false,
+  };
+}
+
 export function normalizeState(raw: unknown): RadioStateDto {
   const r = (raw ?? {}) as Record<string, unknown>;
   return {
@@ -2317,6 +2344,8 @@ export function normalizeState(raw: unknown): RadioStateDto {
     rx2AudioMode: normalizeRx2AudioMode(r.rx2AudioMode),
     rx2AfGainDb: typeof r.rx2AfGainDb === 'number' ? r.rx2AfGainDb : 0,
     txVfo: normalizeTxVfo(r.txVfo),
+    txReceiverIndex:
+      typeof r.txReceiverIndex === 'number' ? r.txReceiverIndex : undefined,
     mode: normalizeMode(r.mode),
     modeB: normalizeMode(r.modeB ?? r.mode),
     filterLowHz: typeof r.filterLowHz === 'number' ? r.filterLowHz : 0,
@@ -2425,6 +2454,18 @@ export function normalizeState(raw: unknown): RadioStateDto {
     cwPitchHz: typeof r.cwPitchHz === 'number' ? r.cwPitchHz : 600,
     // Legacy server without the field → CTUN off (classic recenter-on-click).
     ctunEnabled: typeof r.ctunEnabled === 'boolean' ? r.ctunEnabled : false,
+    // ---- Multi-DDC receivers array (wire v2) ----
+    // A v1 server omits these. Leave them undefined (not []/0) so applyState's
+    // `s.receivers ?? prev.receivers` keeps the store's prior values instead of
+    // collapsing the exposed-receiver control back to RX1. A v2 server projects
+    // RX1/RX2 into [0]/[1] and appends the contiguous extra DDCs, so the array
+    // is authoritative whenever present. (Without this the receivers menu and
+    // the multi-DDC panels never see RX2+.)
+    receivers: Array.isArray(r.receivers)
+      ? (r.receivers as unknown[]).map((entry, i) => normalizeReceiver(entry, i))
+      : undefined,
+    wireVersion: typeof r.wireVersion === 'number' ? r.wireVersion : undefined,
+    maxReceivers: typeof r.maxReceivers === 'number' ? r.maxReceivers : undefined,
   };
 }
 
@@ -5578,6 +5619,43 @@ export function setTxVfo(
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ txVfo: txVfo === 'B' ? 1 : 0 }),
+      signal,
+    },
+    normalizeState,
+  );
+}
+
+// Select the transmit target by receiver index (0=RX1, 1=RX2, >=2 extra DDC).
+// Mirrors POST /api/tx/receiver; the server clamps an unexposed index to RX1.
+export function setTxReceiver(
+  index: number,
+  signal?: AbortSignal,
+): Promise<RadioStateDto> {
+  return jsonFetch(
+    '/api/tx/receiver',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ index }),
+      signal,
+    },
+    normalizeState,
+  );
+}
+
+// Per-RX audio mute for the hero mixer / VFO panel. Mirrors
+// POST /api/receivers/{index}/mute. index 0=RX1, 1=RX2, >=2 extra DDC.
+export function setReceiverMuted(
+  index: number,
+  muted: boolean,
+  signal?: AbortSignal,
+): Promise<RadioStateDto> {
+  return jsonFetch(
+    `/api/receivers/${index}/mute`,
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ muted }),
       signal,
     },
     normalizeState,

--- a/zeus-web/src/components/MultiRxMonitorStrip.test.tsx
+++ b/zeus-web/src/components/MultiRxMonitorStrip.test.tsx
@@ -20,6 +20,7 @@ function rx(index: number, enabled: boolean): ReceiverDto {
     filterPresetName: 'VAR1',
     afGainDb: 0,
     sampleRateHz: 192_000,
+    muted: false,
   };
 }
 

--- a/zeus-web/src/components/MultiRxMonitorStrip.tsx
+++ b/zeus-web/src/components/MultiRxMonitorStrip.tsx
@@ -26,12 +26,19 @@ export function MultiRxMonitorStrip() {
 
   if (!connected || !isP2 || extraReceivers.length === 0) return null;
 
+  // Stitch up to 4 receivers across one row; beyond that, stack into additional
+  // rows of 4 (intuitive stacking for the last receivers). Columns are capped at
+  // the row width so each pane keeps a usable size instead of shrinking to slivers.
+  const MAX_PER_ROW = 4;
+  const columns = Math.min(extraReceivers.length, MAX_PER_ROW);
+
   return (
     <div
       data-multi-rx-strip
       style={{
         display: 'grid',
-        gridTemplateColumns: `repeat(${extraReceivers.length}, minmax(0, 1fr))`,
+        gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+        gridAutoRows: '1fr',
         gap: 2,
         width: '100%',
         height: '100%',

--- a/zeus-web/src/components/ReceiversPanel.test.tsx
+++ b/zeus-web/src/components/ReceiversPanel.test.tsx
@@ -32,6 +32,7 @@ function rx(index: number, enabled: boolean, adcSource = 0): ReceiverDto {
     filterPresetName: 'VAR1',
     afGainDb: 0,
     sampleRateHz: 192_000,
+    muted: false,
   };
 }
 

--- a/zeus-web/src/components/RxWaterfallPane.tsx
+++ b/zeus-web/src/components/RxWaterfallPane.tsx
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Read-only live WATERFALL pane for a multi-DDC RX3+ receiver (rxId >= 2). The
+// sibling RxMonitorPane draws the panadapter trace; this draws the scrolling
+// waterfall history for the same receiver. It reuses the production waterfall GL
+// renderer (gl/waterfall.ts) and the shared per-frame shift planner, but with a
+// stripped draw path: the receiver's own frames scroll anchored at their own
+// centre — no view-centre glide, no zoom tween, no stitch normalisation, and no
+// tuning gestures or overlays (those belong to the VFO-A/B model RX1/RX2 own).
+// Keeping RX3+ panes isolated means they cannot perturb the primary receivers.
+
+import { useEffect, useRef, type CSSProperties } from 'react';
+import { createWfRenderer } from '../gl/waterfall';
+import { planForFrame, resetFramePlan } from '../gl/frame-plan';
+import { cancelDrawBusFrame, requestDrawBusFrame } from '../realtime/draw-bus';
+import {
+  registerFrameConsumer,
+  selectDisplaySliceByRxId,
+  useDisplayStore,
+} from '../state/display-store';
+import { useDisplaySettingsStore } from '../state/display-settings-store';
+
+type RxWaterfallPaneProps = {
+  // 0-based receiver index (intended for RX3+, index >= 2). The wire rxId equals
+  // this, so the display slice is selectDisplaySliceByRxId(state, rxIndex).
+  rxIndex: number;
+};
+
+export function RxWaterfallPane({ rxIndex }: RxWaterfallPaneProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const container = containerRef.current;
+    if (!canvas || !container) return;
+
+    const gl = canvas.getContext('webgl2', {
+      antialias: false,
+      alpha: true,
+      premultipliedAlpha: true,
+    });
+    if (!gl) {
+      console.error('WebGL2 not available');
+      return;
+    }
+
+    const releaseFrameConsumer = registerFrameConsumer();
+    const renderer = createWfRenderer(gl);
+    // Unique plan key so this pane's shift history never collides with RX1/RX2
+    // ('A'/'B') or another extra receiver.
+    const planKey = `rx${rxIndex}`;
+    resetFramePlan(planKey);
+
+    const settings0 = useDisplaySettingsStore.getState();
+    renderer.setColormap(settings0.colormap);
+    renderer.setScrollSpeed(settings0.waterfallScrollSpeed);
+    renderer.setTransparent(false);
+
+    let inViewport = true;
+    let pageVisible = !document.hidden;
+    const isActive = () => inViewport && pageVisible;
+
+    const redraw = () => {
+      if (!isActive()) return;
+      const s = useDisplaySettingsStore.getState();
+      renderer.draw(s.wfDbMin, s.wfDbMax);
+    };
+    const requestRedraw = () => {
+      if (!isActive()) return;
+      requestDrawBusFrame(redraw);
+    };
+
+    const resize = () => {
+      const { width, height } = container.getBoundingClientRect();
+      const dpr = Math.min(1, window.devicePixelRatio || 1);
+      const w = Math.max(1, Math.round(width * dpr));
+      const h = Math.max(1, Math.round(height * dpr));
+      canvas.width = w;
+      canvas.height = h;
+      renderer.resize(w, h);
+      requestRedraw();
+    };
+
+    const ro = new ResizeObserver(resize);
+    ro.observe(container);
+    resize();
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) inViewport = e.isIntersecting;
+        if (isActive()) requestRedraw();
+      },
+      { threshold: 0 },
+    );
+    io.observe(container);
+    const onVisibilityChange = () => {
+      pageVisible = !document.hidden;
+      if (isActive()) requestRedraw();
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    let lastSeqPushed = -1;
+    const unsub = useDisplayStore.subscribe((state) => {
+      const slice = selectDisplaySliceByRxId(state, rxIndex);
+      if (slice.lastSeq === 0 || slice.lastSeq === lastSeqPushed) return;
+      lastSeqPushed = slice.lastSeq;
+      // Shared shift planner keyed to this receiver — geometry (shift/reset)
+      // applies even when the wf payload is invalid, so the history stays aligned.
+      const decision = planForFrame({
+        seq: slice.lastSeq,
+        centerHz: slice.centerHz,
+        hzPerPixel: slice.hzPerPixel,
+        width: slice.width,
+        planKey,
+      });
+      const wfDb = slice.wfValid && slice.wfDb ? slice.wfDb : null;
+      renderer.pushFrame(decision, wfDb, slice.centerHz, slice.hzPerPixel);
+      requestRedraw();
+    });
+
+    // Repaint / re-tune on dB-range, colormap, and scroll-speed changes.
+    const unsubSettings = useDisplaySettingsStore.subscribe((state, prev) => {
+      if (state.colormap !== prev.colormap) renderer.setColormap(state.colormap);
+      if (state.waterfallScrollSpeed !== prev.waterfallScrollSpeed)
+        renderer.setScrollSpeed(state.waterfallScrollSpeed);
+      if (
+        state.wfDbMin !== prev.wfDbMin ||
+        state.wfDbMax !== prev.wfDbMax ||
+        state.colormap !== prev.colormap
+      ) {
+        requestRedraw();
+      }
+    });
+
+    return () => {
+      unsub();
+      unsubSettings();
+      ro.disconnect();
+      io.disconnect();
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      cancelDrawBusFrame(redraw);
+      renderer.dispose();
+      resetFramePlan(planKey);
+      releaseFrameConsumer();
+    };
+  }, [rxIndex]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="spectrum-canvas"
+      style={
+        {
+          position: 'relative',
+          minHeight: 0,
+          width: '100%',
+          height: '100%',
+          background: 'var(--spec-bg)',
+        } as CSSProperties
+      }
+    >
+      <canvas
+        ref={canvasRef}
+        style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }}
+      />
+    </div>
+  );
+}

--- a/zeus-web/src/components/VfoDisplay.tsx
+++ b/zeus-web/src/components/VfoDisplay.tsx
@@ -53,9 +53,9 @@ import {
   useRef,
   useState,
 } from 'react';
-import { fetchState, setVfo, setVfoB } from '../api/client';
+import { fetchState, setReceiver, setVfo, setVfoB } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
-import { spectrumReceiverFilterColor, type SpectrumReceiverId } from './spectrumReceiverColor';
+import { receiverColorByIndex, type SpectrumReceiverId } from './spectrumReceiverColor';
 
 const MAX_HZ = 60_000_000;
 const STATE_POLL_MS = 2000;
@@ -109,30 +109,62 @@ type ReceiverId = SpectrumReceiverId;
 
 type VfoDisplayProps = {
   receiver?: ReceiverId;
+  // Multi-DDC: tune an arbitrary receiver by index (0=RX1, 1=RX2, >=2 extra
+  // DDC). Overrides `receiver`. RX3+ read/write the canonical Receivers[] entry
+  // via POST /api/receivers/{index}; RX1/RX2 keep the flat setVfo/setVfoB path.
+  rxIndex?: number;
   label?: string;
   compact?: boolean;
 };
 
-function readReceiverVfo(receiver: ReceiverId): number {
-  const s = useConnectionStore.getState();
-  return receiver === 'B' ? s.vfoBHz : s.vfoHz;
+// Resolve the 0-based receiver index a display targets from its props.
+function resolveTargetIndex(receiver: ReceiverId, rxIndex?: number): number {
+  if (rxIndex !== undefined) return rxIndex;
+  return receiver === 'B' ? 1 : 0;
 }
 
-function patchReceiverVfo(receiver: ReceiverId, hz: number) {
-  return receiver === 'B' ? { vfoBHz: hz } : { vfoHz: hz };
+function readReceiverVfo(targetIndex: number): number {
+  const s = useConnectionStore.getState();
+  if (targetIndex === 0) return s.vfoHz;
+  if (targetIndex === 1) return s.vfoBHz;
+  return s.receivers.find((r) => r.index === targetIndex)?.vfoHz ?? 0;
+}
+
+// Optimistic store patch so the digits track the wheel before the POST lands.
+function patchReceiverVfo(targetIndex: number, hz: number) {
+  if (targetIndex === 0) useConnectionStore.setState({ vfoHz: hz });
+  else if (targetIndex === 1) useConnectionStore.setState({ vfoBHz: hz });
+  else
+    useConnectionStore.setState((s) => ({
+      receivers: s.receivers.map((r) => (r.index === targetIndex ? { ...r, vfoHz: hz } : r)),
+    }));
 }
 
 export function VfoDisplay({
   receiver = 'A',
-  label = receiver === 'B' ? 'VFO B' : 'VFO A',
+  rxIndex,
+  label,
   compact = false,
 }: VfoDisplayProps = {}) {
+  const targetIndex = resolveTargetIndex(receiver, rxIndex);
+  const resolvedLabel =
+    label ?? (targetIndex === 1 ? 'VFO B' : targetIndex >= 2 ? `RX${targetIndex + 1}` : 'VFO A');
   const vfoHz = useConnectionStore((s) =>
-    receiver === 'B' ? s.vfoBHz : s.vfoHz,
+    targetIndex === 0
+      ? s.vfoHz
+      : targetIndex === 1
+      ? s.vfoBHz
+      : s.receivers.find((r) => r.index === targetIndex)?.vfoHz ?? 0,
   );
   const applyState = useConnectionStore((s) => s.applyState);
-  const postVfo = receiver === 'B' ? setVfoB : setVfo;
-  const receiverFilterColor = spectrumReceiverFilterColor(receiver);
+  const postVfo = useCallback(
+    (hz: number, signal?: AbortSignal) =>
+      targetIndex >= 2
+        ? setReceiver(targetIndex, { vfoHz: hz }, signal)
+        : (targetIndex === 1 ? setVfoB : setVfo)(hz, signal),
+    [targetIndex],
+  );
+  const receiverFilterColor = receiverColorByIndex(targetIndex);
 
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState('');
@@ -149,7 +181,7 @@ export function VfoDisplay({
   }, []);
 
   useEffect(() => {
-    if (receiver !== 'A') return;
+    if (targetIndex !== 0) return;
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
     const tick = async () => {
@@ -168,7 +200,7 @@ export function VfoDisplay({
       cancelled = true;
       if (timer != null) clearTimeout(timer);
     };
-  }, [applyState, editing, receiver]);
+  }, [applyState, editing, targetIndex]);
 
   const beginEdit = useCallback(() => {
     setDraft(formatKhz(vfoHz));
@@ -185,13 +217,13 @@ export function VfoDisplay({
     setEditing(false);
     setDraft('');
     if (next == null || next === vfoHz) return;
-    useConnectionStore.setState(patchReceiverVfo(receiver, next));
+    patchReceiverVfo(targetIndex, next);
     postVfo(next)
       .then(applyState)
       .catch(() => {
         /* next poll will reconcile */
       });
-  }, [draft, vfoHz, applyState, postVfo, receiver]);
+  }, [draft, vfoHz, applyState, postVfo, targetIndex]);
 
   useLayoutEffect(() => {
     if (editing && inputRef.current) {
@@ -242,10 +274,10 @@ export function VfoDisplay({
       e.preventDefault();
 
       const direction = e.deltaY < 0 ? 1 : -1;
-      const current = readReceiverVfo(receiver);
+      const current = readReceiverVfo(targetIndex);
       const next = clampHz(current + direction * decade);
       if (next === current) return;
-      useConnectionStore.setState(patchReceiverVfo(receiver, next));
+      patchReceiverVfo(targetIndex, next);
       wheelPending.current = next;
 
       if (wheelTimer.current != null) clearTimeout(wheelTimer.current);
@@ -272,7 +304,7 @@ export function VfoDisplay({
     // passive:false so preventDefault() actually stops the ancestor scroll.
     el.addEventListener('wheel', handler, { passive: false });
     return () => el.removeEventListener('wheel', handler);
-  }, [applyState, editing, postVfo, receiver]);
+  }, [applyState, editing, postVfo, targetIndex]);
 
   const digits = useMemo(() => DIGIT_PLACES, []);
   return (
@@ -290,7 +322,7 @@ export function VfoDisplay({
             onChange={(e) => setDraft(e.target.value)}
             onKeyDown={onKeyDown}
             onBlur={cancelEdit}
-            aria-label={`${label} frequency in kHz`}
+            aria-label={`${resolvedLabel} frequency in kHz`}
             style={{
               width: compact ? '100%' : 220,
               minWidth: 0,
@@ -315,7 +347,7 @@ export function VfoDisplay({
           type="button"
           onClick={beginEdit}
           aria-label="Edit frequency"
-          title={`${label}: click to enter frequency in kHz - scroll the wheel over a digit to tune it`}
+          title={`${resolvedLabel}: click to enter frequency in kHz - scroll the wheel over a digit to tune it`}
           className="freq-digits mono"
           style={{
             background: 'none',
@@ -347,7 +379,7 @@ export function VfoDisplay({
         </button>
       )}
       <div className="freq-bot">
-        <span className="label-xs">{label}</span>
+        <span className="label-xs">{resolvedLabel}</span>
         <span className="label-xs">{compact ? 'MHz' : 'MHz · click to type · wheel on a digit to step'}</span>
       </div>
     </div>

--- a/zeus-web/src/components/spectrumReceiverColor.ts
+++ b/zeus-web/src/components/spectrumReceiverColor.ts
@@ -9,3 +9,14 @@ export type SpectrumReceiverId = 'A' | 'B';
 export function spectrumReceiverFilterColor(receiver: SpectrumReceiverId): string {
   return receiver === 'B' ? 'var(--signal, #25d366)' : 'var(--accent, #4a9eff)';
 }
+
+// Per-receiver identity colour for the multi-DDC panels (VFO lanes, hero mixer
+// chips). RX1/RX2 keep the canonical A/B accent/signal pair; RX3+ get distinct
+// hues spread around the wheel, kept clear of the reserved accent/tx/power
+// bands. This is data-viz identity (which receiver is which), not UI chrome.
+export function receiverColorByIndex(index: number): string {
+  if (index <= 0) return 'var(--accent, #4a9eff)';
+  if (index === 1) return 'var(--signal, #25d366)';
+  const hue = (175 + (index - 2) * 53) % 360;
+  return `hsl(${hue} 68% 62%)`;
+}

--- a/zeus-web/src/layout/panels/HeroPanel.tsx
+++ b/zeus-web/src/layout/panels/HeroPanel.tsx
@@ -45,16 +45,17 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from 'react';
-import { GripVertical, X } from 'lucide-react';
+import { GripVertical, Sliders, Volume2, VolumeX, X } from 'lucide-react';
 import { Panadapter } from '../../components/Panadapter';
 import { WaterfallSurface } from '../../components/WaterfallSurface';
-import { MultiRxMonitorStrip } from '../../components/MultiRxMonitorStrip';
+import { RxMonitorPane } from '../../components/RxMonitorPane';
+import { RxWaterfallPane } from '../../components/RxWaterfallPane';
 import { ZoomControl } from '../../components/ZoomControl';
 import { WaterfallSpeedControl } from '../../components/WaterfallSpeedControl';
 import { SpectrumControls } from '../../components/SpectrumControls';
 import { LeafletWorldMap } from '../../components/design/LeafletWorldMap';
 import { LeafletMapErrorBoundary } from '../../components/design/LeafletMapErrorBoundary';
-import { setRx2, type Rx2AudioMode } from '../../api/client';
+import { setReceiverMuted } from '../../api/client';
 import { useConnectionStore } from '../../state/connection-store';
 import { useTxStore } from '../../state/tx-store';
 import { useRotatorStore } from '../../state/rotator-store';
@@ -79,12 +80,6 @@ interface HeroPanelProps {
   workspaceLocked?: boolean;
   onToggleLock?: () => void;
 }
-
-const RX_AUDIO_MODES: readonly { mode: Rx2AudioMode; label: string; title: string }[] = [
-  { mode: 'rx1', label: 'RX 1', title: 'Hear RX1 only' },
-  { mode: 'both', label: 'Both', title: 'Hear RX1 and RX2 together' },
-  { mode: 'rx2', label: 'RX 2', title: 'Hear RX2 only' },
-];
 
 // Hero panel: Panadapter + Waterfall with optional Leaflet world-map overlay.
 // Registered as headerless in panels.ts — this component owns the single
@@ -127,14 +122,15 @@ export function HeroPanel({
   const connected = useConnectionStore((s) => s.status === 'Connected');
   const applyState = useConnectionStore((s) => s.applyState);
   const rx2Enabled = useConnectionStore((s) => s.rx2Enabled);
-  // Multi-DDC RX3+ (receiver index >= 2). When any are exposed, a strip of
-  // read-only monitor panes renders below the RX1/RX2 panadapter/waterfall.
-  const hasExtraRx = useConnectionStore((s) =>
-    s.receivers.some((r) => r.index >= 2 && r.enabled),
-  );
-  const rx2AudioMode = useConnectionStore((s) => s.rx2AudioMode);
+  // Per-RX listen/mute mixer + focus selector + the multi-DDC spectrum grid all
+  // read the exposed-receiver list. RX1/RX2 keep their interactive A/B
+  // panadapter/waterfall; RX3+ render read-only monitor + waterfall panes.
+  const receivers = useConnectionStore((s) => s.receivers);
+  const focusedRxIndex = useConnectionStore((s) => s.focusedRxIndex);
+  const setFocusedRxIndex = useConnectionStore((s) => s.setFocusedRxIndex);
+  // A/B stitched-view foreground for the RX1/RX2 panadapter/waterfall. Kept in
+  // lockstep with focusedRxIndex by setFocusedRxIndex.
   const rxFocus = useConnectionStore((s) => s.rxFocus);
-  const setRxFocus = useConnectionStore((s) => s.setRxFocus);
   // During TX the waterfall region shows the live transmitted spectrum
   // (WDSP TX analyzer pixels, streamed by the server while keyed).
   const keyed = useTxStore((s) => s.moxOn || s.tunOn);
@@ -151,6 +147,12 @@ export function HeroPanel({
   const tileInstanceConfig = tile?.instanceConfig;
   const [split, setSplit] = useState(() => readInitialSplit(tileInstanceConfig));
   const [splitDragging, setSplitDragging] = useState(false);
+  // RX audio mixer popout — small movable window (replaces the cramped inline
+  // header switch). Position is null until first opened, then set from the
+  // trigger button so it appears next to it; the title bar drags it anywhere.
+  const [mixerOpen, setMixerOpen] = useState(false);
+  const [mixerPos, setMixerPos] = useState<{ x: number; y: number } | null>(null);
+  const mixerTriggerRef = useRef<HTMLButtonElement | null>(null);
 
   useEffect(() => {
     const persisted = readInstanceSplit(tileInstanceConfig);
@@ -242,19 +244,69 @@ export function HeroPanel({
   // tile-drag start. The .workspace-tile-header strip itself stays the
   // drag handle.
   const stopDrag = (e: ReactPointerEvent | ReactMouseEvent) => e.stopPropagation();
-  const chooseRxAudioMode = (mode: Rx2AudioMode) => {
-    if (mode === 'rx1') setRxFocus('A');
-    if (mode === 'rx2') setRxFocus('B');
-    useConnectionStore.setState({ rx2AudioMode: mode });
-    setRx2({ audioMode: mode }).then(applyState).catch(() => {});
+  // Per-RX listen/mute (Thetis chkMUT/chkRX2Mute). "audible" is the UI sense;
+  // the wire/state field is `muted`. Optimistic so the chip reacts immediately.
+  const toggleAudible = (index: number, audible: boolean) => {
+    const muted = !audible;
+    useConnectionStore.setState((s) => ({
+      receivers: s.receivers.map((r) => (r.index === index ? { ...r, muted } : r)),
+    }));
+    setReceiverMuted(index, muted).then(applyState).catch(() => {});
+  };
+  // Receivers exposed in the mixer/focus row: RX1 always, RX2 when enabled, plus
+  // every active extra DDC.
+  const exposedReceivers = receivers.filter((r) => r.index === 0 || r.enabled);
+  const multiRx = exposedReceivers.length > 1;
+
+  const toggleMixer = () => {
+    setMixerOpen((open) => {
+      if (!open && mixerPos === null) {
+        const rect = mixerTriggerRef.current?.getBoundingClientRect();
+        if (rect) setMixerPos({ x: Math.max(8, rect.right - 184), y: rect.bottom + 6 });
+      }
+      return !open;
+    });
   };
 
-  const stitchedGridStyle = {
+  // Drag the mixer popout by its title bar. Window-level listeners (like the
+  // splitter) so the drag keeps tracking even if the cursor outruns the bar.
+  const onMixerDragStart = (e: ReactPointerEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const base = mixerPos ?? { x: e.clientX - 90, y: e.clientY };
+    const originX = e.clientX;
+    const originY = e.clientY;
+    const onMove = (ev: PointerEvent) => {
+      setMixerPos({ x: base.x + (ev.clientX - originX), y: base.y + (ev.clientY - originY) });
+    };
+    const onEnd = () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onEnd);
+      window.removeEventListener('pointercancel', onEnd);
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onEnd);
+    window.addEventListener('pointercancel', onEnd);
+  };
+
+  // Exposed receivers in DDC order — drives the multi-DDC spectrum grid. RX1
+  // always; RX2 when enabled; then each active extra DDC (RX3+).
+  const spectrumPanes: { index: number; abId?: 'A' | 'B' }[] = [{ index: 0, abId: 'A' }];
+  if (rx2Enabled) spectrumPanes.push({ index: 1, abId: 'B' });
+  for (const r of receivers.filter((r) => r.index >= 2 && r.enabled))
+    spectrumPanes.push({ index: r.index });
+  const multiRxSpectrum = spectrumPanes.length > 1;
+
+  // ≤4 receivers stitched across one row; beyond that the grid wraps so the last
+  // receivers stack into a second row (e.g. 8 RX = two rows of 4). The panadapter
+  // and waterfall regions share this column count so their cells line up.
+  const spectrumGridStyle = {
     position: 'relative',
     minHeight: 0,
     height: '100%',
     display: 'grid',
-    gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr)',
+    gridTemplateColumns: `repeat(${Math.min(spectrumPanes.length, 4)}, minmax(0, 1fr))`,
+    gridAutoRows: '1fr',
     gap: 0,
     overflow: 'hidden',
   } as const;
@@ -280,40 +332,21 @@ export function HeroPanel({
         <span className="workspace-tile-title" title={typeof heroTitle === 'string' ? heroTitle : undefined}>
           {heroTitle}
         </span>
-        {rx2Enabled && (
-          <div
-            className="hero-rx-audio-switch"
+        {multiRx && (
+          <button
+            ref={mixerTriggerRef}
+            type="button"
+            className={`hero-rx-mixer-trigger ${mixerOpen ? 'is-open' : ''}`}
+            onClick={toggleMixer}
             onPointerDown={stopDrag}
             onMouseDown={stopDrag}
-            role="group"
-            aria-label="Select RX audio and VFO target"
+            aria-pressed={mixerOpen}
+            aria-label="Receiver audio mixer"
+            title="Receiver audio mixer — hear/mute and focus each DDC"
           >
-            {RX_AUDIO_MODES.map((m) => (
-              <button
-                key={m.mode}
-                type="button"
-                className={`hero-rx-audio-switch__key ${rx2AudioMode === m.mode ? 'is-active' : ''}`}
-                onClick={() => chooseRxAudioMode(m.mode)}
-                aria-pressed={rx2AudioMode === m.mode}
-                title={m.title}
-              >
-                <span>{m.label}</span>
-              </button>
-            ))}
-            <span className="hero-rx-audio-switch__divider" aria-hidden="true" />
-            {(['A', 'B'] as const).map((receiver) => (
-              <button
-                key={receiver}
-                type="button"
-                className={`hero-rx-audio-switch__key hero-rx-audio-switch__key--vfo ${rxFocus === receiver ? 'is-active' : ''}`}
-                onClick={() => setRxFocus(receiver)}
-                aria-pressed={rxFocus === receiver}
-                title={`Focus VFO ${receiver} for mode, filter, band, keyboard tuning, and meters.`}
-              >
-                <span>{receiver}</span>
-              </button>
-            ))}
-          </div>
+            <Sliders size={11} />
+            <span>RX MIX</span>
+          </button>
         )}
         <div
           className="hero-tile-controls"
@@ -401,6 +434,72 @@ export function HeroPanel({
           </button>
         ) : null}
       </div>
+      {multiRx && mixerOpen && (
+        <div
+          className="hero-rx-mixer-popout"
+          style={{ left: mixerPos?.x ?? 80, top: mixerPos?.y ?? 64 }}
+          onPointerDown={stopDrag}
+          onMouseDown={stopDrag}
+          role="dialog"
+          aria-label="Receiver audio mixer"
+        >
+          <div className="hero-rx-mixer-popout__bar" onPointerDown={onMixerDragStart}>
+            <span className="hero-rx-mixer-popout__grip" aria-hidden="true">
+              <GripVertical size={11} />
+            </span>
+            <span className="hero-rx-mixer-popout__title">RX Mixer</span>
+            <button
+              type="button"
+              className="hero-rx-mixer-popout__close"
+              onClick={() => setMixerOpen(false)}
+              aria-label="Close mixer"
+              title="Close"
+            >
+              <X size={12} />
+            </button>
+          </div>
+          <div className="hero-rx-mixer-popout__section">
+            <div className="hero-rx-mixer-popout__label">Listen / mute</div>
+            <div className="hero-rx-mixer-popout__row">
+              {exposedReceivers.map((r) => {
+                const audible = !r.muted;
+                return (
+                  <button
+                    key={`hear-${r.index}`}
+                    type="button"
+                    className={`hero-rx-audio-switch__key ${audible ? 'is-active' : 'is-muted'}`}
+                    onClick={() => toggleAudible(r.index, !audible)}
+                    aria-pressed={audible}
+                    title={audible ? `Mute RX${r.index + 1} audio` : `Hear RX${r.index + 1} audio`}
+                  >
+                    {audible ? <Volume2 size={11} /> : <VolumeX size={11} />}
+                    <span>{`RX${r.index + 1}`}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+          <div className="hero-rx-mixer-popout__section">
+            <div className="hero-rx-mixer-popout__label">Focus</div>
+            <div className="hero-rx-mixer-popout__row">
+              {exposedReceivers.map((r) => (
+                <button
+                  key={`focus-${r.index}`}
+                  type="button"
+                  className={`hero-rx-audio-switch__key hero-rx-audio-switch__key--vfo ${
+                    focusedRxIndex === r.index ? 'is-active' : ''
+                  }`}
+                  onClick={() => setFocusedRxIndex(r.index)}
+                  aria-pressed={focusedRxIndex === r.index}
+                  title={`Focus RX${r.index + 1} for mode, filter, band, keyboard tuning, and meters.`}
+                >
+                  <span>{`RX${r.index + 1}`}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
       <div className="hero-body" style={{ flex: 1, position: 'relative' }}>
         {imageMode && (
           <div
@@ -451,37 +550,30 @@ export function HeroPanel({
             position: 'absolute',
             inset: 0,
             display: 'grid',
-            gridTemplateRows: hasExtraRx
-              ? `${split}fr 8px ${1 - split}fr minmax(96px, 26%)`
-              : `${split}fr 8px ${1 - split}fr`,
+            gridTemplateRows: `${split}fr 8px ${1 - split}fr`,
             zIndex: 1,
           }}
         >
+          {/* Panadapter region — one cell per exposed receiver, ≤4 per row, the
+              rest stacked. RX1/RX2 keep the interactive A/B panadapter; RX3+ get
+              read-only monitor traces. */}
           {connected && (
-            rx2Enabled ? (
-              <div
-                style={stitchedGridStyle}
-              >
-                <div style={{ minWidth: 0, minHeight: 0 }}>
-                  <Panadapter
-                    receiver="A"
-                    stitched
-                    foreground={rxFocus === 'A'}
-                    tuneReceiver="A"
-                  />
+            <div style={spectrumGridStyle}>
+              {spectrumPanes.map((p) => (
+                <div key={p.index} style={{ minWidth: 0, minHeight: 0 }}>
+                  {p.abId ? (
+                    <Panadapter
+                      receiver={p.abId}
+                      stitched={multiRxSpectrum}
+                      foreground={rxFocus === p.abId}
+                      tuneReceiver={p.abId}
+                    />
+                  ) : (
+                    <RxMonitorPane rxIndex={p.index} />
+                  )}
                 </div>
-                <div style={{ minWidth: 0, minHeight: 0 }}>
-                  <Panadapter
-                    receiver="B"
-                    stitched
-                    foreground={rxFocus === 'B'}
-                    tuneReceiver="B"
-                  />
-                </div>
-              </div>
-            ) : (
-              <Panadapter receiver="A" />
-            )
+              ))}
+            </div>
           )}
           <div
             className={`spectrum-splitter ${splitDragging ? 'dragging' : ''}`}
@@ -491,46 +583,33 @@ export function HeroPanel({
             title="Drag to resize panadapter / waterfall"
             onPointerDown={onSplitterPointerDown}
           />
+          {/* Waterfall region. While keyed the server feeds the WDSP TX analyzer
+              pixels into the main display stream, so a single full-width waterfall
+              shows the transmitted spectrum (the TX panafall, issue #81).
+              Otherwise: one waterfall cell per exposed receiver, ≤4 per row then
+              stacked, matching the panadapter grid above. */}
           {connected && (
             keyed ? (
-              // On TX both receivers transmit the same audio, and the server
-              // feeds the WDSP TX analyzer's pixels into the main display
-              // stream while keyed (DspPipelineService, issue #81). So a single
-              // full-width waterfall shows the live transmitted spectrum
-              // scrolling — paired with the panadapter above (also TX while
-              // keyed) it forms a real TX panafall. The TX dB window
-              // (wfTxDbMin/Max) and the left-edge WfDbScale drag let the
-              // operator set the in-passband brightness independently of RX.
               <WaterfallSurface transparent={bgActive} />
-            ) : rx2Enabled ? (
-              <div style={stitchedGridStyle}>
-                <div style={{ minWidth: 0, minHeight: 0 }}>
-                  <WaterfallSurface
-                    receiver="A"
-                    transparent={bgActive}
-                    stitched
-                    foreground={rxFocus === 'A'}
-                    tuneReceiver="A"
-                  />
-                </div>
-                <div style={{ minWidth: 0, minHeight: 0 }}>
-                  <WaterfallSurface
-                    receiver="B"
-                    transparent={bgActive}
-                    stitched
-                    foreground={rxFocus === 'B'}
-                    tuneReceiver="B"
-                  />
-                </div>
-              </div>
             ) : (
-              <WaterfallSurface transparent={bgActive} />
+              <div style={spectrumGridStyle}>
+                {spectrumPanes.map((p) => (
+                  <div key={p.index} style={{ minWidth: 0, minHeight: 0 }}>
+                    {p.abId ? (
+                      <WaterfallSurface
+                        receiver={p.abId}
+                        transparent={bgActive}
+                        stitched={multiRxSpectrum}
+                        foreground={rxFocus === p.abId}
+                        tuneReceiver={p.abId}
+                      />
+                    ) : (
+                      <RxWaterfallPane rxIndex={p.index} />
+                    )}
+                  </div>
+                ))}
+              </div>
             )
-          )}
-          {connected && hasExtraRx && (
-            <div style={{ minWidth: 0, minHeight: 0, overflow: 'hidden' }}>
-              <MultiRxMonitorStrip />
-            </div>
           )}
         </div>
       </div>

--- a/zeus-web/src/layout/panels/VfoPanel.tsx
+++ b/zeus-web/src/layout/panels/VfoPanel.tsx
@@ -44,10 +44,17 @@
 // License for details.
 
 import type { CSSProperties } from 'react';
-import { Copy, Headphones, Repeat2, Send } from 'lucide-react';
-import { setRx2, setTxVfo, setVfo, swapVfos, type TxVfo } from '../../api/client';
+import { Copy, Headphones, Repeat2, Send, Volume2, VolumeX } from 'lucide-react';
+import {
+  setReceiver,
+  setReceiverMuted,
+  setRx2,
+  setTxReceiver,
+  setVfo,
+  swapVfos,
+} from '../../api/client';
 import { bandOf } from '../../components/design/data';
-import { spectrumReceiverFilterColor } from '../../components/spectrumReceiverColor';
+import { receiverColorByIndex } from '../../components/spectrumReceiverColor';
 import { VfoDisplay } from '../../components/VfoDisplay';
 import { useConnectionStore } from '../../state/connection-store';
 
@@ -56,11 +63,11 @@ export function VfoPanel() {
   const vfoHz = useConnectionStore((s) => s.vfoHz);
   const vfoBHz = useConnectionStore((s) => s.vfoBHz);
   const rx2Enabled = useConnectionStore((s) => s.rx2Enabled);
-  const rx2AudioMode = useConnectionStore((s) => s.rx2AudioMode);
   const rx2AfGainDb = useConnectionStore((s) => s.rx2AfGainDb);
-  const txVfo = useConnectionStore((s) => s.txVfo);
-  const rxFocus = useConnectionStore((s) => s.rxFocus);
-  const setRxFocus = useConnectionStore((s) => s.setRxFocus);
+  const receivers = useConnectionStore((s) => s.receivers);
+  const txReceiverIndex = useConnectionStore((s) => s.txReceiverIndex);
+  const focusedRxIndex = useConnectionStore((s) => s.focusedRxIndex);
+  const setFocusedRxIndex = useConnectionStore((s) => s.setFocusedRxIndex);
 
   const patchRx2 = (req: {
     enabled?: boolean;
@@ -75,10 +82,25 @@ export function VfoPanel() {
     setRx2(req).then(applyState).catch(() => {});
   };
 
-  const chooseTxVfo = (next: TxVfo) => {
-    useConnectionStore.setState({ txVfo: next });
-    setTxVfo(next).then(applyState).catch(() => {});
+  // Transmit on any receiver's VFO (RX1=0, RX2=1, RX3+=index). The server moves
+  // the TX DUC/CTUN LO to the chosen receiver; clamps an unexposed index to RX1.
+  const chooseTxReceiver = (index: number) => {
+    useConnectionStore.setState({ txReceiverIndex: index, txVfo: index === 1 ? 'B' : 'A' });
+    setTxReceiver(index).then(applyState).catch(() => {});
   };
+
+  // Per-RX listen/mute (Thetis chkMUT/chkRX2Mute). "audible" is the UI sense;
+  // the wire/state field is `muted`. Optimistic so the lane reacts immediately.
+  const toggleAudible = (index: number, audible: boolean) => {
+    const muted = !audible;
+    useConnectionStore.setState((s) => ({
+      receivers: s.receivers.map((r) => (r.index === index ? { ...r, muted } : r)),
+    }));
+    setReceiverMuted(index, muted).then(applyState).catch(() => {});
+  };
+
+  const audibleOf = (index: number) =>
+    !(receivers.find((r) => r.index === index)?.muted ?? false);
 
   const copyBToA = () => {
     useConnectionStore.setState({ vfoHz: vfoBHz });
@@ -87,94 +109,156 @@ export function VfoPanel() {
 
   const toggleRx2 = () => {
     const enabled = !rx2Enabled;
-    if (enabled) setRxFocus('B');
-    else setRxFocus('A');
+    setFocusedRxIndex(enabled ? 1 : 0);
     patchRx2({ enabled });
   };
 
-  const receiverRow = (receiver: TxVfo, freqHz: number, enabled = true) => {
-    const focused = rxFocus === receiver;
-    const txSelected = txVfo === receiver;
-    const title = receiver === 'A' ? 'RX1 / VFO A' : 'RX2 / VFO B';
-    const label = receiver === 'A' ? 'VFO A' : 'VFO B';
-    const receiverFilterColor = spectrumReceiverFilterColor(receiver);
-    const mutedByListenMode = enabled && rx2Enabled && rx2AudioMode !== 'both'
-      && ((rx2AudioMode === 'rx1' && receiver === 'B') || (rx2AudioMode === 'rx2' && receiver === 'A'));
-    return (
-      <div
-        className={`vfo-lane ${focused ? 'is-focused' : ''} ${txSelected ? 'is-tx' : ''} ${
-          mutedByListenMode ? 'is-listen-muted' : ''
-        } ${enabled ? '' : 'is-disabled'}`}
-        style={{ '--vfo-filter-color': receiverFilterColor } as CSSProperties}
-        onClick={() => {
-          if (enabled) setRxFocus(receiver);
-        }}
-      >
-        <button
-          type="button"
-          className="vfo-focus-key"
-          disabled={!enabled}
-          onClick={(e) => {
-            e.stopPropagation();
-            setRxFocus(receiver);
-          }}
-          title={`Focus ${title}`}
-          aria-label={`Focus ${title}`}
-          aria-pressed={focused}
-        >
-          {receiver}
-        </button>
-        <div className="vfo-lane-body">
-          <div className="vfo-lane-meta">
-            <span className="vfo-lane-title">
-              {title}
-            </span>
-            <span className="vfo-lane-band mono">{bandOf(freqHz)}</span>
-          </div>
-          <VfoDisplay receiver={receiver} label={label} compact />
-        </div>
-        <button
-          type="button"
-          className={`vfo-tx-key ${txSelected ? 'is-selected' : ''}`}
-          disabled={!enabled}
-          onClick={(e) => {
-            e.stopPropagation();
-            chooseTxVfo(receiver);
-          }}
-          title={`Transmit on VFO ${receiver}`}
-          aria-label={`Transmit on VFO ${receiver}`}
-          aria-pressed={txSelected}
-        >
-          <Send size={13} />
-          <span>TX</span>
-        </button>
-      </div>
-    );
+  // AF gain for the active receiver. RX1's level is the main RX volume (lives in
+  // the toolbar), so the lane AF targets RX2 (flat field) and RX3+ (per-receiver).
+  const afGainOf = (index: number) =>
+    index === 1
+      ? rx2AfGainDb
+      : index >= 2
+      ? receivers.find((r) => r.index === index)?.afGainDb ?? 0
+      : 0;
+
+  const setAfGain = (index: number, db: number) => {
+    if (index === 1) {
+      patchRx2({ afGainDb: db });
+      return;
+    }
+    useConnectionStore.setState((s) => ({
+      receivers: s.receivers.map((r) => (r.index === index ? { ...r, afGainDb: db } : r)),
+    }));
+    setReceiver(index, { afGainDb: db }).then(applyState).catch(() => {});
   };
 
+  // Exposed receivers, in DDC order: RX1 always, RX2 when enabled, then every
+  // active extra DDC. The chip rail lists these; one is the active detail.
+  const lanes: { index: number; vfoHz: number; abId?: 'A' | 'B' }[] = [
+    { index: 0, vfoHz, abId: 'A' },
+  ];
+  if (rx2Enabled) lanes.push({ index: 1, vfoHz: vfoBHz, abId: 'B' });
+  for (const r of receivers.filter((r) => r.index >= 2 && r.enabled))
+    lanes.push({ index: r.index, vfoHz: r.vfoHz });
+
+  // lanes always contains RX1, so this fallback is just to satisfy the compiler.
+  const active =
+    lanes.find((l) => l.index === focusedRxIndex) ??
+    lanes[0] ?? { index: 0, vfoHz, abId: 'A' as const };
+  const activeTitle =
+    active.index === 0 ? 'RX1 · VFO A' : active.index === 1 ? 'RX2 · VFO B' : `RX${active.index + 1}`;
+  const activeLabel =
+    active.index === 0 ? 'VFO A' : active.index === 1 ? 'VFO B' : `RX${active.index + 1}`;
+  const activeAudible = audibleOf(active.index);
+  const activeTx = txReceiverIndex === active.index;
+
   return (
-    <div className="freq-panel vfo-dual-panel">
-      <div className="vfo-command-strip">
-        <button
-          type="button"
-          className={`vfo-rx2-pill ${rx2Enabled ? 'is-on' : ''}`}
-          onClick={toggleRx2}
-          aria-pressed={rx2Enabled}
-          title={rx2Enabled ? 'Disable RX2' : 'Enable RX2'}
-        >
-          <Headphones size={13} />
-          <span>RX2</span>
-          <span className="vfo-status-dot" aria-hidden="true" />
-        </button>
-        <div className="vfo-copy-bank" role="group" aria-label="VFO copy and swap">
+    <div className="freq-panel vfo-md">
+      {/* Compact chip rail — one chip per exposed receiver, scrolls past 4. */}
+      <div className="vfo-md__rail" role="tablist" aria-label="Receivers">
+        {lanes.map((l) => {
+          const muted = !audibleOf(l.index);
+          const isTx = txReceiverIndex === l.index;
+          const isActive = l.index === active.index;
+          return (
+            <button
+              key={l.index}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              className={`vfo-chip ${isActive ? 'is-active' : ''} ${isTx ? 'is-tx' : ''} ${
+                muted ? 'is-muted' : ''
+              }`}
+              style={{ '--vfo-filter-color': receiverColorByIndex(l.index) } as CSSProperties}
+              onClick={() => setFocusedRxIndex(l.index)}
+              title={`${l.index === 0 ? 'RX1 / VFO A' : l.index === 1 ? 'RX2 / VFO B' : `RX${l.index + 1}`}${
+                isTx ? ' · transmitting here' : ''
+              }${muted ? ' · muted' : ''}`}
+            >
+              <span className="vfo-chip__id">
+                {l.index === 0 ? 'A' : l.index === 1 ? 'B' : l.index + 1}
+                {isTx && <span className="vfo-chip__tx">TX</span>}
+                {muted && <VolumeX size={9} />}
+              </span>
+              <span className="vfo-chip__freq mono">{(l.vfoHz / 1_000_000).toFixed(3)}</span>
+              <span className="vfo-chip__band mono">{bandOf(l.vfoHz)}</span>
+            </button>
+          );
+        })}
+        {!rx2Enabled && (
+          <button
+            type="button"
+            className="vfo-chip vfo-chip--add"
+            onClick={toggleRx2}
+            title="Enable RX2 (second receiver)"
+            aria-label="Enable RX2"
+          >
+            <Headphones size={13} />
+            <span className="vfo-chip__band">+ RX2</span>
+          </button>
+        )}
+      </div>
+
+      {/* Active receiver detail — the full-size tuning surface. */}
+      <div
+        className={`vfo-md__detail ${activeTx ? 'is-tx' : ''}`}
+        style={{ '--vfo-filter-color': receiverColorByIndex(active.index) } as CSSProperties}
+      >
+        <div className="vfo-md__head">
+          <span className="vfo-md__title">{activeTitle}</span>
+          <span className="vfo-md__band mono">{bandOf(active.vfoHz)}</span>
+        </div>
+        <VfoDisplay
+          key={active.index}
+          {...(active.abId ? { receiver: active.abId } : { rxIndex: active.index })}
+          label={activeLabel}
+        />
+        <div className="vfo-md__actions">
+          <button
+            type="button"
+            className={`vfo-listen-key ${activeAudible ? 'is-on' : ''}`}
+            onClick={() => toggleAudible(active.index, !activeAudible)}
+            title={activeAudible ? `Mute ${activeLabel} audio` : `Hear ${activeLabel} audio`}
+            aria-pressed={activeAudible}
+          >
+            {activeAudible ? <Volume2 size={13} /> : <VolumeX size={13} />}
+          </button>
+          <button
+            type="button"
+            className={`vfo-tx-key ${activeTx ? 'is-selected' : ''}`}
+            onClick={() => chooseTxReceiver(active.index)}
+            title={`Transmit on ${activeTitle}`}
+            aria-pressed={activeTx}
+          >
+            <Send size={13} />
+            <span>TX</span>
+          </button>
+          {active.index >= 1 && (
+            <label className="vfo-md__af mono" title={`${activeLabel} audio gain`}>
+              <span>AF</span>
+              <input
+                type="range"
+                min={-30}
+                max={12}
+                step={1}
+                value={afGainOf(active.index)}
+                onChange={(e) => setAfGain(active.index, Number(e.currentTarget.value))}
+                aria-label={`${activeLabel} audio gain`}
+              />
+              <span className="vfo-md__af-val">{afGainOf(active.index).toFixed(0)}</span>
+            </label>
+          )}
+        </div>
+        {/* Dual-VFO tools — copy/swap A↔B. */}
+        <div className="vfo-md__tools" role="group" aria-label="VFO copy and swap">
           <button
             type="button"
             className="vfo-tool-key"
             onClick={() => patchRx2({ vfoBHz: vfoHz })}
             title="Copy VFO A to VFO B"
-            aria-label="Copy VFO A to VFO B"
           >
-            <Copy size={13} />
+            <Copy size={12} />
             <span>A&gt;B</span>
           </button>
           <button
@@ -183,44 +267,32 @@ export function VfoPanel() {
             onClick={copyBToA}
             disabled={!rx2Enabled}
             title="Copy VFO B to VFO A"
-            aria-label="Copy VFO B to VFO A"
           >
-            <Copy size={13} />
+            <Copy size={12} />
             <span>B&gt;A</span>
           </button>
           <button
             type="button"
             className="vfo-tool-key"
             onClick={() => swapVfos().then(applyState).catch(() => {})}
+            disabled={!rx2Enabled}
             title="Swap VFO A and VFO B"
-            aria-label="Swap VFO A and VFO B"
           >
-            <Repeat2 size={14} />
+            <Repeat2 size={13} />
             <span>Swap</span>
           </button>
+          {rx2Enabled && (
+            <button
+              type="button"
+              className="vfo-tool-key"
+              onClick={toggleRx2}
+              title="Disable RX2"
+            >
+              <Headphones size={12} />
+              <span>RX2 off</span>
+            </button>
+          )}
         </div>
-      </div>
-
-      <div className="vfo-stack">
-        {receiverRow('A', vfoHz)}
-        {receiverRow('B', vfoBHz, rx2Enabled)}
-      </div>
-
-      <div className="vfo-audio-strip">
-        <label className="vfo-af-control mono">
-          <span className="vfo-af-label">AF</span>
-          <input
-            type="range"
-            min={-30}
-            max={12}
-            step={1}
-            value={rx2AfGainDb}
-            disabled={!rx2Enabled}
-            onChange={(e) => patchRx2({ afGainDb: Number(e.currentTarget.value) })}
-            aria-label="RX2 audio gain"
-          />
-          <span className="vfo-af-value">{rx2AfGainDb.toFixed(0)} dB</span>
-        </label>
       </div>
     </div>
   );

--- a/zeus-web/src/state/connection-store.ts
+++ b/zeus-web/src/state/connection-store.ts
@@ -79,7 +79,14 @@ export type ConnectionState = {
   rx2AudioMode: Rx2AudioMode;
   rx2AfGainDb: number;
   txVfo: TxVfo;
+  // Authoritative TX target as a receiver index (0=RX1, 1=RX2, >=2 extra DDC);
+  // txVfo stays the legacy A/B projection. Driven by the VFO panel TX-select.
+  txReceiverIndex: number;
   rxFocus: TxVfo;
+  // Which exposed receiver the operator is working in the multi-DDC panels
+  // (0=RX1..). Drives the VFO-lane / hero highlight across all DDCs; rxFocus
+  // stays the A/B stitched-view focus and mirrors this for indices 0/1.
+  focusedRxIndex: number;
   mode: RxMode;
   modeB: RxMode;
   filterLowHz: number;
@@ -159,6 +166,7 @@ export type ConnectionState = {
   setSquelch: (squelch: SquelchConfigDto) => void;
   setTxLeveling: (txLeveling: TxLevelingConfigDto) => void;
   setRxFocus: (rxFocus: TxVfo) => void;
+  setFocusedRxIndex: (index: number) => void;
   setZoomLevel: (level: ZoomLevel) => void;
   setLastConnectedEndpoint: (ep: string | null) => void;
   setWisdomPhase: (phase: WisdomPhase) => void;
@@ -176,7 +184,9 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
   receivers: [],
   maxReceivers: 8,
   txVfo: 'A',
+  txReceiverIndex: 0,
   rxFocus: 'A',
+  focusedRxIndex: 0,
   mode: 'USB',
   modeB: 'USB',
   filterLowHz: 150,
@@ -234,7 +244,10 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
         receivers: s.receivers ?? prev.receivers,
         maxReceivers: s.maxReceivers ?? prev.maxReceivers,
         txVfo: s.txVfo,
+        txReceiverIndex: s.txReceiverIndex ?? prev.txReceiverIndex,
         rxFocus: s.rx2Enabled ? prev.rxFocus : 'A',
+        // UI-only focus — preserved across server state reconciles.
+        focusedRxIndex: prev.focusedRxIndex,
         mode: s.mode,
         modeB: s.modeB,
         filterLowHz: s.filterLowHz,
@@ -275,6 +288,14 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
   setSquelch: (squelch) => set({ squelch }),
   setTxLeveling: (txLeveling) => set({ txLeveling }),
   setRxFocus: (rxFocus) => set({ rxFocus }),
+  // Focus a receiver in the multi-DDC panels. Mirror into rxFocus for the
+  // RX1/RX2 stitched view so the existing A/B focus stays consistent.
+  setFocusedRxIndex: (focusedRxIndex) =>
+    set(
+      focusedRxIndex <= 1
+        ? { focusedRxIndex, rxFocus: focusedRxIndex === 1 ? 'B' : 'A' }
+        : { focusedRxIndex },
+    ),
   setZoomLevel: (zoomLevel) => set({ zoomLevel }),
   setLastConnectedEndpoint: (lastConnectedEndpoint) =>
     set({ lastConnectedEndpoint }),

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -1449,6 +1449,108 @@
   background: linear-gradient(180deg, var(--accent-bright), var(--accent));
   box-shadow: 0 0 12px rgba(78,166,255,0.26);
 }
+
+/* RX audio mixer — small header trigger + movable popout (replaces the inline
+ * switch so any number of DDC receivers fit without crowding the header). */
+.hero-rx-mixer-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 20px;
+  padding: 0 7px;
+  border-radius: 6px;
+  color: var(--fg-2);
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.09);
+  font: 800 9px/1 var(--font-sans);
+  letter-spacing: 0.06em;
+  cursor: pointer;
+}
+.hero-rx-mixer-trigger:hover {
+  color: var(--fg-0);
+  border-color: rgba(255,255,255,0.16);
+}
+.hero-rx-mixer-trigger.is-open {
+  color: var(--fg-0);
+  border-color: var(--accent);
+  box-shadow: 0 0 9px rgba(78,166,255,0.22);
+}
+.hero-rx-mixer-popout {
+  position: fixed;
+  z-index: 60;
+  min-width: 172px;
+  max-width: 280px;
+  background:
+    linear-gradient(180deg, var(--panel-top, #14181d), var(--panel-bot, #0c0f12));
+  border: 1px solid rgba(255,255,255,0.13);
+  border-radius: 9px;
+  box-shadow: 0 12px 34px rgba(0,0,0,0.52);
+  padding-bottom: 9px;
+  user-select: none;
+}
+.hero-rx-mixer-popout__bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 7px 6px 9px;
+  cursor: grab;
+  border-bottom: 1px solid rgba(255,255,255,0.08);
+}
+.hero-rx-mixer-popout__bar:active {
+  cursor: grabbing;
+}
+.hero-rx-mixer-popout__grip {
+  color: var(--fg-3);
+  display: inline-flex;
+}
+.hero-rx-mixer-popout__title {
+  flex: 1;
+  font: 800 9px/1 var(--font-sans);
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--fg-1);
+}
+.hero-rx-mixer-popout__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--fg-3);
+  cursor: pointer;
+}
+.hero-rx-mixer-popout__close:hover {
+  color: var(--fg-0);
+  background: rgba(255,255,255,0.08);
+}
+.hero-rx-mixer-popout__section {
+  padding: 8px 9px 0;
+}
+.hero-rx-mixer-popout__label {
+  font: 700 8px/1 var(--font-sans);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  margin-bottom: 5px;
+}
+.hero-rx-mixer-popout__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+.hero-rx-mixer-popout .hero-rx-audio-switch__key {
+  min-width: 34px;
+  height: 22px;
+  border: 1px solid rgba(255,255,255,0.09);
+  background: rgba(255,255,255,0.03);
+}
+.hero-rx-mixer-popout .hero-rx-audio-switch__key.is-muted {
+  color: var(--fg-3);
+  opacity: 0.6;
+}
 .spectrum-wrap,
 .spectrum-canvas,
 .waterfall-canvas {
@@ -1854,6 +1956,7 @@
 .vfo-rx2-pill,
 .vfo-tool-key,
 .vfo-focus-key,
+.vfo-listen-key,
 .vfo-tx-key {
   display: inline-flex;
   align-items: center;
@@ -1877,6 +1980,7 @@
 .vfo-rx2-pill:hover,
 .vfo-tool-key:hover,
 .vfo-focus-key:hover,
+.vfo-listen-key:hover,
 .vfo-tx-key:hover {
   color: var(--fg-0);
   background:
@@ -1887,6 +1991,7 @@
 .vfo-rx2-pill:disabled,
 .vfo-tool-key:disabled,
 .vfo-focus-key:disabled,
+.vfo-listen-key:disabled,
 .vfo-tx-key:disabled {
   opacity: 0.42;
   cursor: default;
@@ -1927,7 +2032,8 @@
 }
 .vfo-stack {
   display: grid;
-  grid-template-rows: repeat(2, 70px);
+  /* One row per exposed receiver (RX1..RXN); grows with the multi-DDC count. */
+  grid-auto-rows: 70px;
   min-height: 140px;
   overflow: hidden;
   background:
@@ -1940,7 +2046,7 @@
 .vfo-lane {
   position: relative;
   display: grid;
-  grid-template-columns: 34px minmax(0, 1fr) 38px;
+  grid-template-columns: 34px minmax(0, 1fr) 30px 38px;
   align-items: center;
   gap: 7px;
   min-height: 70px;
@@ -2032,6 +2138,22 @@
   border-color: color-mix(in srgb, var(--vfo-filter-color, var(--accent)) 62%, transparent);
   box-shadow: 0 0 13px color-mix(in srgb, var(--vfo-filter-color, var(--accent)) 28%, transparent);
 }
+.vfo-listen-key {
+  width: 28px;
+  min-width: 28px;
+  height: 32px;
+  padding: 0;
+  color: var(--fg-3);
+}
+.vfo-listen-key.is-on {
+  color: var(--fg-0);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--vfo-filter-color, var(--accent)) 60%, white),
+    var(--vfo-filter-color, var(--accent))
+  );
+  border-color: color-mix(in srgb, var(--vfo-filter-color, var(--accent)) 55%, transparent);
+}
 .vfo-tx-key {
   width: 36px;
   min-width: 36px;
@@ -2047,6 +2169,135 @@
   background: var(--tx-soft);
   border-color: var(--tx);
   box-shadow: 0 0 10px rgba(230,58,43,0.18);
+}
+
+/* ===== Multi-DDC VFO panel — chip rail + active detail (master-detail) ===== */
+.vfo-md {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+.vfo-md__rail {
+  display: flex;
+  gap: 5px;
+  overflow-x: auto;
+  padding: 2px;
+  scrollbar-width: thin;
+}
+.vfo-md__rail::-webkit-scrollbar { height: 5px; }
+.vfo-md__rail::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.16); border-radius: 3px; }
+.vfo-chip {
+  position: relative;
+  flex: 0 0 auto;
+  display: grid;
+  gap: 1px;
+  min-width: 72px;
+  padding: 5px 9px 5px 10px;
+  text-align: left;
+  color: var(--fg-2);
+  background:
+    linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.012)),
+    rgba(0,0,0,0.18);
+  border: 1px solid rgba(255,255,255,0.09);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: border-color var(--dur-fast), background var(--dur-fast), opacity var(--dur-fast);
+}
+.vfo-chip::before {
+  content: "";
+  position: absolute;
+  left: 0; top: 6px; bottom: 6px;
+  width: 2px;
+  border-radius: 0 2px 2px 0;
+  background: transparent;
+}
+.vfo-chip:hover { border-color: rgba(255,255,255,0.16); color: var(--fg-1); }
+.vfo-chip.is-active {
+  color: var(--fg-0);
+  border-color: color-mix(in srgb, var(--vfo-filter-color, var(--accent)) 62%, transparent);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--vfo-filter-color, var(--accent)) 13%, transparent), transparent),
+    rgba(0,0,0,0.2);
+}
+.vfo-chip.is-active::before {
+  background: var(--vfo-filter-color, var(--accent));
+  box-shadow: 0 0 10px color-mix(in srgb, var(--vfo-filter-color, var(--accent)) 70%, transparent);
+}
+.vfo-chip.is-muted { opacity: 0.55; }
+.vfo-chip.is-tx { border-color: color-mix(in srgb, var(--tx) 55%, transparent); }
+.vfo-chip__id {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font: 800 10px/1 var(--font-sans);
+  color: var(--vfo-filter-color, var(--accent));
+}
+.vfo-chip__tx {
+  font: 800 8px/1 var(--font-sans);
+  color: var(--tx);
+  letter-spacing: 0.04em;
+}
+.vfo-chip__freq { font: 700 12px/1.1 var(--font-mono, monospace); color: var(--fg-0); }
+.vfo-chip__band { font: 700 8px/1 var(--font-mono, monospace); color: var(--fg-3); letter-spacing: 0.04em; }
+.vfo-chip--add {
+  align-items: center;
+  justify-content: center;
+  min-width: 56px;
+  color: var(--fg-3);
+}
+.vfo-chip--add:hover { color: var(--fg-0); }
+
+.vfo-md__detail {
+  position: relative;
+  display: grid;
+  gap: 7px;
+  padding: 9px 10px 10px;
+  background:
+    linear-gradient(180deg, rgba(255,255,255,0.03), rgba(255,255,255,0.008)),
+    rgba(0,0,0,0.16);
+  border: 1px solid rgba(255,255,255,0.09);
+  border-left: 2px solid var(--vfo-filter-color, var(--accent));
+  border-radius: 8px;
+  min-width: 0;
+}
+.vfo-md__detail.is-tx { border-left-color: var(--tx); }
+.vfo-md__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+}
+.vfo-md__title {
+  font: 800 11px/1 var(--font-sans);
+  letter-spacing: 0.03em;
+  color: var(--fg-0);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.vfo-md__band { font: 700 10px/1 var(--font-mono, monospace); color: var(--fg-2); }
+.vfo-md__actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.vfo-md__af {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1;
+  min-width: 0;
+  color: var(--fg-2);
+  font: 700 9px/1 var(--font-sans);
+}
+.vfo-md__af input[type="range"] { flex: 1; min-width: 0; }
+.vfo-md__af-val { min-width: 24px; text-align: right; color: var(--fg-1); }
+.vfo-md__tools {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
 }
 .vfo-audio-strip {
   display: grid;


### PR DESCRIPTION
## Summary
Builds on develop's multi-DDC receivers + per-RX **mute** to make all exposed DDCs first-class.

1. **Receivers menu fix** — `normalizeState` now carries `receivers[]` / `maxReceivers` / `wireVersion`; develop dropped them, so the "exposed receivers" control and the multi-DDC panels never saw RX2+. (Clicking >2 did nothing.)
2. **TX on any receiver** — `StateDto.TxReceiverIndex` + `SetTxReceiver` + `POST /api/tx/receiver`; `TxFrequencyHz`, the CTUN/CW LO alignment, and the OrionMkII split-TX guard generalize from the A/B `TxVfo` to a receiver index. An unexposed/out-of-range index clamps to RX1 (never key a receiver that isn't streaming); disabling the TX-target receiver falls TX back to RX1.
3. **RX3+ relay-chatter fix** — `Protocol2Client.SetExtraReceiverFreqHz` is now idempotent. `OnRadioStateChanged` re-pushes every extra receiver's NCO on every state broadcast; without a change-guard that re-sent the high-priority packet and re-latched the alex/OC band relays, chattering them when RX3 was exposed. Mirrors the existing RX2 DDC idempotency.
4. **UI** — VFO panel reworked to a compact **chip-rail + active-detail** master layout (fixed footprint at any receiver count); the RX audio mixer is a small **movable popout**; the hero panadapter/waterfall lay out one cell per exposed receiver, **≤4 stitched per row then stacked** (new `RxWaterfallPane` gives RX3+ a live waterfall). Per-RX mute is wired to develop's existing `ReceiverDto.Muted` / `SetReceiverMuted` (no duplicate audio backend).

See `docs/designs/multi-ddc-tx-and-audio.md` (top "Reconciliation with develop" note).

## Verification
- Web typecheck clean; **955** web unit tests pass.
- **29** server tests pass (8 new multi-DDC TX-target tests + Ctun/ModeTarget/SetRadioLo regressions).
- Builds: `Zeus.slnx` + web bundle.

## Bench review (KB2UKA / EI6LF)
TX-on-RX3+ reuses the single TX DUC/CTUN mechanism — no new TX drive/amplitude path — but please verify on HL2 + a P2 board that selecting TX on RX3 places the carrier on RX3's VFO and un-key restores the RX LO. No change to PureSignal, drive bytes, or PA gain.

## Scaling note
8 receivers = up to 16 WebGL contexts (8 trace + 8 waterfall); panes handle context loss, a pooled renderer is a follow-up if weak GPUs starve.