### PR TITLE
fix(vst): make RX/TX VST editors usable on a fresh PC

### DIFF
--- a/Zeus.Plugins.Host/Audio/VstHostAudioPlugin.cs
+++ b/Zeus.Plugins.Host/Audio/VstHostAudioPlugin.cs
@@ -63,6 +63,15 @@ public sealed class VstHostAudioPlugin : IAudioPlugin, IAsyncDisposable
             && Environment.GetEnvironmentVariable("ZEUS_DISABLE_RX_VST_LOAD") != "1";
     }
 
+    /// <summary>
+    /// Whether the in-process bridge will natively host a TX-slot VST. Stays
+    /// opt-in (a crashing in-process TX VST can hard-crash the radio backend),
+    /// so this is false for a normal operator and true only when the developer
+    /// escape hatch <c>ZEUS_ENABLE_VST_LOAD=1</c> is set. When false, the
+    /// supported way to run TX VSTs is the crash-isolated out-of-process engine.
+    /// </summary>
+    public static bool TxNativeLoadEnabled => NativeLoadEnabled("tx.post-leveler");
+
     public Task InitializeAudioAsync(IAudioHost host, CancellationToken ct)
     {
         if (!NativeLoadEnabled(_slot))

--- a/Zeus.Server.Hosting/VstEditorHint.cs
+++ b/Zeus.Server.Hosting/VstEditorHint.cs
@@ -8,31 +8,56 @@
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 //
-// VstEditorHint — picks the operator-facing message when a plugin editor is
-// opened while the out-of-process VST route is selected but the engine isn't
-// routing. Without this, the open falls through to the in-process bridge and
-// surfaces its "set ZEUS_ENABLE_VST_LOAD=1" hint, which is irrelevant to VST
-// mode and points a new operator at the wrong fix. The real fix in VST mode is
-// to install the engine ("Download VST Engine") or wait for it to come up.
+// VstEditorHint — picks the operator-facing message when a plugin editor can't
+// be opened because no host will load the plugin in the current mode. Two cases:
+//   * VST processing mode selected but the out-of-process engine isn't routing.
+//   * Native processing mode while the in-process bridge won't host the plugin
+//     (TX native load stays opt-in — a crashing in-process TX VST takes the
+//     radio down).
+// In both, the bare in-process bridge would surface a "set ZEUS_ENABLE_VST_LOAD=1"
+// hint — a developer-only escape hatch that points a new operator at the wrong
+// (and unsafe) fix. The supported path is the crash-isolated out-of-process
+// engine: install it ("Download VST Engine") and run the Audio Suite in VST mode.
 
 namespace Zeus.Server;
 
 internal static class VstEditorHint
 {
     /// <summary>
-    /// The error to return when opening an editor in VST mode without a routing
-    /// engine, or <c>null</c> when the guard does not apply — i.e. the route is
-    /// Native (in-process editor path is correct) or the engine is already
-    /// active (the editor open should be attempted normally).
+    /// The operator-facing error to return when an editor open can't succeed, or
+    /// <c>null</c> when the open should be attempted normally — i.e. the engine
+    /// is routing, or Native mode with the in-process bridge able to host the
+    /// plugin (<paramref name="nativeLoadEnabled"/> is true).
     /// </summary>
+    /// <param name="nativeLoadEnabled">Whether the in-process bridge will host
+    /// this plugin in Native mode. RX VSTs load in-process by default; TX VSTs
+    /// only when <c>ZEUS_ENABLE_VST_LOAD=1</c>. When false, the in-process editor
+    /// can't open, so point the operator at the out-of-process engine instead.</param>
     public static string? EngineUnavailableMessage(
-        AudioProcessingMode mode, bool engineActive, bool engineInstalled)
+        AudioProcessingMode mode, bool engineActive, bool engineInstalled,
+        bool nativeLoadEnabled = true)
     {
-        if (mode != AudioProcessingMode.Vst || engineActive)
+        // Engine is routing — the editor open should be attempted via the engine.
+        if (engineActive)
             return null;
-        return engineInstalled
-            ? "The VST engine is installed but isn't routing yet. Give it a moment, then reopen the editor."
-            : "The VST engine isn't installed yet. Open the TX Audio Suite and click "
-              + "\"Download VST Engine\" to download and enable it, then reopen the editor.";
+
+        // VST processing mode selected but the engine isn't routing yet.
+        if (mode == AudioProcessingMode.Vst)
+            return engineInstalled
+                ? "The VST engine is installed but isn't routing yet. Give it a moment, then reopen the editor."
+                : "The VST engine isn't installed yet. Open the TX Audio Suite and click "
+                  + "\"Download VST Engine\" to download and enable it, then reopen the editor.";
+
+        // Native mode, but the in-process bridge won't host this plugin (the safe
+        // default for TX). Guide to the crash-isolated engine, not the dev hatch.
+        if (!nativeLoadEnabled)
+            return engineInstalled
+                ? "TX VSTs run in the dedicated VST engine. Switch the Audio Suite "
+                  + "processing mode to \"VST\" to load and edit this plugin."
+                : "TX VSTs run in the dedicated VST engine. Open the TX Audio Suite, click "
+                  + "\"Download VST Engine\", then switch the processing mode to \"VST\" to "
+                  + "load and edit this plugin.";
+
+        return null;
     }
 }

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -691,18 +691,24 @@ public static class ZeusEndpoints
             _                            => Results.StatusCode(500),
         };
 
-        // When the operator has selected the out-of-process VST route but the
-        // engine isn't routing, an editor open would otherwise fall through to
-        // the in-process bridge and surface the in-process "set
-        // ZEUS_ENABLE_VST_LOAD=1" hint — which is irrelevant to VST mode and
-        // sends a new operator down the wrong path. Point them at the actual
-        // fix instead: install the engine (the "Download VST Engine" affordance)
-        // or wait for it to come up. Returns null in every other case so Native
-        // mode keeps the existing in-process editor behaviour unchanged.
-        static IResult? VstEngineEditorGuard(AudioProcessingModeService mode)
+        // When an editor open can't succeed in the current mode, a naive open
+        // would fall through to the in-process bridge and surface its "set
+        // ZEUS_ENABLE_VST_LOAD=1" hint — a developer-only escape hatch that sends
+        // a new operator down the wrong (and unsafe) path. Point them at the
+        // supported fix instead: the crash-isolated out-of-process engine
+        // ("Download VST Engine" + VST processing mode). This covers two cases:
+        // VST mode with no routing engine, and Native mode where the in-process
+        // bridge won't host the plugin (TX native load is opt-in). Returns null
+        // when the open should proceed — the engine is routing, or the bridge can
+        // host this plugin (RX VSTs load in-process; TX only with the dev opt-in).
+        static IResult? VstEngineEditorGuard(string id, AudioProcessingModeService mode)
         {
+            var nativeLoadEnabled = VstDirectoryScanService.IsRxPluginId(id)
+                || Zeus.Plugins.Host.Audio.VstHostAudioPlugin.TxNativeLoadEnabled;
             var error = VstEditorHint.EngineUnavailableMessage(
-                mode.Mode, mode.EngineActive, AudioProcessingModeService.FindEngineExe() is not null);
+                mode.Mode, mode.EngineActive,
+                AudioProcessingModeService.FindEngineExe() is not null,
+                nativeLoadEnabled);
             return error is null ? null : Results.Json(new { error }, statusCode: 409);
         }
 
@@ -728,7 +734,7 @@ public static class ZeusEndpoints
                 // processing mode; only the TX path is gated on the VST engine.
                 if (rxVst.HasEngineSlot(id))
                     return MapEditorResult(rxVst.OpenEditor(id), open: true);
-                if (VstEngineEditorGuard(mode) is { } guard)
+                if (VstEngineEditorGuard(id, mode) is { } guard)
                     return guard;
                 var result = mode.EngineActive && mode.HasEngineSlot(id)
                     ? mode.OpenEditor(id)
@@ -758,7 +764,7 @@ public static class ZeusEndpoints
         app.MapPost("/api/tx-audio-suite/plugins/{id}/editor",
             (string id, AudioPluginBridge bridge, AudioProcessingModeService mode) =>
             {
-                if (VstEngineEditorGuard(mode) is { } guard)
+                if (VstEngineEditorGuard(id, mode) is { } guard)
                     return guard;
                 var result = mode.EngineActive && mode.HasEngineSlot(id)
                     ? mode.OpenEditor(id)
@@ -780,29 +786,36 @@ public static class ZeusEndpoints
         // auto-detects RX slots, but route-aware callers should use this
         // receive-side URL so separate TX/RX VST instances never depend on
         // ambiguous editor routing.
+        // RX VSTs are hosted out-of-process only when the dedicated RX engine is
+        // installed AND active; otherwise (Native mode — the default, and the
+        // only option until the operator installs the VST engine) the in-process
+        // AudioPluginBridge loads and renders the RX VST editor. So fall back to
+        // the bridge exactly like the generic /api/audio-suite route does. Without
+        // this fallback a fresh install 404s the editor for a perfectly-loaded
+        // in-process RX VST and surfaces the wrong "engine missing" hint.
         app.MapGet("/api/rx-audio-suite/plugins/{id}/editor",
-            (string id, RxVstEngineService rxVst) =>
+            (string id, RxVstEngineService rxVst, AudioPluginBridge bridge) =>
             {
-                if (!rxVst.HasEngineSlot(id))
-                    return Results.NotFound(new { error = "No such plugin in the RX Audio Suite chain." });
-                return Results.Ok(new { open = rxVst.IsEditorOpen(id) });
+                if (rxVst.HasEngineSlot(id))
+                    return Results.Ok(new { open = rxVst.IsEditorOpen(id) });
+                return Results.Ok(new { open = bridge.IsEditorOpen(id) });
             });
 
         app.MapPost("/api/rx-audio-suite/plugins/{id}/editor",
-            (string id, RxVstEngineService rxVst) =>
+            (string id, RxVstEngineService rxVst, AudioPluginBridge bridge) =>
             {
                 var result = rxVst.HasEngineSlot(id)
                     ? rxVst.OpenEditor(id)
-                    : EditorActionResult.NotFound;
+                    : bridge.OpenEditor(id);
                 return MapEditorResult(result, open: true);
             });
 
         app.MapDelete("/api/rx-audio-suite/plugins/{id}/editor",
-            (string id, RxVstEngineService rxVst) =>
+            (string id, RxVstEngineService rxVst, AudioPluginBridge bridge) =>
             {
                 var result = rxVst.HasEngineSlot(id)
                     ? rxVst.CloseEditor(id)
-                    : EditorActionResult.NotFound;
+                    : bridge.CloseEditor(id);
                 return MapEditorResult(result, open: false);
             });
 

--- a/tests/Zeus.Server.Tests/AudioSuitePreviewEndpointTests.cs
+++ b/tests/Zeus.Server.Tests/AudioSuitePreviewEndpointTests.cs
@@ -135,6 +135,25 @@ public class AudioSuitePreviewEndpointTests : IClassFixture<AudioSuitePreviewEnd
         Assert.Equal(HttpStatusCode.BadRequest, rxScan.StatusCode);
     }
 
+    [Fact]
+    public async Task RxEditorRouteFallsBackToInProcessBridge_WhenOutOfProcessEngineInactive()
+    {
+        // Fresh-install / Native mode: the out-of-process RX VST engine isn't
+        // installed, so RX VSTs are hosted by the in-process AudioPluginBridge.
+        // The RX editor route must fall back to the bridge (open=false for an
+        // unknown/unloaded plugin) rather than 404 — a 404 here is what spammed
+        // the console and surfaced the wrong "engine missing" hint on a new PC.
+        using var client = _factory.CreateClient();
+
+        var res = await client.GetAsync(
+            "/api/rx-audio-suite/plugins/com.openhpsdr.zeus.rxvst.clear/editor");
+
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+        using var json = await res.Content.ReadFromJsonAsync<JsonDocument>();
+        Assert.NotNull(json);
+        Assert.False(json!.RootElement.GetProperty("open").GetBoolean());
+    }
+
     public sealed class Factory : IsolatedPrefsFactory
     {
     }

--- a/tests/Zeus.Server.Tests/VstEditorEngineHintTests.cs
+++ b/tests/Zeus.Server.Tests/VstEditorEngineHintTests.cs
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 //
-// When the operator has selected the out-of-process VST route but no engine is
-// routing, opening a plugin editor must point them at the actual fix (install
-// the engine via "Download VST Engine") — NOT the in-process
-// "set ZEUS_ENABLE_VST_LOAD=1" hint, which is irrelevant to VST mode and sends
-// a new operator down the wrong path. Native mode keeps the in-process hint.
+// Opening a plugin editor when no host will load it must point the operator at
+// the actual fix (install/route the out-of-process engine via "Download VST
+// Engine" + VST mode) — NOT the in-process "set ZEUS_ENABLE_VST_LOAD=1" hint, a
+// developer-only escape hatch that sends a new operator down the wrong (and
+// unsafe) path. This applies to VST mode with no routing engine AND to Native
+// mode when the in-process bridge won't host the plugin (TX native load is
+// opt-in). Native mode WITH in-process load available keeps the normal path.
 
 using Zeus.Server;
 
@@ -48,11 +50,43 @@ public class VstEditorEngineHintTests
     [InlineData(false, true)]
     [InlineData(true, false)]
     [InlineData(true, true)]
-    public void NativeMode_NeverGuards(bool engineActive, bool engineInstalled)
+    public void NativeMode_WithInProcessLoad_NeverGuards(bool engineActive, bool engineInstalled)
     {
-        // Native is the in-process editor path; the VST-engine guard must never
-        // hijack it regardless of engine presence.
+        // Native + the in-process bridge able to host the plugin (RX VSTs, or TX
+        // with ZEUS_ENABLE_VST_LOAD=1): the in-process editor path is correct, so
+        // the guard must never hijack it regardless of engine presence.
         Assert.Null(VstEditorHint.EngineUnavailableMessage(
-            AudioProcessingMode.Native, engineActive, engineInstalled));
+            AudioProcessingMode.Native, engineActive, engineInstalled, nativeLoadEnabled: true));
+    }
+
+    [Fact]
+    public void NativeMode_TxLoadGatedOff_EngineMissing_PointsAtDownloadAndVstMode()
+    {
+        // Fresh PC, Native mode (default), TX native load gated off (safe default):
+        // the in-process editor can't open. Guide to the engine + VST mode, never
+        // the dangerous dev hatch.
+        var msg = VstEditorHint.EngineUnavailableMessage(
+            AudioProcessingMode.Native, engineActive: false, engineInstalled: false,
+            nativeLoadEnabled: false);
+
+        Assert.NotNull(msg);
+        Assert.Contains("Download VST Engine", msg);
+        Assert.Contains("VST", msg);
+        Assert.DoesNotContain("ZEUS_ENABLE_VST_LOAD", msg);
+    }
+
+    [Fact]
+    public void NativeMode_TxLoadGatedOff_EngineInstalled_SaysSwitchToVstMode()
+    {
+        // Engine already downloaded but operator still in Native mode: tell them to
+        // switch processing mode to VST, not to re-download.
+        var msg = VstEditorHint.EngineUnavailableMessage(
+            AudioProcessingMode.Native, engineActive: false, engineInstalled: true,
+            nativeLoadEnabled: false);
+
+        Assert.NotNull(msg);
+        Assert.Contains("VST", msg);
+        Assert.DoesNotContain("Download VST Engine", msg);
+        Assert.DoesNotContain("ZEUS_ENABLE_VST_LOAD", msg);
     }
 }


### PR DESCRIPTION
## Problem

On a new PC (where the out-of-process VST engine hasn't been downloaded yet — i.e. **Native** processing mode), loading VSTs in the Audio Suite was broken on both routes:

- **RX:** the console spammed `404` on `GET /api/rx-audio-suite/plugins/<id>/editor`, and opening the editor failed — even though the RX VST was loaded and working.
- **TX:** opening a TX VST editor showed *"…native VST hosting is off… set `ZEUS_ENABLE_VST_LOAD=1`."* — a developer-only escape hatch that is wrong (and unsafe) guidance for an operator.

## Root cause

Zeus has two VST hosting paths: the **out-of-process** engine (crash-isolated, opt-in VST mode) and the **in-process** `AudioPluginBridge` (Native mode).

- The generic `/api/audio-suite` and TX routes already fall back to the in-process bridge when the engine isn't routing. The **RX-specific route did not** — it only consulted `RxVstEngineService`, so it `404`d for RX VSTs that are hosted in-process (RX native load is default-on).
- The TX editor guard only corrected the message in **VST** processing mode. In **Native** mode it fell through to the in-process bridge's `ZEUS_ENABLE_VST_LOAD=1` hint. In-process TX native load is intentionally gated off (a crashing in-process TX VST takes the radio backend down), so the supported path is the out-of-process engine.

## Fix

- **RX route** (`GET`/`POST`/`DELETE /api/rx-audio-suite/plugins/{id}/editor`): fall back to the in-process `AudioPluginBridge`, mirroring the generic route. No 404, editor opens in Native mode.
- **TX guard**: when the in-process bridge won't host the plugin and we're in Native mode, point operators at the real path — *Download VST Engine + switch processing mode to VST* — instead of the dev hatch. The guard is plugin-aware: RX plugins (default-on in-process) never trigger the TX hint.

No change to the TX safety gate: in-process TX native load stays opt-in. Once an operator downloads the engine and switches to VST mode, TX VSTs load and the editor works.

## Tests

- `RxEditorRouteFallsBackToInProcessBridge_WhenOutOfProcessEngineInactive` — RX editor route returns `200 {open:false}` (bridge fallback), not `404`.
- `NativeMode_TxLoadGatedOff_EngineMissing_PointsAtDownloadAndVstMode` / `…EngineInstalled_SaysSwitchToVstMode` — Native-mode TX hint points at Download/VST mode and never mentions `ZEUS_ENABLE_VST_LOAD`.

All 19 RX-route / hint / endpoint tests pass; `Zeus.Server.Hosting` and `Zeus.Plugins.Host` build clean.