### PR TITLE
feat(chat): admin console — global message, clear public chat, unban

### DIFF
--- a/Zeus.Contracts/ChatDtos.cs
+++ b/Zeus.Contracts/ChatDtos.cs
@@ -147,3 +147,9 @@ public sealed record ChatRoomRequest(string Room);
 
 /// <summary>Toggle whether this operator's frequency may be shared (eye toggle).</summary>
 public sealed record ChatFreqVisibilityRequest(bool Public);
+
+/// <summary>Admin: clear a room's history. <paramref name="Room"/> defaults to the public lobby.</summary>
+public sealed record ChatClearRequest(string? Room = null);
+
+/// <summary>Admin: broadcast a one-off global announcement to every connected operator.</summary>
+public sealed record ChatBroadcastRequest(string Text);

--- a/Zeus.Contracts/ChatEventFrame.cs
+++ b/Zeus.Contracts/ChatEventFrame.cs
@@ -21,6 +21,8 @@ namespace Zeus.Contracts;
 /// {"kind":"friends","friends":{...ChatFriendsDto...}}
 /// {"kind":"rooms","rooms":[{...ChatRoomDto...}, ...]}
 /// {"kind":"banned","message":"..."}
+/// {"kind":"cleared","room":"lobby"}
+/// {"kind":"notice","from":"N9WAR","text":"...","ts":123}
 /// </code>
 ///
 /// JSON (rather than fixed binary) because the payload is small, low-rate, and
@@ -63,6 +65,14 @@ public static class ChatEventFrame
     /// <summary>Encodes a ban/kick notice into a 0x35 frame.</summary>
     public static byte[] Banned(string message) =>
         Encode(new BannedEnvelope(message));
+
+    /// <summary>Encodes a "room history cleared" notice into a 0x35 frame.</summary>
+    public static byte[] Cleared(string room) =>
+        Encode(new ClearedEnvelope(room));
+
+    /// <summary>Encodes a global admin announcement into a 0x35 frame.</summary>
+    public static byte[] Notice(string from, string text, long ts) =>
+        Encode(new NoticeEnvelope(from, text, ts));
 
     /// <summary>Serialises <paramref name="envelope"/> to UTF-8 JSON and
     /// prefixes the ChatEvent type byte.</summary>
@@ -123,5 +133,15 @@ public static class ChatEventFrame
     public sealed record BannedEnvelope(string Message)
     {
         public string Kind => "banned";
+    }
+
+    public sealed record ClearedEnvelope(string Room)
+    {
+        public string Kind => "cleared";
+    }
+
+    public sealed record NoticeEnvelope(string From, string Text, long Ts)
+    {
+        public string Kind => "notice";
     }
 }

--- a/Zeus.Server.Hosting/ChatService.cs
+++ b/Zeus.Server.Hosting/ChatService.cs
@@ -251,6 +251,21 @@ public sealed class ChatService : BackgroundService
     public Task UnbanAsync(string callsign, CancellationToken ct) =>
         SendFriendActionAsync("admin_unban", "callsign", callsign, ct);
 
+    /// <summary>Admin: clears a room's history (defaults to the public lobby).</summary>
+    public Task ClearRoomAsync(string? room, CancellationToken ct)
+    {
+        var roomId = string.IsNullOrWhiteSpace(room) ? "lobby" : room.Trim();
+        return SendFrameAsync(RequireSocket(), new { t = "admin_clear_room", room = roomId }, ct);
+    }
+
+    /// <summary>Admin: broadcasts a one-off global announcement to all operators.</summary>
+    public Task BroadcastAsync(string text, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            throw new ArgumentException("message text is empty", nameof(text));
+        return SendFrameAsync(RequireSocket(), new { t = "admin_broadcast", text = text.Trim() }, ct);
+    }
+
     private Task SendRoomMemberAsync(string verb, string room, string callsign, CancellationToken ct)
     {
         var call = (callsign ?? string.Empty).Trim().ToUpperInvariant();
@@ -539,6 +554,19 @@ public sealed class ChatService : BackgroundService
                     _lastError = ReadString(root, "message") ?? "You have been banned from ZeusChat.";
                     _hub.BroadcastChatEvent(ChatEventFrame.Banned(_lastError));
                     PushStatus();
+                    break;
+                case "cleared":
+                    var clearedRoom = ReadString(root, "room") ?? "lobby";
+                    // The in-memory ring caches only the public room; group/DM
+                    // scrollback lives on the relay, so nothing local to drop.
+                    if (clearedRoom == "lobby") _messages.Clear();
+                    _hub.BroadcastChatEvent(ChatEventFrame.Cleared(clearedRoom));
+                    break;
+                case "notice":
+                    _hub.BroadcastChatEvent(ChatEventFrame.Notice(
+                        ReadString(root, "from") ?? string.Empty,
+                        ReadString(root, "text") ?? string.Empty,
+                        ReadLong(root, "ts") ?? DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()));
                     break;
                 case "error":
                     var code = ReadString(root, "code");

--- a/Zeus.Server.Hosting/ChatSupport.cs
+++ b/Zeus.Server.Hosting/ChatSupport.cs
@@ -50,6 +50,12 @@ public sealed class ChatMessageRing
         }
     }
 
+    /// <summary>Drops all retained messages (e.g. after an admin clears the room).</summary>
+    public void Clear()
+    {
+        lock (_sync) _items.Clear();
+    }
+
     /// <summary>
     /// Returns up to <paramref name="limit"/> of the most recent messages in
     /// chronological (oldest-first) order. A non-positive limit returns all.

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -3005,6 +3005,10 @@ public static class ZeusEndpoints
             Run(() => chat.BanAsync(req.Callsign, ctx.RequestAborted)));
         app.MapPost("/api/chat/admin/unban", (ChatFriendRequest req, ChatService chat, HttpContext ctx) =>
             Run(() => chat.UnbanAsync(req.Callsign, ctx.RequestAborted)));
+        app.MapPost("/api/chat/admin/clear", (ChatClearRequest req, ChatService chat, HttpContext ctx) =>
+            Run(() => chat.ClearRoomAsync(req.Room, ctx.RequestAborted)));
+        app.MapPost("/api/chat/admin/broadcast", (ChatBroadcastRequest req, ChatService chat, HttpContext ctx) =>
+            Run(() => chat.BroadcastAsync(req.Text, ctx.RequestAborted)));
 
         // Point-to-point propagation (DE → DX). Proxies the HamClock sidecar's
         // ITU-R P.533-14 engine; always returns 200 with an {available:false}

--- a/cloud/zeuschat-relay/src/chat-room.ts
+++ b/cloud/zeuschat-relay/src/chat-room.ts
@@ -255,6 +255,12 @@ export class ChatRoom extends DurableObject<Env> {
       case 'admin_unban':
         if (this.isAdmin(me)) await this.unbanUser(norm(msg.callsign ?? ''));
         return;
+      case 'admin_clear_room':
+        if (this.isAdmin(me)) await this.clearRoom(msg.room ?? PUBLIC_ROOM);
+        return;
+      case 'admin_broadcast':
+        if (this.isAdmin(me)) this.broadcastNotice(me, (msg.text ?? '').slice(0, MAX_MESSAGE_LEN));
+        return;
 
       case 'ping':
         this.send(ws, { t: 'pong' });
@@ -474,6 +480,29 @@ export class ChatRoom extends DurableObject<Env> {
     const msgKeys = [...(await this.ctx.storage.list({ prefix: `m:${room}:` })).keys()];
     if (msgKeys.length) await this.ctx.storage.delete(msgKeys);
     for (const call of exMembers) this.pushRooms(call);
+  }
+
+  // --- admin: clear history / global announcement ----------------------------
+
+  /**
+   * Admin: permanently delete a room's stored messages and tell everyone who can
+   * see the room to drop their local scrollback. Defaults to the public lobby.
+   */
+  private async clearRoom(room: string): Promise<void> {
+    if (room !== PUBLIC_ROOM && !this.rooms.has(room)) return;
+    const msgKeys = [...(await this.ctx.storage.list({ prefix: `m:${room}:` })).keys()];
+    if (msgKeys.length) await this.ctx.storage.delete(msgKeys);
+    this.deliverToRoom(room, { t: 'cleared', room });
+  }
+
+  /**
+   * Admin: push a one-off global announcement to every connected operator. The
+   * notice is ephemeral (not persisted) — it surfaces as a prominent banner on
+   * each client regardless of which room they're viewing.
+   */
+  private broadcastNotice(admin: string, text: string): void {
+    if (!text.trim()) return;
+    this.broadcast({ t: 'notice', from: admin, text, ts: Date.now() });
   }
 
   // --- bans ------------------------------------------------------------------

--- a/cloud/zeuschat-relay/src/protocol.ts
+++ b/cloud/zeuschat-relay/src/protocol.ts
@@ -98,6 +98,10 @@ export type ClientToRelay =
   | { t: 'admin_remove_member'; room: string; callsign: string }
   | { t: 'admin_ban'; callsign: string }
   | { t: 'admin_unban'; callsign: string }
+  // Wipe a room's stored history (defaults to the public lobby).
+  | { t: 'admin_clear_room'; room?: string }
+  // Push a one-off global announcement to every connected operator.
+  | { t: 'admin_broadcast'; text: string }
   // Keepalive. The relay auto-responds with {t:"pong"} without waking (see
   // setWebSocketAutoResponse in chat-room.ts) — send this EXACT string:
   // '{"t":"ping"}'.
@@ -117,6 +121,11 @@ export type RelayToClient =
   | { t: 'history'; room: string; messages: Msg[] }
   // A chat message in a room the operator is a member of (including own echo).
   | { t: 'msg'; id: string; from: string; text: string; ts: number; room: string }
+  // A room's history was wiped by an admin — clients should drop their scrollback.
+  | { t: 'cleared'; room: string }
+  // A one-off global announcement from an admin, shown to everyone regardless of
+  // which room they're viewing.
+  | { t: 'notice'; from: string; text: string; ts: number }
   // The operator's friend graph (see ChatFriendsDto on the C# side).
   | { t: 'friends'; accepted: string[]; incoming: string[]; outgoing: string[] }
   // The operator has been banned/kicked; the socket is about to close.

--- a/zeus-web/src/api/chat.ts
+++ b/zeus-web/src/api/chat.ts
@@ -303,3 +303,9 @@ export const chatBan = (callsign: string, signal?: AbortSignal) =>
   postOk('/api/chat/admin/ban', { callsign }, signal);
 export const chatUnban = (callsign: string, signal?: AbortSignal) =>
   postOk('/api/chat/admin/unban', { callsign }, signal);
+/** Admin: wipe a room's history (defaults to the public lobby). */
+export const chatClearRoom = (room?: string, signal?: AbortSignal) =>
+  postOk('/api/chat/admin/clear', room ? { room } : {}, signal);
+/** Admin: broadcast a one-off global announcement to every connected operator. */
+export const chatBroadcast = (text: string, signal?: AbortSignal) =>
+  postOk('/api/chat/admin/broadcast', { text }, signal);

--- a/zeus-web/src/layout/panels/ChatPanel.tsx
+++ b/zeus-web/src/layout/panels/ChatPanel.tsx
@@ -988,6 +988,112 @@ function GroupManagementStrip({
 }
 
 // ---------------------------------------------------------------------------
+// Admin console (relay moderators only — N9WAR / KB2UKA)
+// ---------------------------------------------------------------------------
+
+/**
+ * Collapsible strip of network-wide moderator tools, shown only to operators the
+ * relay flagged as admins. Gathers the actions that aren't tied to a single
+ * roster row or room: global announcement, clear the public lobby, and unban.
+ * Per-row ban and per-group management live with their row/tab as before.
+ */
+function AdminConsole() {
+  const [open, setOpen] = useState(false);
+  const [dialog, setDialog] = useState<null | 'broadcast' | 'clear' | 'unban'>(null);
+  const broadcast = useChatStore((s) => s.broadcast);
+  const clearRoom = useChatStore((s) => s.clearRoom);
+  const unban = useChatStore((s) => s.unban);
+
+  return (
+    <div style={{ borderBottom: '1px solid var(--panel-border)', background: 'var(--bg-1)', flexShrink: 0 }}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+          width: '100%',
+          padding: '4px 10px',
+          background: 'none',
+          border: 'none',
+          cursor: 'pointer',
+          fontSize: 9.5,
+          fontWeight: 700,
+          letterSpacing: '0.10em',
+          textTransform: 'uppercase',
+          color: 'var(--power)',
+        }}
+      >
+        <span style={{ fontSize: 9, opacity: 0.7 }}>{open ? '▼' : '▶'}</span>
+        Admin Console
+      </button>
+      {open && (
+        <div style={{ padding: '0 10px 8px', display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+          <button type="button" className="btn sm" onClick={() => setDialog('broadcast')}>
+            📢 Global message
+          </button>
+          <button type="button" className="btn sm" onClick={() => setDialog('unban')}>
+            Unban…
+          </button>
+          <button
+            type="button"
+            className="btn sm"
+            onClick={() => setDialog('clear')}
+            style={{ color: 'var(--tx)', borderColor: 'var(--tx)', marginLeft: 'auto' }}
+          >
+            Clear public chat
+          </button>
+        </div>
+      )}
+
+      {dialog === 'broadcast' && (
+        <PromptDialog
+          title="Global message"
+          label="Announcement broadcast to every operator"
+          placeholder="e.g. Net starting now on 7.200"
+          confirmLabel="Send"
+          onSubmit={(v) => {
+            void broadcast(v);
+            setDialog(null);
+          }}
+          onCancel={() => setDialog(null)}
+        />
+      )}
+      {dialog === 'unban' && (
+        <PromptDialog
+          title="Unban operator"
+          label="Callsign"
+          placeholder="e.g. N0CALL"
+          confirmLabel="Unban"
+          onSubmit={(v) => {
+            void unban(v.toUpperCase());
+            setDialog(null);
+          }}
+          onCancel={() => setDialog(null)}
+        />
+      )}
+      {dialog === 'clear' && (
+        <ConfirmDialog
+          title="Clear public chat"
+          confirmLabel="Clear"
+          intent="danger"
+          onConfirm={() => {
+            void clearRoom(PUBLIC_ROOM);
+            setDialog(null);
+          }}
+          onCancel={() => setDialog(null)}
+        >
+          Permanently delete <strong>all messages</strong> in the public lobby for everyone? This
+          cannot be undone.
+        </ConfirmDialog>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Main panel
 // ---------------------------------------------------------------------------
 
@@ -1006,6 +1112,8 @@ export function ChatPanel() {
   const acceptedFriends = useChatStore((s) => s.acceptedFriends);
   const incomingRequests = useChatStore((s) => s.incomingRequests);
   const outgoingRequests = useChatStore((s) => s.outgoingRequests);
+  const announcement = useChatStore((s) => s.announcement);
+  const dismissAnnouncement = useChatStore((s) => s.dismissAnnouncement);
 
   const refreshStatus = useChatStore((s) => s.refreshStatus);
   const setEnabled = useChatStore((s) => s.setEnabled);
@@ -1370,6 +1478,56 @@ export function ChatPanel() {
           {relayError}
         </div>
       )}
+
+      {/* ── Global announcement banner (admin broadcast) ── */}
+      {announcement && (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: 8,
+            padding: '7px 10px',
+            borderBottom: '1px solid var(--panel-border)',
+            background: 'var(--accent-soft)',
+            fontSize: 11.5,
+            color: 'var(--fg-1)',
+            lineHeight: 1.4,
+            flexShrink: 0,
+          }}
+        >
+          <span style={{ fontSize: 13, lineHeight: 1 }} aria-hidden>
+            📢
+          </span>
+          <div style={{ flex: 1, minWidth: 0, wordBreak: 'break-word' }}>
+            {announcement.from && (
+              <span className="mono" style={{ fontWeight: 700, color: 'var(--accent-bright)', marginRight: 6 }}>
+                {announcement.from}
+              </span>
+            )}
+            <span>{announcement.text}</span>
+          </div>
+          <button
+            type="button"
+            onClick={dismissAnnouncement}
+            aria-label="Dismiss announcement"
+            style={{
+              background: 'none',
+              border: 'none',
+              padding: 2,
+              cursor: 'pointer',
+              color: 'var(--fg-3)',
+              fontSize: 11,
+              lineHeight: 1,
+              flexShrink: 0,
+            }}
+          >
+            ✕
+          </button>
+        </div>
+      )}
+
+      {/* ── Admin console (relay moderators only) ── */}
+      {isAdmin && <AdminConsole />}
 
       {/* ── Body: sidebar + right column ── */}
       <div style={{ flex: 1, display: 'flex', minHeight: 0, overflow: 'hidden' }}>

--- a/zeus-web/src/state/chat-store.ts
+++ b/zeus-web/src/state/chat-store.ts
@@ -45,6 +45,8 @@ import {
   chatRemoveMember,
   chatBan,
   chatUnban,
+  chatClearRoom,
+  chatBroadcast,
   normalizeStatus,
   normalizeOperator,
   normalizeMessage,
@@ -89,7 +91,12 @@ export type ChatEnvelope =
   | { kind: 'history'; room?: unknown; messages: unknown }
   | { kind: 'friends'; friends: unknown }
   | { kind: 'rooms'; rooms: unknown }
-  | { kind: 'banned'; message?: unknown };
+  | { kind: 'banned'; message?: unknown }
+  | { kind: 'cleared'; room?: unknown }
+  | { kind: 'notice'; from?: unknown; text?: unknown; ts?: unknown };
+
+/** A one-off global announcement pushed by an admin (shown as a banner). */
+export type ChatAnnouncement = { from: string; text: string; ts: number };
 
 export type ChatStoreState = {
   enabled: boolean;
@@ -114,6 +121,9 @@ export type ChatStoreState = {
   acceptedFriends: string[];
   incomingRequests: string[];
   outgoingRequests: string[];
+
+  // The latest global admin announcement, shown as a dismissible banner.
+  announcement: ChatAnnouncement | null;
 
   refreshStatus: () => Promise<void>;
   setEnabled: (enabled: boolean) => Promise<void>;
@@ -140,6 +150,9 @@ export type ChatStoreState = {
   removeMember: (room: string, callsign: string) => Promise<void>;
   ban: (callsign: string) => Promise<void>;
   unban: (callsign: string) => Promise<void>;
+  clearRoom: (room?: string) => Promise<void>;
+  broadcast: (text: string) => Promise<void>;
+  dismissAnnouncement: () => void;
   ingest: (envelope: ChatEnvelope) => void;
 };
 
@@ -201,6 +214,7 @@ export const useChatStore = create<ChatStoreState>((set, get) => ({
   acceptedFriends: [],
   incomingRequests: [],
   outgoingRequests: [],
+  announcement: null,
 
   refreshStatus: async () => {
     try {
@@ -367,6 +381,15 @@ export const useChatStore = create<ChatStoreState>((set, get) => ({
   unban: async (callsign) => {
     try { await chatUnban(callsign); } catch (err) { set({ relayError: errMsg(err) }); }
   },
+  clearRoom: async (room) => {
+    try { await chatClearRoom(room); } catch (err) { set({ relayError: errMsg(err) }); }
+  },
+  broadcast: async (text) => {
+    const t = text.trim();
+    if (!t) return;
+    try { await chatBroadcast(t); } catch (err) { set({ relayError: errMsg(err) }); }
+  },
+  dismissAnnouncement: () => set({ announcement: null }),
 
   ingest: (envelope) => {
     if (!envelope || typeof envelope !== 'object') return;
@@ -422,6 +445,19 @@ export const useChatStore = create<ChatStoreState>((set, get) => ({
       case 'banned':
         set({ relayError: typeof envelope.message === 'string' ? envelope.message : 'You have been banned from ZeusChat.' });
         return;
+      case 'cleared': {
+        const room = typeof envelope.room === 'string' ? envelope.room : PUBLIC_ROOM;
+        set((s) => ({ messagesByRoom: { ...s.messagesByRoom, [room]: [] } }));
+        return;
+      }
+      case 'notice': {
+        const text = typeof envelope.text === 'string' ? envelope.text : '';
+        if (!text) return;
+        const from = typeof envelope.from === 'string' ? envelope.from : '';
+        const ts = typeof envelope.ts === 'number' && Number.isFinite(envelope.ts) ? envelope.ts : Date.now();
+        set({ announcement: { from, text, ts } });
+        return;
+      }
       default:
         warnOnce('chat-ingest-unknown-kind', `unknown chat envelope kind: ${String((envelope as { kind?: unknown }).kind)}`);
     }


### PR DESCRIPTION
## What

Adds an **Admin Console** to the Chat panel for relay moderators (the existing `ADMINS` set — **N9WAR**, **KB2UKA**). It gathers network-wide moderation actions that aren't tied to a single roster row or room, and adds three capabilities that didn't exist before:

| Action | Behaviour |
|--------|-----------|
| 📢 **Global message** | Broadcasts a one-off announcement to *every* connected operator, shown as a dismissible banner regardless of which room they're viewing |
| 🧹 **Clear public chat** | Permanently wipes the public lobby history for everyone (confirm dialog) |
| **Unban…** | Lifts a ban by callsign — per-row **ban** already existed; **unban** had no UI |

The console is a collapsible strip below the header, rendered **only** when the relay flags the operator as an admin. Per-row ban and per-group management stay where they are.

## How

Wired full-stack, following the existing **relay-authoritative** admin pattern — the backend only forwards frames; the relay (`ADMINS` set) enforces who is actually a moderator, exactly like the current ban / room-management actions:

- **relay** (`cloud/zeuschat-relay/`): new `admin_clear_room` / `admin_broadcast` inbound frames (gated by the existing `isAdmin(me)` check) and `cleared` / `notice` outbound frames. `clearRoom()` deletes the room's `m:<room>:*` storage keys and tells members to drop scrollback; `broadcastNotice()` pushes an ephemeral notice to all sockets.
- **contracts**: `ChatClearRequest` / `ChatBroadcastRequest`; `ChatEventFrame.Cleared` / `Notice` envelopes.
- **server**: `ChatService.ClearRoomAsync` / `BroadcastAsync`; handles inbound `cleared` (clears the in-memory lobby ring) and `notice`; `ChatMessageRing.Clear()`.
- **endpoints**: `POST /api/chat/admin/clear`, `POST /api/chat/admin/broadcast` (sharing the existing 400/409 error map).
- **web**: `chatClearRoom` / `chatBroadcast` API fns; chat-store gains `clearRoom` / `broadcast` / `dismissAnnouncement`, an `announcement` slice, and `cleared` / `notice` ingest; `ChatPanel` renders the `AdminConsole` and the announcement banner.

## Notes

- The "global message" is intentionally **ephemeral** (a prominent banner, not persisted to lobby scrollback). Easy to also persist it to lobby history if preferred.
- Admin gating is **relay-side** by design — consistent with the existing moderation surface. The REST endpoints don't pre-check admin status, matching the current ban/room endpoints.
- **Deploy note:** the relay changes require a `wrangler deploy` of `cloud/zeuschat-relay` to take effect in production.

## Verification

- `dotnet build Zeus.Server.Hosting` — clean (0 errors).
- `tsc --noEmit` in `zeus-web` and `cloud/zeuschat-relay` — both clean.
- Visual verification of the admin-gated UI wasn't possible locally: `isAdmin` requires a live QRZ-authenticated relay session as N9WAR/KB2UKA. The change is DOM (not canvas), so it renders once connected as an admin.