### PR TITLE
feat(web): add Chat to the default workspace layout

### DIFF
--- a/zeus-web/src/layout/defaultLayout.ts
+++ b/zeus-web/src/layout/defaultLayout.ts
@@ -16,8 +16,8 @@
 // Coordinates are in the 24-column × 48-row (schema-v8) grid. Total height =
 // WORKSPACE_TARGET_ROWS (48). The top-left row pairs the Bandwidth Filter
 // (mini-pan only) with the split-out Filter Presets panel; the
-// panadapter hero fills the rest of the left column, and the right column
-// stacks vfo / smeter / tx / txmeters / dsp.
+// panadapter hero fills most of the left column with a Chat strip docked
+// beneath it, and the right column stacks vfo / smeter / tx / txmeters / dsp.
 //
 // ASCII sanity check (columns 0..23):
 //
@@ -28,13 +28,13 @@
 //   │                                               ├─────────────┤  y=11
 //   │                                               │   smeter    │
 //   │                                               │   (h=5)     │  y=16
-//   │                                               ├─────────────┤
-//   │            hero (0..17, h=38)                 │     tx      │
+//   │            hero (0..17, h=30)                 ├─────────────┤
+//   │                                               │     tx      │
 //   │                                               │   (h=10)    │
 //   │                                               ├─────────────┤  y=26
 //   │                                               │  txmeters   │
-//   │                                               │   (h=12)    │
-//   │                                               ├─────────────┤  y=38
+//   ├───────────────────────────────────────────────┤   (h=12)    │
+//   │            chat (0..17, h=8)                  ├─────────────┤  y=38
 //   │                                               │     dsp     │
 //   └───────────────────────────────────────────────┴─────────────┘  y=48
 
@@ -48,7 +48,8 @@ export const DEFAULT_WORKSPACE_LAYOUT: WorkspaceLayout = {
     // losing operator overrides.
     { uid: 'tile-filter',        panelId: 'filter',        x: 0,  y: 0,  w: 12, h: 10 },
     { uid: 'tile-filterpresets', panelId: 'filterpresets', x: 12, y: 0,  w: 6,  h: 10 },
-    { uid: 'tile-hero',          panelId: 'hero',          x: 0,  y: 10, w: 18, h: 38 },
+    { uid: 'tile-hero',          panelId: 'hero',          x: 0,  y: 10, w: 18, h: 30 },
+    { uid: 'tile-chat',          panelId: 'chat',          x: 0,  y: 40, w: 18, h: 8  },
     { uid: 'tile-vfo',           panelId: 'vfo',           x: 18, y: 0,  w: 6,  h: 11 },
     { uid: 'tile-smeter',        panelId: 'smeter',        x: 18, y: 11, w: 6,  h: 5 },
     { uid: 'tile-tx',            panelId: 'tx',            x: 18, y: 16, w: 6,  h: 10 },


### PR DESCRIPTION
## What

Adds the **Chat** panel to the default workspace seed (`DEFAULT_WORKSPACE_LAYOUT`) so new users — and any empty or reset radio — get it out of the box.

## How

- New `tile-chat` tile at `x:0 y:40 w:18 h:8`, docked as a wide strip beneath the panadapter in the left column.
- Panadapter `tile-hero` shrunk from `h:38` to `h:30` to make room.
- Total layout height stays at `WORKSPACE_TARGET_ROWS` (48) with no gap and no free 8×8 slot, so the existing "page full → spill to a new workspace tab" behaviour is preserved.
- ASCII diagram + prose comment updated to match.

## Scope / impact

- **Existing operators are unaffected** — this only changes the default seed. Saved layouts keep their arrangement; only fresh radios and "Reset to default" pick up Chat.
- Placement (wide bottom strip, ~21% hero height reduction) is a default-layout/UX call — happy to re-tile if maintainers prefer a different slot or a smaller hero reduction.

## Verification

`zeus-web` layout-store suite passes (28/28), including the test that asserts the default layout fully packs the page.