### PR TITLE
fix(web): rename NR2 'Nlevel' gauge label to 'Level'

### DIFF
--- a/zeus-web/src/components/nr/NrSettingsSection.tsx
+++ b/zeus-web/src/components/nr/NrSettingsSection.tsx
@@ -464,7 +464,7 @@ function Nr2Panel() {
       <GaugeRow
         accent="green"
         icon={<Activity size={14} strokeWidth={2.25} />}
-        label="Nlevel"
+        label="Level"
         value={nlevel}
         min={0}
         max={100}


### PR DESCRIPTION
## What

In the NR2 (EMNR) Post-Process section of the inline NR settings panel, the comfort-noise level gauge displayed the label **Nlevel**. This renames the visible label to **Level**.

## Why

"Level" reads clearer and matches the capitalized style of the sibling gauges in the same panel (Factor, Rate, Taper).

## Scope

- Display label only — `zeus-web/src/components/nr/NrSettingsSection.tsx`.
- Wire/API identifiers (`nlevel`, `post2Nlevel`) are intentionally unchanged, so persistence and the server contract are untouched.