### PR TITLE
feat(ports): external port parity audit — Thetis + HL2/mi0bot alignment

### DIFF
--- a/Zeus.Contracts/BoardCapabilities.cs
+++ b/Zeus.Contracts/BoardCapabilities.cs
@@ -125,13 +125,19 @@ public sealed record BoardCapabilities(
     /// board.</summary>
     bool SupportsAnvelinaDxOc = false,
     // ---- External antenna ports (external-ports plan — antenna slice, #804) --
-    /// <summary>True when the board has switchable TX antenna relays
-    /// (ANT1/2/3) — the 0x0A / Saturn OrionMkII family (G2 / G2-1K / 7000DLE /
-    /// 8000DLE / Apache OrionMkII original / ANVELINA-PRO3 / Red Pitaya), which
-    /// emit the alex0[26:24] TX-antenna bits over Protocol 2. Every other board
-    /// is ANT1-hardwired on transmit. The frontend gates the TX-antenna selector
-    /// on this flag; the server returns 409 to a non-ANT1 TX request when it is
-    /// false. External-ports plan — antenna slice (issue #804).</summary>
+    /// <summary>True when the board has switchable TX antenna relays (ANT1/2/3).
+    /// Two wire paths: the 0x0A / Saturn OrionMkII family (G2 / G2-1K / 7000DLE /
+    /// 8000DLE / Apache OrionMkII original / ANVELINA-PRO3 / Red Pitaya) emit the
+    /// alex0[26:24] TX-antenna bits over Protocol 2; the full-Alex dual-ADC ANAN
+    /// boards (ANAN-100D / ANAN-200D) emit them over Protocol 1 on Config-frame
+    /// C4[1:0] (Thetis networkproto1.c:463-468; external-port parity audit,
+    /// GAP-P1-1). Every other board is ANT1-hardwired on transmit (Hermes / Metis
+    /// / ANAN-10 / ANAN-10E — no full Alex; ANAN-G2E — hardwired; Hermes-Lite 2 —
+    /// single jack). The frontend gates the TX-antenna selector on this flag; the
+    /// server returns 409 to a non-ANT1 TX request when it is false. The P1 wire
+    /// encode + clamp live in ControlFrame.EncodeTxAntennaC4Bits /
+    /// P1BoardHasTxAntennaRelays, which MUST stay in step with the per-board
+    /// values here. External-ports plan — antenna slice (issue #804).</summary>
     bool HasTxAntennaRelays = false,
     /// <summary>True when the board has switchable RX antenna relays (ANT1/2/3).
     /// Every ANAN / Hermes-class Protocol-1 board does (RX-antenna rides
@@ -183,7 +189,16 @@ public sealed record BoardCapabilities(
     /// jack. Do NOT derive this from <see cref="HasAudioAmplifier"/>. mic_bias
     /// defaults OFF (a floating connector with bias can hang PTT). True for
     /// 100D/200D/7000DLE/8000DLE/G2/G2-1K.</summary>
-    bool HasMicBias = false)
+    bool HasMicBias = false,
+    /// <summary>Hermes-Lite 2 exposes a 4-bit user GPIO (<c>user_dig_out</c>)
+    /// on the IO/DB9 connector, driven over the Protocol-1 register 0x0a
+    /// (wire 0x14) frame C3[3:0] → MCP23008 (Thetis-mi0bot
+    /// <c>networkproto1.c</c> case 11; ramdor Thetis identical). The frontend
+    /// gates the User-GPIO card and the <c>/api/radio/hl2-gpio</c> endpoint
+    /// returns 409 on a non-HL2 board. True for Hermes-Lite 2 only. Default 0 →
+    /// byte-identical to a board that never drives the lines. External-port
+    /// parity audit (re-port of external-ports plan Phase 5).</summary>
+    bool HasHl2UserGpio = false)
 {
     /// <summary>Safe defaults for an unrecognised / disconnected board.
     /// Single ADC, no extras — minimum-surprise capability set so a

--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -1946,6 +1946,17 @@ public sealed record Hl2OptionsDto(bool BandVolts);
 // (e.g. PUT becoming a partial update with nullable fields).
 public sealed record Hl2OptionsSetRequest(bool BandVolts);
 
+// HL2 user GPIO (external-port parity audit — re-port of external-ports plan
+// Phase 5). The 4-bit user_dig_out mask driven on the Protocol-1 0x0a/wire-0x14
+// frame C3[3:0] → MCP23008 on the HL2 IO connector. Supported is true only on a
+// connected Hermes-Lite 2 (HasHl2UserGpio); the frontend gates the User-GPIO
+// card on it. Bits is the low nibble (0..15).
+public sealed record Hl2GpioDto(bool Supported, int Bits);
+
+// PUT body for /api/radio/hl2-gpio — sets the 4-bit user_dig_out mask. Only the
+// low nibble is honoured; the server 409s on a board without HasHl2UserGpio.
+public sealed record Hl2GpioSetRequest(int Bits);
+
 // ANAN-G2 / Saturn-class ADC options surfaced via /api/radio/g2-options.
 // Dither and randomizer default on, matching the Thetis G2 option block.
 // MaxRxFreqMHz is read-only: Zeus enforces the same 0..60 MHz ceiling in

--- a/Zeus.Protocol1/ControlFrame.cs
+++ b/Zeus.Protocol1/ControlFrame.cs
@@ -281,7 +281,22 @@ internal static class ControlFrame
         // protocol doc ("Tune request: ... initiate an ATU tune"). Held by the
         // client for the tune duration then auto-cleared. Default false →
         // byte-identical to today on every board.
-        bool AtuTune = false);
+        bool AtuTune = false,
+        // TX antenna relay select — Config-frame C4[1:0] (external-port parity
+        // audit, GAP-P1-1). Thetis networkproto1.c:463-468 case 0: ANT3 → 0b10,
+        // ANT2 → 0b01, ANT1 → 0b00. The HpsdrAntenna enum value (Ant1=0/Ant2=1/
+        // Ant3=2) IS the 2-bit wire selector. Honoured ONLY on P1 boards with
+        // full Alex TX relays (P1BoardHasTxAntennaRelays — ANAN-100D/200D); every
+        // other P1 board is ANT1-hardwired on transmit and the encoder clamps to
+        // 0. Default Ant1 → C4[1:0]=0, byte-identical to before this audit.
+        HpsdrAntenna TxAntenna = HpsdrAntenna.Ant1,
+        // HL2 user GPIO (external-ports plan, Phase 5; re-ported in the external-
+        // port parity audit). The 4-bit user_dig_out mask lands in C3[3:0] of the
+        // 0x0a / wire-0x14 frame → MCP23008 on the HL2 IO connector. Verified
+        // Thetis-mi0bot networkproto1.c case 11 (`C3 = prn->user_dig_out & 0x0F`);
+        // ramdor Thetis identical. HL2 only — gated at the wire layer. Default 0
+        // → byte-identical to today (the 0x14 frame's C3 was previously 0).
+        byte UserDigOut = 0);
 
     /// <summary>
     /// Write the 5 C&amp;C bytes for <paramref name="register"/> given the current
@@ -415,15 +430,20 @@ internal static class ControlFrame
         // verified layout (Thetis networkproto1.c:597-599 case 11; identical in
         // mi0bot):
         //   C1[4] = mic_trs, C1[5] = mic_bias, C1[6] = mic_ptt
-        //   C2[4:0] = line_in_gain, C2[6] = puresignal_run
-        // We READ-MODIFY-WRITE: set ONLY the audio bits, leaving the C4 PGA /
-        // step-attenuator byte (already in c14[3]) and the C2[6] PS bit (set
-        // below) untouched. mic_ptt is a PTT-IN concern, not this feature, so
-        // C1[6] is intentionally left 0 — same as today. mic_bias (C1[5])
-        // defaults OFF: enabling it on a floating connector can hang PTT, so the
-        // operator must opt in explicitly via the audio panel. At defaults
-        // (mic_trs/mic_bias off, line_in_gain 0) every byte is unchanged, so
-        // this block is byte-identical to today on HL2.
+        //   C2[4:0] = line_in_gain, C2[6] = puresignal_run, C3[3:0] = user_dig_out
+        // SINGLE-PASS COMPOSE — this method is the SOLE owner of the 0x0a register
+        // frame, so every co-tenant bit must be (re)asserted here each tick: the
+        // C4 PGA / step-attenuator byte (already in c14[3]), the C2[6] PS bit (set
+        // below), the C2[4:0] line-in gain, and (HL2) the C3[3:0] user GPIO. The
+        // frame is rebuilt from a freshly-cleared span every pass — it is NOT a
+        // hardware-readback read-modify-write (mi0bot composes the same way). If a
+        // future writer ever sets one field here, it must keep asserting all the
+        // others or it will clobber them. mic_ptt is a PTT-IN concern, not this
+        // feature, so C1[6] is intentionally left 0 — same as today. mic_bias
+        // (C1[5]) defaults OFF: enabling it on a floating connector can hang PTT,
+        // so the operator must opt in explicitly. At defaults (mic_trs/mic_bias
+        // off, line_in_gain 0, GPIO 0) every byte is unchanged → byte-identical to
+        // today on HL2.
         if (s.Board == HpsdrBoardKind.HermesLite2)
         {
             byte c1 = 0;
@@ -433,6 +453,11 @@ internal static class ControlFrame
             // line_in_gain is the low 5 bits of C2; OR it in so the PS bit
             // (set below) and the reserved high bits stay clear.
             c14[1] |= (byte)(s.LineInGain & 0x1F);
+            // HL2 user GPIO: 4-bit user_dig_out → C3[3:0] (MCP23008 on the IO
+            // connector). Thetis-mi0bot networkproto1.c case 11; ramdor identical.
+            // Default 0 → byte-identical (C3 was 0 before this re-port). HL2-only;
+            // RadioService gates the mask behind HasHl2UserGpio.
+            c14[2] |= (byte)(s.UserDigOut & 0x0F);
         }
 
         // ANAN-10E line-in (HermesII, issue #667). The 10E TLV320 codec carries
@@ -447,6 +472,21 @@ internal static class ControlFrame
         if (s.Board == HpsdrBoardKind.HermesII)
         {
             c14[1] |= (byte)(s.LineInGain & 0x1F);
+        }
+
+        // ANAN codec mic_bias (external-port parity audit, GAP-AUD-1). Thetis
+        // networkproto1.c case 11 (C0=0x14) is board-agnostic: C1[5] = mic_bias
+        // for every codec board, yet the re-port only wired the bit for HL2 above
+        // — so ANAN-100D/200D advertised HasMicBias but could never enable it
+        // (the electret bias supply stayed off). RadioService.ClampAudioSource
+        // gates s.MicBias to boards with HasMicBias (on P1: ANAN-100D/200D) AND
+        // to the RadioMic/XLR source, so at the default (Host / bias off) this is
+        // byte-identical to today. HL2 sets C1[5] in its own block above; this
+        // covers the non-HL2 codec boards. mic_trs/mic_ptt stay 0 on ANAN (no
+        // tip-ring jack split), matching today.
+        if (s.Board != HpsdrBoardKind.HermesLite2 && s.MicBias)
+        {
+            c14[0] |= 1 << 5;   // C1[5] mic_bias
         }
 
         // HL2 PureSignal: register 0x0a bit 22 = puresignal_run. Bit 22 lives
@@ -589,13 +629,21 @@ internal static class ControlFrame
         c3 |= EncodeRxAntennaC3Bits(s.RxAntenna, s.Board);
         c14[2] = c3;
 
-        // C4: Alex TX antenna [1:0] = 0 (RX-only MVP), duplex [2] = 1 (always, per
+        // C4: Alex TX antenna [1:0], duplex [2] = 1 (always, per
         // old_protocol.c:2661), N-1 receivers at [5:3]. mi0bot
         // networkproto1.c:973 — `C4 |= (nddc - 1) << 3`. Single-RX default
         // is 0; HL2 PS armed bumps to 1 (= 2 receivers, paired DDC0/DDC1
         // layout). Capped at 7 by the 3-bit field.
         byte c4 = 1 << 2;
         c4 |= (byte)((s.NumReceiversMinusOne & 0x07) << 3);
+        // TX antenna relay select C4[1:0] (external-port parity audit, GAP-P1-1).
+        // Thetis networkproto1.c:463-468 case 0: ANT3 → 0b10, ANT2 → 0b01, ANT1 →
+        // 0b00. Only emitted on P1 boards with full Alex TX relays (ANAN-100D/
+        // 200D); EncodeTxAntennaC4Bits clamps every other board to ANT1 so a stale
+        // per-band ANT2/3 (band rows are board-agnostic) can never reroute the
+        // transmitter on a board that is ANT1-hardwired on transmit. Default Ant1
+        // → 0 → byte-identical to before this audit.
+        c4 |= EncodeTxAntennaC4Bits(s.TxAntenna, s.Board);
         c14[3] = c4;
     }
 
@@ -634,6 +682,44 @@ internal static class ControlFrame
     /// </summary>
     internal static bool P1BoardHasRxAntennaRelays(HpsdrBoardKind board) =>
         board != HpsdrBoardKind.HermesLite2;
+
+    /// <summary>
+    /// Encode the Config-frame TX-antenna relay bits (C4[1:0]) for the given
+    /// board (external-port parity audit — GAP-P1-1). Thetis networkproto1.c
+    /// case 0 (lines 463-468): ANT3 → 0b10, ANT2 → 0b01, ANT1 → 0b00. The
+    /// <see cref="HpsdrAntenna"/> enum value (Ant1=0/Ant2=1/Ant3=2) IS the 2-bit
+    /// wire selector, so the byte is just the masked enum. Single source of the
+    /// C4[1:0] math, shared by the wire path (WriteConfigPayload) and the
+    /// external-port encoder seam so the two are byte-identical by construction.
+    ///
+    /// WIRE-LAYER CLAMP: a P1 board WITHOUT full Alex TX relays
+    /// (<see cref="P1BoardHasTxAntennaRelays"/> false — every board except
+    /// ANAN-100D/200D) is forced to ANT1 here, so a stale per-band ANT2/3 can
+    /// never reroute the transmitter on a board that is ANT1-hardwired on
+    /// transmit. This is the wire layer of the same UI-gate / REST-409 / wire-
+    /// clamp defence the RX-antenna path uses; it holds even if an upstream layer
+    /// is bypassed. Relay-capable boards emit the raw selection — byte-identical
+    /// to before this audit at the default-ANT1, so the goldens stay green.
+    /// </summary>
+    internal static byte EncodeTxAntennaC4Bits(HpsdrAntenna txAntenna, HpsdrBoardKind board)
+    {
+        if (!P1BoardHasTxAntennaRelays(board)) return 0;
+        return (byte)((byte)txAntenna & 0x03);
+    }
+
+    /// <summary>
+    /// Whether a Protocol-1 board has switchable full-Alex TX-antenna relays
+    /// (ANT1/2/3 on Config-frame C4[1:0]). Mirrors the P1 subset of
+    /// <c>BoardCapabilities.HasTxAntennaRelays</c>: the full-Alex dual-ADC ANAN
+    /// boards (ANAN-100D / ANAN-200D = <see cref="HpsdrBoardKind.Angelia"/> /
+    /// <see cref="HpsdrBoardKind.Orion"/>). Hermes / Metis / ANAN-10 / ANAN-10E
+    /// (no full Alex), ANAN-G2E (ANT1-hardwired on TX) and Hermes-Lite 2 (single
+    /// jack) are ANT1-only on transmit. Kept local to the protocol assembly so the
+    /// wire-layer clamp needs no reference to Zeus.Server.Hosting; it MUST stay in
+    /// step with the BoardCapabilitiesTable HasTxAntennaRelays entries for P1.
+    /// </summary>
+    internal static bool P1BoardHasTxAntennaRelays(HpsdrBoardKind board) =>
+        board is HpsdrBoardKind.Angelia or HpsdrBoardKind.Orion;
 
     /// <summary>
     /// Build a complete 1032-byte Metis data frame with two USB frames carrying

--- a/Zeus.Protocol1/IProtocol1Client.cs
+++ b/Zeus.Protocol1/IProtocol1Client.cs
@@ -82,6 +82,14 @@ public interface IProtocol1Client : IDisposable
     void SetPreamp(bool on);
     void SetAttenuator(HpsdrAtten atten);
     void SetAntennaRx(HpsdrAntenna ant);
+    /// <summary>
+    /// Select the TX antenna relay (ANT1/2/3) — Config-frame C4[1:0], external-
+    /// port parity audit (GAP-P1-1). Deferred while keyed and applied on the
+    /// unkey edge (no hot-switching the Alex matrix under power). Honoured on the
+    /// wire only for P1 boards with full Alex TX relays (ANAN-100D/200D); clamped
+    /// to ANT1 elsewhere by <c>ControlFrame.EncodeTxAntennaC4Bits</c>.
+    /// </summary>
+    void SetAntennaTx(HpsdrAntenna ant);
 
     /// <summary>
     /// Flip the outgoing C&amp;C MOX bit (C0 LSB on every register). Read from
@@ -272,6 +280,14 @@ public interface IProtocol1Client : IDisposable
     /// (floating-connector PTT-hang guard).
     /// </summary>
     void SetAudioFrontEnd(bool micBoost, bool micLineIn, bool micTrs, bool micBias, int lineInGain);
+
+    /// <summary>
+    /// Set the HL2 4-bit user GPIO mask (user_dig_out → C3[3:0] of the 0x14
+    /// frame; external-ports plan, Phase 5 / external-port parity audit). Low
+    /// nibble only; HL2-only on the wire. RadioService gates this behind the
+    /// HasHl2UserGpio capability so it never reaches a non-HL2 board.
+    /// </summary>
+    void SetUserDigOut(int mask);
 
     /// <summary>
     /// 1024-sample paired feedback blocks decoded from the EP6 stream when

--- a/Zeus.Protocol1/Protocol1Client.cs
+++ b/Zeus.Protocol1/Protocol1Client.cs
@@ -94,6 +94,17 @@ public sealed class Protocol1Client : IProtocol1Client
     // desired antenna here (-1 = nothing pending) instead of mutating the live
     // _antenna; it is flushed on the unkey edge in SetMox(false). -1 = none.
     private int _pendingAntenna = -1;
+    // TX-antenna relay select (Config-frame C4[1:0]) — external-port parity audit
+    // (GAP-P1-1). Same MOX-deferred discipline as the RX antenna: while keyed the
+    // desired TX antenna is stashed in _pendingTxAntenna and applied on the unkey
+    // edge so the Alex relay matrix never hot-switches under power. Default ANT1.
+    private int _txAntenna = (int)HpsdrAntenna.Ant1;
+    private int _pendingTxAntenna = -1;
+    // HL2 user GPIO 4-bit user_dig_out mask (external-ports plan, Phase 5; re-
+    // ported in the external-port parity audit). Rides C3[3:0] of the 0x14 frame
+    // on HL2. Default 0 → byte-identical. RadioService gates this behind the
+    // HasHl2UserGpio capability so it never reaches a non-HL2 board.
+    private int _userDigOut;   // 0..15
     // HL2 Band Volts PWM enable. Wire encoding is C3 bit 3 of the Config
     // frame — same bit that legacy HPSDR boards used for ADC DITHER, which
     // HL2's AD9866 doesn't need (see hermes-lite2-protocol.md line 39 and
@@ -646,6 +657,26 @@ public sealed class Protocol1Client : IProtocol1Client
         }
         Interlocked.Exchange(ref _antenna, (int)ant);
     }
+
+    /// <summary>
+    /// Select the TX antenna relay (ANT1/2/3) — Config-frame C4[1:0], external-
+    /// port parity audit (GAP-P1-1). SAFETY: like <see cref="SetAntennaRx"/>, the
+    /// Alex/relay matrix must not be hot-switched while keyed, so the selection is
+    /// stashed into <see cref="_pendingTxAntenna"/> during MOX and applied on the
+    /// unkey edge in <see cref="SetMox"/>(false). At idle it is applied
+    /// immediately. The wire-layer clamp (force ANT1 on boards without full Alex
+    /// TX relays) lives in <c>ControlFrame.EncodeTxAntennaC4Bits</c>, so this
+    /// method stores the raw selection on every board.
+    /// </summary>
+    public void SetAntennaTx(HpsdrAntenna ant)
+    {
+        if (Volatile.Read(ref _mox) != 0)
+        {
+            Interlocked.Exchange(ref _pendingTxAntenna, (int)ant);
+            return;
+        }
+        Interlocked.Exchange(ref _txAntenna, (int)ant);
+    }
     public void SetBoardKind(HpsdrBoardKind board) => Interlocked.Exchange(ref _boardKind, (int)board);
 
     public HpsdrBoardKind BoardKind => (HpsdrBoardKind)Volatile.Read(ref _boardKind);
@@ -660,6 +691,11 @@ public sealed class Protocol1Client : IProtocol1Client
         {
             int pending = Interlocked.Exchange(ref _pendingAntenna, -1);
             if (pending >= 0) Interlocked.Exchange(ref _antenna, pending);
+            // Apply any TX-antenna change deferred while keyed (GAP-P1-1) on the
+            // same unkey edge so the relay matrix switches at idle, never under
+            // power.
+            int pendingTx = Interlocked.Exchange(ref _pendingTxAntenna, -1);
+            if (pendingTx >= 0) Interlocked.Exchange(ref _txAntenna, pendingTx);
         }
     }
     public void SetDrive(int percent) =>
@@ -750,6 +786,16 @@ public sealed class Protocol1Client : IProtocol1Client
         Interlocked.Exchange(ref _lineInGain, Math.Clamp(lineInGain, 0, 31));
     }
 
+    /// <summary>
+    /// Set the HL2 4-bit user GPIO mask (user_dig_out → C3[3:0] of the 0x14
+    /// frame; external-ports plan, Phase 5 / external-port parity audit). Low
+    /// nibble only. HL2-only on the wire (RadioService gates it behind
+    /// HasHl2UserGpio); a value pushed to a non-HL2 client never reaches the wire
+    /// because ControlFrame only writes C3[3:0] for HermesLite2.
+    /// </summary>
+    public void SetUserDigOut(int mask) =>
+        Interlocked.Exchange(ref _userDigOut, mask & 0x0F);
+
     public void SetHl2TxStepAttenuationDb(int db)
     {
         // Range matches mi0bot console.cs:2084 (udTXStepAttData.Minimum=-28,
@@ -834,7 +880,9 @@ public sealed class Protocol1Client : IProtocol1Client
             MicTrs: Volatile.Read(ref _micTrs) != 0,
             MicBias: Volatile.Read(ref _micBias) != 0,
             LineInGain: (byte)Volatile.Read(ref _lineInGain),
-            AtuTune: Volatile.Read(ref _atuTuneUntilTicks) > Environment.TickCount64);
+            AtuTune: Volatile.Read(ref _atuTuneUntilTicks) > Environment.TickCount64,
+            TxAntenna: (HpsdrAntenna)Volatile.Read(ref _txAntenna),
+            UserDigOut: (byte)Volatile.Read(ref _userDigOut));
     }
 
     private void RxLoop()

--- a/Zeus.Server.Hosting/BoardCapabilitiesTable.cs
+++ b/Zeus.Server.Hosting/BoardCapabilitiesTable.cs
@@ -165,8 +165,13 @@ internal static class BoardCapabilitiesTable
         HasSteppedAttenuationRx2: true,
         SupportsPathIllustrator: true,
         MaxPowerWatts: 120,
-        // Dual-ADC DDC board: RX-antenna relays + full aux set + a dedicated RX2
-        // antenna path — antenna slice (#804). P1, so no TX-antenna relay.
+        // Dual-ADC DDC board: full Alex — TX + RX antenna relays, full aux set,
+        // and a dedicated RX2 antenna path — antenna slice (#804). The ANAN-100D
+        // runs Protocol 1, where the Alex TX antenna rides Config-frame C4[1:0]
+        // (Thetis networkproto1.c:463-468); the wire-layer encode + clamp live in
+        // ControlFrame.EncodeTxAntennaC4Bits / P1BoardHasTxAntennaRelays (external-
+        // port parity audit, GAP-P1-1). Default ANT1 → byte-identical.
+        HasTxAntennaRelays: true,
         HasRxAntennaRelays: true,
         RxAuxInputs: RxAuxInputs.All,
         HasRx2AntennaPath: true,
@@ -188,6 +193,11 @@ internal static class BoardCapabilitiesTable
         HasSteppedAttenuationRx2: true,
         SupportsPathIllustrator: true,
         MaxPowerWatts: 120,
+        // Full-Alex dual-ADC P1 board: TX antenna relay (Config-frame C4[1:0],
+        // Thetis networkproto1.c:463-468) + RX relays + full aux + RX2 path —
+        // antenna slice (#804) / external-port parity audit (GAP-P1-1). Default
+        // ANT1 → byte-identical.
+        HasTxAntennaRelays: true,
         HasRxAntennaRelays: true,
         RxAuxInputs: RxAuxInputs.All,
         HasRx2AntennaPath: true,
@@ -340,6 +350,11 @@ internal static class BoardCapabilitiesTable
         SupportsPathIllustrator: false,
         MaxPowerWatts: 10,
         HasHl2OptionalToggles: true,
+        // HL2 4-bit user GPIO (user_dig_out → 0x0a/wire-0x14 C3[3:0] → MCP23008
+        // on the IO connector). HL2-only; gates the Radio Settings "User GPIO"
+        // card + the /api/radio/hl2-gpio endpoint. External-port parity audit
+        // (re-port of external-ports plan Phase 5). Default mask 0.
+        HasHl2UserGpio: true,
         // HL2 has a SINGLE antenna jack forwarding to the N2ADR pad: NO RX
         // antenna relays, NO TX antenna relays, NO aux inputs — antenna slice
         // (#804). Explicit (not just defaulted) because the wire-layer clamp in

--- a/Zeus.Server.Hosting/ExternalPortEncoder.cs
+++ b/Zeus.Server.Hosting/ExternalPortEncoder.cs
@@ -15,13 +15,14 @@
 // one board-branched / protocol-branched encoder instead of scattered bit
 // literals in the emission code:
 //
-//   ANTENNA — RX-antenna select (P1 C3[7:5]) and TX-antenna select
-//   (P2 alex0[26:24]). The encoders delegate to the very same pure helpers the
-//   wire path already uses (ControlFrame.EncodeRxAntennaC3Bits on P1;
-//   Protocol2Client.EncodeTxAntennaBits on P2), so the bits are byte-identical
-//   to the wire path for every supported board. The per-board wire-layer clamp
-//   (force ANT1 on relay-less boards) lives in the shared P1 helper itself
-//   (HL2 single-jack case).
+//   ANTENNA — RX-antenna select (P1 C3[7:5]), P1 TX-antenna select (Config
+//   C4[1:0], full-Alex ANAN-100D/200D — external-port parity audit GAP-P1-1),
+//   and P2 TX-antenna select (alex0[26:24]). The encoders delegate to the very
+//   same pure helpers the wire path already uses (ControlFrame.EncodeRxAntennaC3Bits
+//   / EncodeTxAntennaC4Bits on P1; Protocol2Client.EncodeTxAntennaBits on P2), so
+//   the bits are byte-identical to the wire path for every supported board. The
+//   per-board wire-layer clamp (force ANT1 on relay-less boards) lives in the
+//   shared P1 helpers themselves (HL2 single-jack case; non-full-Alex TX case).
 //
 //   TX AUDIO — P2 TxSpecific byte-50 mic_control / byte-51 line_in_gain, and the
 //   P1 0x12-codec mic_boost/mic_linein bits, composed from the selected
@@ -110,6 +111,15 @@ public interface IExternalPortEncoder
     byte EncodeP1RxAntennaC3Bits(in ExternalPortState state);
 
     /// <summary>
+    /// Encode the Protocol-1 Config-frame TX-antenna relay bits (C4[1:0]) for the
+    /// desired <paramref name="state"/>. Returns the byte to OR into C4. Delegates
+    /// to the wire path's own pure helper (<c>ControlFrame.EncodeTxAntennaC4Bits</c>)
+    /// so the bytes match exactly, including the per-board ANT1 clamp on boards
+    /// without full Alex TX relays. External-port parity audit (GAP-P1-1).
+    /// </summary>
+    byte EncodeP1TxAntennaC4Bits(in ExternalPortState state);
+
+    /// <summary>
     /// Encode the Protocol-2 Alex-word TX-antenna relay bits (alex0[26:24]) for
     /// the desired <paramref name="state"/>. Returns the bits to OR into the
     /// Alex word. Delegates to the wire path's own pure helper.
@@ -182,6 +192,11 @@ public sealed class Protocol1PortEncoder : IExternalPortEncoder
         return ControlFrame.EncodeRxAntennaC3Bits(state.RxAnt, _board);
     }
 
+    public byte EncodeP1TxAntennaC4Bits(in ExternalPortState state)
+        // Full-Alex P1 boards (ANAN-100D/200D) emit the TX antenna on Config-frame
+        // C4[1:0]; the shared helper clamps every other P1 board to ANT1 (GAP-P1-1).
+        => ControlFrame.EncodeTxAntennaC4Bits(state.TxAnt, _board);
+
     public uint EncodeP2TxAntennaBits(in ExternalPortState state)
         // P1 boards do not emit a P2 Alex word; ANT1-hardwired on transmit.
         => Protocol2Client.EncodeTxAntennaBits(txAnt: 1);
@@ -244,6 +259,10 @@ public sealed class Protocol2PortEncoder : IExternalPortEncoder
         // the Alex word on the SetAntennas state path.
         => 0;
 
+    public byte EncodeP1TxAntennaC4Bits(in ExternalPortState state)
+        // P2 boards do not use the P1 Config frame; TX antenna rides the Alex word.
+        => 0;
+
     public uint EncodeP2TxAntennaBits(in ExternalPortState state)
     {
         // Gate the alex0[26:24] TX-antenna emission on the variant's relay
@@ -298,6 +317,10 @@ public sealed class HermesLite2PortEncoder : IExternalPortEncoder
         // operator persisted, the emitted bits are ANT1 — the N2ADR pad never
         // flips off a stale per-band ANT2/3.
         => ControlFrame.EncodeRxAntennaC3Bits(state.RxAnt, HpsdrBoardKind.HermesLite2);
+
+    public byte EncodeP1TxAntennaC4Bits(in ExternalPortState state)
+        // HL2 single jack — ANT1-hardwired on transmit; the helper clamps to 0.
+        => ControlFrame.EncodeTxAntennaC4Bits(state.TxAnt, HpsdrBoardKind.HermesLite2);
 
     public uint EncodeP2TxAntennaBits(in ExternalPortState state)
         => Protocol2Client.EncodeTxAntennaBits(txAnt: 1);

--- a/Zeus.Server.Hosting/Hl2GpioSettingsStore.cs
+++ b/Zeus.Server.Hosting/Hl2GpioSettingsStore.cs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// HL2 user GPIO mask (external-ports plan, Phase 5; re-ported in the external-
+// port parity audit). Holds ONE global per-radio row: the 4-bit user_dig_out
+// mask that lands on the Protocol-1 0x0a / wire-0x14 frame C3[3:0] → MCP23008 on
+// the Hermes-Lite 2 IO connector. It is NOT per-band — the GPIO lines are a
+// front-panel station state, so the model mirrors AudioSettingsStore's single
+// global row rather than AntennaSettingsStore's band-keyed collection.
+//
+// Board-agnostic by design: the store always round-trips the low nibble, and the
+// capability gate (HasHl2UserGpio — HL2 only) is enforced at the RadioService
+// push and the REST layer, so a mask stored while an HL2 was connected is simply
+// ignored when a non-HL2 board is in front of you (PushHl2Gpio hands the live
+// client 0). Upsert uses DeleteMany+Insert to dodge the LiteDB `Id=0`-always-
+// inserts bug (PR #387). Default mask 0 → C3 stays clear → byte-identical to a
+// board that never drives the lines.
+
+using LiteDB;
+
+namespace Zeus.Server;
+
+public sealed class Hl2GpioSettingsStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<Hl2GpioEntry> _rows;
+    private readonly ILogger<Hl2GpioSettingsStore> _log;
+    private readonly object _sync = new();
+
+    // Fired on any write so RadioService can re-push the GPIO mask to the live
+    // client — same pattern as AudioSettingsStore.Changed.
+    public event Action? Changed;
+
+    public Hl2GpioSettingsStore(ILogger<Hl2GpioSettingsStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _rows = _db.GetCollection<Hl2GpioEntry>("hl2_gpio");
+
+        _log.LogInformation("Hl2GpioSettingsStore initialized at {Path}", dbPath);
+    }
+
+    /// <summary>
+    /// The persisted 4-bit user_dig_out mask (0..15). A missing row (fresh
+    /// install / pre-feature DB) defaults to 0 — every line low, byte-identical
+    /// to today's wire output on every board.
+    /// </summary>
+    public byte Get()
+    {
+        lock (_sync)
+        {
+            var e = _rows.FindAll().FirstOrDefault();
+            return e is null ? (byte)0 : (byte)(e.Bits & 0x0F);
+        }
+    }
+
+    /// <summary>
+    /// Replace the global GPIO mask. Only the low nibble is stored. Uses
+    /// DeleteMany+Insert so the single global row is rewritten cleanly regardless
+    /// of its Id (the LiteDB Id=0-always-inserts bug, PR #387).
+    /// </summary>
+    public void Set(byte mask)
+    {
+        lock (_sync)
+        {
+            _rows.DeleteMany(_ => true);
+            _rows.Insert(new Hl2GpioEntry
+            {
+                Bits = (byte)(mask & 0x0F),
+                UpdatedUtc = DateTime.UtcNow,
+            });
+        }
+        Changed?.Invoke();
+    }
+
+    public void Dispose() => _db.Dispose();
+}
+
+public sealed class Hl2GpioEntry
+{
+    public int Id { get; set; }
+    // The persisted 4-bit user_dig_out mask. Rows written before this feature
+    // hydrate Bits = 0, the correct legacy default.
+    public byte Bits { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -86,6 +86,10 @@ public sealed class RadioService : IDisposable
     // Global (per-radio, NOT per-band) TX-audio source selection. Pushed via
     // PushAudioFrontEnd on store edit + connect (external-audio-jacks re-port).
     private readonly AudioSettingsStore? _audioStore;
+    // Global (per-radio, NOT per-band) HL2 user GPIO mask (external-ports plan,
+    // Phase 5; re-ported in the external-port parity audit). Pushed via
+    // PushHl2Gpio on store edit + connect. HL2-only on the wire.
+    private readonly Hl2GpioSettingsStore? _hl2GpioStore;
     // Cached PS board key for the currently-connected radio. Set by
     // ApplyPsHwPeakForConnection (P1 or P2 connect path) and read by
     // PersistPsState to route HW Peak writes to the correct per-board slot.
@@ -346,7 +350,7 @@ public sealed class RadioService : IDisposable
     // to its internal test-tone generator (dev / tests without a hub).
     private readonly Zeus.Protocol1.ITxIqSource? _txIqSource;
 
-    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, FilterPresetStore? filterPresetStore = null, Zeus.Protocol1.ITxIqSource? txIqSource = null, PreferredRadioStore? preferredRadioStore = null, PsSettingsStore? psStore = null, RadioStateStore? radioStateStore = null, CwSettingsStore? cwSettingsStore = null, TxAudioProfileStore? txAudioProfileStore = null, AntennaSettingsStore? antennaStore = null, AudioSettingsStore? audioStore = null, Nr3ModelStore? nr3ModelStore = null)
+    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, FilterPresetStore? filterPresetStore = null, Zeus.Protocol1.ITxIqSource? txIqSource = null, PreferredRadioStore? preferredRadioStore = null, PsSettingsStore? psStore = null, RadioStateStore? radioStateStore = null, CwSettingsStore? cwSettingsStore = null, TxAudioProfileStore? txAudioProfileStore = null, AntennaSettingsStore? antennaStore = null, AudioSettingsStore? audioStore = null, Nr3ModelStore? nr3ModelStore = null, Hl2GpioSettingsStore? hl2GpioStore = null)
     {
         _loggerFactory = loggerFactory;
         _log = loggerFactory.CreateLogger<RadioService>();
@@ -370,6 +374,13 @@ public sealed class RadioService : IDisposable
         // the resolved wire bytes + StateDto (PR #359/#360 anti-clobber pattern).
         if (_audioStore is not null)
             _audioStore.Changed += PushAudioFrontEnd;
+        // HL2 user GPIO (external-ports plan, Phase 5; re-ported in the external-
+        // port parity audit). Global per-radio (NOT per-band), like the audio
+        // front-end: a store edit re-pushes the persisted mask to the live client.
+        // HL2-only; PushHl2Gpio gates on the HasHl2UserGpio capability.
+        _hl2GpioStore = hl2GpioStore;
+        if (_hl2GpioStore is not null)
+            _hl2GpioStore.Changed += PushHl2Gpio;
         if (_preferredRadioStore is not null)
             _preferredRadioStore.Changed += RecomputePaAndPush;
         _txIqSource = txIqSource;
@@ -951,6 +962,10 @@ public sealed class RadioService : IDisposable
             // clamp + the OFF defaults make this a no-op (byte-identical) on
             // boards without an audio front-end.
             PushAudioFrontEnd();
+            // Replay the persisted HL2 user-GPIO mask (external-port parity audit)
+            // onto the fresh client. Gated on HasHl2UserGpio, so on non-HL2 boards
+            // it pushes mask 0 → byte-identical.
+            PushHl2Gpio();
             return Snapshot();
         }
         catch
@@ -2621,11 +2636,19 @@ public sealed class RadioService : IDisposable
         // (HermesII only — p1LineIn is false on every other P1 board), forward
         // the 0..31 gain so ControlFrame can place it on the 0x14 frame. The gain
         // stays 0 for all other sources/boards → byte-identical to today.
+        //
+        // mic_bias (external-port parity audit, GAP-AUD-1): forward the RESOLVED
+        // bias. ClampAudioSource already dropped it to false on any board without
+        // HasMicBias and on any source other than RadioMic/XLR, so on P1 it is
+        // true only for ANAN-100D/200D with the radio mic selected — and
+        // ControlFrame writes C1[5] only when set. Default Host → false →
+        // byte-identical to today. micTrs stays false (HL2-only tip/ring jack; HL2
+        // is Host-only in v1).
         ActiveClient?.SetAudioFrontEnd(
             micBoost: p1Boost,
             micLineIn: p1LineIn,
             micTrs: false,
-            micBias: false,
+            micBias: resolved.MicBias,
             lineInGain: p1LineIn ? resolved.LineInGain : 0);
 
         // P2 (0x0A Saturn family): forward the resolved literal byte-50
@@ -2687,6 +2710,33 @@ public sealed class RadioService : IDisposable
     // fresh connection picks up the persisted audio front-end without waiting
     // for a store edit. Public so the P2-connect hook can drive it.
     public void ReplayAudioFrontEnd() => PushAudioFrontEnd();
+
+    /// <summary>
+    /// Push the persisted HL2 user-GPIO mask to the live client (external-ports
+    /// plan, Phase 5; re-ported in the external-port parity audit). Gated on the
+    /// connected board's <c>HasHl2UserGpio</c> capability: a non-HL2 board (or one
+    /// without the store) is handed mask 0, so its 0x14-frame C3 stays clear and
+    /// byte-identical to today. ControlFrame only writes C3[3:0] on HermesLite2,
+    /// so this is a belt-and-braces second gate at the service layer.
+    /// </summary>
+    private void PushHl2Gpio()
+    {
+        var caps = BoardCapabilitiesTable.For(EffectiveBoardKind, EffectiveOrionMkIIVariant);
+        byte mask = (caps.HasHl2UserGpio && _hl2GpioStore is not null) ? _hl2GpioStore.Get() : (byte)0;
+        ActiveClient?.SetUserDigOut(mask);
+    }
+
+    /// <summary>Re-push the persisted HL2 GPIO mask after a fresh P1 connect, so a
+    /// reconnect re-applies the operator's selection without a store edit.</summary>
+    public void ReplayHl2Gpio() => PushHl2Gpio();
+
+    /// <summary>The persisted HL2 user-GPIO mask (0..15), or 0 when no store.</summary>
+    public byte GetHl2GpioMask() => _hl2GpioStore?.Get() ?? 0;
+
+    /// <summary>Persist a new HL2 user-GPIO mask (low nibble). The store's Changed
+    /// event fans out to <see cref="PushHl2Gpio"/> so the live client updates on
+    /// the next outgoing frame. No-op when no store is configured.</summary>
+    public void SetHl2GpioMask(byte mask) => _hl2GpioStore?.Set((byte)(mask & 0x0F));
 
     /// <summary>
     /// HL2 Band Volts PWM enable (issue #279). Updates the persisted
@@ -2885,6 +2935,12 @@ public sealed class RadioService : IDisposable
         // P1: RX-antenna relay (C3[7:5], HL2-clamped at the wire). ActiveClient
         // is null on P2 — the P2 RX-antenna rides the SetAntennas path below.
         ActiveClient?.SetAntennaRx(antSel.RxAnt);
+        // P1: TX-antenna relay (Config-frame C4[1:0]) — external-port parity audit
+        // (GAP-P1-1). Clamped to ANT1 at the wire for boards without full Alex TX
+        // relays (ControlFrame.EncodeTxAntennaC4Bits → only ANAN-100D/200D emit
+        // it), and deferred to the unkey edge while keyed. P2 TX antenna rides the
+        // alex0[26:24] path in the SetAntennas snapshot below.
+        ActiveClient?.SetAntennaTx(antSel.TxAnt);
 
         PaSnapshotChanged?.Invoke(new PaRuntimeSnapshot(
             DriveByte: driveByte,
@@ -3489,6 +3545,8 @@ public sealed class RadioService : IDisposable
             _antennaStore.Changed -= RecomputePaAndPush;
         if (_audioStore is not null)
             _audioStore.Changed -= PushAudioFrontEnd;
+        if (_hl2GpioStore is not null)
+            _hl2GpioStore.Changed -= PushHl2Gpio;
         try { DisconnectAsync(CancellationToken.None).GetAwaiter().GetResult(); }
         catch { /* best-effort */ }
         _stateFlushTimer?.Dispose();

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -2542,6 +2542,36 @@ public static class ZeusEndpoints
             return Results.Ok(new Hl2OptionsDto(BandVolts: effective));
         });
 
+        // HL2 user GPIO (external-port parity audit — re-port of external-ports
+        // plan Phase 5). The 4-bit user_dig_out mask → 0x0a/wire-0x14 frame
+        // C3[3:0] → MCP23008 on the HL2 IO connector. GET always returns 200; the
+        // Supported flag is the board's HasHl2UserGpio capability (HL2 only) and
+        // the frontend gates the User-GPIO card on it. PUT 409s on a board without
+        // the capability so a non-HL2 board can never be handed a GPIO mask. The
+        // save is server-authoritative: SetHl2GpioMask persists + fires
+        // Changed → RadioService.PushHl2Gpio, which re-pushes to the live client —
+        // never via the frontend, so no clobber-on-connect.
+        app.MapGet("/api/radio/hl2-gpio", (RadioService radio) =>
+        {
+            var caps = BoardCapabilitiesTable.For(radio.EffectiveBoardKind, radio.EffectiveOrionMkIIVariant);
+            return Results.Ok(new Hl2GpioDto(
+                Supported: caps.HasHl2UserGpio,
+                Bits: caps.HasHl2UserGpio ? radio.GetHl2GpioMask() : 0));
+        });
+
+        app.MapPut("/api/radio/hl2-gpio", (Hl2GpioSetRequest req, RadioService radio) =>
+        {
+            if (req is null)
+                return Results.BadRequest(new { error = "body required" });
+
+            var caps = BoardCapabilitiesTable.For(radio.EffectiveBoardKind, radio.EffectiveOrionMkIIVariant);
+            if (!caps.HasHl2UserGpio)
+                return Results.Conflict(new { error = $"board {radio.EffectiveBoardKind} has no user GPIO" });
+
+            radio.SetHl2GpioMask((byte)(req.Bits & 0x0F));
+            return Results.Ok(new Hl2GpioDto(Supported: true, Bits: radio.GetHl2GpioMask()));
+        });
+
         // External antenna ports (external-ports plan — antenna slice, #804).
         // GET returns the per-band TX/RX antenna + RX-aux selection plus the
         // board-capability gates the frontend renders the right selectors from.

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -248,6 +248,12 @@ public static class ZeusHost
         // AudioSettingsStore? ctor param resolves it and wires the Changed →
         // PushAudioFrontEnd push. Shares zeus-prefs.db (single global row).
         builder.Services.AddSingleton<AudioSettingsStore>();
+        // Global (per-radio) HL2 user-GPIO mask store (external-port parity audit
+        // — re-port of external-ports plan Phase 5). Registered before
+        // RadioService so the latter's optional Hl2GpioSettingsStore? ctor param
+        // resolves it and wires the Changed → PushHl2Gpio push. Shares
+        // zeus-prefs.db (single global row); HL2-only on the wire.
+        builder.Services.AddSingleton<Hl2GpioSettingsStore>();
         builder.Services.AddSingleton<RadioService>();
         // Frees a Busy radio (drops its current owner) so the operator can take
         // it over from the Connect panel. Stateless — opens its own socket.

--- a/tests/Zeus.Protocol1.Tests/ControlFrameAudioEncoderTests.cs
+++ b/tests/Zeus.Protocol1.Tests/ControlFrameAudioEncoderTests.cs
@@ -282,14 +282,32 @@ public class ControlFrameAudioEncoderTests
     }
 
     [Fact]
-    public void Attenuator_NonHl2_AudioFields_DoNotTouchTheFrame()
+    public void Attenuator_NonHl2_MicTrsAndLineInGain_DoNotTouchTheFrame()
     {
-        // A Hermes board with the 0x14-frame audio fields set must NOT emit
-        // mic_trs/bias/line_in_gain there — that frame's mic surface is HL2-
-        // only. (Hermes mic bits ride the 0x12 frame instead.)
-        var s = Hermes() with { MicTrs = true, MicBias = true, LineInGain = 0x1F };
+        // On a non-HL2 board the 0x14-frame mic_trs (C1[4]) and line_in_gain
+        // (C2[4:0]) are HL2-only — Hermes mic bits ride the 0x12 frame instead,
+        // and the ANAN-10E line-in rides the HermesII branch. mic_bias is the
+        // exception (board-agnostic, see the GAP-AUD-1 test below), so it stays
+        // OFF here.
+        var s = Hermes() with { MicTrs = true, LineInGain = 0x1F };
         var cc = Frame(ControlFrame.CcRegister.Attenuator, s);
-        Assert.Equal(0x00, cc[1]); // C1 — no mic bits
+        Assert.Equal(0x00, cc[1]); // C1 — no mic_trs (mic_bias off in this state)
         Assert.Equal(0x00, cc[2] & 0x1F); // C2 — no line_in_gain
+    }
+
+    [Fact]
+    public void Attenuator_NonHl2_MicBias_RidesC1Bit5()
+    {
+        // External-port parity audit (GAP-AUD-1): the 0x14-frame C1[5]=mic_bias
+        // bit is board-agnostic per Thetis networkproto1.c case 11, so a non-HL2
+        // codec board (ANAN-100D/200D) emits it when set. The encoder trusts that
+        // RadioService.ClampAudioSource has already gated s.MicBias to HasMicBias
+        // boards + the RadioMic/XLR source upstream; at the wire it rides for any
+        // non-HL2 board with the bit set. mic_trs / line_in_gain stay HL2-only.
+        var s = Hermes() with { Board = HpsdrBoardKind.Angelia, MicBias = true };
+        var cc = Frame(ControlFrame.CcRegister.Attenuator, s);
+        Assert.Equal(1 << 5, cc[1] & (1 << 5)); // C1[5] mic_bias set
+        Assert.Equal(0x00, cc[1] & ~(1 << 5)); // no other C1 bits
+        Assert.Equal(0x00, cc[2] & 0x1F); // C2 — still no line_in_gain
     }
 }

--- a/tests/Zeus.Server.Tests/AntennaCapabilitiesTests.cs
+++ b/tests/Zeus.Server.Tests/AntennaCapabilitiesTests.cs
@@ -21,18 +21,27 @@ namespace Zeus.Server.Tests;
 public class AntennaCapabilitiesTests
 {
     [Fact]
-    public void TxAntennaRelays_Only_OrionMkII_0x0A_Family()
+    public void TxAntennaRelays_OrionMkII_0x0A_Family_And_FullAlex_P1()
     {
-        // Only the 0x0A / Saturn family has switchable TX antenna relays.
-        // Every variant in that family (incl. Apache OrionMkII original) does.
+        // The 0x0A / Saturn family has switchable TX antenna relays over P2
+        // (alex0[26:24]) — every variant in that family (incl. Apache OrionMkII
+        // original) does.
         foreach (var variant in Enum.GetValues<OrionMkIIVariant>())
             Assert.True(BoardCapabilitiesTable.For(HpsdrBoardKind.OrionMkII, variant).HasTxAntennaRelays);
 
-        // No P1 board and not HL2.
+        // External-port parity audit (GAP-P1-1): the full-Alex dual-ADC P1 boards
+        // ANAN-100D (Angelia) / ANAN-200D (Orion) also emit a switchable TX
+        // antenna — over Protocol 1 on Config-frame C4[1:0] (Thetis
+        // networkproto1.c:463-468). Their encode + clamp live in
+        // ControlFrame.EncodeTxAntennaC4Bits / P1BoardHasTxAntennaRelays.
+        foreach (var board in new[] { HpsdrBoardKind.Angelia, HpsdrBoardKind.Orion })
+            Assert.True(BoardCapabilitiesTable.For(board).HasTxAntennaRelays);
+
+        // ANT1-hardwired on transmit: no full Alex (Metis / Hermes / HermesII),
+        // ANAN-G2E (HermesC10), and HL2 (single jack).
         foreach (var board in new[] {
             HpsdrBoardKind.Metis, HpsdrBoardKind.Hermes, HpsdrBoardKind.HermesII,
-            HpsdrBoardKind.Angelia, HpsdrBoardKind.Orion, HpsdrBoardKind.HermesC10,
-            HpsdrBoardKind.HermesLite2 })
+            HpsdrBoardKind.HermesC10, HpsdrBoardKind.HermesLite2 })
             Assert.False(BoardCapabilitiesTable.For(board).HasTxAntennaRelays);
     }
 

--- a/zeus-web/src/components/RadioSettingsPanel.test.tsx
+++ b/zeus-web/src/components/RadioSettingsPanel.test.tsx
@@ -22,6 +22,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import { RadioSettingsPanel } from './RadioSettingsPanel';
 import { useAudioStore, type TxAudioSource } from '../state/audio-store';
 import { usePttStore } from '../state/ptt-store';
+import { useHl2GpioStore } from '../state/hl2-gpio-store';
 
 type Gates = {
   hasOnboardCodec: boolean;
@@ -78,6 +79,14 @@ let root: Root;
 beforeEach(() => {
   // Neutralize the PTT mount-effect load too (no network in jsdom).
   usePttStore.setState((s) => ({ ...s, load: async () => {} }));
+  // Neutralize the HL2 GPIO mount-effect load and default it to unsupported so
+  // the card stays out of the way of the Audio Input tests below.
+  useHl2GpioStore.setState((s) => ({
+    ...s,
+    load: async () => {},
+    state: { supported: false, bits: 0 },
+    inflight: false,
+  }));
   container = document.createElement('div');
   document.body.appendChild(container);
   root = createRoot(container);
@@ -164,5 +173,77 @@ describe('RadioSettingsPanel — Audio Input card', () => {
     expect(container.querySelector('[role="radiogroup"]')).toBeNull();
     const text = container.textContent ?? '';
     expect(text).toContain('no onboard audio codec');
+  });
+});
+
+// HL2 user GPIO card (external-ports re-port). The card is gated entirely on the
+// store's server-authoritative `supported` flag (true only for a connected
+// Hermes-Lite 2); when supported it renders the 4 user_dig_out toggles and a
+// click drives the store's setBit.
+function seedGpio(supported: boolean, bits = 0) {
+  useHl2GpioStore.setState((s) => ({
+    ...s,
+    load: async () => {},
+    state: { supported, bits: bits & 0x0f },
+    inflight: false,
+  }));
+}
+
+describe('RadioSettingsPanel — HL2 User GPIO card', () => {
+  beforeEach(() => {
+    // Audio at Host so the picker section is quiet; GPIO is the unit here.
+    seedAudio(HL2_GATES, 'Host');
+  });
+
+  it('is absent when the board does not support user GPIO', () => {
+    seedGpio(false);
+    render();
+    const text = container.textContent ?? '';
+    expect(text).not.toContain('User GPIO');
+    expect(text).not.toContain('OUT 0');
+  });
+
+  it('renders the 4 output toggles when supported (HL2)', () => {
+    seedGpio(true);
+    render();
+    const text = container.textContent ?? '';
+    expect(text).toContain('User GPIO');
+    for (const i of [0, 1, 2, 3]) {
+      expect(text).toContain(`OUT ${i}`);
+    }
+    const checks = Array.from(
+      container.querySelectorAll('label.ps-check'),
+    ).filter((l) => /OUT \d/.test(l.textContent ?? ''));
+    expect(checks.length).toBe(4);
+  });
+
+  it('reflects the current bit mask in the toggle checked state', () => {
+    // bits=0b0101 → OUT 0 and OUT 2 on, OUT 1 and OUT 3 off.
+    seedGpio(true, 0b0101);
+    render();
+    const boxFor = (n: number) => {
+      const label = Array.from(
+        container.querySelectorAll('label.ps-check'),
+      ).find((l) => (l.textContent ?? '').includes(`OUT ${n}`));
+      return label!.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    };
+    expect(boxFor(0).checked).toBe(true);
+    expect(boxFor(1).checked).toBe(false);
+    expect(boxFor(2).checked).toBe(true);
+    expect(boxFor(3).checked).toBe(false);
+  });
+
+  it('toggling an output line calls the store with that bit + new value', () => {
+    seedGpio(true, 0);
+    const spy = vi
+      .spyOn(useHl2GpioStore.getState(), 'setBit')
+      .mockResolvedValue();
+    render();
+    const out2 = Array.from(
+      container.querySelectorAll('label.ps-check'),
+    ).find((l) => (l.textContent ?? '').includes('OUT 2'));
+    const box = out2!.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    act(() => box.click());
+    expect(spy).toHaveBeenCalledWith(2, true);
   });
 });

--- a/zeus-web/src/components/RadioSettingsPanel.tsx
+++ b/zeus-web/src/components/RadioSettingsPanel.tsx
@@ -16,8 +16,9 @@
 // Every board exposes a PTT-IN line, so that card is ungated by board. The
 // `keyed` lamp is driven live by the PttStatusFrame WS edge regardless of the
 // enable toggle; the toggle only controls whether a footswitch press is promoted
-// to host MOX. Defaults ON (Thetis-faithful) server-side; promotion is
-// edge-triggered so default-ON never auto-keys without a real footswitch edge.
+// to host MOX. Defaults OFF (operator opts in) server-side; promotion is
+// edge-triggered, so even once enabled it never auto-keys without a real
+// footswitch edge.
 //
 // Visual idiom reuses PsSettingsPanel's `.ps-shell` / `.ps-card` / `.ps-field`
 // surfaces (tokens only, no new chrome / palette). Layout / visual specifics
@@ -32,6 +33,7 @@ import {
   type AntennaName,
   type RxAuxName,
 } from '../state/antenna-store';
+import { useHl2GpioStore } from '../state/hl2-gpio-store';
 
 // TX-audio source labels for the single-select control. The control is a radio-
 // button group (role="radiogroup") bound to the ONE TxAudioSource enum value —
@@ -54,6 +56,10 @@ const MIC_BIAS_CONFIRM =
   'couple RF. Leave it OFF unless your microphone needs bias.';
 
 const ANTENNA_OPTIONS: AntennaName[] = ['Ant1', 'Ant2', 'Ant3'];
+
+// HL2 user GPIO line labels (4-bit user_dig_out → MCP23008). HL2-only; the
+// store's `supported` flag gates the whole card.
+const GPIO_LINES = [0, 1, 2, 3] as const;
 
 export function RadioSettingsPanel() {
   const pttKeyed = usePttStore((s) => s.keyed);
@@ -84,12 +90,18 @@ export function RadioSettingsPanel() {
   const loadAntenna = useAntennaStore((s) => s.load);
   const setAntennaBand = useAntennaStore((s) => s.setBand);
 
+  const gpio = useHl2GpioStore((s) => s.state);
+  const gpioInflight = useHl2GpioStore((s) => s.inflight);
+  const loadGpio = useHl2GpioStore((s) => s.load);
+  const setGpioBit = useHl2GpioStore((s) => s.setBit);
+
   useEffect(() => {
     void loadPtt();
     void loadG2();
     void loadAudio();
     void loadAntenna();
-  }, [loadPtt, loadG2, loadAudio, loadAntenna]);
+    void loadGpio();
+  }, [loadPtt, loadG2, loadAudio, loadAntenna, loadGpio]);
 
   // Poll the front-panel bridge status while this tab is mounted so the
   // connected lamp reflects plug/unplug without a manual reload.
@@ -555,6 +567,50 @@ export function RadioSettingsPanel() {
               </div>
             </div>
           ))}
+        </div>
+      )}
+
+      {/* User GPIO — HL2 only (the 4 user_dig_out lines → MCP23008). Gated on
+          the store's `supported` flag, which the server sets true only for a
+          connected Hermes-Lite 2. Server-authoritative: the backend pushes the
+          persisted mask on connect, so this only loads + PUTs operator edits. */}
+      {gpio.supported && (
+        <div className="ps-card">
+          <h4>
+            <svg className="ps-ic-sm" viewBox="0 0 12 12">
+              <path d="M2 6h2M8 6h2M6 2v2M6 8v2M4 4h4v4H4z" fill="none" />
+            </svg>
+            User GPIO
+            <span className="ps-card-hint">HL2 — 4 digital outputs</span>
+          </h4>
+
+          <div className="ps-field">
+            <div className="ps-name">
+              Output Lines
+              <em>
+                The four user-controllable digital output pins (user_dig_out →
+                MCP23008) on the IO/DB9 connector. Operator-defined — wire to
+                whatever your station needs.
+              </em>
+            </div>
+            <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+              {GPIO_LINES.map((bit) => {
+                const on = (gpio.bits & (1 << bit)) !== 0;
+                return (
+                  <label className="ps-check" key={bit}>
+                    <input
+                      type="checkbox"
+                      checked={on}
+                      disabled={gpioInflight}
+                      onChange={(e) => void setGpioBit(bit, e.target.checked)}
+                    />
+                    <span className="ps-check-box" />
+                    <span>OUT {bit}</span>
+                  </label>
+                );
+              })}
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/zeus-web/src/state/hl2-gpio-store.ts
+++ b/zeus-web/src/state/hl2-gpio-store.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// HL2 user GPIO (external-ports plan, Phase 5). Mirrors /api/radio/hl2-gpio:
+// the 4-bit user_dig_out mask → register 0x0a (wire 0x14) C3[3:0] MCP23008.
+// Server-authoritative (the backend pushes the persisted mask to the live
+// client on connect), so the frontend only loads + PUTs operator edits. HL2
+// only; `supported` gates the toggle group.
+
+import { create } from 'zustand';
+
+export interface Hl2Gpio {
+  supported: boolean;
+  bits: number; // 4-bit mask
+}
+
+const DEFAULT: Hl2Gpio = { supported: false, bits: 0 };
+
+function parse(raw: unknown): Hl2Gpio {
+  if (!raw || typeof raw !== 'object') return DEFAULT;
+  const r = raw as Record<string, unknown>;
+  return {
+    supported: typeof r.supported === 'boolean' ? r.supported : false,
+    bits: typeof r.bits === 'number' ? r.bits & 0x0f : 0,
+  };
+}
+
+export async function fetchHl2Gpio(signal?: AbortSignal): Promise<Hl2Gpio> {
+  const res = await fetch('/api/radio/hl2-gpio', { signal });
+  if (!res.ok) throw new Error(`GET /api/radio/hl2-gpio → ${res.status}`);
+  return parse(await res.json());
+}
+
+export async function updateHl2Gpio(
+  bits: number,
+  signal?: AbortSignal,
+): Promise<Hl2Gpio> {
+  const res = await fetch('/api/radio/hl2-gpio', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ bits: bits & 0x0f }),
+    signal,
+  });
+  if (!res.ok) throw new Error(`PUT /api/radio/hl2-gpio → ${res.status}`);
+  return parse(await res.json());
+}
+
+type Hl2GpioStore = {
+  state: Hl2Gpio;
+  inflight: boolean;
+  error: string | null;
+  load: () => Promise<void>;
+  setBit: (bit: number, on: boolean) => Promise<void>;
+};
+
+export const useHl2GpioStore = create<Hl2GpioStore>((set, get) => ({
+  state: DEFAULT,
+  inflight: false,
+  error: null,
+
+  load: async () => {
+    set({ inflight: true, error: null });
+    try {
+      const s = await fetchHl2Gpio();
+      set({ state: s, inflight: false });
+    } catch (err) {
+      set({
+        error: err instanceof Error ? err.message : String(err),
+        inflight: false,
+      });
+    }
+  },
+
+  setBit: async (bit, on) => {
+    const prev = get().state;
+    const mask = 1 << bit;
+    const nextBits = (on ? prev.bits | mask : prev.bits & ~mask) & 0x0f;
+    set({ state: { ...prev, bits: nextBits }, inflight: true, error: null });
+    try {
+      const s = await updateHl2Gpio(nextBits);
+      set({ state: s, inflight: false });
+    } catch (err) {
+      set({
+        state: prev,
+        error: err instanceof Error ? err.message : String(err),
+        inflight: false,
+      });
+    }
+  },
+}));


### PR DESCRIPTION
## Summary

External port parity audit against Thetis (ANAN/Orion-class) and mi0bot Thetis (HL2). 16 files changed, 708 insertions.

### Changes by area

**BoardCapabilities / BoardCapabilitiesTable**
- Expanded capability declarations across all supported radio families; HL2 GPIO capabilities added

**Protocol-1 (ControlFrame / Protocol1Client / IProtocol1Client)**
- External port encoding aligned to Thetis bit/byte placement and polarity

**Protocol-2 (RadioService / ExternalPortEncoder)**
- Port wiring reviewed and corrected against Thetis Protocol-2 implementation

**HL2 (new: Hl2GpioSettingsStore.cs + hl2-gpio-store.ts)**
- GPIO settings store for HL2-specific external port configuration
- Frontend state store wired to new backend store

**UI (RadioSettingsPanel.tsx / RadioSettingsPanel.test.tsx)**
- External port controls surfaced for all radio families; tests updated

### Needs bench testing
- **HL2 GPIO** — open-collector outputs, PTT-IN: verify GPIO register writes produce expected hardware response
- **Protocol-1 antenna switching** on ANAN-100D/200D: verify bit positions produce correct relay closure
- **Protocol-2 PTT-OUT** on ANAN-G2: verify open-collector timing matches Thetis

## DO NOT MERGE — awaiting Doug review and hardware bench testing