### PR TITLE
fix(web): reload HamClock iframe once after cold-start install

### DIFF
--- a/zeus-web/src/layout/panels/HamClockPanel.tsx
+++ b/zeus-web/src/layout/panels/HamClockPanel.tsx
@@ -10,7 +10,7 @@
 // then shows the iframe; otherwise it shows install/start state and points the
 // operator at Settings → HamClock.
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { ActivationSpotDto } from '../../api/client';
 import { hamclockIframeUrl, useHamClockStore } from '../../state/hamclock-store';
 import { useSpotsStore } from '../../state/spots-store';
@@ -68,6 +68,13 @@ export function HamClockPanel() {
   const loadSpotSettings = useSpotsStore((s) => s.loadSettings);
   const tuneToSpot = useSpotsStore((s) => s.tuneToSpot);
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  // Bumped to force a one-time iframe remount after a cold start (see below).
+  const [reloadNonce, setReloadNonce] = useState(0);
+  // false once we know HamClock was NOT already running when this panel
+  // mounted (i.e. this panel cold-started the sidecar). null until status
+  // first resolves; true means a returning session that needs no reload.
+  const wasRunningOnMountRef = useRef<boolean | null>(null);
+  const didColdStartReloadRef = useRef(false);
 
   // Auto-start the sidecar on mount if it's installed but not running, then
   // poll until it reaches Running so the iframe appears. Faster tick while an
@@ -78,6 +85,7 @@ export function HamClockPanel() {
       await loadStatus();
       if (cancelled) return;
       const s = useHamClockStore.getState().status;
+      wasRunningOnMountRef.current = s.running && s.port > 0;
       if (s.installed && !s.running && !s.busy && s.phase !== 'Starting') {
         await start();
       }
@@ -98,6 +106,22 @@ export function HamClockPanel() {
 
   const running = status.running && status.port > 0;
   const url = running ? hamclockIframeUrl(status.port) : '';
+
+  // Cold-start fix: on a brand-new install the backend reports Running as soon
+  // as the sidecar's TCP socket accepts (HamClockService.WaitForHealthAsync) —
+  // before OpenHamClock has fetched the upstream data/imagery it renders, so the
+  // first paint shows broken content (a stray weather glyph). Returning sessions
+  // have that data cached. When this panel cold-started the sidecar, do the one
+  // reload the operator would otherwise do by hand, a few seconds after it goes
+  // Running, by remounting the iframe via its key.
+  useEffect(() => {
+    if (!running) return;
+    if (didColdStartReloadRef.current) return;
+    if (wasRunningOnMountRef.current !== false) return; // already running → no reload needed
+    didColdStartReloadRef.current = true;
+    const id = window.setTimeout(() => setReloadNonce((n) => n + 1), 3000);
+    return () => window.clearTimeout(id);
+  }, [running]);
 
   useEffect(() => {
     if (!running || !url) return;
@@ -130,6 +154,7 @@ export function HamClockPanel() {
   if (running) {
     return (
       <iframe
+        key={reloadNonce}
         ref={iframeRef}
         title="HamClock"
         src={url}


### PR DESCRIPTION
## Problem

New users report a broken-image placeholder (a stray gray weather/cloud glyph) in the HamClock workspace on their **first** install. A hard refresh (Ctrl+Shift+R) fixes it, and it doesn't recur on later sessions.

## Root cause

The backend marks the sidecar `Running` as soon as its **TCP socket accepts** a connection (`HamClockService.WaitForHealthAsync` — *"the listening socket is the only signal we need before showing the iframe"*). That only means Node hit `app.listen()`; it does **not** mean OpenHamClock has finished booting its Express CORS-proxy and fetched the upstream data/imagery it renders.

`HamClockPanel` reveals the cross-origin `<iframe>` the instant `running` flips true, so on a **cold install** (no cached data yet) the first paint shows broken content. Returning sessions have the data cached, which is why it only bites new installs — and why a manual reload fixes it.

Ruled out: it is **not** the PWA service worker (the iframe is cross-origin to the Zeus SW scope) and **not** a failed lazy chunk (`HamClockPanel` is statically imported).

## Fix

When the panel itself cold-started the sidecar this session, do the one reload the operator was doing by hand — remount the iframe via a `key` bump ~3s after it goes `Running`. Tightly scoped:

- `wasRunningOnMountRef` — if HamClock was *already* running when the panel mounted (returning user, cached data), **no reload**, no flicker.
- `didColdStartReloadRef` — fires **at most once** per mount.

## Verification

- `tsc -b --noEmit` and `eslint` pass on the changed file.
- The live cold-start flow can't be exercised in headless preview (needs a real install + the cross-origin sidecar); the logic mirrors the manual workaround exactly. Worth a bench check on a genuinely fresh install before merge.