### PR TITLE
feat(freedv): spec DSP profile + working text sidechannel

### DIFF
--- a/Zeus.Dsp.FreeDv/FreeDvModem.cs
+++ b/Zeus.Dsp.FreeDv/FreeDvModem.cs
@@ -26,6 +26,7 @@
 // path via a dirty flag, so they need no handle swap.
 
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 using Zeus.Contracts;
@@ -90,12 +91,112 @@ public sealed class FreeDvModem : IDisposable
     private float _snrSquelchThresh = DefaultSquelchThresh(FreeDvSubmode.Mode700D);
     private int _squelchDirty;
 
+    // ---- Text sidechannel (FreeDV low-bit-rate "txt" stream: callsign etc.) ----
+    // The codec2 modem carries a slow varicode text stream alongside voice. The
+    // RX/TX callbacks fire INSIDE freedv_rx / freedv_tx on the hot path, so they
+    // are strictly lock-free and allocation-free. The delegate instances are held
+    // in fields for the modem's lifetime so the GC can never collect them while
+    // native code holds their function pointers.
+    private readonly FreeDvNativeMethods.FreeDvRxTextCallback _rxTextCb;
+    private readonly FreeDvNativeMethods.FreeDvTxTextCallback _txTextCb;
+    private readonly IntPtr _rxTextCbPtr;
+    private readonly IntPtr _txTextCbPtr;
+    // TX text to transmit, ASCII + trailing CR delimiter. Control thread swaps the
+    // reference; the hot-path TX callback Volatile.Reads it and cycles forever.
+    private byte[] _txTextBytes = Array.Empty<byte>();
+    private int _txTextPos;                              // hot-path-owned cursor
+    // RX decoded chars: hot path enqueues, the status thread drains + assembles.
+    private readonly FreeDvByteRing _rxTextRing = new(256);
+    private readonly object _rxTextLock = new();         // status-thread reassembly only
+    private readonly StringBuilder _rxTextWork = new(80);
+    private string? _rxTextLine;
+
     public FreeDvModem(ILogger<FreeDvModem>? log = null)
     {
         _log = log;
         _nativeAvailable = FreeDvNativeLoader.TryProbe();
         if (!_nativeAvailable)
             _log?.LogWarning("FreeDV: codec2 native library not found; FreeDV mode will pass audio through unchanged.");
+        _rxTextCb = OnRxTextChar;
+        _txTextCb = OnTxTextChar;
+        _rxTextCbPtr = Marshal.GetFunctionPointerForDelegate(_rxTextCb);
+        _txTextCbPtr = Marshal.GetFunctionPointerForDelegate(_txTextCb);
+    }
+
+    // Hot path (inside freedv_rx). Single-byte lock-free enqueue; drop on overflow.
+    private void OnRxTextChar(IntPtr state, byte c) => _rxTextRing.WriteByte(c);
+
+    // Hot path (inside freedv_tx). Returns the next char of the repeating TX text,
+    // or 0 when no text is configured (codec2 sends an idle txt stream).
+    private byte OnTxTextChar(IntPtr state)
+    {
+        var bytes = Volatile.Read(ref _txTextBytes);
+        if (bytes.Length == 0) return 0;
+        int pos = _txTextPos;
+        byte c = bytes[pos % bytes.Length];
+        _txTextPos = pos + 1;
+        return c;
+    }
+
+    /// <summary>
+    /// Set the low-bit-rate TX text (callsign / short message). Control-thread
+    /// only. Encoded as 7-bit ASCII with a trailing CR so the receiver gets a
+    /// line delimiter; published atomically to the hot-path TX callback.
+    /// </summary>
+    public void SetTxText(string? text)
+    {
+        byte[] bytes;
+        if (string.IsNullOrEmpty(text))
+        {
+            bytes = Array.Empty<byte>();
+        }
+        else
+        {
+            var t = text.Length > 63 ? text[..63] : text;
+            bytes = new byte[t.Length + 1];
+            for (int i = 0; i < t.Length; i++) bytes[i] = (byte)(t[i] & 0x7f);
+            bytes[t.Length] = (byte)'\r';
+        }
+        Volatile.Write(ref _txTextBytes, bytes);
+    }
+
+    /// <summary>
+    /// Last fully-received line of RX text (callsign etc.), or null if none has
+    /// been decoded yet. Drains the lock-free RX-text ring and reassembles on the
+    /// caller's (status) thread — never touched by the hot path beyond the ring
+    /// enqueue. Guarded so concurrent status polls don't race the reassembly.
+    /// </summary>
+    public string? RxText
+    {
+        get
+        {
+            lock (_rxTextLock)
+            {
+                Span<byte> buf = stackalloc byte[64];
+                int n;
+                while ((n = _rxTextRing.Read(buf)) > 0)
+                {
+                    for (int i = 0; i < n; i++)
+                    {
+                        char c = (char)buf[i];
+                        if (c is '\r' or '\n')
+                        {
+                            if (_rxTextWork.Length > 0)
+                            {
+                                _rxTextLine = _rxTextWork.ToString();
+                                _rxTextWork.Clear();
+                            }
+                        }
+                        else if (c is >= ' ' and < (char)127)
+                        {
+                            if (_rxTextWork.Length >= 64) _rxTextWork.Clear();
+                            _rxTextWork.Append(c);
+                        }
+                    }
+                }
+                return _rxTextLine;
+            }
+        }
     }
 
     public bool NativeAvailable => _nativeAvailable;
@@ -336,6 +437,14 @@ public sealed class FreeDvModem : IDisposable
         _synced = false;
         Volatile.Write(ref _snrDb, 0f);
 
+        // Wire the text sidechannel on the fresh handles BEFORE publishing them to
+        // the hot path: RX handle decodes received chars, TX handle pulls chars to
+        // send. Restart the TX cursor so a reopen (submode change) re-sends from
+        // the start of the message. Both handles are still gated out here.
+        FreeDvNativeMethods.freedv_set_callback_txt(rx, _rxTextCbPtr, IntPtr.Zero, IntPtr.Zero);
+        FreeDvNativeMethods.freedv_set_callback_txt(tx, IntPtr.Zero, _txTextCbPtr, IntPtr.Zero);
+        _txTextPos = 0;
+
         RetireRx(rx);
         RetireTx(tx);
 
@@ -355,6 +464,7 @@ public sealed class FreeDvModem : IDisposable
         if (old != IntPtr.Zero) FreeDvNativeMethods.freedv_close(old);
         _rx8In.Clear(); _rxOut48.Clear();
         _rxDown.Reset(); _rxUp.Reset();
+        _rxTextRing.Clear(); // drop stale decoded chars across a resync/close
         Volatile.Write(ref _rxFreedv, replacement);
     }
 

--- a/Zeus.Dsp.FreeDv/FreeDvNativeMethods.cs
+++ b/Zeus.Dsp.FreeDv/FreeDvNativeMethods.cs
@@ -93,4 +93,22 @@ internal static partial class FreeDvNativeMethods
     [LibraryImport(LibraryName)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial void freedv_set_snr_squelch_thresh(IntPtr freedv, float snr_squelch_thresh);
+
+    // Low-bit-rate text sidechannel (FreeDV "txt" varicode stream — callsign /
+    // short message carried alongside voice). The codec2 API delivers received
+    // chars via rx_func and pulls chars to transmit via tx_func; both fire
+    // synchronously INSIDE freedv_rx / freedv_tx. Passing IntPtr.Zero for either
+    // callback disables that direction (codec2 NULL-checks before calling).
+    // callback_state is opaque; Zeus closes over the modem instance via the
+    // delegate itself, so it passes IntPtr.Zero here.
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate void FreeDvRxTextCallback(IntPtr state, byte c);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate byte FreeDvTxTextCallback(IntPtr state);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void freedv_set_callback_txt(
+        IntPtr freedv, IntPtr rx_func, IntPtr tx_func, IntPtr callback_state);
 }

--- a/Zeus.Dsp.FreeDv/FreeDvResampler.cs
+++ b/Zeus.Dsp.FreeDv/FreeDvResampler.cs
@@ -267,3 +267,59 @@ internal sealed class FreeDvSampleRing
         Volatile.Write(ref _head, Volatile.Read(ref _tail));
     }
 }
+
+/// <summary>
+/// Lock-free single-producer/single-consumer byte ring for the FreeDV text
+/// sidechannel. The producer is the RX hot path (the codec2 txt callback fires
+/// inside freedv_rx); the consumer is the status thread draining decoded chars.
+/// Same Volatile release/acquire discipline and power-of-two wrap as
+/// <see cref="FreeDvSampleRing"/> — a byte twin so the hot-path enqueue never
+/// allocates or blocks. Oldest bytes are dropped on overflow (text is advisory).
+/// </summary>
+internal sealed class FreeDvByteRing
+{
+    private readonly byte[] _buffer;
+    private readonly int _mask;
+    private readonly int _capacity;
+    private long _head; // consumer cursor
+    private long _tail; // producer cursor
+
+    internal FreeDvByteRing(int capacityPowerOfTwo)
+    {
+        if (capacityPowerOfTwo <= 0 || (capacityPowerOfTwo & (capacityPowerOfTwo - 1)) != 0)
+            throw new ArgumentException("Capacity must be a positive power of two.", nameof(capacityPowerOfTwo));
+        _buffer = new byte[capacityPowerOfTwo];
+        _capacity = capacityPowerOfTwo;
+        _mask = capacityPowerOfTwo - 1;
+    }
+
+    /// <summary>Enqueue one byte; drop the oldest if full. Producer-side, no alloc.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void WriteByte(byte value)
+    {
+        long tail = _tail;
+        long head = Volatile.Read(ref _head);
+        if (tail - head >= _capacity)
+            Volatile.Write(ref _head, head + 1); // drop oldest to make room
+        _buffer[(int)(tail & _mask)] = value;
+        Volatile.Write(ref _tail, tail + 1);
+    }
+
+    /// <summary>Reads up to dst.Length bytes; returns the number read (0 on empty).</summary>
+    internal int Read(Span<byte> dst)
+    {
+        long head = _head;
+        long tail = Volatile.Read(ref _tail);
+        long avail = tail - head;
+        if (avail <= 0) return 0;
+        int n = dst.Length;
+        if (n > (int)avail) n = (int)avail;
+        for (int i = 0; i < n; i++)
+            dst[i] = _buffer[(int)((head + i) & _mask)];
+        Volatile.Write(ref _head, head + n);
+        return n;
+    }
+
+    /// <summary>Discards everything. Call only while quiesced (hot path gated out).</summary>
+    internal void Clear() => Volatile.Write(ref _head, Volatile.Read(ref _tail));
+}

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -3193,10 +3193,31 @@ public class DspPipelineService : BackgroundService,
         RaiseEngineChanged(synth);
     }
 
+    // FreeDV is a linear digital mode: the OFDM waveform must pass the TX chain
+    // undistorted and the decoder must see un-pumped RX audio. When Mode==FreeDv
+    // the apply-loop substitutes these spec profiles for the operator's stored
+    // values at the ENGINE seam only — the stores/StateDto keep the operator's
+    // real SSB settings, so leaving FreeDV restores the SSB chain automatically
+    // (the latches re-push the stored values once the effective config flips
+    // back). RX AGC goes Fixed so AGC pumping/clipping can't corrupt the modem
+    // audio fed to freedv_rx; Leveler + Compressor off and CFC off keep TX
+    // linear. ALC run-state is never touched (the engine keeps ALC on — the SSB
+    // modulator emits zero IQ with ALC off), so it still acts as a safety limiter.
+    // The Fixed AGC gain is seeded from the operator's own AGC-T baseline (the
+    // band-appropriate level they already receive at) rather than a blind
+    // constant, so the modem audio lands in a healthy range without pumping.
+    // Bench-tunable: if decode level proves off, this is the single knob.
+    private static readonly TxLevelingConfig FreeDvTxLevelingProfile =
+        new(LevelerEnabled: false, CompressorEnabled: false);
+
     private void OnRadioStateChanged(StateDto s)
     {
         lock (_engineLock)
         {
+        // FreeDV spec-profile override (see the AGC/TX-leveling/CFC pushes below):
+        // gates those engine pushes to linear-friendly values while the operator's
+        // stored config stays untouched for automatic restore on exit.
+        bool freeDvMode = s.Mode == RxMode.FreeDv;
         // Forward VFO changes to the P2 client when it's active. RadioService
         // does this for P1 via ActiveClient?.SetVfoAHz() inside SetVfo, but
         // ActiveClient is null for P2 connections, so the radio never learns
@@ -3404,7 +3425,9 @@ public class DspPipelineService : BackgroundService,
             ApplyDiversityConfig(diversity);
             _appliedDiversity = diversity;
         }
-        var agc = s.Agc ?? new AgcConfig(AgcMode.Med);
+        var agc = freeDvMode
+            ? new AgcConfig(AgcMode.Fixed, FixedGainDb: s.AgcTopDb)
+            : (s.Agc ?? new AgcConfig(AgcMode.Med));
         if (!agc.Equals(_appliedAgc))
         {
             engine.SetAgc(channel, agc);
@@ -3418,7 +3441,9 @@ public class DspPipelineService : BackgroundService,
             if (rx2Channel >= 0) engine.SetSquelch(rx2Channel, squelch);
             _appliedSquelch = squelch;
         }
-        var txLeveling = s.TxLeveling ?? new TxLevelingConfig();
+        var txLeveling = freeDvMode
+            ? FreeDvTxLevelingProfile
+            : (s.TxLeveling ?? new TxLevelingConfig());
         if (!txLeveling.Equals(_appliedTxLeveling))
         {
             engine.SetTxLeveling(channel, txLeveling);
@@ -3599,7 +3624,10 @@ public class DspPipelineService : BackgroundService,
         // Equals — but `record` only does reference equality on arrays, so
         // value-compare manually). null on the wire (legacy state frame)
         // falls back to CfcConfig.Default → engine sees a clean OFF profile.
-        var cfc = s.Cfc ?? CfcConfig.Default;
+        // FreeDV: force CFC off (transparent) so the multi-band compressor can't
+        // distort the OFDM. CfcConfig.Default is the all-zero / Enabled=false
+        // profile. Operator's stored CFC is untouched and restored on exit.
+        var cfc = freeDvMode ? CfcConfig.Default : (s.Cfc ?? CfcConfig.Default);
         if (resync || !CfcConfigsEqual(cfc, _appliedCfc))
         {
             engine.SetCfcConfig(cfc);

--- a/Zeus.Server.Hosting/FreeDvService.cs
+++ b/Zeus.Server.Hosting/FreeDvService.cs
@@ -53,6 +53,7 @@ public sealed class FreeDvService : IDisposable
         var fresh = new FreeDvModem(_loggerFactory.CreateLogger<FreeDvModem>());
         fresh.SetSubmode(_modem.Submode);
         fresh.SetSquelch(_modem.SquelchEnabled, _modem.SnrSquelchThreshDb);
+        fresh.SetTxText(_txText); // carry the operator's TX callsign/text across the swap
         var old = _modem;
         _modem = fresh;
         old.Dispose();
@@ -101,9 +102,9 @@ public sealed class FreeDvService : IDisposable
         SnrSquelchThreshDb: _modem.SnrSquelchThreshDb,
         SpeechSampleRateHz: _modem.SpeechSampleRateHz,
         ModemSampleRateHz: _modem.ModemSampleRateHz,
-        // RX text sidechannel (callsign etc.) decoding is a follow-up — it needs
-        // freedv_set_callback_txt wired through the modem. Reported as null for now.
-        RxText: null,
+        // RX text sidechannel (callsign etc.) decoded from the FreeDV txt stream
+        // via freedv_set_callback_txt; null until a full line has been received.
+        RxText: _modem.RxText,
         TxText: _txText,
         LibraryVersion: _modem.LibraryVersion);
 
@@ -112,7 +113,11 @@ public sealed class FreeDvService : IDisposable
         if (req.Submode.HasValue) _modem.SetSubmode(req.Submode.Value);
         if (req.SquelchEnabled.HasValue || req.SnrSquelchThreshDb.HasValue)
             _modem.SetSquelch(req.SquelchEnabled, req.SnrSquelchThreshDb);
-        if (req.TxText is not null) _txText = req.TxText;
+        if (req.TxText is not null)
+        {
+            _txText = req.TxText;
+            _modem.SetTxText(req.TxText); // push to the modem's TX varicode callback
+        }
         return Status();
     }
 

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -1646,6 +1646,16 @@ public sealed class RadioService : IDisposable
     private FamilyFilter _fmTxFilter = new(0, 3000);
     private FamilyFilter _cwTxFilter = new(475, 725);
 
+    // FreeDV runs USB underneath but is spec-locked to a tight bandpass around
+    // the 1500 Hz-centred modem — 700C/700D/700E, 1600 and 800XA all fit inside
+    // 300..2700 Hz. Kept in its own family slot (RX + TX) so entering/leaving
+    // FreeDV saves and restores the operator's SSB widths through the same
+    // mode-family memory every other mode uses, instead of stomping the shared
+    // SSB slot. Re-seeded to the FreeDV spec passband each session (not
+    // persisted) so the digital width can't silently drift across restarts.
+    private FamilyFilter _freeDvFilter = new(300, 2700);
+    private FamilyFilter _freeDvTxFilter = new(300, 2700);
+
     public StateDto SetMode(RxMode mode) => SetMode(mode, TxVfo.A);
 
     public StateDto SetMode(RxMode mode, TxVfo receiver)
@@ -1857,6 +1867,9 @@ public sealed class RadioService : IDisposable
                 if (targetB) _fmFilterB = slot; else _fmFilter = slot; break;
             case RxMode.CWL: case RxMode.CWU:
                 if (targetB) _cwFilterB = slot; else _cwFilter = slot; break;
+            case RxMode.FreeDv:
+                // FreeDV shares one spec slot across VFOs (no per-VFO digital width).
+                _freeDvFilter = slot; break;
         }
     }
 
@@ -1873,6 +1886,8 @@ public sealed class RadioService : IDisposable
                 _fmTxFilter = slot; break;
             case RxMode.CWL: case RxMode.CWU:
                 _cwTxFilter = slot; break;
+            case RxMode.FreeDv:
+                _freeDvTxFilter = slot; break;
         }
     }
 
@@ -1882,6 +1897,7 @@ public sealed class RadioService : IDisposable
         RxMode.AM or RxMode.SAM or RxMode.DSB => _amTxFilter,
         RxMode.FM => _fmTxFilter,
         RxMode.CWL or RxMode.CWU => _cwTxFilter,
+        RxMode.FreeDv => _freeDvTxFilter,
         _ => _ssbTxFilter,
     };
 
@@ -1891,6 +1907,7 @@ public sealed class RadioService : IDisposable
         RxMode.AM or RxMode.SAM or RxMode.DSB => _amFilter,
         RxMode.FM => _fmFilter,
         RxMode.CWL or RxMode.CWU => _cwFilter,
+        RxMode.FreeDv => _freeDvFilter,
         _ => _ssbFilter,
     };
 
@@ -1905,6 +1922,7 @@ public sealed class RadioService : IDisposable
             RxMode.AM or RxMode.SAM or RxMode.DSB => _amFilterB,
             RxMode.FM => _fmFilterB,
             RxMode.CWL or RxMode.CWU => _cwFilterB,
+            RxMode.FreeDv => _freeDvFilter,
             _ => _ssbFilterB,
         };
     }

--- a/tests/Zeus.Dsp.FreeDv.Tests/FreeDvLoopbackTests.cs
+++ b/tests/Zeus.Dsp.FreeDv.Tests/FreeDvLoopbackTests.cs
@@ -73,6 +73,51 @@ public class FreeDvLoopbackTests
     }
 
     [SkippableFact]
+    public void NativeLoopback_TextSidechannel_RoundTrips()
+    {
+        using var tx = new FreeDvModem();
+        Skip.IfNot(tx.NativeAvailable, "codec2 native library not present — text loopback skipped.");
+        using var rx = new FreeDvModem();
+
+        tx.SetSubmode(FreeDvSubmode.Mode700D);
+        rx.SetSubmode(FreeDvSubmode.Mode700D);
+        rx.SetSquelch(enabled: false, threshDb: null);
+        tx.Activate();
+        rx.Activate();
+        tx.SetTxText("N9WAR");
+
+        const int blockSize = 960;   // 20 ms @ 48 kHz
+        // The txt channel is very low rate (a few bits per OFDM frame), so allow a
+        // generous window for sync acquisition + one full "N9WAR\r" to arrive.
+        const int txBlocks = 2500;   // ~50 s of transmit; the RX loop breaks early
+
+        var modemAudio = new List<float>(txBlocks * blockSize);
+        var block = new float[blockSize];
+        for (int b = 0; b < txBlocks; b++)
+        {
+            FillSpeechLike(block, b);
+            tx.ProcessTxInPlace(block);
+            modemAudio.AddRange(block);
+        }
+
+        string? rxText = null;
+        var rxBlock = new float[blockSize];
+        int total = modemAudio.Count;
+        for (int i = 0; i + blockSize <= total; i += blockSize)
+        {
+            modemAudio.CopyTo(i, rxBlock, 0, blockSize);
+            rx.ProcessRxInPlace(rxBlock);
+            rxText = rx.RxText;
+            if (rxText is not null && rxText.Contains("N9WAR")) break;
+        }
+
+        Assert.True(
+            rxText is not null && rxText.Contains("N9WAR"),
+            $"FreeDV text sidechannel did not round-trip 'N9WAR' (got: '{rxText ?? "<null>"}'). " +
+            "The freedv_set_callback_txt TX/RX wiring or varicode path is broken.");
+    }
+
+    [SkippableFact]
     public void NativeModem_ReportsExpectedSampleRates()
     {
         using var m = new FreeDvModem();

--- a/tests/Zeus.Server.Tests/RadioServiceFreeDvFilterTests.cs
+++ b/tests/Zeus.Server.Tests/RadioServiceFreeDvFilterTests.cs
@@ -1,0 +1,90 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// FreeDV is a linear digital mode spec-locked to a tight bandpass (300..2700 Hz,
+/// USB) around the 1500 Hz-centred modem. It must NOT inherit the shared SSB
+/// filter slot — entering FreeDV applies the spec passband and leaving it restores
+/// the operator's SSB widths via the same mode-family memory every other mode uses.
+/// </summary>
+public sealed class RadioServiceFreeDvFilterTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-freedv-filter-{Guid.NewGuid():N}.db");
+    private readonly PaSettingsStore _paStore;
+    private readonly DspSettingsStore _dspStore;
+
+    public RadioServiceFreeDvFilterTests()
+    {
+        _paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance, _dbPath + ".pa");
+        _dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance, _dbPath + ".dsp");
+    }
+
+    public void Dispose()
+    {
+        _paStore.Dispose();
+        _dspStore.Dispose();
+        foreach (var suffix in new[] { "", ".pa", ".dsp" })
+        {
+            try { if (File.Exists(_dbPath + suffix)) File.Delete(_dbPath + suffix); } catch { }
+        }
+    }
+
+    private RadioService BuildRadio() =>
+        new(NullLoggerFactory.Instance, _dspStore, _paStore);
+
+    [Fact]
+    public void SetMode_FreeDv_AppliesSpecBandpassToRxAndTx()
+    {
+        using var radio = BuildRadio();
+        radio.SetMode(RxMode.USB);
+
+        var after = radio.SetMode(RxMode.FreeDv);
+
+        Assert.Equal(RxMode.FreeDv, after.Mode);
+        // USB-signed positive spec passband on both RX and TX.
+        Assert.Equal(300, after.FilterLowHz);
+        Assert.Equal(2700, after.FilterHighHz);
+        Assert.Equal(300, after.TxFilterLowHz);
+        Assert.Equal(2700, after.TxFilterHighHz);
+    }
+
+    [Fact]
+    public void SetMode_LeavingFreeDv_RestoresOperatorSsbWidths()
+    {
+        using var radio = BuildRadio();
+        radio.SetMode(RxMode.USB);
+        // Operator picks a non-default SSB RX + TX width.
+        radio.SetFilter(100, 3000, "VAR1");
+        radio.SetTxFilter(120, 2900);
+
+        radio.SetMode(RxMode.FreeDv);
+        var back = radio.SetMode(RxMode.USB);
+
+        Assert.Equal(RxMode.USB, back.Mode);
+        Assert.Equal(100, back.FilterLowHz);
+        Assert.Equal(3000, back.FilterHighHz);
+        Assert.Equal(120, back.TxFilterLowHz);
+        Assert.Equal(2900, back.TxFilterHighHz);
+    }
+
+    [Fact]
+    public void SetMode_FreeDv_DoesNotStompSharedSsbSlot()
+    {
+        using var radio = BuildRadio();
+        radio.SetMode(RxMode.USB);
+        radio.SetFilter(150, 2850, "VAR1");
+
+        // Round-trip USB -> FreeDV -> DIGU. DIGU shares the SSB slot, so if FreeDV
+        // had written its 300/2700 into the SSB slot, DIGU would inherit it.
+        radio.SetMode(RxMode.FreeDv);
+        var digu = radio.SetMode(RxMode.DIGU);
+
+        // DIGU is USB-family; SignedFilterForMode zeroes the low edge for DIGU.
+        Assert.Equal(RxMode.DIGU, digu.Mode);
+        Assert.Equal(2850, digu.FilterHighHz);
+    }
+}


### PR DESCRIPTION
## Why

FreeDV mode inherited the generic SSB chain, so the OFDM waveform was run through the SSB voice processing (Leveler/CFC/ALC compression) on TX, and the decoder was fed AGC-pumped audio on RX — and the text sidechannel was never actually wired (TX text stored but not sent; RX text hardcoded `null`). This made FreeDV non-spec on the air and unable to surface callsign text.

## What

**Spec DSP profile (applied while `Mode == FreeDv`, auto-restored on exit):**
- TX/RX bandpass locked to **300–2700 Hz** via dedicated FreeDV filter slots. The operator's SSB widths are saved on enter and restored on exit through the existing per-mode-family memory — stored prefs are never clobbered.
- TX kept **linear**: Leveler, Compressor and CFC bypassed (ALC run-state untouched so it still acts as a limiter).
- RX AGC forced to **Fixed** (seeded from the operator's AGC-T baseline) so AGC pumping/clipping can't corrupt the modem audio handed to `freedv_rx`.
- Processing/AGC overrides apply at the **engine seam only** — the stores/StateDto keep the operator's real values, so leaving FreeDV restores the SSB chain automatically.

**Text sidechannel (now functional both directions):**
- TX callsign/text is transmitted via `freedv_set_callback_txt`; RX text is decoded and reported (`RxText` was hardcoded `null`).
- Decoded chars cross the hot path via a lock-free byte ring; callbacks are allocation-free and the delegates are pinned for the modem lifetime.
- The existing FreeDV panel (TX input auto-seeded from QRZ, RX text display) surfaces both with **no frontend change**.

## Testing

- **Native end-to-end loopback** (`Zeus.Dsp.FreeDv.Tests`): new `NativeLoopback_TextSidechannel_RoundTrips` proves a TX→RX text round-trip ("N9WAR") through the real codec2 modem; existing 700D/700E sync loopback still passes.
- New `RadioServiceFreeDvFilterTests` covers FreeDV bandpass apply + SSB save/restore + no shared-slot stomp.
- Full FreeDV suite (24 passed / 1 skipped) and server FreeDV + filter + mode + sideband tests (33 passed) green. Builds clean.

## Out of scope

**2020 / 2020B (LPCNet neural) modes** are intentionally not included — they require vendoring LPCNet + neural weights into the native codec2 build, which conflicts with the deliberate no-LPCNet / cross-platform (arm64 / Raspberry Pi) constraint. Worth a separate, scoped effort.

## Bench note

On-air decode still benefits from a real two-station confirmation (key a matched 700D exchange). The Fixed AGC gain is a single bench-tunable knob (commented in `DspPipelineService`) if RX levels need nudging.
