### PR TITLE
fix(web): render VFO panel native instead of ScaleToFit

### DIFF
--- a/zeus-web/src/layout/panels.ts
+++ b/zeus-web/src/layout/panels.ts
@@ -226,17 +226,17 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'vfo',
     tags: ['frequency', 'vfo', 'tuning'],
     component: VfoPanel,
-    // The VFO detail card's frequency readout (.freq-display) is a
-    // container-query box (container-type:size + 9cqw digits), so it needs a
-    // DEFINITE box from an ancestor — auto-measure's max-content would collapse
-    // it (blank panel). An explicit design size lets ScaleToFitTile pin that box
-    // and scale the chip-rail + detail master layout uniformly as the tile
-    // grows. designH must cover the full master-detail stack (rail + head +
-    // readout + actions + tools ≈ 290px); the old 210 was sized for the retired
-    // compact dual-VFO grid and clipped the new layout's lower controls, leaving
-    // only the chip rail visible/scrolling. Bench-tune if the nominal zoom is off.
-    designW: 340,
-    designH: 290,
+    // Render native (NOT ScaleToFitTile). The post-#894 master-detail layout
+    // (chip rail + detail card) is variable-height — the rail grows with the
+    // receiver count — so a fixed design box can never be right: a short box
+    // clips the lower controls, a tall box shrinks the whole panel to a
+    // thumbnail in the default short/wide tile (digits scaled to ~0.58, dead
+    // space either side). Filling the tile keeps the digits full-size; the
+    // readout (.freq-display, container-type:size) gets its definite height from
+    // the tile chain + its own min-height, and .vfo-md scrolls if the tile is
+    // shorter than the detail stack. See the all-panels.css flex-body list and
+    // the .vfo-md overflow rule that make the fill + scroll work.
+    fillNative: true,
     minW: 4,
     minH: 6,
   },

--- a/zeus-web/src/styles/all-panels.css
+++ b/zeus-web/src/styles/all-panels.css
@@ -465,6 +465,7 @@
 .workspace-tile[data-panel-id='qrz'] > .workspace-tile-body,
 .workspace-tile[data-panel-id='dsp'] > .workspace-tile-body,
 .workspace-tile[data-panel-id='freedv'] > .workspace-tile-body,
+.workspace-tile[data-panel-id='vfo'] > .workspace-tile-body,
 .workspace-tile[data-panel-id='chat'] > .workspace-tile-body,
 .workspace-tile[data-panel-id='filterpresets'] > .workspace-tile-body {
   display: flex;
@@ -480,6 +481,7 @@
 .workspace-tile[data-panel-id='qrz'] > .workspace-tile-body > *,
 .workspace-tile[data-panel-id='dsp'] > .workspace-tile-body > *,
 .workspace-tile[data-panel-id='freedv'] > .workspace-tile-body > *,
+.workspace-tile[data-panel-id='vfo'] > .workspace-tile-body > *,
 .workspace-tile[data-panel-id='chat'] > .workspace-tile-body > *,
 .workspace-tile[data-panel-id='filterpresets'] > .workspace-tile-body > * {
   flex: 1 1 auto;

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -2192,10 +2192,17 @@
   flex-direction: column;
   gap: 8px;
   min-width: 0;
+  /* Render native (no ScaleToFitTile) — fill the tile and scroll the detail
+     stack when the tile is shorter than it, instead of uniformly shrinking the
+     digits to a thumbnail. The chip rail stays pinned at the top. */
+  min-height: 0;
+  overflow-y: auto;
+  scrollbar-width: thin;
 }
 .vfo-md__rail {
   display: flex;
   gap: 5px;
+  flex: 0 0 auto;
   overflow-x: auto;
   padding: 2px;
   scrollbar-width: thin;


### PR DESCRIPTION
Finishes fix/vfo-fill-native-no-scaletofit.

Target: develop