### PR TITLE
fix(tci): default unconfigured TCI bind to loopback, not all interfaces

### DIFF
--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -97,7 +97,12 @@ public static class ZeusHost
         // an http.sys URL ACL — see #30.
         var tciSection = builder.Configuration.GetSection("Tci");
         var tciEnabled = tciSection.GetValue<bool>("Enabled");
-        var tciBindAddress = tciSection.GetValue<string?>("BindAddress") ?? "0.0.0.0";
+        // Fail safe: an unconfigured bind address is loopback-only, NOT all
+        // interfaces. TCI has no authentication, so the transport (LAN trust,
+        // or a VPN like Tailscale bound to a specific 100.x IP) is the security
+        // boundary — an operator who enables TCI in appsettings without naming
+        // a bind address must not silently expose full TX control to the LAN/WAN.
+        var tciBindAddress = tciSection.GetValue<string?>("BindAddress") ?? "127.0.0.1";
         var tciPort = tciSection.GetValue<int?>("Port") ?? 40001;
 
         // Prefs-DB integrity guard (#637). Probe the shared zeus-prefs.db ONCE


### PR DESCRIPTION
## Summary

The raw-appsettings fallback for `Tci:BindAddress` in `ZeusHost.cs` defaulted to `0.0.0.0` while `TciOptions` and the runtime config store both default to `127.0.0.1`. An operator enabling TCI via `appsettings.json` with `Enabled=true` but no `BindAddress` would silently listen on **every interface**. TCI has no authentication, so this exposed full TX control to the LAN/WAN.

This aligns the fallback to `127.0.0.1` so the unconfigured path fails safe. Explicit LAN/tailnet exposure (`0.0.0.0`, `localhost`, or a specific VPN IP) is unchanged.

## Why this PR exists

This fix was authored locally but had never been opened as a PR — surfaced during a worktree/branch cleanup audit. Cherry-picked verbatim onto current `develop`.

## Change

- `Zeus.Server.Hosting/ZeusHost.cs`: `?? "0.0.0.0"` → `?? "127.0.0.1"` (+ comment).

## Test

- `dotnet build Zeus.Server.Hosting` passes.
- One-line default change; existing TCI bind-resolution paths (explicit `0.0.0.0`/`localhost`/IP) unchanged.