### PR TITLE
fix(web): restore service-worker 'prompt' mode (revert accidental autoUpdate)

### DIFF
--- a/zeus-web/vite.config.ts
+++ b/zeus-web/vite.config.ts
@@ -96,7 +96,11 @@ export default defineConfig({
     react(),
     tailwindcss(),
     VitePWA({
-      registerType: 'autoUpdate',
+      // 'prompt' (not 'autoUpdate') is load-bearing: the manual handler in
+      // src/service-worker/registerSW.ts listens for the workbox `waiting`
+      // event and surfaces UpdatePrompt. autoUpdate caused the stale-frontend
+      // -on-first-run bug. See docs/lessons/service-worker-updates.md.
+      registerType: 'prompt',
       includeAssets: ['mic-uplink-worklet.js'],
       injectRegister: null, // We handle registration manually
       manifest: {
@@ -116,8 +120,12 @@ export default defineConfig({
         ],
       },
       workbox: {
-        skipWaiting: true,
-        clientsClaim: true,
+        // Do NOT set skipWaiting/clientsClaim here. With 'prompt' mode the new
+        // SW must stay in the waiting state until the operator clicks "RELOAD
+        // NOW", which posts SKIP_WAITING (see registerSW.ts). skipWaiting:true
+        // would activate the new SW immediately, the `waiting` event would
+        // never fire, UpdatePrompt would never show, and the page would be
+        // claimed mid-session — the exact bug in the lesson doc.
         globPatterns: ['**/*.{js,css,html,svg,png,woff2}'],
         navigateFallback: '/index.html',
         navigateFallbackDenylist: [/^\/api/, /^\/ws/],


### PR DESCRIPTION
## Problem

`zeus-web/vite.config.ts` had VitePWA configured with `registerType: 'autoUpdate'` plus `workbox.skipWaiting: true` / `clientsClaim: true`. This contradicts [`docs/lessons/service-worker-updates.md`](docs/lessons/service-worker-updates.md), which documents the deliberate move **away** from `autoUpdate` to `prompt` mode to fix the stale-frontend-on-first-run bug (old UI shown until a manual restart).

This was an accidental regression: commit `83dedd1e6` ("Enhance diagnostics and TX fidelity controls") — unrelated to PWA work — flipped `prompt` → `autoUpdate` and added `skipWaiting`/`clientsClaim`. The original `prompt` decision came from `bd51fa29e` ("fix: implement service worker update prompt to prevent stale frontend after install"). No commit anywhere documents a deliberate re-adoption of autoUpdate.

With `skipWaiting: true` the new SW never enters the `waiting` state, so the workbox `waiting` event never fires, the manual `UpdatePrompt` banner (wired through `registerSW.ts` → `App.tsx`) never shows, and the new SW can claim the page mid-session — exactly the bug the lesson was written to prevent.

## Fix

- Restore `registerType: 'prompt'`.
- Remove `workbox.skipWaiting` / `workbox.clientsClaim` so the new SW waits for the operator's explicit `SKIP_WAITING` (the **RELOAD NOW** button), matching the canonical [vite-pwa prompt-for-update recipe](https://vite-pwa-org.netlify.app/guide/prompt-for-update.html) and the existing `registerSW.ts` + `UpdatePrompt.tsx` handler.
- Added comments at both sites pointing to the lesson so this doesn't regress again.

No change to the lesson doc was needed — it already describes the prompt model, which is now restored.

## Verification

- `npm --prefix zeus-web run build` → green (`tsc -b` + `vite build`, `sw.js` regenerated).
- Inspected the generated `sw.js`: **no `clientsClaim`**, and `skipWaiting()` fires **only** behind the message listener (`"SKIP_WAITING"===e.data.type&&self.skipWaiting()`) — i.e. only on explicit operator action. The full lifecycle (install → waiting → `waiting` event → UpdatePrompt → SKIP_WAITING → controlling → reload) is intact.