### PR TITLE
FreeDV: Reporter stations channel, report-mode, band-convention sideband, and RADE V1 decode

### DIFF
--- a/.github/workflows/build-rade.yml
+++ b/.github/workflows/build-rade.yml
@@ -16,10 +16,14 @@
 #   - linux-x64 / linux-arm64 : the exact composition was PROVEN end-to-end in
 #     WSL Ubuntu-24.04 (2620 synced ticks / 14 dB / 0.999969 max-amp). Scalar
 #     build (OPUS_DISABLE_INTRINSICS=ON), so arm64 is the same code path.
-#   - win-x64 / osx-arm64     : same CMake recipe + toolchain wired, but NOT yet
-#     run on a CI runner — expect to iterate the first dispatch. The opus_dnn
-#     slice is scalar-only with stubbed SIMD subtrees (see the stub step below),
-#     which is compiler-agnostic, so the risk is toolchain/link flags, not code.
+#   - win-x64 : PROVEN locally with MinGW UCRT64 gcc — decoded the same off-air
+#     sample to the identical numbers, and the produced zeus_rade.dll is
+#     standalone (KERNEL32 + UCRT only). The static-link + PREFIX="" fixes are now
+#     baked into native/radae/CMakeLists.txt, so no win-specific flags are passed
+#     here. (CI runner toolchain — msys2 python3/shell — may still need a tweak.)
+#   - osx-arm64 : same CMake recipe + toolchain wired, NOT yet run — expect to
+#     iterate the first dispatch. The opus_dnn slice is scalar-only with stubbed
+#     SIMD subtrees, compiler-agnostic, so the risk is toolchain/link, not code.
 
 name: build-rade
 

--- a/.github/workflows/build-rade.yml
+++ b/.github/workflows/build-rade.yml
@@ -1,0 +1,161 @@
+# Build the RADE V1 native decoder (libzeus_rade) for every Zeus RID.
+#
+# Manual-dispatch + artifact-upload, exactly like build-native-libs.yml: this
+# workflow builds the one shared library `zeus_rade` (radae_c + opus_dnn/FARGAN +
+# Zeus's shim — see native/radae/CMakeLists.txt and vendor/PROVENANCE.md) and
+# uploads it as a per-RID artifact. The maintainer downloads the artifact from
+# the run summary and commits it to Zeus.Dsp/runtimes/<rid>/native/. Nothing is
+# committed or pushed by this workflow, and it does NOT run on PRs — so a build
+# step that needs tweaking can never break the main CI.
+#
+# The three upstream C slices (~95 MB of compiled-in NN weights) are NOT in the
+# Zeus tree; this workflow vendors them from sv1eia/Thetis-RADE at the pinned SHA
+# recorded in native/radae/vendor/PROVENANCE.md.
+#
+# Validation status (2026-06-24):
+#   - linux-x64 / linux-arm64 : the exact composition was PROVEN end-to-end in
+#     WSL Ubuntu-24.04 (2620 synced ticks / 14 dB / 0.999969 max-amp). Scalar
+#     build (OPUS_DISABLE_INTRINSICS=ON), so arm64 is the same code path.
+#   - win-x64 / osx-arm64     : same CMake recipe + toolchain wired, but NOT yet
+#     run on a CI runner — expect to iterate the first dispatch. The opus_dnn
+#     slice is scalar-only with stubbed SIMD subtrees (see the stub step below),
+#     which is compiler-agnostic, so the risk is toolchain/link flags, not code.
+
+name: build-rade
+
+on:
+  workflow_dispatch:
+
+env:
+  # Pinned upstream for the vendored slices — keep in lockstep with
+  # native/radae/vendor/PROVENANCE.md.
+  THETIS_RADE_SHA: f7605a46bd21275ab8b9edd00d4a1b6fae6eabe8
+
+jobs:
+  build-rade:
+    name: zeus_rade (${{ matrix.rid }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-22.04, rid: linux-x64,  lib: libzeus_rade.so }
+          - { os: ubuntu-22.04, rid: linux-arm64, lib: libzeus_rade.so, cross: arm64 }
+          - { os: windows-2022, rid: win-x64,    lib: zeus_rade.dll }
+          - { os: macos-14,     rid: osx-arm64,  lib: libzeus_rade.dylib }
+    steps:
+      - name: Checkout Zeus
+        uses: actions/checkout@v4
+
+      - name: Set up CMake + Ninja
+        uses: lukka/get-cmake@latest
+
+      - name: Set up MinGW (Windows)
+        if: runner.os == 'Windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-cmake
+            mingw-w64-ucrt-x86_64-ninja
+
+      - name: Set up cross GCC (linux-arm64)
+        if: matrix.cross == 'arm64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+      # ----------------------------------------------------------------------
+      # Vendor the three upstream slices from Thetis-RADE @ the pinned SHA into
+      # native/radae/vendor/{radae_c,opus_dnn,freedv_text}. Sparse checkout so we
+      # only fetch "Project Files/lib" (still ~95 MB of weight tables).
+      # ----------------------------------------------------------------------
+      - name: Vendor radae_c + opus_dnn + freedv_text
+        shell: bash
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+          git -C "$tmp" init -q
+          git -C "$tmp" remote add origin https://github.com/sv1eia/Thetis-RADE.git
+          git -C "$tmp" config core.sparseCheckout true
+          git -C "$tmp" sparse-checkout set "Project Files/lib"
+          git -C "$tmp" fetch -q --depth 1 origin "$THETIS_RADE_SHA"
+          git -C "$tmp" checkout -q FETCH_HEAD
+          dst="native/radae/vendor"
+          mkdir -p "$dst"
+          for slice in radae_c opus_dnn freedv_text; do
+            rm -rf "$dst/$slice"
+            cp -R "$tmp/Project Files/lib/$slice" "$dst/$slice"
+          done
+          echo "Vendored slices:"; ls -la "$dst"
+
+      # ----------------------------------------------------------------------
+      # opus_dnn ships an MSVC-x64 scalar slice: its silk/{x86,arm}, celt/{x86,
+      # arm}, dnn/{x86,arm} SIMD subtrees are stripped, but its CMake source/
+      # header .mk lists still reference ~65 of those files. With
+      # OPUS_DISABLE_INTRINSICS=ON those SIMD sources aren't compiled, but CMake
+      # still validates that every referenced path EXISTS. Create empty
+      # placeholders for the missing referenced files so configure succeeds.
+      # (Documented in native/radae/vendor/PROVENANCE.md.)
+      # ----------------------------------------------------------------------
+      - name: Stub missing opus_dnn SIMD source references
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os, re, glob
+          root = "native/radae/vendor/opus_dnn"
+          made = 0
+          # Collect file references from every *.mk list under opus_dnn.
+          for mk in glob.glob(os.path.join(root, "**", "*.mk"), recursive=True):
+              with open(mk, "r", errors="ignore") as f:
+                  text = f.read()
+              for tok in re.findall(r'[\w./\\-]+\.[ch]', text):
+                  rel = tok.strip().replace("\\", "/")
+                  # .mk paths are relative to the opus_dnn root.
+                  path = os.path.normpath(os.path.join(root, rel))
+                  if not os.path.exists(path):
+                      os.makedirs(os.path.dirname(path), exist_ok=True)
+                      open(path, "a").close()
+                      made += 1
+          print(f"Created {made} placeholder source stubs")
+          PY
+
+      - name: Configure + build zeus_rade
+        shell: bash
+        run: |
+          set -euo pipefail
+          GEN="Ninja"
+          EXTRA=""
+          if [ "${{ matrix.cross }}" = "arm64" ]; then
+            EXTRA="-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64"
+          fi
+          cmake -S native/radae -B native/build-rade -G "$GEN" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DOPUS_DISABLE_INTRINSICS=ON \
+            -DZEUS_RADE_VENDOR="$PWD/native/radae/vendor" \
+            -DZEUS_RADE_BUILD_TEST=OFF \
+            $EXTRA
+          cmake --build native/build-rade --config Release --parallel
+
+      - name: Stage the artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          rid="${{ matrix.rid }}"
+          lib="${{ matrix.lib }}"
+          dest="Zeus.Dsp/runtimes/$rid/native"
+          mkdir -p "$dest"
+          found="$(find native/build-rade -name "$lib" | head -n1)"
+          if [ -z "$found" ]; then echo "::error::built $lib not found"; exit 1; fi
+          cp "$found" "$dest/$lib"
+          ls -la "$dest"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zeus_rade-${{ matrix.rid }}
+          path: Zeus.Dsp/runtimes/${{ matrix.rid }}/native/${{ matrix.lib }}
+          if-no-files-found: error

--- a/Zeus.Contracts/FreeDvDtos.cs
+++ b/Zeus.Contracts/FreeDvDtos.cs
@@ -51,11 +51,16 @@ public sealed record FreeDvStatusDto(
     int ModemSampleRateHz,
     string? RxText,
     string? TxText,
-    string? LibraryVersion);
+    string? LibraryVersion,
+    // True when auto submode detection is engaged: while unsynced the modem
+    // cycles submodes until one locks. Submode reflects the live (possibly
+    // scanner-chosen) mode.
+    bool AutoDetect = false);
 
 /// <summary>Operator config for the FreeDV modem. Null fields leave the current value unchanged.</summary>
 public sealed record FreeDvConfigRequest(
     FreeDvSubmode? Submode = null,
     bool? SquelchEnabled = null,
     double? SnrSquelchThreshDb = null,
-    string? TxText = null);
+    string? TxText = null,
+    bool? AutoDetect = null);

--- a/Zeus.Contracts/FreeDvDtos.cs
+++ b/Zeus.Contracts/FreeDvDtos.cs
@@ -32,6 +32,13 @@ public enum FreeDvSubmode : byte
     Mode1600 = 3,
     /// <summary>800XA — 4FSK 2 kHz, narrowband (legacy interop).</summary>
     Mode800XA = 4,
+    /// <summary>
+    /// RADE V1 — neural "Radio Autoencoder" (FreeDV's flagship ML mode). NOT a
+    /// codec2/freedv_open submode: it's a separate native modem (librade + FARGAN
+    /// vocoder, complex IO, 16 kHz speech). Selectable but gated until the native
+    /// RADE library is integrated — see the rade-v1-integration design.
+    /// </summary>
+    RadeV1 = 5,
 }
 
 /// <summary>
@@ -55,7 +62,11 @@ public sealed record FreeDvStatusDto(
     // True when auto submode detection is engaged: while unsynced the modem
     // cycles submodes until one locks. Submode reflects the live (possibly
     // scanner-chosen) mode.
-    bool AutoDetect = false);
+    bool AutoDetect = false,
+    // True when the native RADE (Radio Autoencoder) modem is available. False
+    // until librade is integrated — selecting RadeV1 then runs no decoder
+    // (passthrough), and the panel shows a "RADE not installed" state.
+    bool RadeAvailable = false);
 
 /// <summary>Operator config for the FreeDV modem. Null fields leave the current value unchanged.</summary>
 public sealed record FreeDvConfigRequest(

--- a/Zeus.Contracts/FreeDvDtos.cs
+++ b/Zeus.Contracts/FreeDvDtos.cs
@@ -104,9 +104,71 @@ public sealed record FreeDvStationDto(
 /// <see cref="ConnectionState"/> mirrors the upstream Socket.IO link state
 /// ("Disconnected" | "Connecting" | "Connected" | "Reconnecting") so the panel
 /// can show a live/stale indicator; <see cref="Stations"/> is sorted by
-/// frequency ascending.
+/// frequency ascending. <see cref="Reporting"/> is true when the operator is
+/// connected in the "report" role (on the public map); <see cref="MySid"/> is
+/// the operator's own per-connection session id while reporting (null otherwise),
+/// so the panel can highlight the operator's own row.
 /// </summary>
 public sealed record FreeDvStationsResponseDto(
     string ConnectionState,
     bool Enabled,
-    IReadOnlyList<FreeDvStationDto> Stations);
+    IReadOnlyList<FreeDvStationDto> Stations,
+    bool Reporting = false,
+    string? MySid = null);
+
+/// <summary>
+/// Operator config for FreeDV Reporter "report" mode. Strictly opt-in: when
+/// <see cref="ReportEnabled"/> is false (the default), or callsign / grid are
+/// blank, Zeus stays a read-only "view" observer and broadcasts nothing. When
+/// enabled with a callsign + Maidenhead grid, Zeus connects in the "report" role
+/// and publishes the operator's callsign, grid, frequency and TX activity to the
+/// public qso.freedv.org map. <see cref="Message"/> is an optional status text.
+/// </summary>
+public sealed record FreeDvReporterSettings(
+    bool ReportEnabled = false,
+    string Callsign = "",
+    string GridSquare = "",
+    string Message = "")
+{
+    public const int MaxGridLength = 6;
+    public const int MaxMessageLength = 80;
+
+    /// <summary>
+    /// Trim/normalize so a hand-crafted POST or stale persisted row can't push
+    /// junk to the public reporter: callsign upper-cased, grid trimmed/capped to
+    /// a Maidenhead-shaped prefix, message trimmed/capped. Reporting still only
+    /// engages when ReportEnabled is true AND both callsign and grid are present.
+    /// </summary>
+    public FreeDvReporterSettings Normalized() => this with
+    {
+        Callsign = (Callsign ?? "").Trim().ToUpperInvariant(),
+        GridSquare = NormalizeGrid(GridSquare),
+        Message = NormalizeMessage(Message),
+    };
+
+    /// <summary>True when the settings are sufficient to connect in report role.</summary>
+    public bool CanReport =>
+        ReportEnabled
+        && !string.IsNullOrWhiteSpace(Callsign)
+        && !string.IsNullOrWhiteSpace(GridSquare);
+
+    private static string NormalizeGrid(string? grid)
+    {
+        var g = (grid ?? "").Trim();
+        if (g.Length == 0) return "";
+        // A Maidenhead locator is field/square[/subsquare]: two letters, two
+        // digits, optionally two more letters. Keep only that leading run, cap
+        // at six chars, and upper-case the field/subsquare so it round-trips
+        // consistently. Anything that doesn't even start letter-letter is
+        // dropped (so a typo can't broadcast a bogus location).
+        if (g.Length > MaxGridLength) g = g[..MaxGridLength];
+        if (g.Length < 2 || !char.IsLetter(g[0]) || !char.IsLetter(g[1])) return "";
+        return g.ToUpperInvariant();
+    }
+
+    private static string NormalizeMessage(string? message)
+    {
+        var m = (message ?? "").Trim();
+        return m.Length > MaxMessageLength ? m[..MaxMessageLength] : m;
+    }
+}

--- a/Zeus.Contracts/FreeDvDtos.cs
+++ b/Zeus.Contracts/FreeDvDtos.cs
@@ -75,3 +75,38 @@ public sealed record FreeDvConfigRequest(
     double? SnrSquelchThreshDb = null,
     string? TxText = null,
     bool? AutoDetect = null);
+
+/// <summary>
+/// One live station from the FreeDV Reporter network (qso.freedv.org). The
+/// reporter aggregates stations running FreeDV-GUI / Zeus that opted into
+/// spotting; Zeus mirrors the feed read-only ("view" role) for a click-to-tune
+/// stations panel. <see cref="Sid"/> is the reporter's per-connection session id
+/// (the dictionary key, stable for the life of a station's connection).
+/// </summary>
+public sealed record FreeDvStationDto(
+    string Sid,
+    string Callsign,
+    string? GridSquare,
+    long FreqHz,
+    string Mode,
+    bool Transmitting,
+    bool RxOnly,
+    string? Message,
+    string? Version,
+    double? LastRxSnr,
+    string? LastRxCallsign,
+    string? LastRxMode,
+    string LastUpdate,     // ISO-8601 UTC, e.g. DateTime.UtcNow.ToString("o")
+    string? ConnectTime);  // ISO-8601 UTC or null
+
+/// <summary>
+/// Snapshot of the FreeDV Reporter stations channel for the Stations panel.
+/// <see cref="ConnectionState"/> mirrors the upstream Socket.IO link state
+/// ("Disconnected" | "Connecting" | "Connected" | "Reconnecting") so the panel
+/// can show a live/stale indicator; <see cref="Stations"/> is sorted by
+/// frequency ascending.
+/// </summary>
+public sealed record FreeDvStationsResponseDto(
+    string ConnectionState,
+    bool Enabled,
+    IReadOnlyList<FreeDvStationDto> Stations);

--- a/Zeus.Dsp.FreeDv/FreeDvAutoScanner.cs
+++ b/Zeus.Dsp.FreeDv/FreeDvAutoScanner.cs
@@ -34,29 +34,44 @@ public sealed class FreeDvAutoScanner
     };
 
     private readonly FreeDvSubmode[] _order;
-    private readonly long _dwellMs;      // time given to each candidate to acquire
-    private readonly long _reacquireMs;  // grace to re-lock a known-good mode before resuming the scan
+    private readonly long _dwellMs;        // time given to each candidate to acquire while scanning
+    private readonly long _lockConfirmMs;  // continuous sync needed to declare LOCKED and stop scanning
+    private readonly long _unlockMs;       // continuous loss-of-sync needed to give up a lock and resume
 
-    private long _dwellStartMs;
-    private long _lastSyncMs;
-    private bool _everSynced;
+    // Two states: SCANNING (cycling modes by dwell) and LOCKED (camped on a mode).
+    // Transitions are debounced by *continuous* sync/loss duration so a flickering
+    // marginal signal can't make the scanner chatter between modes — that thrash
+    // reopens the modem every hop and destroys decode. We only camp after sync has
+    // held for _lockConfirmMs, and only leave after it has been lost for _unlockMs.
+    private bool _locked;
+    private bool _prevSynced;
+    private long _stateChangeMs;  // when the sync flag last flipped (start of current sync/unsync run)
+    private long _dwellStartMs;   // when the current candidate began its scan dwell
     private bool _haveTimebase;
 
     /// <param name="dwellMs">
-    /// How long to sit on each candidate submode before advancing while unsynced.
-    /// OFDM acquisition on a good signal is sub-second; 2.5 s tolerates marginal
-    /// signals without making a full 5-mode cycle feel sluggish (~12.5 s worst case).
+    /// How long to sit on each candidate while scanning (no sustained sync) before
+    /// advancing. 3 s tolerates a marginal signal's acquisition without making a
+    /// full 4-mode cycle feel sluggish.
     /// </param>
-    /// <param name="reacquireMs">
-    /// After a mode has locked and then lost sync (a QSO gap or a fade), hold it
-    /// this long before resuming the scan — overs and deep fades shouldn't bump
-    /// the operator off a mode that was demonstrably correct.
+    /// <param name="lockConfirmMs">
+    /// Continuous sync required before declaring LOCKED and halting the scan. Long
+    /// enough (1.5 s) that a brief false-sync flicker on the wrong mode never camps us.
     /// </param>
-    public FreeDvAutoScanner(long dwellMs = 2500, long reacquireMs = 4000, FreeDvSubmode[]? order = null)
+    /// <param name="unlockMs">
+    /// Continuous loss-of-sync required to give up a lock and resume scanning. Long
+    /// (8 s) so QSO overs and deep fades don't bump the operator off the right mode.
+    /// </param>
+    public FreeDvAutoScanner(
+        long dwellMs = 3000,
+        long lockConfirmMs = 1500,
+        long unlockMs = 8000,
+        FreeDvSubmode[]? order = null)
     {
         _order = order is { Length: > 0 } ? order : DefaultOrder;
         _dwellMs = dwellMs;
-        _reacquireMs = reacquireMs;
+        _lockConfirmMs = lockConfirmMs;
+        _unlockMs = unlockMs;
     }
 
     /// <summary>Submodes this scanner cycles through, in scan order.</summary>
@@ -69,11 +84,15 @@ public sealed class FreeDvAutoScanner
     /// </summary>
     public void Reset(long nowMs)
     {
+        _locked = false;
+        _prevSynced = false;
+        _stateChangeMs = nowMs;
         _dwellStartMs = nowMs;
-        _lastSyncMs = nowMs;
-        _everSynced = false;
         _haveTimebase = true;
     }
+
+    /// <summary>True once a mode has held sync long enough to be camped on.</summary>
+    public bool Locked => _locked;
 
     /// <summary>
     /// Decide whether to switch submode. Returns the submode to switch to, or
@@ -86,26 +105,40 @@ public sealed class FreeDvAutoScanner
     {
         if (!_haveTimebase) Reset(nowMs);
 
+        // Track how long we've been continuously in the current sync state.
+        if (synced != _prevSynced)
+        {
+            _prevSynced = synced;
+            _stateChangeMs = nowMs;
+        }
+        long inState = nowMs - _stateChangeMs;
+
+        if (_locked)
+        {
+            // Camped on a mode. Only give it up after sync has been lost
+            // *continuously* for the unlock window (rides out overs/fades).
+            if (!synced && inState >= _unlockMs)
+            {
+                _locked = false;
+                _dwellStartMs = nowMs; // give the resumed scan a fresh dwell here
+            }
+            return null; // never change mode while locked
+        }
+
+        // SCANNING.
         if (synced)
         {
-            // Locked — hold here indefinitely and keep the dwell window fresh so
-            // a momentary sync drop doesn't advance us on the very next tick.
-            _everSynced = true;
-            _lastSyncMs = nowMs;
-            _dwellStartMs = nowMs;
+            // Sustained sync → camp here and stop scanning. A brief flicker
+            // (inState < _lockConfirmMs) does NOT lock and does NOT reset the
+            // dwell, so it can't stall or chatter the scan.
+            if (inState >= _lockConfirmMs) _locked = true;
             return null;
         }
 
-        // Unsynced. If this mode locked recently, give it the re-acquire grace
-        // before considering a move (covers transmit overs and fades).
-        if (_everSynced && nowMs - _lastSyncMs < _reacquireMs)
-            return null;
-
-        // Scanning: stay on the current candidate until its dwell elapses.
+        // Unsynced: stay on this candidate until its dwell elapses, then advance.
         if (nowMs - _dwellStartMs < _dwellMs)
             return null;
 
-        // Advance to the next candidate (wrapping). Unknown current → start of order.
         int idx = Array.IndexOf(_order, current);
         int next = idx < 0 ? 0 : (idx + 1) % _order.Length;
         _dwellStartMs = nowMs;

--- a/Zeus.Dsp.FreeDv/FreeDvAutoScanner.cs
+++ b/Zeus.Dsp.FreeDv/FreeDvAutoScanner.cs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Auto submode detection for FreeDV. A received FreeDV signal carries no
+// in-band "which mode am I?" marker, so an operator on the wrong submode hears
+// nothing and the decoder silently never syncs — the single most common
+// "receiving but no decode" trap. This scanner removes the guesswork: while the
+// modem is unsynced it dwells on each candidate submode in turn until one locks,
+// then holds that mode. It is a PURE, deterministic state machine — it owns no
+// clock and no modem handle; the caller supplies a monotonic timestamp and the
+// live sync state on each Tick and applies the returned submode. That keeps it
+// unit-testable without real time and keeps all native/threading concerns in the
+// owning service.
+
+using Zeus.Contracts;
+
+namespace Zeus.Dsp.FreeDv;
+
+public sealed class FreeDvAutoScanner
+{
+    // Scan order: the on-air-common OFDM voice modes first (700D is the global
+    // FreeDV default), then the legacy interop modes. Matches the panel order.
+    private static readonly FreeDvSubmode[] DefaultOrder =
+    {
+        FreeDvSubmode.Mode700D,
+        FreeDvSubmode.Mode700E,
+        FreeDvSubmode.Mode700C,
+        FreeDvSubmode.Mode1600,
+        FreeDvSubmode.Mode800XA,
+    };
+
+    private readonly FreeDvSubmode[] _order;
+    private readonly long _dwellMs;      // time given to each candidate to acquire
+    private readonly long _reacquireMs;  // grace to re-lock a known-good mode before resuming the scan
+
+    private long _dwellStartMs;
+    private long _lastSyncMs;
+    private bool _everSynced;
+    private bool _haveTimebase;
+
+    /// <param name="dwellMs">
+    /// How long to sit on each candidate submode before advancing while unsynced.
+    /// OFDM acquisition on a good signal is sub-second; 2.5 s tolerates marginal
+    /// signals without making a full 5-mode cycle feel sluggish (~12.5 s worst case).
+    /// </param>
+    /// <param name="reacquireMs">
+    /// After a mode has locked and then lost sync (a QSO gap or a fade), hold it
+    /// this long before resuming the scan — overs and deep fades shouldn't bump
+    /// the operator off a mode that was demonstrably correct.
+    /// </param>
+    public FreeDvAutoScanner(long dwellMs = 2500, long reacquireMs = 4000, FreeDvSubmode[]? order = null)
+    {
+        _order = order is { Length: > 0 } ? order : DefaultOrder;
+        _dwellMs = dwellMs;
+        _reacquireMs = reacquireMs;
+    }
+
+    /// <summary>Submodes this scanner cycles through, in scan order.</summary>
+    public IReadOnlyList<FreeDvSubmode> Order => _order;
+
+    /// <summary>
+    /// (Re)seed the scan timebase. Call when auto-detect is enabled, when the
+    /// modem (re)activates, or when the operator manually jumps to a submode —
+    /// the current mode then gets a fresh full dwell before the scan advances.
+    /// </summary>
+    public void Reset(long nowMs)
+    {
+        _dwellStartMs = nowMs;
+        _lastSyncMs = nowMs;
+        _everSynced = false;
+        _haveTimebase = true;
+    }
+
+    /// <summary>
+    /// Decide whether to switch submode. Returns the submode to switch to, or
+    /// null to stay on <paramref name="current"/>.
+    /// </summary>
+    /// <param name="nowMs">A monotonic millisecond timestamp (e.g. Environment.TickCount64).</param>
+    /// <param name="synced">The modem's live sync state.</param>
+    /// <param name="current">The modem's current submode.</param>
+    public FreeDvSubmode? Tick(long nowMs, bool synced, FreeDvSubmode current)
+    {
+        if (!_haveTimebase) Reset(nowMs);
+
+        if (synced)
+        {
+            // Locked — hold here indefinitely and keep the dwell window fresh so
+            // a momentary sync drop doesn't advance us on the very next tick.
+            _everSynced = true;
+            _lastSyncMs = nowMs;
+            _dwellStartMs = nowMs;
+            return null;
+        }
+
+        // Unsynced. If this mode locked recently, give it the re-acquire grace
+        // before considering a move (covers transmit overs and fades).
+        if (_everSynced && nowMs - _lastSyncMs < _reacquireMs)
+            return null;
+
+        // Scanning: stay on the current candidate until its dwell elapses.
+        if (nowMs - _dwellStartMs < _dwellMs)
+            return null;
+
+        // Advance to the next candidate (wrapping). Unknown current → start of order.
+        int idx = Array.IndexOf(_order, current);
+        int next = idx < 0 ? 0 : (idx + 1) % _order.Length;
+        _dwellStartMs = nowMs;
+        return _order[next];
+    }
+}

--- a/Zeus.Dsp.FreeDv/FreeDvModem.cs
+++ b/Zeus.Dsp.FreeDv/FreeDvModem.cs
@@ -210,6 +210,14 @@ public sealed class FreeDvModem : IDisposable
     public int ModemSampleRateHz => _modemRate;
     public string? LibraryVersion => _nativeAvailable ? "codec2 1.2.0 (FreeDV)" : null;
 
+    /// <summary>
+    /// True when the native RADE (Radio Autoencoder) modem is available. RADE V1
+    /// is a separate native library (librade + FARGAN) not yet integrated, so this
+    /// is always false for now; <see cref="FreeDvSubmode.RadeV1"/> runs as
+    /// passthrough (no decode) until it lands. See rade-v1-integration.
+    /// </summary>
+    public bool RadeAvailable => false;
+
     private static int ToNativeMode(FreeDvSubmode m) => m switch
     {
         FreeDvSubmode.Mode700D => FreeDvNativeMethods.FREEDV_MODE_700D,
@@ -398,6 +406,20 @@ public sealed class FreeDvModem : IDisposable
 
     private void OpenLocked()
     {
+        // RADE V1 is a separate native modem (librade) not yet integrated. Never
+        // route it through freedv_open — a classic decoder mis-opened on a RADE
+        // signal just emits garbage. Tear down any classic handles and run as a
+        // clean passthrough until RADE lands; the UI gates on RadeAvailable.
+        if (_submode == FreeDvSubmode.RadeV1)
+        {
+            RetireRx(IntPtr.Zero);
+            RetireTx(IntPtr.Zero);
+            _synced = false;
+            Volatile.Write(ref _snrDb, 0f);
+            _log?.LogInformation("FreeDV: RADE V1 selected — native RADE not yet available; passthrough (no decode).");
+            return;
+        }
+
         int mode = ToNativeMode(_submode);
         IntPtr rx = FreeDvNativeMethods.freedv_open(mode);
         IntPtr tx = FreeDvNativeMethods.freedv_open(mode);

--- a/Zeus.Dsp.FreeDv/FreeDvNativeLoader.cs
+++ b/Zeus.Dsp.FreeDv/FreeDvNativeLoader.cs
@@ -31,6 +31,8 @@ public static class FreeDvNativeLoader
     private static bool _registered;
     private static bool _probedLoadable;
     private static bool _loadable;
+    private static bool _radeProbed;
+    private static bool _radeLoadable;
 
     internal static void EnsureResolverRegistered()
     {
@@ -65,10 +67,33 @@ public static class FreeDvNativeLoader
         }
     }
 
+    /// <summary>True if the zeus_rade shim shared library can be located and loaded.</summary>
+    internal static bool TryProbeRade()
+    {
+        EnsureResolverRegistered();
+        if (_radeProbed) return _radeLoadable;
+        lock (Gate)
+        {
+            if (_radeProbed) return _radeLoadable;
+            if (TryResolveRade(typeof(RadeNativeMethods).Assembly, out var handle))
+            {
+                NativeLibrary.Free(handle);
+                _radeLoadable = true;
+            }
+            else
+            {
+                _radeLoadable = false;
+            }
+            _radeProbed = true;
+            return _radeLoadable;
+        }
+    }
+
     /// <summary>
-    /// Drop the cached <see cref="TryProbe"/> result so the next probe re-scans
-    /// the candidate paths. Called after the in-app installer stages a new
-    /// codec2 binary so FreeDV can go live without restarting the host.
+    /// Drop the cached <see cref="TryProbe"/> and <see cref="TryProbeRade"/>
+    /// results so the next probe re-scans the candidate paths. Called after the
+    /// in-app installer stages a new codec2 / zeus_rade binary so FreeDV / RADE
+    /// can go live without restarting the host.
     /// </summary>
     public static void ResetProbe()
     {
@@ -76,18 +101,23 @@ public static class FreeDvNativeLoader
         {
             _probedLoadable = false;
             _loadable = false;
+            _radeProbed = false;
+            _radeLoadable = false;
         }
     }
 
     private static IntPtr Resolve(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
     {
-        if (libraryName != FreeDvNativeMethods.LibraryName) return IntPtr.Zero;
-        return TryResolve(assembly, out var handle) ? handle : IntPtr.Zero;
+        if (libraryName == FreeDvNativeMethods.LibraryName)
+            return TryResolve(assembly, out var handle) ? handle : IntPtr.Zero;
+        if (libraryName == RadeNativeMethods.LibraryName)
+            return TryResolveRade(assembly, out var radeHandle) ? radeHandle : IntPtr.Zero;
+        return IntPtr.Zero;
     }
 
     private static bool TryResolve(Assembly assembly, out IntPtr handle)
     {
-        foreach (var candidate in CandidatePaths(assembly))
+        foreach (var candidate in CandidatePaths(assembly, NativeFileName()))
         {
             if (File.Exists(candidate) && NativeLibrary.TryLoad(candidate, out handle))
                 return true;
@@ -95,15 +125,24 @@ public static class FreeDvNativeLoader
         return NativeLibrary.TryLoad(FreeDvNativeMethods.LibraryName, assembly, null, out handle);
     }
 
-    private static IEnumerable<string> CandidatePaths(Assembly assembly)
+    private static bool TryResolveRade(Assembly assembly, out IntPtr handle)
+    {
+        foreach (var candidate in CandidatePaths(assembly, RadeNativeFileName()))
+        {
+            if (File.Exists(candidate) && NativeLibrary.TryLoad(candidate, out handle))
+                return true;
+        }
+        return NativeLibrary.TryLoad(RadeNativeMethods.LibraryName, assembly, null, out handle);
+    }
+
+    private static IEnumerable<string> CandidatePaths(Assembly assembly, string fileName)
     {
         string rid = CurrentRid();
-        string fileName = NativeFileName();
 
         // Writable per-user install location first: a binary staged by the
         // in-app installer should win over (and back-fill) a missing bundled one.
-        string? managed = ManagedLibraryPath();
-        if (managed is not null) yield return managed;
+        string? managedDir = ManagedLibraryDir();
+        if (managedDir is not null) yield return Path.Combine(managedDir, fileName);
 
         string? asmDir = Path.GetDirectoryName(assembly.Location);
         if (!string.IsNullOrEmpty(asmDir))
@@ -162,5 +201,14 @@ public static class FreeDvNativeLoader
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return "libcodec2.so";
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return "codec2.dll";
         return "libcodec2";
+    }
+
+    /// <summary>Platform shared-library filename for the zeus_rade shim (zeus_rade.dll / libzeus_rade.so / libzeus_rade.dylib).</summary>
+    public static string RadeNativeFileName()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return "libzeus_rade.dylib";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return "libzeus_rade.so";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return "zeus_rade.dll";
+        return "libzeus_rade";
     }
 }

--- a/Zeus.Dsp.FreeDv/RadeModem.cs
+++ b/Zeus.Dsp.FreeDv/RadeModem.cs
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// RADE V1 (Radio Autoencoder) modem as a streaming, frame-synchronous insert in
+// the Zeus audio bus — the RADE twin of FreeDvModem. RX ONLY this pass: it turns
+// received SSB audio into decoded 16 kHz speech via the native zeus_rade shim
+// (radae_c + opus_dnn/FARGAN), absorbing the 48 kHz <-> 8 kHz modem-rate and
+// 16 kHz -> 48 kHz speech-rate changes internally with resamplers + fixed
+// lock-free SPSC rings, silence-padded while starved (before sync). RADE TX is a
+// follow-up; ProcessTxInPlace silences the block when active (does NOT transmit
+// raw mic).
+//
+// REALTIME DISCIPLINE — identical to FreeDvModem: the hot path (ProcessRxInPlace)
+// takes NO lock and allocates NOTHING; all scratch and ring storage is sized once
+// when the modem opens (off the hot path). Reconfiguring (open/close) runs on a
+// control thread serialised by _reconfigGate, handing the native handle off to
+// the hot path through a Dekker-fenced seqlock: the control thread publishes
+// IntPtr.Zero, full-fences, then spins until the busy flag clears before closing
+// the old handle. The realtime thread never spins or blocks — it sets a busy flag
+// and reads the published handle. When the handle is Zero (native missing /
+// reconfiguring), RX passes audio through UNCHANGED.
+
+using System.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace Zeus.Dsp.FreeDv;
+
+public sealed class RadeModem : IDisposable
+{
+    private readonly ILogger<RadeModem>? _log;
+    private readonly object _reconfigGate = new();   // serialises control-thread reconfig only
+    private readonly bool _nativeAvailable;
+
+    // Output latency ceiling (48 kHz samples). ~250 ms — past this the modem
+    // stalled or drifted; drop oldest to stay real-time.
+    private const int MaxOutFifo = RadeResampler.FsHigh / 4;
+    private const int MaxBlock = 8192;               // generous cap on a 48 kHz audio block
+
+    // Native handle — published to the hot path via Volatile; IntPtr.Zero means
+    // "do not process" (closed / reconfiguring / native missing).
+    private IntPtr _rade = IntPtr.Zero;
+    private int _rxBusy;                              // 0/1 seqlock busy flag (hot path owns)
+
+    private volatile bool _active;
+
+    // RX chain (touched only by the hot path, or during reconfig while gated out).
+    // 48k -> 8k decimation reuses the classic FreeDV decimator (6:1, voice-band
+    // low-pass is fine for the narrowband OFDM modem input). 16k -> 48k uses the
+    // dedicated wideband 3:1 interpolator so FARGAN's full bandwidth survives.
+    private readonly FreeDvResampler.Decimator _rxDown = FreeDvResampler.NewDecimator();
+    private readonly RadeResampler.Interpolator _rxUp = RadeResampler.NewInterpolator();
+    private readonly FreeDvSampleRing _rx8In = new(8192);     // 8 kHz modem samples awaiting zeus_rade_rx
+    private readonly FreeDvSampleRing _rxOut48 = new(16384);  // decoded speech, 48 kHz, awaiting playout
+    private readonly float[] _rxDecScratch = new float[FreeDvResampler.MaxDecimatedLength(MaxBlock)];
+    private float[] _rx8Block = new float[256];       // nin 8k real samples pulled from the ring
+    private float[] _rxIn = new float[512];            // interleaved complex IQ (2 * ninMax), imag stays 0
+    private short[] _rxPcm = new short[256];           // int16 PCM @16k from the decoder
+    private float[] _rxSpeechFloat = new float[256];   // PCM as float
+    private float[] _rxInterp = new float[256];        // 48k after wideband interpolation
+    private int _ninMax;                               // cached at open
+
+    // Telemetry (lock-free reads)
+    private volatile bool _synced;
+    private double _snrDb;
+
+    public RadeModem(ILogger<RadeModem>? log = null)
+    {
+        _log = log;
+        _nativeAvailable = FreeDvNativeLoader.TryProbeRade();
+        if (_nativeAvailable)
+        {
+            RadeNativeMethods.zeus_rade_global_init();
+        }
+        else
+        {
+            _log?.LogWarning("RADE: zeus_rade native library not found; RADE V1 will pass audio through unchanged.");
+        }
+    }
+
+    /// <summary>True when the native zeus_rade shim is loadable and RADE can decode.</summary>
+    public bool RadeAvailable => _nativeAvailable;
+    public bool Active => _active;
+    public bool Synced => _synced;
+    public double SnrDb => Volatile.Read(ref _snrDb);
+    public int SpeechSampleRateHz => 16000;
+    public int ModemSampleRateHz => 8000;
+    public string? LibraryVersion => _nativeAvailable ? "RADE V1 (radae_c)" : null;
+
+    /// <summary>
+    /// RX text sidechannel. RADE carries an End-of-Over callsign, but the
+    /// zeus_rade EOO decode is KNOWN-GARBLED until freedv_text is wired, so it is
+    /// not surfaced yet — always null.
+    /// </summary>
+    public string? RxText => null;
+
+    // -------- control thread (rare; serialised by _reconfigGate) --------
+
+    public void Activate()
+    {
+        if (!_nativeAvailable) { _active = true; return; }
+        lock (_reconfigGate)
+        {
+            OpenLocked();
+            _active = true;
+        }
+    }
+
+    public void Deactivate()
+    {
+        _active = false;
+        lock (_reconfigGate)
+        {
+            RetireRx(IntPtr.Zero);
+        }
+    }
+
+    /// <summary>
+    /// No-op. RADE has no codec2-style SNR squelch; kept for API symmetry with
+    /// FreeDvModem so callers can drive both modems uniformly. Inert.
+    /// </summary>
+    public void SetSquelch(bool? enabled, double? threshDb) { /* RADE has no squelch — inert */ }
+
+    // -------- RX hot path (DSP tick thread; no lock, no alloc) --------
+
+    public void ProcessRxInPlace(Span<float> block48k)
+    {
+        if (!_active) return;
+        Volatile.Write(ref _rxBusy, 1);
+        Thread.MemoryBarrier(); // StoreLoad fence vs. the reconfig handoff
+        try
+        {
+            IntPtr h = Volatile.Read(ref _rade);
+            if (h == IntPtr.Zero) return; // passthrough (native missing / reconfiguring) — leave block unchanged
+
+            // 1. decimate 48k -> 8k real into the 8k input ring.
+            int n8 = _rxDown.Process(block48k, _rxDecScratch);
+            _rx8In.Write(_rxDecScratch.AsSpan(0, n8));
+
+            // 2. drain the 8k ring through the decoder, nin samples at a time.
+            int nin = RadeNativeMethods.zeus_rade_nin(h);
+            while (nin > 0 && nin <= _ninMax && _rx8In.Count >= nin)
+            {
+                _rx8In.Read(_rx8Block.AsSpan(0, nin));
+                // Pack as interleaved complex: real = sample, imag = 0. Odd indices
+                // were pre-zeroed at open and the decoder never writes rx_in, so
+                // they stay 0 across calls — only the real lanes need refreshing.
+                for (int i = 0; i < nin; i++) _rxIn[2 * i] = _rx8Block[i];
+
+                int npcm = RadeNativeMethods.zeus_rade_rx(h, _rxIn, _rxPcm);
+                _synced = RadeNativeMethods.zeus_rade_sync(h) != 0;
+                Volatile.Write(ref _snrDb, RadeNativeMethods.zeus_rade_snr_db(h));
+
+                if (npcm > 0)
+                {
+                    ShortToFloat(_rxPcm, _rxSpeechFloat, npcm);
+                    int up = _rxUp.Process(_rxSpeechFloat.AsSpan(0, npcm), _rxInterp);
+                    WriteBounded(_rxOut48, _rxInterp.AsSpan(0, up));
+                }
+                nin = RadeNativeMethods.zeus_rade_nin(h);
+            }
+
+            // 3. read decoded speech into the block; silence-pad the remainder
+            // (decoded speech replaces the demod audio, exactly like FreeDvModem).
+            int filled = _rxOut48.Read(block48k);
+            if (filled < block48k.Length) block48k.Slice(filled).Clear();
+        }
+        finally
+        {
+            Volatile.Write(ref _rxBusy, 0);
+        }
+    }
+
+    // -------- TX hot path (mic-ingest thread; no lock, no alloc) --------
+
+    public void ProcessTxInPlace(Span<float> block48k)
+    {
+        if (!_active) return;
+        // TODO RADE TX (encode + EOO): RADE TX is not implemented this pass. When
+        // active, silence the block rather than transmitting raw mic audio (which
+        // would put plain SSB on a RADE frequency). Passthrough when inactive.
+        block48k.Clear();
+    }
+
+    private static void WriteBounded(FreeDvSampleRing ring, ReadOnlySpan<float> src)
+    {
+        if (ring.Count > MaxOutFifo) ring.Drop(ring.Count - MaxOutFifo);
+        ring.Write(src); // short write (ring full) acts as a final safety drop
+    }
+
+    private static void ShortToFloat(short[] src, float[] dst, int n)
+    {
+        for (int i = 0; i < n; i++) dst[i] = src[i] * (1f / 32768f);
+    }
+
+    // -------- reconfig helpers (control thread, under _reconfigGate) --------
+
+    private void OpenLocked()
+    {
+        if (!_nativeAvailable)
+        {
+            // Leave the handle Zero — the hot path runs as a clean passthrough.
+            RetireRx(IntPtr.Zero);
+            return;
+        }
+
+        IntPtr h = RadeNativeMethods.zeus_rade_open();
+        if (h == IntPtr.Zero)
+        {
+            _log?.LogError("RADE: zeus_rade_open failed — passthrough (no decode).");
+            RetireRx(IntPtr.Zero);
+            return;
+        }
+
+        // Size scratch from the new context (off the hot path).
+        _ninMax = RadeNativeMethods.zeus_rade_nin_max(h);
+        int maxPcm = RadeNativeMethods.zeus_rade_max_pcm_per_rx(h);
+
+        EnsureFloat(ref _rx8Block, _ninMax);
+        // 2 * ninMax interleaved complex floats; pre-zeroed so imag lanes stay 0.
+        EnsureFloatZeroed(ref _rxIn, 2 * _ninMax);
+        EnsureShort(ref _rxPcm, maxPcm);
+        EnsureFloat(ref _rxSpeechFloat, maxPcm);
+        EnsureFloat(ref _rxInterp, RadeResampler.InterpolatedLength(maxPcm));
+
+        _synced = false;
+        Volatile.Write(ref _snrDb, 0d);
+
+        RetireRx(h);
+
+        _log?.LogInformation(
+            "RADE: opened ninMax={NinMax} maxPcm={MaxPcm} modemFs={ModemFs} speechFs={SpeechFs}",
+            _ninMax, maxPcm, ModemSampleRateHz, SpeechSampleRateHz);
+    }
+
+    // Gate the RX hot path out, close the old handle, reset RX buffers, publish
+    // the replacement (IntPtr.Zero to leave RX disengaged / passthrough).
+    private void RetireRx(IntPtr replacement)
+    {
+        IntPtr old = Volatile.Read(ref _rade);
+        Volatile.Write(ref _rade, IntPtr.Zero);
+        Thread.MemoryBarrier();
+        SpinUntilIdle(ref _rxBusy);
+        if (old != IntPtr.Zero) RadeNativeMethods.zeus_rade_close(old);
+        _rx8In.Clear(); _rxOut48.Clear();
+        _rxDown.Reset(); _rxUp.Reset();
+        Volatile.Write(ref _rade, replacement);
+    }
+
+    private static void SpinUntilIdle(ref int busyFlag)
+    {
+        var sw = new SpinWait();
+        while (Volatile.Read(ref busyFlag) == 1) sw.SpinOnce();
+    }
+
+    private static void EnsureFloat(ref float[] buf, int n)
+    {
+        if (buf.Length < n) buf = new float[Math.Max(n, buf.Length * 2)];
+    }
+
+    // For the interleaved IQ buffer: a fresh allocation is zeroed by the runtime,
+    // so a grow leaves all lanes (including imag) at 0. When the existing buffer
+    // is large enough, re-zero it so a reopen can't leave a stale imag lane.
+    private static void EnsureFloatZeroed(ref float[] buf, int n)
+    {
+        if (buf.Length < n) buf = new float[Math.Max(n, buf.Length * 2)];
+        else Array.Clear(buf, 0, buf.Length);
+    }
+
+    private static void EnsureShort(ref short[] buf, int n)
+    {
+        if (buf.Length < n) buf = new short[Math.Max(n, buf.Length * 2)];
+    }
+
+    public void Dispose()
+    {
+        _active = false;
+        lock (_reconfigGate)
+        {
+            RetireRx(IntPtr.Zero);
+        }
+    }
+}

--- a/Zeus.Dsp.FreeDv/RadeNativeMethods.cs
+++ b/Zeus.Dsp.FreeDv/RadeNativeMethods.cs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// P/Invoke bindings for the zeus_rade shim (native/radae/shim/zeus_rade.h) — a
+// thin single-entry wrapper over RADE V1 (radae_nopy) + the FARGAN vocoder that
+// hides RADE's two-stage decode behind one streaming "complex IQ in -> 16 kHz
+// PCM out" surface. Loaded dynamically as a shared library — zeus_rade.dll on
+// Windows, libzeus_rade.so / libzeus_rade.dylib elsewhere — resolved by
+// FreeDvNativeLoader (same once-per-assembly resolver as codec2).
+//
+// The native binary is built separately by CI and may be absent; every call
+// site MUST guard via FreeDvNativeLoader.TryProbeRade() before invoking these.
+//
+// RADE_COMP is a C struct of two floats {real, imag}; an array of N complex
+// samples is therefore 2*N interleaved floats [r0,i0,r1,i1,...], which the
+// managed side passes as a float[] (rx_in) — see zeus_rade_rx.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Zeus.Dsp.FreeDv;
+
+internal static partial class RadeNativeMethods
+{
+    // NativeLibrary resolves "zeus_rade" -> zeus_rade.dll / libzeus_rade.so / libzeus_rade.dylib.
+    internal const string LibraryName = "zeus_rade";
+
+    // Library lifecycle (wrap rade_initialize/finalize; call once per process).
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void zeus_rade_global_init();
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void zeus_rade_global_shutdown();
+
+    // Open/close a decoder context. Returns IntPtr.Zero on failure.
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial IntPtr zeus_rade_open();
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void zeus_rade_close(IntPtr z);
+
+    // Buffer-sizing helpers (call after open).
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial int zeus_rade_nin(IntPtr z);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial int zeus_rade_nin_max(IntPtr z);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial int zeus_rade_max_pcm_per_rx(IntPtr z);
+
+    // Decode one block of IQ to 16 kHz PCM.
+    //   rx_in   : zeus_rade_nin(z) complex (interleaved real,imag) samples @ 8 kHz
+    //   pcm_out : caller buffer, >= zeus_rade_max_pcm_per_rx(z) int16 samples @ 16 kHz
+    // Returns the number of int16 PCM samples written (0 while unsynced / priming).
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial int zeus_rade_rx(IntPtr z, float[] rx_in, short[] pcm_out);
+
+    // Telemetry (valid when synced).
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial int zeus_rade_sync(IntPtr z);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial float zeus_rade_freq_offset(IntPtr z);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial int zeus_rade_snr_db(IntPtr z);
+
+    // Last decoded End-of-Over callsign. Copies into callsign_out (>= 9 bytes);
+    // returns chars written, 0 if none since the last over. KNOWN-GARBLED until
+    // freedv_text is wired — not surfaced as RxText this pass.
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial int zeus_rade_get_eoo_callsign(IntPtr z, byte[] callsign_out);
+}

--- a/Zeus.Dsp.FreeDv/RadeResampler.cs
+++ b/Zeus.Dsp.FreeDv/RadeResampler.cs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Wideband output resampler for RADE V1. RADE's FARGAN vocoder synthesizes
+// 16 kHz speech with energy out to ~8 kHz — far wider than the ~2.4 kHz FreeDV
+// codec2 voice band. The classic FreeDvResampler.Interpolator is a 6:1 stage
+// with a 3.4 kHz cutoff prototype; reusing it for RADE would dull the audio by
+// rolling off everything above 3.4 kHz. This is a dedicated 3:1 polyphase
+// interpolator (16 kHz -> 48 kHz) with a WIDEBAND prototype low-pass (cutoff
+// ~7.2 kHz at Fs=48 kHz, below the 8 kHz output Nyquist) so the full FARGAN
+// bandwidth survives the rate change. The polyphase structure, energy
+// compensation (x Factor per phase), streaming history preservation, and
+// zero-alloc / lock-free span -> span discipline mirror the classic
+// FreeDvResampler.Interpolator exactly — only the ratio (3 vs 6) and the
+// prototype cutoff (wideband vs voice) differ. The classic 6:1 path is left
+// untouched.
+
+namespace Zeus.Dsp.FreeDv;
+
+/// <summary>
+/// Wideband 16 kHz -&gt; 48 kHz (3:1) polyphase interpolator for RADE speech
+/// output. Streaming, history-preserving, zero-allocation.
+/// </summary>
+internal static class RadeResampler
+{
+    internal const int Factor = 3;            // 48000 / 16000
+    internal const int FsHigh = 48000;
+    internal const int FsLow = 16000;
+    private const int TapsPerPhase = 20;      // -> 60-tap prototype (divisible by 3)
+    private const double CutoffHz = 7200.0;   // wideband: below 8 kHz output Nyquist, keep FARGAN HF
+
+    // Prototype low-pass, normalized so DC gain == 1.
+    private static readonly float[] Prototype = DesignLowpass(TapsPerPhase * Factor, CutoffHz, FsHigh);
+
+    private static float[] DesignLowpass(int numTaps, double cutoffHz, double fsHz)
+    {
+        var h = new double[numTaps];
+        double fc = cutoffHz / fsHz;          // normalized cutoff (cycles/sample)
+        double mid = (numTaps - 1) / 2.0;
+        double sum = 0.0;
+        for (int i = 0; i < numTaps; i++)
+        {
+            double n = i - mid;
+            double sinc = (Math.Abs(n) < 1e-9) ? 2.0 * fc : Math.Sin(2.0 * Math.PI * fc * n) / (Math.PI * n);
+            double w = 0.54 - 0.46 * Math.Cos(2.0 * Math.PI * i / (numTaps - 1)); // Hamming
+            double v = sinc * w;
+            h[i] = v;
+            sum += v;
+        }
+        var taps = new float[numTaps];
+        for (int i = 0; i < numTaps; i++) taps[i] = (float)(h[i] / sum); // DC gain 1
+        return taps;
+    }
+
+    /// <summary>Exact interpolator output for a given input length.</summary>
+    internal static int InterpolatedLength(int inputLen) => inputLen * Factor;
+
+    internal static Interpolator NewInterpolator() => new(Prototype);
+
+    /// <summary>16 kHz -&gt; 48 kHz. Polyphase: each input sample yields Factor output samples.</summary>
+    internal sealed class Interpolator
+    {
+        private readonly float[][] _phases; // [Factor][tapsPerPhase]
+        private readonly float[] _delay;    // input history, length = tapsPerPhase
+        private int _head;
+
+        internal Interpolator(float[] prototype)
+        {
+            int perPhase = prototype.Length / Factor;
+            _phases = new float[Factor][];
+            for (int p = 0; p < Factor; p++)
+            {
+                var sub = new float[perPhase];
+                for (int k = 0; k < perPhase; k++)
+                    sub[k] = prototype[k * Factor + p] * Factor; // x Factor: zero-stuff energy comp
+                _phases[p] = sub;
+            }
+            _delay = new float[perPhase];
+        }
+
+        internal void Reset()
+        {
+            Array.Clear(_delay);
+            _head = 0;
+        }
+
+        /// <summary>Consumes all of <paramref name="input"/>; writes produced 48 kHz
+        /// samples to <paramref name="output"/> (size at least InterpolatedLength).
+        /// Returns the number of samples written. No allocation.</summary>
+        internal int Process(ReadOnlySpan<float> input, Span<float> output)
+        {
+            int n = _delay.Length;
+            int outCount = 0;
+            foreach (float x in input)
+            {
+                _head = (_head + 1) % n;
+                _delay[_head] = x;
+                for (int p = 0; p < Factor; p++)
+                {
+                    float[] sub = _phases[p];
+                    float acc = 0f;
+                    int idx = _head;
+                    for (int k = 0; k < n; k++)
+                    {
+                        acc += sub[k] * _delay[idx];
+                        idx = (idx == 0) ? n - 1 : idx - 1;
+                    }
+                    output[outCount++] = acc;
+                }
+            }
+            return outCount;
+        }
+    }
+}

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -747,6 +747,11 @@ public class DspPipelineService : BackgroundService,
     private bool _radioMicAttached;
 
     private RxMode _appliedMode = RxMode.USB;
+    // Sideband actually pushed to WDSP. Equals _appliedMode for every mode except
+    // FreeDv, where it follows the FreeDV band convention (LSB < 10 MHz, USB ≥) so
+    // a dial crossing 10 MHz while staying in FreeDv re-flips the demod/mod
+    // orientation. See RadioService.EffectiveEngineMode.
+    private RxMode _appliedEngineMode = RxMode.USB;
     private int _appliedLowHz;
     private int _appliedHighHz;
     // WDSP RX filter shift currently applied (Hz). Equals
@@ -770,7 +775,25 @@ public class DspPipelineService : BackgroundService,
     {
         int loAbs = Math.Min(Math.Abs(s.TxFilterLowHz), Math.Abs(s.TxFilterHighHz));
         int hiAbs = Math.Max(Math.Abs(s.TxFilterLowHz), Math.Abs(s.TxFilterHighHz));
-        return RadioService.SignedFilterForMode(s.Mode, loAbs, hiAbs);
+        // EffectiveEngineMode is a no-op for every mode except FreeDv, where the
+        // TX bandpass must follow the same band-convention sideband as the RX/TXA
+        // demod so the transmitted OFDM carriers land on the band's shared
+        // orientation (LSB < 10 MHz, USB ≥). See RadioService.EffectiveEngineMode.
+        return RadioService.SignedFilterForMode(
+            RadioService.EffectiveEngineMode(s.Mode, s.VfoHz), loAbs, hiAbs);
+    }
+
+    // RX bandpass signed for the effective engine sideband. For FreeDv this
+    // re-signs the stored (USB-positive) FreeDV passband to the convention
+    // sideband so an LSB sub-10 MHz demod gets a negative-frequency passband
+    // rather than a dead positive one. Every other mode passes its already-signed
+    // stored width straight through (byte-identical to the prior direct push).
+    private static (int low, int high) SignedRxFilterFor(StateDto s, RxMode engineMode)
+    {
+        if (s.Mode != RxMode.FreeDv) return (s.FilterLowHz, s.FilterHighHz);
+        int loAbs = Math.Min(Math.Abs(s.FilterLowHz), Math.Abs(s.FilterHighHz));
+        int hiAbs = Math.Max(Math.Abs(s.FilterLowHz), Math.Abs(s.FilterHighHz));
+        return RadioService.SignedFilterForMode(engineMode, loAbs, hiAbs);
     }
     private double _appliedAgcTopDb;
     private double _appliedAgcOffsetDb;
@@ -3328,19 +3351,31 @@ public class DspPipelineService : BackgroundService,
         for (int ri = 2; ri < MaxReceivers; ri++)
             _ = EnsureSecondaryRxChannel(engine, ri, s);
 
-        if (s.Mode != _appliedMode)
+        // FreeDV has no WDSP sideband of its own — resolve the effective demod/mod
+        // orientation from the dial (LSB < 10 MHz, USB ≥). For every other mode
+        // this equals s.Mode, so the change-detection and pushes are byte-identical
+        // to before. Tracked via _appliedEngineMode so a dial crossing 10 MHz while
+        // staying in FreeDv re-flips the sideband. See RadioService.EffectiveEngineMode.
+        var engineMode = RadioService.EffectiveEngineMode(s.Mode, s.VfoHz);
+        if (s.Mode != _appliedMode || engineMode != _appliedEngineMode)
         {
-            engine.SetMode(channel, s.Mode);
+            engine.SetMode(channel, engineMode);
             // Keep TXA modulator mode in sync with the RX side. On Synthetic
             // and before OpenTxChannel has run this is a no-op.
-            engine.SetTxMode(s.Mode);
+            engine.SetTxMode(engineMode);
             _appliedMode = s.Mode;
+            _appliedEngineMode = engineMode;
         }
-        if (s.FilterLowHz != _appliedLowHz || s.FilterHighHz != _appliedHighHz)
+        // FreeDV's stored bandpass is USB-positive; re-sign it for the effective
+        // sideband so an LSB (sub-10 MHz) FreeDV demod gets a negative-frequency
+        // passband instead of a dead positive one. Non-FreeDv modes carry their
+        // already-signed width through unchanged.
+        var (rxLowHz, rxHighHz) = SignedRxFilterFor(s, engineMode);
+        if (rxLowHz != _appliedLowHz || rxHighHz != _appliedHighHz)
         {
-            engine.SetFilter(channel, s.FilterLowHz, s.FilterHighHz);
-            _appliedLowHz = s.FilterLowHz;
-            _appliedHighHz = s.FilterHighHz;
+            engine.SetFilter(channel, rxLowHz, rxHighHz);
+            _appliedLowHz = rxLowHz;
+            _appliedHighHz = rxHighHz;
         }
         // Frozen-NCO frequency shift. The dial sits off-centre on the WDSP
         // IF (the radio's NCO is frozen at RadioLoHz); WDSP's `shift` stage
@@ -3746,12 +3781,16 @@ public class DspPipelineService : BackgroundService,
         var agc = s.Agc ?? new AgcConfig(AgcMode.Med);
         var squelch = s.Squelch ?? new SquelchConfig();
         var txLeveling = s.TxLeveling ?? new TxLevelingConfig();
-        engine.SetMode(channelId, s.Mode);
+        // FreeDV resolves to the band-convention sideband (LSB < 10 MHz, USB ≥);
+        // every other mode passes through as itself. See RadioService.EffectiveEngineMode.
+        var openEngineMode = RadioService.EffectiveEngineMode(s.Mode, s.VfoHz);
+        engine.SetMode(channelId, openEngineMode);
         // Sync TXA modulator with RX mode at engine-open time so the first
         // key-down lands with the correct sideband (no-op on Synthetic / pre-
         // OpenTxChannel).
-        engine.SetTxMode(s.Mode);
-        engine.SetFilter(channelId, s.FilterLowHz, s.FilterHighHz);
+        engine.SetTxMode(openEngineMode);
+        var (openRxLow, openRxHigh) = SignedRxFilterFor(s, openEngineMode);
+        engine.SetFilter(channelId, openRxLow, openRxHigh);
         // Sign the TX bandpass from the live mode (see SignedTxFilterFor) so a
         // fresh engine doesn't key up with a USB-positive default while in LSB.
         var (txOpenLow, txOpenHigh) = SignedTxFilterFor(s);
@@ -3806,8 +3845,11 @@ public class DspPipelineService : BackgroundService,
         engine.SetNotches(_radio.Notches);
         engine.SetZoom(channelId, s.ZoomLevel);
         _appliedMode = s.Mode;
-        _appliedLowHz = s.FilterLowHz;
-        _appliedHighHz = s.FilterHighHz;
+        _appliedEngineMode = openEngineMode;
+        // Cache the SIGNED values we actually pushed (FreeDv re-signs by sideband)
+        // so the first OnRadioStateChanged tick doesn't see a phantom width change.
+        _appliedLowHz = openRxLow;
+        _appliedHighHz = openRxHigh;
         _appliedCtunOffsetHz = ctunShiftHz;
         _appliedTxLowHz = txOpenLow;
         _appliedTxHighHz = txOpenHigh;
@@ -3974,7 +4016,16 @@ public class DspPipelineService : BackgroundService,
         var agc = s.Agc ?? new AgcConfig(AgcMode.Med);
         var squelch = s.Squelch ?? new SquelchConfig();
         var (mode, vfoHz, filterLow, filterHigh, afGainDb) = SecondaryRxParams(s, rxIndex);
-        engine.SetMode(channelId, mode);
+        // FreeDV on a secondary RX follows the same band-convention sideband as the
+        // primary (LSB < 10 MHz, USB ≥); other modes pass through unchanged.
+        var secEngineMode = RadioService.EffectiveEngineMode(mode, vfoHz);
+        engine.SetMode(channelId, secEngineMode);
+        if (mode == RxMode.FreeDv)
+        {
+            int loAbs = Math.Min(Math.Abs(filterLow), Math.Abs(filterHigh));
+            int hiAbs = Math.Max(Math.Abs(filterLow), Math.Abs(filterHigh));
+            (filterLow, filterHigh) = RadioService.SignedFilterForMode(secEngineMode, loAbs, hiAbs);
+        }
         engine.SetFilter(channelId, filterLow, filterHigh);
         engine.SetVfoHz(channelId, vfoHz);
         UpdateRxLo(rxIndex, s);

--- a/Zeus.Server.Hosting/FreeDvReporter/SocketIoReporterClient.cs
+++ b/Zeus.Server.Hosting/FreeDvReporter/SocketIoReporterClient.cs
@@ -7,14 +7,24 @@
 //
 // SocketIoReporterClient — a minimal, clean-room Engine.IO v4 / Socket.IO
 // client over a single WebSocket, just enough to consume the FreeDV Reporter
-// stations feed at qso.freedv.org as a read-only ("view") observer.
+// stations feed at qso.freedv.org and (opt-in) report the operator's own
+// station back onto the public map.
 //
 // This is a from-scratch implementation of the public Engine.IO 4 / Socket.IO
 // framing (no third-party Socket.IO library, no NuGet dependency, no GPL source
 // copied). It uses only System.Net.WebSockets.ClientWebSocket and
 // System.Text.Json so it builds cleanly on every platform Zeus targets
 // (macOS / Windows / Linux x64+arm). It does NOT touch the radio / DSP / TX
-// path; it only opens an outbound TLS WebSocket and dispatches parsed events.
+// path; it only opens an outbound TLS WebSocket and dispatches parsed events
+// (and, in report role, emits the operator's own freq/TX/message events).
+//
+// Roles:
+//   "view"   — read-only observer (default). CONNECT payload identifies no
+//              operator and Zeus only RECEIVES the roster. This is the
+//              historical behaviour, preserved byte-for-byte.
+//   "report" — opt-in. CONNECT payload carries the operator's callsign + grid +
+//              version + os; Zeus still receives the full roster but ALSO emits
+//              freq_change / tx_report / message_update / qsy_request events.
 //
 // Framing handled (text frames only):
 //   Engine.IO OPEN   "0{...sid,pingInterval,pingTimeout...}"  (server -> client)
@@ -22,7 +32,7 @@
 //   Engine.IO PONG   "3"                                       (client -> server)
 //   Socket.IO CONNECT     "40{...}"  (both directions; ack carries the sid)
 //   Socket.IO DISCONNECT  "41"       (namespace disconnect; server -> client)
-//   Socket.IO EVENT       "42[name,payload]"                   (server -> client)
+//   Socket.IO EVENT       "42[name,payload]"          (both directions)
 //   Socket.IO CONNECT_ERR "44{...}"  (rejected; we throw to force a reconnect)
 
 using System.Net.WebSockets;
@@ -31,6 +41,18 @@ using System.Text.Json;
 using Microsoft.Extensions.Logging;
 
 namespace Zeus.Server.FreeDvReporter;
+
+/// <summary>
+/// Operator identity used to build the Socket.IO CONNECT auth payload. When
+/// <see cref="Role"/> is "report" the callsign / grid are broadcast publicly; in
+/// "view" role they are ignored and only the role is sent.
+/// </summary>
+public sealed record ReporterIdentity(
+    string Role,        // "view" | "report"
+    string Callsign,
+    string GridSquare,
+    string Version,
+    string Os);
 
 /// <summary>
 /// Single-WebSocket Engine.IO v4 / Socket.IO client for the FreeDV Reporter
@@ -44,19 +66,60 @@ public sealed class SocketIoReporterClient
     private const string ReporterUrl = "wss://qso.freedv.org/socket.io/?EIO=4&transport=websocket";
 
     private readonly Action<string, JsonElement> _onEvent;
+    private readonly Func<ReporterIdentity> _identityProvider;
     private readonly ILogger _log;
 
     // Published as a plain string so the snapshot DTO can surface it verbatim.
     private volatile string _connectionState = "Disconnected";
 
-    public SocketIoReporterClient(Action<string, JsonElement> onEvent, ILogger log)
+    // The role we actually connected with this session (resolved at connect time
+    // from the identity provider). Drives whether emits are live. Volatile so a
+    // reader on another thread sees the latest handshake outcome.
+    private volatile string _role = "view";
+
+    // Our own per-connection session id, captured from the CONNECT ack
+    // ("40{"sid":"..."}"). Null until acked / after disconnect. Exposed as MySid
+    // so the frontend can highlight the operator's own roster row.
+    private volatile string? _mySid;
+
+    // Live socket reference so emits can run between handshakes. Guarded together
+    // with the send semaphore below; null when no socket is open.
+    private ClientWebSocket? _ws;
+
+    // ClientWebSocket forbids concurrent SendAsync calls; this serialises every
+    // send (handshake frames, pongs and report-role emits) onto one writer.
+    private readonly SemaphoreSlim _sendLock = new(1, 1);
+
+    // Cached last-published report state so a reconnect can re-publish the
+    // operator's current freq / mode / TX / message without waiting for the next
+    // radio event. Mutated under _stateLock; read when (re)connecting.
+    private readonly object _stateLock = new();
+    private long _lastFreqHz;
+    private string _lastMode = "";
+    private bool _lastTransmitting;
+    private string _lastMessage = "";
+
+    public SocketIoReporterClient(
+        Action<string, JsonElement> onEvent,
+        Func<ReporterIdentity> identityProvider,
+        ILogger log)
     {
         _onEvent = onEvent;
+        _identityProvider = identityProvider;
         _log = log;
     }
 
     /// <summary>Live link state: Disconnected | Connecting | Connected | Reconnecting.</summary>
     public string ConnectionState => _connectionState;
+
+    /// <summary>The role of the current connection: "view" (read-only) or "report".</summary>
+    public string Role => _role;
+
+    /// <summary>True when connected in report role (the operator is on the public map).</summary>
+    public bool Reporting => _role == "report" && _connectionState == "Connected";
+
+    /// <summary>Our own session id while connected, else null.</summary>
+    public string? MySid => _mySid;
 
     /// <summary>
     /// Connects, performs the Engine.IO/Socket.IO handshake, then pumps the
@@ -68,10 +131,13 @@ public sealed class SocketIoReporterClient
     public async Task RunLoopAsync(CancellationToken ct, bool reconnect = false)
     {
         _connectionState = reconnect ? "Reconnecting" : "Connecting";
-        using var ws = new ClientWebSocket();
+        var ws = new ClientWebSocket();
         try
         {
             await ws.ConnectAsync(new Uri(ReporterUrl), ct).ConfigureAwait(false);
+
+            // Publish the live socket so emits can find it between handshakes.
+            _ws = ws;
 
             // 1) Engine.IO OPEN — a "0{...}" text frame with the session params.
             var open = await ReceiveMessageAsync(ws, ct).ConfigureAwait(false);
@@ -81,8 +147,13 @@ public sealed class SocketIoReporterClient
             // server drives the heartbeat (sends "2", we answer "3"), so we just
             // react to pings rather than scheduling our own.
 
-            // 2) Socket.IO CONNECT — join the default namespace as a read-only viewer.
-            await SendTextAsync(ws, "40{\"protocol_version\":2,\"role\":\"view\"}", ct).ConfigureAwait(false);
+            // 2) Socket.IO CONNECT — join the default namespace with the
+            //    identity-driven auth payload. View role keeps the historical
+            //    {"protocol_version":2,"role":"view"} byte-for-byte; report role
+            //    adds the operator's credentials.
+            var identity = _identityProvider();
+            _role = identity.Role == "report" ? "report" : "view";
+            await SendTextAsync(ws, BuildConnectPacket(identity), ct).ConfigureAwait(false);
 
             // 3) Pump. The CONNECT ack ("40{...}") or reject ("44{...}") arrives
             //    inline in the receive loop; a stray ping may precede it.
@@ -97,6 +168,8 @@ public sealed class SocketIoReporterClient
         finally
         {
             _connectionState = "Disconnected";
+            _mySid = null;
+            _ws = null;
             if (ws.State == WebSocketState.Open || ws.State == WebSocketState.CloseReceived)
             {
                 try
@@ -106,6 +179,147 @@ public sealed class SocketIoReporterClient
                 }
                 catch { /* best-effort close */ }
             }
+            ws.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Force the current connection to drop so the service's reconnect loop
+    /// re-handshakes with a fresh identity (e.g. after the operator toggles
+    /// report mode). No-op if nothing is connected. The receive loop returns when
+    /// the socket aborts, the caller waits its backoff, then reconnects.
+    /// </summary>
+    public void ForceReconnect()
+    {
+        var ws = _ws;
+        if (ws is null) return;
+        try { ws.Abort(); }
+        catch { /* best-effort — the loop will surface the close */ }
+    }
+
+    // ----- report-role emits (no-ops unless connected in report role) -----
+
+    /// <summary>Emit the operator's current VFO frequency (Hz). Cached for re-publish.</summary>
+    public void EmitFreqChange(long hz)
+    {
+        lock (_stateLock) _lastFreqHz = hz;
+        if (!Reporting) return;
+        var payload = new Dictionary<string, object?> { ["freq"] = hz };
+        EmitEvent("freq_change", payload);
+    }
+
+    /// <summary>Emit the operator's current mode + TX state. Cached for re-publish.</summary>
+    public void EmitTxReport(string mode, bool transmitting)
+    {
+        lock (_stateLock)
+        {
+            _lastMode = mode ?? "";
+            _lastTransmitting = transmitting;
+        }
+        if (!Reporting) return;
+        var payload = new Dictionary<string, object?>
+        {
+            ["mode"] = mode ?? "",
+            ["transmitting"] = transmitting,
+        };
+        EmitEvent("tx_report", payload);
+    }
+
+    /// <summary>Emit the operator's optional status message. Cached for re-publish.</summary>
+    public void EmitMessageUpdate(string msg)
+    {
+        lock (_stateLock) _lastMessage = msg ?? "";
+        if (!Reporting) return;
+        var payload = new Dictionary<string, object?> { ["message"] = msg ?? "" };
+        EmitEvent("message_update", payload);
+    }
+
+    /// <summary>Ask another station (by sid) to QSY to the given frequency.</summary>
+    public void EmitQsy(string destSid, long freqHz, string message)
+    {
+        if (!Reporting || string.IsNullOrEmpty(destSid)) return;
+        var payload = new Dictionary<string, object?>
+        {
+            ["dest_sid"] = destSid,
+            ["message"] = message ?? "",
+            ["frequency"] = freqHz,
+        };
+        EmitEvent("qsy_request", payload);
+    }
+
+    /// <summary>
+    /// Re-publish the operator's cached freq / mode / TX / message after a
+    /// (re)connect in report role. Called by the service once the link is up.
+    /// </summary>
+    public void RepublishState()
+    {
+        if (!Reporting) return;
+        long freq;
+        string mode, message;
+        bool tx;
+        lock (_stateLock)
+        {
+            freq = _lastFreqHz;
+            mode = _lastMode;
+            tx = _lastTransmitting;
+            message = _lastMessage;
+        }
+        if (freq > 0)
+            EmitEvent("freq_change", new Dictionary<string, object?> { ["freq"] = freq });
+        EmitEvent("tx_report", new Dictionary<string, object?>
+        {
+            ["mode"] = mode,
+            ["transmitting"] = tx,
+        });
+        if (!string.IsNullOrEmpty(message))
+            EmitEvent("message_update", new Dictionary<string, object?> { ["message"] = message });
+    }
+
+    // Builds the Socket.IO CONNECT auth packet via System.Text.Json so the
+    // callsign / grid are JSON-escaped (never hand-concatenated). View role emits
+    // exactly the historical payload; report role adds operator fields.
+    private static string BuildConnectPacket(ReporterIdentity id)
+    {
+        Dictionary<string, object?> auth;
+        if (id.Role == "report")
+        {
+            auth = new Dictionary<string, object?>
+            {
+                ["protocol_version"] = 2,
+                ["role"] = "report",
+                ["callsign"] = id.Callsign,
+                ["grid_square"] = id.GridSquare,
+                ["version"] = string.IsNullOrWhiteSpace(id.Version) ? "Zeus" : id.Version,
+                ["rx_only"] = false,
+                ["os"] = id.Os,
+            };
+        }
+        else
+        {
+            auth = new Dictionary<string, object?>
+            {
+                ["protocol_version"] = 2,
+                ["role"] = "view",
+            };
+        }
+        return "40" + JsonSerializer.Serialize(auth);
+    }
+
+    // Serialises one Socket.IO EVENT ("42[name,payload]") and ships it on the
+    // live socket. Best-effort: a closed/absent socket or a serialisation hiccup
+    // is swallowed — emits must never disturb the radio path.
+    private void EmitEvent(string name, object payload)
+    {
+        var ws = _ws;
+        if (ws is null) return;
+        try
+        {
+            var frame = "42" + JsonSerializer.Serialize(new object[] { name, payload });
+            _ = SendTextAsync(ws, frame, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            _log.LogDebug(ex, "FreeDV Reporter: emit '{Event}' dropped", name);
         }
     }
 
@@ -130,14 +344,17 @@ public sealed class SocketIoReporterClient
         char sio = msg[1];
         switch (sio)
         {
-            case '0': // Socket.IO CONNECT ack — namespace joined.
+            case '0': // Socket.IO CONNECT ack — namespace joined; ack carries our sid.
                 _connectionState = "Connected";
-                _log.LogInformation("FreeDV Reporter: connected");
+                _mySid = ExtractSid(msg.AsSpan(2));
+                _log.LogInformation("FreeDV Reporter: connected (role={Role}, sid={Sid})",
+                    _role, _mySid ?? "?");
                 break;
 
             case '1': // Socket.IO DISCONNECT (namespace) — treat as link down.
                 _log.LogInformation("FreeDV Reporter: server sent namespace disconnect");
                 _connectionState = "Disconnected";
+                _mySid = null;
                 break;
 
             case '2': // Socket.IO EVENT — "42[name, payload]".
@@ -152,6 +369,23 @@ public sealed class SocketIoReporterClient
                 // 3 = ACK, 5 = BINARY_EVENT, 6 = BINARY_ACK — not used by the feed.
                 break;
         }
+    }
+
+    // Parses the CONNECT-ack body ("{"sid":"..."}") for our session id. Tolerant
+    // of a missing/odd body — returns null rather than throwing.
+    private static string? ExtractSid(ReadOnlySpan<char> body)
+    {
+        if (body.IsEmpty || body[0] != '{') return null;
+        try
+        {
+            using var doc = JsonDocument.Parse(body.ToString());
+            if (doc.RootElement.ValueKind == JsonValueKind.Object
+                && doc.RootElement.TryGetProperty("sid", out var sid)
+                && sid.ValueKind == JsonValueKind.String)
+                return sid.GetString();
+        }
+        catch (JsonException) { /* no sid available */ }
+        return null;
     }
 
     // Parses "[eventName, payload]" (the body after the "42" prefix) and invokes
@@ -182,10 +416,20 @@ public sealed class SocketIoReporterClient
         }
     }
 
-    private static async Task SendTextAsync(ClientWebSocket ws, string text, CancellationToken ct)
+    // Serialises sends onto a single writer (ClientWebSocket forbids concurrent
+    // SendAsync). Best-effort: a closed socket throws, which the caller logs/ignores.
+    private async Task SendTextAsync(ClientWebSocket ws, string text, CancellationToken ct)
     {
         var bytes = Encoding.UTF8.GetBytes(text);
-        await ws.SendAsync(bytes, WebSocketMessageType.Text, endOfMessage: true, ct).ConfigureAwait(false);
+        await _sendLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await ws.SendAsync(bytes, WebSocketMessageType.Text, endOfMessage: true, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _sendLock.Release();
+        }
     }
 
     // Accumulates frames until EndOfMessage, then UTF-8 decodes the whole

--- a/Zeus.Server.Hosting/FreeDvReporter/SocketIoReporterClient.cs
+++ b/Zeus.Server.Hosting/FreeDvReporter/SocketIoReporterClient.cs
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// SocketIoReporterClient — a minimal, clean-room Engine.IO v4 / Socket.IO
+// client over a single WebSocket, just enough to consume the FreeDV Reporter
+// stations feed at qso.freedv.org as a read-only ("view") observer.
+//
+// This is a from-scratch implementation of the public Engine.IO 4 / Socket.IO
+// framing (no third-party Socket.IO library, no NuGet dependency, no GPL source
+// copied). It uses only System.Net.WebSockets.ClientWebSocket and
+// System.Text.Json so it builds cleanly on every platform Zeus targets
+// (macOS / Windows / Linux x64+arm). It does NOT touch the radio / DSP / TX
+// path; it only opens an outbound TLS WebSocket and dispatches parsed events.
+//
+// Framing handled (text frames only):
+//   Engine.IO OPEN   "0{...sid,pingInterval,pingTimeout...}"  (server -> client)
+//   Engine.IO PING   "2"                                       (server -> client)
+//   Engine.IO PONG   "3"                                       (client -> server)
+//   Socket.IO CONNECT     "40{...}"  (both directions; ack carries the sid)
+//   Socket.IO DISCONNECT  "41"       (namespace disconnect; server -> client)
+//   Socket.IO EVENT       "42[name,payload]"                   (server -> client)
+//   Socket.IO CONNECT_ERR "44{...}"  (rejected; we throw to force a reconnect)
+
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace Zeus.Server.FreeDvReporter;
+
+/// <summary>
+/// Single-WebSocket Engine.IO v4 / Socket.IO client for the FreeDV Reporter
+/// feed. One instance is reused across reconnects: each call to
+/// <see cref="RunLoopAsync"/> opens a fresh socket, performs the handshake, and
+/// pumps the receive loop until the socket closes, the token cancels, or an
+/// error is thrown — at which point the caller waits and calls again.
+/// </summary>
+public sealed class SocketIoReporterClient
+{
+    private const string ReporterUrl = "wss://qso.freedv.org/socket.io/?EIO=4&transport=websocket";
+
+    private readonly Action<string, JsonElement> _onEvent;
+    private readonly ILogger _log;
+
+    // Published as a plain string so the snapshot DTO can surface it verbatim.
+    private volatile string _connectionState = "Disconnected";
+
+    public SocketIoReporterClient(Action<string, JsonElement> onEvent, ILogger log)
+    {
+        _onEvent = onEvent;
+        _log = log;
+    }
+
+    /// <summary>Live link state: Disconnected | Connecting | Connected | Reconnecting.</summary>
+    public string ConnectionState => _connectionState;
+
+    /// <summary>
+    /// Connects, performs the Engine.IO/Socket.IO handshake, then pumps the
+    /// receive loop — answering server pings and dispatching events — until the
+    /// socket closes, an error occurs, or <paramref name="ct"/> cancels. Returns
+    /// (or throws) so the caller can wait and reconnect. Set <paramref name="reconnect"/>
+    /// so the reported state is "Reconnecting" rather than "Connecting".
+    /// </summary>
+    public async Task RunLoopAsync(CancellationToken ct, bool reconnect = false)
+    {
+        _connectionState = reconnect ? "Reconnecting" : "Connecting";
+        using var ws = new ClientWebSocket();
+        try
+        {
+            await ws.ConnectAsync(new Uri(ReporterUrl), ct).ConfigureAwait(false);
+
+            // 1) Engine.IO OPEN — a "0{...}" text frame with the session params.
+            var open = await ReceiveMessageAsync(ws, ct).ConfigureAwait(false);
+            if (open is null || open.Length == 0 || open[0] != '0')
+                throw new InvalidOperationException("FreeDV Reporter: expected Engine.IO OPEN frame");
+            // pingInterval/pingTimeout are informational here — in EIO4 the
+            // server drives the heartbeat (sends "2", we answer "3"), so we just
+            // react to pings rather than scheduling our own.
+
+            // 2) Socket.IO CONNECT — join the default namespace as a read-only viewer.
+            await SendTextAsync(ws, "40{\"protocol_version\":2,\"role\":\"view\"}", ct).ConfigureAwait(false);
+
+            // 3) Pump. The CONNECT ack ("40{...}") or reject ("44{...}") arrives
+            //    inline in the receive loop; a stray ping may precede it.
+            while (!ct.IsCancellationRequested && ws.State == WebSocketState.Open)
+            {
+                var msg = await ReceiveMessageAsync(ws, ct).ConfigureAwait(false);
+                if (msg is null) break; // close received
+                if (msg.Length == 0) continue;
+                DispatchPacket(ws, msg, ct);
+            }
+        }
+        finally
+        {
+            _connectionState = "Disconnected";
+            if (ws.State == WebSocketState.Open || ws.State == WebSocketState.CloseReceived)
+            {
+                try
+                {
+                    await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "bye", CancellationToken.None)
+                        .ConfigureAwait(false);
+                }
+                catch { /* best-effort close */ }
+            }
+        }
+    }
+
+    // Routes one decoded Engine.IO / Socket.IO text message by packet prefix.
+    private void DispatchPacket(ClientWebSocket ws, string msg, CancellationToken ct)
+    {
+        char eio = msg[0];
+
+        // Engine.IO PING — answer PONG immediately, at any time in the loop
+        // (including before the Socket.IO connect-ack).
+        if (eio == '2')
+        {
+            // Fire-and-forget the pong; failures surface on the next receive.
+            _ = SendTextAsync(ws, "3", ct);
+            return;
+        }
+
+        // Engine.IO MESSAGE (Socket.IO packet) — prefix '4', then a Socket.IO
+        // packet-type digit.
+        if (eio != '4' || msg.Length < 2) return;
+
+        char sio = msg[1];
+        switch (sio)
+        {
+            case '0': // Socket.IO CONNECT ack — namespace joined.
+                _connectionState = "Connected";
+                _log.LogInformation("FreeDV Reporter: connected");
+                break;
+
+            case '1': // Socket.IO DISCONNECT (namespace) — treat as link down.
+                _log.LogInformation("FreeDV Reporter: server sent namespace disconnect");
+                _connectionState = "Disconnected";
+                break;
+
+            case '2': // Socket.IO EVENT — "42[name, payload]".
+                DispatchEvent(msg.AsSpan(2));
+                break;
+
+            case '4': // Socket.IO CONNECT_ERROR — rejected; force a reconnect.
+                throw new InvalidOperationException(
+                    "FreeDV Reporter: connect rejected by server (" + msg + ")");
+
+            default:
+                // 3 = ACK, 5 = BINARY_EVENT, 6 = BINARY_ACK — not used by the feed.
+                break;
+        }
+    }
+
+    // Parses "[eventName, payload]" (the body after the "42" prefix) and invokes
+    // the handler. Tolerant of malformed bodies and a missing payload element.
+    private void DispatchEvent(ReadOnlySpan<char> body)
+    {
+        string json = body.ToString();
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Array || root.GetArrayLength() == 0)
+                return;
+
+            string? name = root[0].ValueKind == JsonValueKind.String ? root[0].GetString() : null;
+            if (string.IsNullOrEmpty(name))
+                return;
+
+            // Some events (rare) carry no payload object; pass an undefined element.
+            JsonElement payload = root.GetArrayLength() > 1 ? root[1] : default;
+
+            // Clone so the JsonElement outlives the using-disposed document.
+            _onEvent(name!, payload.ValueKind == JsonValueKind.Undefined ? default : payload.Clone());
+        }
+        catch (JsonException ex)
+        {
+            _log.LogDebug(ex, "FreeDV Reporter: dropped malformed event frame");
+        }
+    }
+
+    private static async Task SendTextAsync(ClientWebSocket ws, string text, CancellationToken ct)
+    {
+        var bytes = Encoding.UTF8.GetBytes(text);
+        await ws.SendAsync(bytes, WebSocketMessageType.Text, endOfMessage: true, ct).ConfigureAwait(false);
+    }
+
+    // Accumulates frames until EndOfMessage, then UTF-8 decodes the whole
+    // message. Returns null when the server initiates a close.
+    private static async Task<string?> ReceiveMessageAsync(ClientWebSocket ws, CancellationToken ct)
+    {
+        var buffer = new byte[8192];
+        using var ms = new MemoryStream();
+        while (true)
+        {
+            WebSocketReceiveResult result;
+            try
+            {
+                result = await ws.ReceiveAsync(buffer, ct).ConfigureAwait(false);
+            }
+            catch (WebSocketException)
+            {
+                return null;
+            }
+
+            if (result.MessageType == WebSocketMessageType.Close)
+                return null;
+
+            ms.Write(buffer, 0, result.Count);
+            if (result.EndOfMessage)
+                break;
+        }
+        return Encoding.UTF8.GetString(ms.GetBuffer(), 0, (int)ms.Length);
+    }
+}

--- a/Zeus.Server.Hosting/FreeDvReporterService.cs
+++ b/Zeus.Server.Hosting/FreeDvReporterService.cs
@@ -7,17 +7,26 @@
 //
 // FreeDvReporterService — keeps a live mirror of the FreeDV Reporter stations
 // network (qso.freedv.org) for the Stations panel (GET /api/freedv/stations).
-// It holds a persistent Socket.IO connection (see SocketIoReporterClient) as a
-// read-only "view" observer and folds the event stream into an in-memory
-// station table keyed by the reporter's per-connection session id (sid).
+// It holds a persistent Socket.IO connection (see SocketIoReporterClient) and
+// folds the event stream into an in-memory station table keyed by the
+// reporter's per-connection session id (sid).
+//
+// By default Zeus connects read-only ("view" role) — outbound TLS WebSocket in,
+// station snapshot out, NOTHING on the radio / DSP / TX path. When the operator
+// opts into report mode (FreeDvReporterSettingsStore, default OFF) AND a
+// callsign + grid are present, Zeus instead connects in "report" role and
+// publishes its own freq / TX / message events to the public map. The radio
+// seams are read-only subscriptions (StateChanged / MoxChanged) whose handlers
+// only ever EMIT to the reporter socket — they never call back into the radio,
+// and every emit is wrapped so a reporter fault can't disturb TX.
 //
 // Same shape as ActivationSpotsService — a self-contained BackgroundService
 // registered as a singleton + hosted service — but driven by a streaming
-// Socket.IO link instead of HTTP polling. It touches NOTHING on the radio /
-// DSP / TX path: outbound TLS WebSocket in, station snapshot out.
+// Socket.IO link instead of HTTP polling.
 
 using System.Collections.Concurrent;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -36,14 +45,60 @@ public sealed class FreeDvReporterService : BackgroundService
     private const int ReconnectDelaySeconds = 5;
     private static readonly TimeSpan StaleAfter = TimeSpan.FromHours(1);
 
+    // Coalesce freq_change emits so spinning the VFO doesn't flood the socket.
+    private static readonly TimeSpan FreqEmitInterval = TimeSpan.FromMilliseconds(500);
+
     private readonly ILogger<FreeDvReporterService> _log;
     private readonly ConcurrentDictionary<string, Station> _stations = new();
     private readonly SocketIoReporterClient _client;
 
-    public FreeDvReporterService(ILogger<FreeDvReporterService> log)
+    private readonly RadioService _radio;
+    private readonly QrzService _qrz;
+    private readonly FreeDvReporterSettingsStore _settingsStore;
+    private readonly FreeDvService _freeDv;
+
+    // Last values we actually emitted in report role, so a no-op change (e.g. a
+    // StateChanged that didn't move the VFO or mode) doesn't re-emit.
+    private long _emittedFreqHz;
+    private string _emittedMode = "";
+    private DateTime _lastFreqEmitUtc = DateTime.MinValue;
+    // Latest PTT state, tracked off MoxChanged. StateDto carries no MOX flag
+    // (TX state is session-only), so we keep our own copy to pair with a
+    // mode-change tx_report.
+    private volatile bool _transmitting;
+
+    public FreeDvReporterService(
+        ILogger<FreeDvReporterService> log,
+        RadioService radio,
+        QrzService qrz,
+        FreeDvReporterSettingsStore settingsStore,
+        FreeDvService freeDv)
     {
         _log = log;
-        _client = new SocketIoReporterClient(HandleEvent, log);
+        _radio = radio;
+        _qrz = qrz;
+        _settingsStore = settingsStore;
+        _freeDv = freeDv;
+        _client = new SocketIoReporterClient(HandleEvent, ResolveIdentity, log);
+    }
+
+    public override Task StartAsync(CancellationToken ct)
+    {
+        // Subscribe once; unsubscribed in Dispose. Handlers only ever emit to the
+        // reporter socket (never call back into the radio) and swallow their own
+        // errors, so the radio path is unaffected by reporter state.
+        _radio.StateChanged += OnRadioStateChanged;
+        _radio.MoxChanged += OnRadioMoxChanged;
+        return base.StartAsync(ct);
+    }
+
+    public override void Dispose()
+    {
+        _radio.StateChanged -= OnRadioStateChanged;
+        _radio.MoxChanged -= OnRadioMoxChanged;
+        // _settingsStore is a DI singleton — its lifetime is owned by the
+        // container, not this service; do not dispose it here.
+        base.Dispose();
     }
 
     protected override async Task ExecuteAsync(CancellationToken ct)
@@ -54,6 +109,18 @@ public sealed class FreeDvReporterService : BackgroundService
             // Drop any stale list so a fresh (re)connect starts clean — the
             // reporter resends the full roster via bulk_update on connect.
             _stations.Clear();
+
+            // Seed the report-state cache from the live radio so the first
+            // freq_change / tx_report we publish on connect reflects reality
+            // rather than zeros (no-op in view role).
+            SeedReportStateFromRadio();
+
+            // Watch for the handshake to complete so we can publish the operator's
+            // initial freq/mode/message once in report role. Runs alongside the
+            // receive loop and exits when the loop returns.
+            using var connectedCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            var republishTask = RepublishOnConnectAsync(connectedCts.Token);
+
             try
             {
                 await _client.RunLoopAsync(ct, reconnect).ConfigureAwait(false);
@@ -66,6 +133,12 @@ public sealed class FreeDvReporterService : BackgroundService
             {
                 _log.LogWarning(ex, "FreeDV Reporter link failed; reconnecting in {Delay}s", ReconnectDelaySeconds);
             }
+            finally
+            {
+                connectedCts.Cancel();
+                try { await republishTask.ConfigureAwait(false); }
+                catch (OperationCanceledException) { /* expected on loop exit */ }
+            }
 
             reconnect = true;
             try
@@ -77,6 +150,208 @@ public sealed class FreeDvReporterService : BackgroundService
                 break;
             }
         }
+    }
+
+    // Waits until the link reports Connected (or the token cancels) and, in
+    // report role, publishes the operator's initial freq/mode/message once.
+    private async Task RepublishOnConnectAsync(CancellationToken ct)
+    {
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                if (_client.Reporting)
+                {
+                    _client.RepublishState();
+                    return;
+                }
+                if (_client.ConnectionState == "Connected")
+                    return; // connected in view role — nothing to publish
+                await Task.Delay(200, ct).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) { /* loop exited */ }
+    }
+
+    // Resolves the CONNECT identity at handshake time from current settings,
+    // falling back to the QRZ home station for blank callsign/grid. Returns a
+    // "view" identity unless report mode is enabled AND a callsign + grid exist.
+    private ReporterIdentity ResolveIdentity()
+    {
+        var settings = _settingsStore.Get();
+        var (call, grid) = ResolveOperator(settings);
+
+        if (!settings.ReportEnabled || string.IsNullOrWhiteSpace(call) || string.IsNullOrWhiteSpace(grid))
+            return new ReporterIdentity("view", "", "", "", "");
+
+        return new ReporterIdentity(
+            Role: "report",
+            Callsign: call,
+            GridSquare: grid,
+            Version: "Zeus",
+            Os: OsLabel());
+    }
+
+    // Operator callsign/grid: settings first, QRZ home station as a fallback for
+    // blank fields. Returns ("","") when neither source has them.
+    private (string Call, string Grid) ResolveOperator(FreeDvReporterSettings settings)
+    {
+        var call = settings.Callsign;
+        var grid = settings.GridSquare;
+        if (string.IsNullOrWhiteSpace(call) || string.IsNullOrWhiteSpace(grid))
+        {
+            var home = _qrz.GetStatus().Home;
+            if (home is not null)
+            {
+                if (string.IsNullOrWhiteSpace(call) && !string.IsNullOrWhiteSpace(home.Callsign))
+                    call = home.Callsign.Trim().ToUpperInvariant();
+                if (string.IsNullOrWhiteSpace(grid) && !string.IsNullOrWhiteSpace(home.Grid))
+                {
+                    var g = home.Grid!.Trim();
+                    grid = g.Length > 6 ? g[..6] : g;
+                }
+            }
+        }
+        return (call ?? "", grid ?? "");
+    }
+
+    private static string OsLabel()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return "Windows";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return "macOS";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return "Linux";
+        return "Unknown";
+    }
+
+    // ----- public API for the endpoints -----
+
+    /// <summary>Current report-mode settings (callsign/grid/message + enable flag).</summary>
+    public FreeDvReporterSettings GetSettings() => _settingsStore.Get();
+
+    /// <summary>
+    /// Persist new report-mode settings and force a reconnect so the new role /
+    /// identity takes effect on the next handshake. Returns the saved (normalized)
+    /// settings.
+    /// </summary>
+    public FreeDvReporterSettings SaveSettings(FreeDvReporterSettings settings)
+    {
+        var saved = _settingsStore.Set(settings);
+        // Push the (possibly changed) status message into the client cache so a
+        // republish carries it; the force-reconnect re-handshakes with the new role.
+        _client.EmitMessageUpdate(saved.Message);
+        _client.ForceReconnect();
+        return saved;
+    }
+
+    /// <summary>
+    /// Ask the station identified by <paramref name="destSid"/> to QSY to the
+    /// operator's current VFO frequency. No-op (returns false) unless we are
+    /// connected in report role and the sid is known.
+    /// </summary>
+    public bool RequestQsy(string destSid)
+    {
+        if (!_client.Reporting) return false;
+        if (string.IsNullOrWhiteSpace(destSid) || !_stations.ContainsKey(destSid)) return false;
+        long freqHz = _radio.Snapshot().VfoHz;
+        if (freqHz <= 0) return false;
+        try
+        {
+            _client.EmitQsy(destSid, freqHz, GetSettings().Message);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _log.LogDebug(ex, "FreeDV Reporter: qsy_request to {Sid} failed", destSid);
+            return false;
+        }
+    }
+
+    // ----- radio seams (report role only; never throw, never touch the radio) -----
+
+    private void OnRadioStateChanged(StateDto state)
+    {
+        try
+        {
+            if (!_client.Reporting) return;
+
+            long freqHz = state.VfoHz;
+            if (freqHz != _emittedFreqHz)
+            {
+                // Coalesce so spinning the VFO doesn't flood the socket: at most
+                // one emit per FreqEmitInterval. The latest frequency wins.
+                var now = DateTime.UtcNow;
+                if (now - _lastFreqEmitUtc >= FreqEmitInterval)
+                {
+                    _emittedFreqHz = freqHz;
+                    _lastFreqEmitUtc = now;
+                    _client.EmitFreqChange(freqHz);
+                }
+            }
+
+            string mode = ReportModeLabel(state.Mode);
+            if (!string.Equals(mode, _emittedMode, StringComparison.Ordinal))
+            {
+                _emittedMode = mode;
+                // transmitting tracked via MoxChanged; report current TX state.
+                _client.EmitTxReport(mode, _transmitting);
+            }
+        }
+        catch (Exception ex)
+        {
+            _log.LogDebug(ex, "FreeDV Reporter: state-change emit failed");
+        }
+    }
+
+    private void OnRadioMoxChanged(bool transmitting)
+    {
+        _transmitting = transmitting;
+        try
+        {
+            if (!_client.Reporting) return;
+            string mode = _emittedMode.Length > 0 ? _emittedMode : ReportModeLabel(_radio.Snapshot().Mode);
+            _client.EmitTxReport(mode, transmitting);
+        }
+        catch (Exception ex)
+        {
+            _log.LogDebug(ex, "FreeDV Reporter: mox emit failed");
+        }
+    }
+
+    // Seeds the client's cached report state from the live radio before connect.
+    private void SeedReportStateFromRadio()
+    {
+        try
+        {
+            var snap = _radio.Snapshot();
+            _emittedFreqHz = snap.VfoHz;
+            _emittedMode = ReportModeLabel(snap.Mode);
+            _client.EmitFreqChange(snap.VfoHz);                       // caches only (not Reporting yet)
+            _client.EmitTxReport(_emittedMode, transmitting: false);  // caches only
+            _client.EmitMessageUpdate(_settingsStore.Get().Message);  // caches only
+        }
+        catch (Exception ex)
+        {
+            _log.LogDebug(ex, "FreeDV Reporter: seed report state failed");
+        }
+    }
+
+    // Maps the radio's current mode to the FreeDV Reporter mode label. In FreeDV
+    // mode we report the active submode (700D / RADEV1 / …); otherwise the plain
+    // RxMode name (USB, LSB, …) so the operator still appears with a sensible mode.
+    private string ReportModeLabel(RxMode mode)
+    {
+        if (mode != RxMode.FreeDv)
+            return mode.ToString().ToUpperInvariant();
+        return _freeDv.Status().Submode switch
+        {
+            FreeDvSubmode.Mode700C => "700C",
+            FreeDvSubmode.Mode700D => "700D",
+            FreeDvSubmode.Mode700E => "700E",
+            FreeDvSubmode.Mode1600 => "1600",
+            FreeDvSubmode.Mode800XA => "800XA",
+            FreeDvSubmode.RadeV1 => "RADEV1",
+            _ => "700D",
+        };
     }
 
     /// <summary>
@@ -117,7 +392,12 @@ public sealed class FreeDvReporterService : BackgroundService
         }
 
         list.Sort((a, b) => a.FreqHz.CompareTo(b.FreqHz));
-        return new FreeDvStationsResponseDto(_client.ConnectionState, Enabled: true, list);
+        return new FreeDvStationsResponseDto(
+            _client.ConnectionState,
+            Enabled: true,
+            list,
+            Reporting: _client.Reporting,
+            MySid: _client.MySid);
     }
 
     // ----- Socket.IO event handling -----

--- a/Zeus.Server.Hosting/FreeDvReporterService.cs
+++ b/Zeus.Server.Hosting/FreeDvReporterService.cs
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// FreeDvReporterService — keeps a live mirror of the FreeDV Reporter stations
+// network (qso.freedv.org) for the Stations panel (GET /api/freedv/stations).
+// It holds a persistent Socket.IO connection (see SocketIoReporterClient) as a
+// read-only "view" observer and folds the event stream into an in-memory
+// station table keyed by the reporter's per-connection session id (sid).
+//
+// Same shape as ActivationSpotsService — a self-contained BackgroundService
+// registered as a singleton + hosted service — but driven by a streaming
+// Socket.IO link instead of HTTP polling. It touches NOTHING on the radio /
+// DSP / TX path: outbound TLS WebSocket in, station snapshot out.
+
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Text.Json;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Zeus.Contracts;
+using Zeus.Server.FreeDvReporter;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Background service that mirrors the FreeDV Reporter stations feed and exposes
+/// the current snapshot via <see cref="GetSnapshot"/>. Registered as a singleton
+/// + hosted service in <c>ZeusHost</c>.
+/// </summary>
+public sealed class FreeDvReporterService : BackgroundService
+{
+    private const int ReconnectDelaySeconds = 5;
+    private static readonly TimeSpan StaleAfter = TimeSpan.FromHours(1);
+
+    private readonly ILogger<FreeDvReporterService> _log;
+    private readonly ConcurrentDictionary<string, Station> _stations = new();
+    private readonly SocketIoReporterClient _client;
+
+    public FreeDvReporterService(ILogger<FreeDvReporterService> log)
+    {
+        _log = log;
+        _client = new SocketIoReporterClient(HandleEvent, log);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken ct)
+    {
+        bool reconnect = false;
+        while (!ct.IsCancellationRequested)
+        {
+            // Drop any stale list so a fresh (re)connect starts clean — the
+            // reporter resends the full roster via bulk_update on connect.
+            _stations.Clear();
+            try
+            {
+                await _client.RunLoopAsync(ct, reconnect).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _log.LogWarning(ex, "FreeDV Reporter link failed; reconnecting in {Delay}s", ReconnectDelaySeconds);
+            }
+
+            reconnect = true;
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(ReconnectDelaySeconds), ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Current stations snapshot: connection state, enabled flag, and the live
+    /// station list sorted by frequency ascending (stations that never reported
+    /// a frequency are omitted).
+    /// </summary>
+    public FreeDvStationsResponseDto GetSnapshot()
+    {
+        var cutoff = DateTime.UtcNow - StaleAfter;
+        var list = new List<FreeDvStationDto>(_stations.Count);
+        foreach (var s in _stations.Values)
+        {
+            // Defensive stale-prune — the server normally sends remove_connection,
+            // but a dropped disconnect shouldn't leave a ghost forever.
+            if (s.LastUpdate < cutoff)
+            {
+                _stations.TryRemove(s.Sid, out _);
+                continue;
+            }
+            if (s.FreqHz <= 0) continue; // never reported a usable frequency
+
+            list.Add(new FreeDvStationDto(
+                Sid: s.Sid,
+                Callsign: s.Callsign ?? "",
+                GridSquare: s.GridSquare,
+                FreqHz: s.FreqHz,
+                Mode: s.Mode ?? "",
+                Transmitting: s.Transmitting,
+                RxOnly: s.RxOnly,
+                Message: s.Message,
+                Version: s.Version,
+                LastRxSnr: s.LastRxSnr is double snr && !double.IsNaN(snr) ? snr : null,
+                LastRxCallsign: s.LastRxCallsign,
+                LastRxMode: s.LastRxMode,
+                LastUpdate: s.LastUpdate.ToString("o", CultureInfo.InvariantCulture),
+                ConnectTime: s.ConnectTime?.ToString("o", CultureInfo.InvariantCulture)));
+        }
+
+        list.Sort((a, b) => a.FreqHz.CompareTo(b.FreqHz));
+        return new FreeDvStationsResponseDto(_client.ConnectionState, Enabled: true, list);
+    }
+
+    // ----- Socket.IO event handling -----
+
+    // The single Action handed to SocketIoReporterClient. Dispatches by event
+    // name; bulk_update recurses each contained [name, payload] pair through here.
+    private void HandleEvent(string name, JsonElement payload)
+    {
+        switch (name)
+        {
+            case "bulk_update":
+                // Initial snapshot: a JSON array of [eventName, payload] pairs.
+                if (payload.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var pair in payload.EnumerateArray())
+                    {
+                        if (pair.ValueKind != JsonValueKind.Array || pair.GetArrayLength() == 0)
+                            continue;
+                        string? innerName = pair[0].ValueKind == JsonValueKind.String ? pair[0].GetString() : null;
+                        if (string.IsNullOrEmpty(innerName)) continue;
+                        JsonElement innerPayload = pair.GetArrayLength() > 1 ? pair[1] : default;
+                        HandleEvent(innerName!, innerPayload);
+                    }
+                }
+                break;
+
+            case "new_connection":
+            case "freq_change":
+            case "tx_report":
+            case "message_update":
+                UpsertStation(payload, isRxReport: false);
+                break;
+
+            case "rx_report":
+                UpsertStation(payload, isRxReport: true);
+                break;
+
+            case "remove_connection":
+                {
+                    string? sid = GetString(payload, "sid");
+                    if (!string.IsNullOrEmpty(sid))
+                        _stations.TryRemove(sid!, out _);
+                }
+                break;
+
+            case "connection_successful":
+                _log.LogDebug("FreeDV Reporter: connection_successful");
+                break;
+
+            default:
+                // qsy_request and any other events are not consumed here.
+                break;
+        }
+    }
+
+    private void UpsertStation(JsonElement p, bool isRxReport)
+    {
+        if (p.ValueKind != JsonValueKind.Object) return;
+        string? sid = GetString(p, "sid");
+        if (string.IsNullOrEmpty(sid)) return;
+
+        var s = _stations.GetOrAdd(sid!, k => new Station { Sid = k });
+
+        if (GetString(p, "callsign") is string call)
+        {
+            if (isRxReport) s.LastRxCallsign = call;
+            else s.Callsign = call;
+        }
+        if (GetString(p, "grid_square") is string grid)
+            s.GridSquare = grid.Length > 6 ? grid[..6] : grid;
+        if (GetString(p, "version") is string ver)
+            s.Version = ver;
+        if (GetBool(p, "rx_only") is bool rxOnly)
+            s.RxOnly = rxOnly;
+        if (GetInt64(p, "freq") is long freq)
+            s.FreqHz = freq;
+        if (GetString(p, "mode") is string mode)
+        {
+            if (isRxReport) s.LastRxMode = mode;
+            else s.Mode = mode;
+        }
+        if (GetBool(p, "transmitting") is bool tx)
+            s.Transmitting = tx;
+        if (GetString(p, "message") is string msg)
+            s.Message = msg;
+        if (isRxReport && GetDouble(p, "snr") is double snr)
+            s.LastRxSnr = snr;
+        if (GetDateTime(p, "connect_time") is DateTime connect)
+            s.ConnectTime = connect;
+
+        // Always re-stamp LastUpdate from the report (or now if absent), so the
+        // stale-prune and any "last heard" UI reflect this event.
+        s.LastUpdate = GetDateTime(p, "last_update") ?? DateTime.UtcNow;
+    }
+
+    // ----- tolerant JSON field readers (missing / null / string-or-number) -----
+
+    private static string? GetString(JsonElement obj, string name)
+    {
+        if (obj.ValueKind != JsonValueKind.Object || !obj.TryGetProperty(name, out var el))
+            return null;
+        return el.ValueKind switch
+        {
+            JsonValueKind.String => el.GetString(),
+            JsonValueKind.Number => el.GetRawText(),
+            _ => null,
+        };
+    }
+
+    private static bool? GetBool(JsonElement obj, string name)
+    {
+        if (obj.ValueKind != JsonValueKind.Object || !obj.TryGetProperty(name, out var el))
+            return null;
+        return el.ValueKind switch
+        {
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.String when bool.TryParse(el.GetString(), out var b) => b,
+            JsonValueKind.Number when el.TryGetInt64(out var n) => n != 0,
+            _ => null,
+        };
+    }
+
+    private static long? GetInt64(JsonElement obj, string name)
+    {
+        if (obj.ValueKind != JsonValueKind.Object || !obj.TryGetProperty(name, out var el))
+            return null;
+        return el.ValueKind switch
+        {
+            JsonValueKind.Number when el.TryGetInt64(out var n) => n,
+            JsonValueKind.Number when el.TryGetDouble(out var d) => (long)Math.Round(d),
+            JsonValueKind.String when long.TryParse(el.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var sn) => sn,
+            JsonValueKind.String when double.TryParse(el.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out var sd) => (long)Math.Round(sd),
+            _ => null,
+        };
+    }
+
+    private static double? GetDouble(JsonElement obj, string name)
+    {
+        if (obj.ValueKind != JsonValueKind.Object || !obj.TryGetProperty(name, out var el))
+            return null;
+        return el.ValueKind switch
+        {
+            JsonValueKind.Number when el.TryGetDouble(out var d) => d,
+            JsonValueKind.String when double.TryParse(el.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out var sd) => sd,
+            _ => null,
+        };
+    }
+
+    private static DateTime? GetDateTime(JsonElement obj, string name)
+    {
+        var s = GetString(obj, name);
+        if (string.IsNullOrWhiteSpace(s)) return null;
+        if (DateTime.TryParse(s, CultureInfo.InvariantCulture,
+                DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal, out var dt))
+            return dt;
+        return null;
+    }
+
+    // Internal mutable station record folded from the event stream. Mutated only
+    // on the single Socket.IO receive loop; read (and stale-pruned) under the
+    // ConcurrentDictionary in GetSnapshot.
+    private sealed class Station
+    {
+        public string Sid = "";
+        public string? Callsign;
+        public string? GridSquare;
+        public long FreqHz;
+        public string? Mode;
+        public bool Transmitting;
+        public bool RxOnly;
+        public string? Message;
+        public string? Version;
+        public double? LastRxSnr;
+        public string? LastRxCallsign;
+        public string? LastRxMode;
+        public DateTime LastUpdate = DateTime.UtcNow;
+        public DateTime? ConnectTime;
+    }
+}

--- a/Zeus.Server.Hosting/FreeDvReporterSettingsStore.cs
+++ b/Zeus.Server.Hosting/FreeDvReporterSettingsStore.cs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// FreeDvReporterSettingsStore — persists the operator's FreeDV Reporter
+// "report mode" opt-in (callsign + grid + optional status message) in a
+// single-row LiteDB collection sharing zeus-prefs.db, mirroring
+// SpotsSettingsStore. First run (no row) returns the FreeDvReporterSettings
+// defaults: report mode OFF. Reporting only ever broadcasts the operator's
+// location after an explicit opt-in, so the default-off behaviour is a safety
+// property — see FreeDvReporterService.
+
+using LiteDB;
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Reads/writes the <see cref="FreeDvReporterSettings"/> row. Thread-safe; values
+/// are normalized on write so the reporter link and panel always see a sane
+/// config (callsign upper-cased, grid Maidenhead-shaped, message capped).
+/// </summary>
+public sealed class FreeDvReporterSettingsStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<FreeDvReporterSettingsEntry> _state;
+    private readonly ILogger<FreeDvReporterSettingsStore> _log;
+    private readonly object _sync = new();
+
+    public FreeDvReporterSettingsStore(ILogger<FreeDvReporterSettingsStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _state = _db.GetCollection<FreeDvReporterSettingsEntry>("freedv_reporter_settings");
+
+        _log.LogInformation("FreeDvReporterSettingsStore initialized at {Path}", dbPath);
+    }
+
+    /// <summary>Current settings, or the defaults (report OFF) if nothing has been saved yet.</summary>
+    public FreeDvReporterSettings Get()
+    {
+        lock (_sync)
+        {
+            var e = _state.FindAll().FirstOrDefault();
+            if (e is null) return new FreeDvReporterSettings();
+            return new FreeDvReporterSettings(
+                ReportEnabled: e.ReportEnabled,
+                Callsign: e.Callsign ?? "",
+                GridSquare: e.GridSquare ?? "",
+                Message: e.Message ?? "").Normalized();
+        }
+    }
+
+    /// <summary>Persist settings (normalized) and return what was stored.</summary>
+    public FreeDvReporterSettings Set(FreeDvReporterSettings settings)
+    {
+        var s = settings.Normalized();
+        lock (_sync)
+        {
+            var existing = _state.FindAll().FirstOrDefault();
+            var nowUtc = DateTime.UtcNow;
+            if (existing is null)
+            {
+                _state.Insert(FromSettings(s, nowUtc));
+            }
+            else
+            {
+                existing.ReportEnabled = s.ReportEnabled;
+                existing.Callsign = s.Callsign;
+                existing.GridSquare = s.GridSquare;
+                existing.Message = s.Message;
+                existing.UpdatedUtc = nowUtc;
+                _state.Update(existing);
+            }
+        }
+        return s;
+    }
+
+    private static FreeDvReporterSettingsEntry FromSettings(FreeDvReporterSettings s, DateTime nowUtc) => new()
+    {
+        ReportEnabled = s.ReportEnabled,
+        Callsign = s.Callsign,
+        GridSquare = s.GridSquare,
+        Message = s.Message,
+        UpdatedUtc = nowUtc,
+    };
+
+    public void Dispose() => _db.Dispose();
+}
+
+public sealed class FreeDvReporterSettingsEntry
+{
+    public int Id { get; set; }
+    public bool ReportEnabled { get; set; }
+    public string? Callsign { get; set; }
+    public string? GridSquare { get; set; }
+    public string? Message { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/FreeDvService.cs
+++ b/Zeus.Server.Hosting/FreeDvService.cs
@@ -128,7 +128,8 @@ public sealed class FreeDvService : IDisposable
         RxText: _modem.RxText,
         TxText: _txText,
         LibraryVersion: _modem.LibraryVersion,
-        AutoDetect: _autoDetect);
+        AutoDetect: _autoDetect,
+        RadeAvailable: _modem.RadeAvailable);
 
     public FreeDvStatusDto ApplyConfig(FreeDvConfigRequest req)
     {

--- a/Zeus.Server.Hosting/FreeDvService.cs
+++ b/Zeus.Server.Hosting/FreeDvService.cs
@@ -167,6 +167,16 @@ public sealed class FreeDvService : IDisposable
     /// <summary>True when auto submode detection is engaged.</summary>
     public bool AutoDetect => _autoDetect;
 
+    /// <summary>
+    /// Whether the modem counts as transmitting "now" given the last TX-block
+    /// timestamp. Auto-detect pauses scanning while this is true. The sentinel
+    /// (long.MinValue = never transmitted) is handled explicitly so the
+    /// <c>now - lastTx</c> subtraction can never overflow into a false positive
+    /// that would gate scanning off forever.
+    /// </summary>
+    internal static bool IsTxActive(long nowMs, long lastTxMs, long quietMs) =>
+        lastTxMs != long.MinValue && nowMs - lastTxMs < quietMs;
+
     // Control-loop: while auto-detect is on and the modem is receiving (active,
     // not transmitting), tick the scanner and apply any submode change it asks
     // for. Runs at a few Hz — far off the audio hot path — and is a no-op when
@@ -182,7 +192,7 @@ public sealed class FreeDvService : IDisposable
 
                 var modem = _modem; // may be swapped by ReloadNative; read once per tick
                 long now = Environment.TickCount64;
-                bool transmitting = now - Volatile.Read(ref _lastTxActivityMs) < TxQuietMs;
+                bool transmitting = IsTxActive(now, Volatile.Read(ref _lastTxActivityMs), TxQuietMs);
                 bool scanning = _autoDetect && modem.Active && modem.NativeAvailable && !transmitting;
 
                 if (!scanning) { wasScanning = false; continue; }

--- a/Zeus.Server.Hosting/FreeDvService.cs
+++ b/Zeus.Server.Hosting/FreeDvService.cs
@@ -10,8 +10,11 @@
 // mode (RxMode.FreeDv), and exposes the /api/freedv status/config surface.
 // The DSP pipeline taps ProcessRx (post-demod, RX0) and the TX mic-ingest
 // taps ProcessTx (pre-WDSP) — both no-ops unless FreeDV is active. The radio
-// itself runs USB underneath (WdspDspEngine.MapMode maps FreeDv -> USB), so
-// no WDSP demod mode change is needed here.
+// itself runs a real SSB demod/mod underneath, on the FreeDV band-convention
+// sideband — LSB below 10 MHz, USB at/above (RadioService.EffectiveEngineMode,
+// applied in DspPipelineService) — so the OFDM carriers share one orientation
+// with every other FreeDV station on the band. This service is sideband-agnostic:
+// it processes whatever post-demod audio the pipeline hands it.
 
 using System;
 using System.Threading;

--- a/Zeus.Server.Hosting/FreeDvService.cs
+++ b/Zeus.Server.Hosting/FreeDvService.cs
@@ -30,7 +30,14 @@ public sealed class FreeDvService : IDisposable
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<FreeDvService> _log;
     private FreeDvModem _modem;
+    private RadeModem _rade;
     private volatile string? _txText;
+
+    // Single volatile the audio hot path reads to pick the active modem, so it
+    // never chains through (_modem.Submode == RadeV1 && _rade.Active). Set on the
+    // control path (engage / submode change) under the same flow that toggles the
+    // modems' active state.
+    private volatile bool _radeActive;
 
     // Auto submode detection. The scanner is a pure state machine; this service
     // ticks it on a lightweight control loop and applies its submode decisions.
@@ -49,8 +56,16 @@ public sealed class FreeDvService : IDisposable
         _loggerFactory = loggerFactory;
         _log = loggerFactory.CreateLogger<FreeDvService>();
         _modem = new FreeDvModem(loggerFactory.CreateLogger<FreeDvModem>());
+        _rade = new RadeModem(loggerFactory.CreateLogger<RadeModem>());
         _scanLoop = ScanLoopAsync(_scanCts.Token);
     }
+
+    /// <summary>
+    /// True when the operator has selected the RADE V1 submode. The submode is
+    /// tracked on <see cref="_modem"/> (the single source of truth for the
+    /// selected submode, even for RADE), so RADE routing keys off it.
+    /// </summary>
+    private bool RadeSelected => _modem.Submode == FreeDvSubmode.RadeV1;
 
     /// <summary>True when FreeDV is engaged and the modem is processing audio.</summary>
     public bool Active => _modem.Active;
@@ -68,17 +83,36 @@ public sealed class FreeDvService : IDisposable
     /// </summary>
     public bool ReloadNative()
     {
+        // ResetProbe() clears BOTH the codec2 and zeus_rade probe caches, so a
+        // freshly-installed lib of either kind goes live after this reload.
         FreeDvNativeLoader.ResetProbe();
         var fresh = new FreeDvModem(_loggerFactory.CreateLogger<FreeDvModem>());
         fresh.SetSubmode(_modem.Submode);
         fresh.SetSquelch(_modem.SquelchEnabled, _modem.SnrSquelchThreshDb);
         fresh.SetTxText(_txText); // carry the operator's TX callsign/text across the swap
+
+        // Rebuild RADE too so a newly-installed zeus_rade lib re-probes and goes
+        // live. Capture engaged state BEFORE disposing the old modems (Dispose
+        // clears their active flags).
+        bool wasEngaged = _modem.Active || _rade.Active;
+        _radeActive = false;
+        var freshRade = new RadeModem(_loggerFactory.CreateLogger<RadeModem>());
+
         var old = _modem;
+        var oldRade = _rade;
         _modem = fresh;
+        _rade = freshRade;
         old.Dispose();
+        oldRade.Dispose();
+
+        // Re-engage whichever modem the selected submode calls for, if FreeDV was
+        // active before the reload.
+        if (wasEngaged) ApplyEngagedRouting();
+
         _log.LogInformation(
-            "FreeDV: native reload — codec2 {State}",
-            fresh.NativeAvailable ? "available" : "still unavailable");
+            "FreeDV: native reload — codec2 {State}, RADE {RadeState}",
+            fresh.NativeAvailable ? "available" : "still unavailable",
+            freshRade.RadeAvailable ? "available" : "still unavailable");
         return fresh.NativeAvailable;
     }
 
@@ -90,49 +124,91 @@ public sealed class FreeDvService : IDisposable
     public void SyncMode(RxMode mode)
     {
         bool want = mode == RxMode.FreeDv;
-        if (want && !_modem.Active)
+        bool engaged = _modem.Active || _rade.Active;
+        if (want && !engaged)
         {
             _log.LogInformation("FreeDV: engaging (mode=FreeDv, submode={Submode})", _modem.Submode);
-            _modem.Activate();
+            ApplyEngagedRouting();
         }
-        else if (!want && _modem.Active)
+        else if (!want && engaged)
         {
             _log.LogInformation("FreeDV: disengaging (mode={Mode})", mode);
             _modem.Deactivate();
+            _rade.Deactivate();
+            _radeActive = false;
+        }
+    }
+
+    /// <summary>
+    /// Activate whichever modem the selected submode calls for and deactivate the
+    /// other, then publish the hot-path routing flag. Call only while FreeDV is
+    /// (being) engaged. RADE selected -> _rade active, _modem idle; otherwise
+    /// _modem active, _rade idle.
+    /// </summary>
+    private void ApplyEngagedRouting()
+    {
+        if (RadeSelected)
+        {
+            _modem.Deactivate();
+            _rade.Activate();
+            _radeActive = true;
+        }
+        else
+        {
+            _rade.Deactivate();
+            _radeActive = false;
+            _modem.Activate();
         }
     }
 
     /// <summary>RX0 post-demod insert: turn received modem audio into decoded speech, in place.</summary>
-    public void ProcessRx(Span<float> block48k) => _modem.ProcessRxInPlace(block48k);
+    public void ProcessRx(Span<float> block48k)
+    {
+        if (_radeActive) _rade.ProcessRxInPlace(block48k);
+        else _modem.ProcessRxInPlace(block48k);
+    }
 
     /// <summary>TX mic insert: turn mic speech into the transmitted modem signal, in place.</summary>
     public void ProcessTx(Span<float> block48k)
     {
         // Mark TX active so auto-detect pauses scanning until the over ends.
         Volatile.Write(ref _lastTxActivityMs, Environment.TickCount64);
-        _modem.ProcessTxInPlace(block48k);
+        // RADE TX is not implemented yet — _rade.ProcessTxInPlace silences the
+        // block when active rather than transmitting raw mic on a RADE frequency.
+        if (_radeActive) _rade.ProcessTxInPlace(block48k);
+        else _modem.ProcessTxInPlace(block48k);
     }
 
     /// <summary>Drop buffered TX modem audio on a MOX falling edge so the next over starts clean.</summary>
     public void FlushTx() => _modem.FlushTx();
 
-    public FreeDvStatusDto Status() => new(
-        NativeAvailable: _modem.NativeAvailable,
-        Active: _modem.Active,
-        Submode: _modem.Submode,
-        Synced: _modem.Synced,
-        SnrDb: Math.Round(_modem.SnrDb, 1),
-        SquelchEnabled: _modem.SquelchEnabled,
-        SnrSquelchThreshDb: _modem.SnrSquelchThreshDb,
-        SpeechSampleRateHz: _modem.SpeechSampleRateHz,
-        ModemSampleRateHz: _modem.ModemSampleRateHz,
-        // RX text sidechannel (callsign etc.) decoded from the FreeDV txt stream
-        // via freedv_set_callback_txt; null until a full line has been received.
-        RxText: _modem.RxText,
-        TxText: _txText,
-        LibraryVersion: _modem.LibraryVersion,
-        AutoDetect: _autoDetect,
-        RadeAvailable: _modem.RadeAvailable);
+    public FreeDvStatusDto Status()
+    {
+        bool rade = RadeSelected;
+        return new(
+            // codec2 availability stays the FreeDvModem flag; RADE availability is
+            // the separate RadeAvailable flag below (a real probe now).
+            NativeAvailable: _modem.NativeAvailable,
+            // Sync / SNR / rates / active / version come from whichever modem the
+            // selected submode routes to. RADE has no codec2 squelch, so the
+            // squelch fields fall back to the FreeDvModem's stored selection.
+            Active: rade ? _rade.Active : _modem.Active,
+            Submode: _modem.Submode,
+            Synced: rade ? _rade.Synced : _modem.Synced,
+            SnrDb: Math.Round(rade ? _rade.SnrDb : _modem.SnrDb, 1),
+            SquelchEnabled: _modem.SquelchEnabled,
+            SnrSquelchThreshDb: _modem.SnrSquelchThreshDb,
+            SpeechSampleRateHz: rade ? _rade.SpeechSampleRateHz : _modem.SpeechSampleRateHz,
+            ModemSampleRateHz: rade ? _rade.ModemSampleRateHz : _modem.ModemSampleRateHz,
+            // RX text sidechannel (callsign etc.). FreeDV decodes it from the txt
+            // stream via freedv_set_callback_txt; RADE's EOO callsign is garbled
+            // until freedv_text is wired, so RADE reports null.
+            RxText: rade ? _rade.RxText : _modem.RxText,
+            TxText: _txText,
+            LibraryVersion: rade ? _rade.LibraryVersion : _modem.LibraryVersion,
+            AutoDetect: _autoDetect,
+            RadeAvailable: _rade.RadeAvailable);
+    }
 
     public FreeDvStatusDto ApplyConfig(FreeDvConfigRequest req)
     {
@@ -143,7 +219,13 @@ public sealed class FreeDvService : IDisposable
         {
             if (_autoDetect && (!req.AutoDetect.HasValue || !req.AutoDetect.Value))
                 _autoDetect = false;
+            // _modem stays the record of the selected submode even for RADE V1,
+            // mirroring today; RadeSelected then keys off it.
             _modem.SetSubmode(req.Submode.Value);
+            // If FreeDV is engaged, swap the active modem to match the new submode
+            // (into/out of RADE). No-op when the routing already matches.
+            bool engaged = _modem.Active || _rade.Active;
+            if (engaged) ApplyEngagedRouting();
         }
         if (req.SquelchEnabled.HasValue || req.SnrSquelchThreshDb.HasValue)
             _modem.SetSquelch(req.SquelchEnabled, req.SnrSquelchThreshDb);
@@ -223,5 +305,6 @@ public sealed class FreeDvService : IDisposable
         catch (AggregateException) { /* OperationCanceled on shutdown */ }
         _scanCts.Dispose();
         _modem.Dispose();
+        _rade.Dispose();
     }
 }

--- a/Zeus.Server.Hosting/FreeDvService.cs
+++ b/Zeus.Server.Hosting/FreeDvService.cs
@@ -13,6 +13,9 @@
 // itself runs USB underneath (WdspDspEngine.MapMode maps FreeDv -> USB), so
 // no WDSP demod mode change is needed here.
 
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Zeus.Contracts;
 using Zeus.Dsp.FreeDv;
@@ -26,11 +29,24 @@ public sealed class FreeDvService : IDisposable
     private FreeDvModem _modem;
     private volatile string? _txText;
 
+    // Auto submode detection. The scanner is a pure state machine; this service
+    // ticks it on a lightweight control loop and applies its submode decisions.
+    // Scanning pauses while transmitting (ProcessTx stamps _lastTxActivityMs) so
+    // a long over never bumps the operator off a mode mid-transmission.
+    private volatile bool _autoDetect;
+    private readonly FreeDvAutoScanner _scanner = new();
+    private readonly CancellationTokenSource _scanCts = new();
+    private readonly Task _scanLoop;
+    private long _lastTxActivityMs = long.MinValue;
+    private const int ScanTickMs = 250;
+    private const long TxQuietMs = 400; // hold the scan within this window of the last TX block
+
     public FreeDvService(ILoggerFactory loggerFactory)
     {
         _loggerFactory = loggerFactory;
         _log = loggerFactory.CreateLogger<FreeDvService>();
         _modem = new FreeDvModem(loggerFactory.CreateLogger<FreeDvModem>());
+        _scanLoop = ScanLoopAsync(_scanCts.Token);
     }
 
     /// <summary>True when FreeDV is engaged and the modem is processing audio.</summary>
@@ -87,7 +103,12 @@ public sealed class FreeDvService : IDisposable
     public void ProcessRx(Span<float> block48k) => _modem.ProcessRxInPlace(block48k);
 
     /// <summary>TX mic insert: turn mic speech into the transmitted modem signal, in place.</summary>
-    public void ProcessTx(Span<float> block48k) => _modem.ProcessTxInPlace(block48k);
+    public void ProcessTx(Span<float> block48k)
+    {
+        // Mark TX active so auto-detect pauses scanning until the over ends.
+        Volatile.Write(ref _lastTxActivityMs, Environment.TickCount64);
+        _modem.ProcessTxInPlace(block48k);
+    }
 
     /// <summary>Drop buffered TX modem audio on a MOX falling edge so the next over starts clean.</summary>
     public void FlushTx() => _modem.FlushTx();
@@ -106,11 +127,20 @@ public sealed class FreeDvService : IDisposable
         // via freedv_set_callback_txt; null until a full line has been received.
         RxText: _modem.RxText,
         TxText: _txText,
-        LibraryVersion: _modem.LibraryVersion);
+        LibraryVersion: _modem.LibraryVersion,
+        AutoDetect: _autoDetect);
 
     public FreeDvStatusDto ApplyConfig(FreeDvConfigRequest req)
     {
-        if (req.Submode.HasValue) _modem.SetSubmode(req.Submode.Value);
+        // A manual submode pick implicitly turns auto-detect off — the operator
+        // is asserting a mode, so honour it rather than letting the scanner move
+        // away from it on the next unsynced tick.
+        if (req.Submode.HasValue)
+        {
+            if (_autoDetect && (!req.AutoDetect.HasValue || !req.AutoDetect.Value))
+                _autoDetect = false;
+            _modem.SetSubmode(req.Submode.Value);
+        }
         if (req.SquelchEnabled.HasValue || req.SnrSquelchThreshDb.HasValue)
             _modem.SetSquelch(req.SquelchEnabled, req.SnrSquelchThreshDb);
         if (req.TxText is not null)
@@ -118,8 +148,66 @@ public sealed class FreeDvService : IDisposable
             _txText = req.TxText;
             _modem.SetTxText(req.TxText); // push to the modem's TX varicode callback
         }
+        if (req.AutoDetect.HasValue && req.AutoDetect.Value != _autoDetect)
+        {
+            _autoDetect = req.AutoDetect.Value;
+            if (_autoDetect)
+            {
+                _scanner.Reset(Environment.TickCount64);
+                _log.LogInformation("FreeDV: auto submode detection ENABLED (scanning {N} modes)", _scanner.Order.Count);
+            }
+            else
+            {
+                _log.LogInformation("FreeDV: auto submode detection DISABLED (holding {Submode})", _modem.Submode);
+            }
+        }
         return Status();
     }
 
-    public void Dispose() => _modem.Dispose();
+    /// <summary>True when auto submode detection is engaged.</summary>
+    public bool AutoDetect => _autoDetect;
+
+    // Control-loop: while auto-detect is on and the modem is receiving (active,
+    // not transmitting), tick the scanner and apply any submode change it asks
+    // for. Runs at a few Hz — far off the audio hot path — and is a no-op when
+    // auto-detect is off, so it costs effectively nothing in the common case.
+    private async Task ScanLoopAsync(CancellationToken ct)
+    {
+        bool wasScanning = false;
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                await Task.Delay(ScanTickMs, ct).ConfigureAwait(false);
+
+                var modem = _modem; // may be swapped by ReloadNative; read once per tick
+                long now = Environment.TickCount64;
+                bool transmitting = now - Volatile.Read(ref _lastTxActivityMs) < TxQuietMs;
+                bool scanning = _autoDetect && modem.Active && modem.NativeAvailable && !transmitting;
+
+                if (!scanning) { wasScanning = false; continue; }
+                if (!wasScanning) { _scanner.Reset(now); wasScanning = true; }
+
+                var next = _scanner.Tick(now, modem.Synced, modem.Submode);
+                if (next is { } m && m != modem.Submode)
+                {
+                    _log.LogInformation("FreeDV: auto-detect — no lock, trying submode {Submode}", m);
+                    modem.SetSubmode(m);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // normal shutdown
+        }
+    }
+
+    public void Dispose()
+    {
+        _scanCts.Cancel();
+        try { _scanLoop.Wait(TimeSpan.FromSeconds(1)); }
+        catch (AggregateException) { /* OperationCanceled on shutdown */ }
+        _scanCts.Dispose();
+        _modem.Dispose();
+    }
 }

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -1936,6 +1936,21 @@ public sealed class RadioService : IDisposable
     // call site in DspPipelineService for why (legacy DB / split-on-B paths can
     // leave a positive value behind on an LSB mode and transmit the wrong
     // sideband). Idempotent for well-formed state.
+    // FreeDV rides on an SSB demod/mod. The FreeDV community adopted the SSB
+    // voice-mode convention — LSB below 10 MHz, USB at/above — so every station
+    // on a band shares one spectral orientation. Mismatching it mirror-images the
+    // OFDM carriers in RF and nothing decodes. WDSP has no FreeDv sideband of its
+    // own (WdspDspEngine.MapMode defaults FreeDv → USB, correct only ≥10 MHz), so
+    // we resolve the effective engine sideband from the dial at the point the mode
+    // and filter are pushed. RxMode.FreeDv stays the radio's mode everywhere else;
+    // only the WDSP RXA/TXA orientation + bandpass sign follow this. Non-FreeDv
+    // modes pass through unchanged.
+    internal const long FreeDvUsbThresholdHz = 10_000_000;
+    internal static RxMode EffectiveEngineMode(RxMode mode, long dialHz)
+        => mode == RxMode.FreeDv
+            ? (dialHz < FreeDvUsbThresholdHz ? RxMode.LSB : RxMode.USB)
+            : mode;
+
     internal static (int low, int high) SignedFilterForMode(RxMode mode, int loAbs, int hiAbs)
     {
         return mode switch

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -1281,6 +1281,33 @@ public static class ZeusEndpoints
         // and offers click-to-tune.
         app.MapGet("/api/freedv/stations",
             (FreeDvReporterService svc) => Results.Ok(svc.GetSnapshot()));
+
+        // FreeDV Reporter "report mode" — strictly opt-in (default OFF). When
+        // enabled with a callsign + Maidenhead grid, Zeus connects to the reporter
+        // in "report" role and broadcasts the operator's callsign / grid / freq /
+        // TX activity to the public qso.freedv.org map. GET returns the current
+        // (normalized) settings; POST saves them and forces a reconnect so the new
+        // role / identity takes effect.
+        app.MapGet("/api/freedv/reporter/settings",
+            (FreeDvReporterService svc) => Results.Ok(svc.GetSettings()));
+        app.MapPost("/api/freedv/reporter/settings",
+            (FreeDvReporterSettings req, FreeDvReporterService svc) =>
+            {
+                var saved = svc.SaveSettings(req);
+                log.LogInformation(
+                    "api.freedv.reporter.settings report={Enabled} call={Call} grid={Grid}",
+                    saved.ReportEnabled, saved.Callsign, saved.GridSquare);
+                return Results.Ok(saved);
+            });
+
+        // QSY request — ask the station identified by {sid} to move to the
+        // operator's current VFO frequency. Requires report mode active and a
+        // known sid; 400 otherwise.
+        app.MapPost("/api/freedv/stations/{sid}/qsy",
+            (string sid, FreeDvReporterService svc) =>
+                svc.RequestQsy(sid)
+                    ? Results.Ok(new { ok = true })
+                    : Results.BadRequest(new { error = "Not reporting, or station unknown." }));
         app.MapPut("/api/freedv/config", (FreeDvConfigRequest req, FreeDvService fd) =>
         {
             log.LogInformation(

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -1273,6 +1273,14 @@ public static class ZeusEndpoints
         // squelch / TX-text changes. No-op-safe when the codec2 native library
         // is missing (NativeAvailable=false).
         app.MapGet("/api/freedv/status", (FreeDvService fd) => Results.Ok(fd.Status()));
+
+        // FreeDV Reporter stations — live roster mirrored from qso.freedv.org by
+        // FreeDvReporterService (persistent read-only Socket.IO link). Returns the
+        // current snapshot (connection state + stations sorted by frequency);
+        // empty until the first bulk_update arrives. The Stations panel polls this
+        // and offers click-to-tune.
+        app.MapGet("/api/freedv/stations",
+            (FreeDvReporterService svc) => Results.Ok(svc.GetSnapshot()));
         app.MapPut("/api/freedv/config", (FreeDvConfigRequest req, FreeDvService fd) =>
         {
             log.LogInformation(

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -737,6 +737,15 @@ public static class ZeusHost
         builder.Services.AddSingleton<ActivationSpotsService>();
         builder.Services.AddHostedService(sp => sp.GetRequiredService<ActivationSpotsService>());
 
+        // FreeDvReporterService — holds a persistent read-only Socket.IO link to
+        // the FreeDV Reporter network (qso.freedv.org) and mirrors the live
+        // station roster for the Stations panel (GET /api/freedv/stations). Same
+        // singleton + hosted-service shape as ActivationSpotsService; streaming
+        // Socket.IO instead of HTTP polling. Touches nothing on the radio / DSP /
+        // TX path — outbound TLS WebSocket in, station snapshot out.
+        builder.Services.AddSingleton<FreeDvReporterService>();
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<FreeDvReporterService>());
+
         // TCI (Transceiver Control Interface) — ExpertSDR3-compatible WebSocket server
         // for remote control by loggers (Log4OM, N1MM+), digital-mode apps (JTDX, WSJT-X),
         // and SDR display tools. Disabled by default; enable via appsettings.json Tci:Enabled=true.

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -743,6 +743,10 @@ public static class ZeusHost
         // singleton + hosted-service shape as ActivationSpotsService; streaming
         // Socket.IO instead of HTTP polling. Touches nothing on the radio / DSP /
         // TX path — outbound TLS WebSocket in, station snapshot out.
+        // Persists the operator's FreeDV Reporter "report mode" opt-in (default
+        // OFF). Reporting only broadcasts the operator's callsign/grid/TX activity
+        // to the public map after an explicit opt-in — see FreeDvReporterService.
+        builder.Services.AddSingleton<FreeDvReporterSettingsStore>();
         builder.Services.AddSingleton<FreeDvReporterService>();
         builder.Services.AddHostedService(sp => sp.GetRequiredService<FreeDvReporterService>());
 

--- a/docs/designs/rade-v1-integration.md
+++ b/docs/designs/rade-v1-integration.md
@@ -103,11 +103,49 @@ codec2" plan below is **not possible against upstream main today.**
 
 ### Revised recommendation
 RADE-into-Zeus today = fork/adopt **`radae_nopy`** as the native base and port it
-to Windows (clang-cl, exactly like the codec2 MSVC patch) + arm, OR **wait/track**
-the upstream C port (`freedv-backend`). Both are real multi-day efforts; the first
-builds on a deprecated base, the second isn't available yet. **This is a maintainer
-decision** — pick the base before any native CMake work. The original codec2-style
-"FetchContent drowe67/radae" approach is a dead end (drags in Python).
+to Windows (MinGW+autotools, like freedv-gui) + arm, OR **wait/track** the upstream
+C port (`freedv-backend`). The original codec2-style "FetchContent drowe67/radae"
+approach is a dead end (drags in Python).
+
+> **Maintainer decision (2026-06-23): adopt `radae_nopy`. "Put RADE in."**
+
+### ✅ PROVEN — radae_nopy decodes a real off-air RADE signal (2026-06-23)
+
+Built `peterbmarks/radae_nopy` in WSL Ubuntu 24.04 (cmake + autotools; Opus built
+with `--enable-osce --enable-dred` for FARGAN, then `librade.so`) and decoded the
+repo's off-air sample end-to-end:
+
+```
+sox FDV_offair.wav -r 8000 -e float -b 32 -c 1 -t raw - \
+  | real2iq | radae_rx > features.f32        # OFDM demod + sync + neural decode
+lpcnet_demo -fargan-synthesis features.f32 - \
+  | sox -t .s16 -r 16000 -c 1 - decoded.wav   # FARGAN vocoder → 16 kHz speech
+```
+
+Result: `radae_rx` reported **2717 modem frames, 2624 valid outputs, sync acquired,
+SNR ≈ 12.6 dB**; `decoded.wav` = 16 kHz mono, max amplitude 0.9999 (real speech).
+**The dependency-free C decode path works.** RADE is now an integration task, not a
+feasibility risk.
+
+Key facts confirmed from the real source/build:
+- **Weights compiled in** (`rade_enc_data.c`/`rade_dec_data.c`) — **no model file to
+  ship**. `rade_open(model_file, …)` ignores the path for weights.
+- **Two libraries**: `librade` (IQ↔features, the OFDM modem+sync+NN core; links opus)
+  AND **Opus/FARGAN** (features↔16 kHz audio). RADE's `rade_api.h` does NOT
+  encapsulate the vocoder — Zeus must call the Opus FARGAN C API (`fargan_*` /
+  `lpcnet_demo -fargan-synthesis` path) for the features→speech stage.
+- Bundled **kiss_fft** (no FFTW). C11. `RADE_PYTHON_FREE=1`. BSD-2.
+- Opus is an **autotools** ExternalProject (`autogen.sh && ./configure
+  --enable-osce --enable-dred`), patched via `src/opus-nnet.h.diff`. Windows build
+  = MinGW + autotools (freedv-gui's approach); arm = `--disable-rtcd`.
+- `rade_api.h` streaming RX: `rade_nin()` → `rade_rx(r, features_out, &has_eoo,
+  eoo_out, rx_in)` (complex `RADE_COMP` in, feature floats out), `rade_sync()`,
+  `rade_snrdB_3k_est()`. EOO frame carries an 8-char callsign
+  (`rade_rx_get_eoo_callsign`) — maps nicely to the existing FreeDV RX-text UI.
+
+> Note: `radae_nopy` is upstream-deprecated in favour of `tmiw/freedv-backend`
+> (same C port lineage). Pin radae_nopy now for the proven build; track
+> freedv-backend for the long-term base.
 
 ---
 
@@ -177,7 +215,8 @@ To build (the native phase):
 |------|------|--------|
 | 0 | Diagnose (RADE on-air, classic modes fail), scope, research API/build | ✅ done |
 | 1 | UI/contract groundwork: `RadeV1` submode, gated panel, `RadeAvailable` | ✅ done (committed) |
-| 2 | `native/radae/` vendoring: build `rade`+FARGAN cross-platform, CI binaries | ⏳ next (the hard one) |
+| 2a | Prove the dependency-free decoder (build radae_nopy, decode off-air sample) | ✅ done (WSL, 2026-06-23) |
+| 2b | `native/radae/` vendoring: build `rade`+Opus/FARGAN cross-platform (Win MinGW+autotools, arm), CI binaries | ⏳ next (the hard one) |
 | 3 | Model weights export + bundling/install | ⏳ |
 | 4 | `RadeModem` + P/Invoke + complex IO + FARGAN + 48k↔16k resample; flip `RadeAvailable` | ⏳ |
 | 5 | On-air validation vs a live RADEV1 station | ⏳ |

--- a/docs/designs/rade-v1-integration.md
+++ b/docs/designs/rade-v1-integration.md
@@ -1,0 +1,151 @@
+# RADE V1 integration — design & implementation plan
+
+**Status:** Phase 1 (UI/contract groundwork) landed. Native decoder NOT yet
+implemented — this document is the execution plan for it.
+
+## Why
+
+RADE V1 ("Radio Autoencoder") is FreeDV's neural HF voice mode and is now the
+default in freedv-gui 2.1.0 (selector: **RADEV1 / 700D / 700E / 1600**). Most
+on-air FreeDV activity is moving to it. Zeus ships only the classic codec2 1.2.0
+modes (700C/700D/700E/1600/800XA, `LPCNET=OFF`), so a RADE signal decodes to
+**garbage on every classic mode** — a strong signal still won't produce coherent
+audio, and the classic decoders false-sync on RADE's OFDM-like energy.
+
+This was diagnosed on-air on 2026-06-23 (40 m): operator on a strong signal,
+no decode on any classic mode, station confirmed on RADEV1.
+
+See also: `docs/designs/freedv-integration.md` (the classic-mode integration this
+builds on) and the `rade-v1-integration` agent memory.
+
+## What RADE is (decode pipeline)
+
+RADE is a neural codec: a NN encoder compresses speech to a latent vector
+modulated onto an OFDM waveform; the receiver's NN decoder reconstructs vocoder
+*features*, which the **FARGAN** vocoder synthesises into audio.
+
+RX decode chain Zeus must implement:
+
+```
+radio SSB demod (real, 48 kHz)
+  → resample 48k→8k
+  → real→complex (RADE modem input is complex IQ @ 8 kHz)
+  → rade_rx()  ──► vocoder FEATURES (not audio)  [+ sync/SNR telemetry]
+  → FARGAN vocoder ──► speech @ 16 kHz
+  → resample 16k→48k
+  → audio bus
+```
+
+Two things make this materially harder than classic FreeDV:
+1. **Two ML stages**: `rade_rx` emits *features*; FARGAN turns features→speech.
+2. **Complex modem IO @ 8 kHz**, **16 kHz speech** (not the classic real-short,
+   8 kHz-both world). New resampler rates (48k↔16k = 3:1) and a real→complex
+   front end are required. Zeus's `FreeDvResampler` is 48k↔8k (6:1) only.
+
+## Native C API (`rade_api.h`, drowe67/radae)
+
+```c
+#define RADE_MODEM_SAMPLE_RATE  8000
+#define RADE_SPEECH_SAMPLE_RATE 16000
+#define RADE_USE_C_ENCODER 0x1
+#define RADE_USE_C_DECODER 0x2
+
+void          rade_initialize(void);
+void          rade_finalize(void);
+struct rade  *rade_open(char model_file[], int flags);
+void          rade_close(struct rade *r);
+int           rade_version(void);
+int           rade_nin(struct rade *r);
+int           rade_nin_max(struct rade *r);
+int           rade_n_features_in_out(struct rade *r);
+// RX: provide nin() complex samples in rx_in[]; returns >0 when features_out[] valid.
+int           rade_rx(struct rade *r, float features_out[], int *has_eoo_out,
+                      float eoo_out[], RADE_COMP rx_in[]);
+int           rade_sync(struct rade *r);
+float         rade_freq_offset(struct rade *r);
+int           rade_snrdB_3k_est(struct rade *r);
+// TX (later): rade_n_tx_out, rade_tx, rade_tx_eoo, rade_tx_set_eoo_bits.
+```
+
+`RADE_COMP` is a `{float real; float imag;}` pair. FARGAN synthesis is a separate
+call (Opus/LPCNet `fargan_*` API) consuming `features_out` → 16 kHz PCM.
+
+## Build — the hard part
+
+The native build is the bulk of the effort and the reason this is multi-day:
+
+- **License:** BSD-2-clause (compatible). Good.
+- **drowe67/radae root `CMakeLists.txt` requires `Python3` (Interpreter,
+  Development, NumPy)** for the normal build, and pulls **Opus's `spl_fargan`
+  branch** via `cmake/BuildOpus.cmake` for FARGAN. There is a cross-compile path
+  (`-DPython3_ROOT_DIR`, manual `Python3::Python`/`Python3::NumPy` targets) but it
+  still wants Python present at configure time.
+- The **C-only decoder** path (`RADE_USE_C_DECODER`) needs: the C encoder/decoder
+  sources + the FARGAN/Opus C library + the **model weights as C** (`rade_enc_data.c`
+  / `rade_dec_data.c`, generated from a `.pth` checkpoint via the repo's export
+  scripts), or a runtime binary blob loaded by `rade_open(model_file, ...)`.
+- **This reverses the deliberate `LPCNET=OFF` / dependency-free decision** in
+  `native/codec2/VENDORING.md` — RADE brings the FARGAN/LPCNet ML vocoder. Accepted
+  by the maintainer (2026-06-23): bigger binaries + more CPU, fine on desktop,
+  heavier but feasible on Pi (RADE runs on TI AM625 / Librem 5; ~32 MMACs, 2×1 MB
+  weights). Not micro-controllers.
+- **Cross-platform** (the codec2 precedent): MSVC can't compile the C99 `_Complex`
+  OFDM/filter code, so Windows builds via **clang-cl** with an `if(NOT MSVC)`
+  patch (see `native/codec2/patch-codec2-msvc.cmake`). RADE will need the same
+  treatment plus the Opus/FARGAN branch building under clang-cl and arm.
+
+### Recommended build approach
+1. Pin a drowe67/radae release tag (no moving HEAD), FetchContent like codec2.
+2. Use the C decoder path; **avoid the Python build coupling** by exporting the
+   model weights to C once (committed or downloaded), and building only the
+   `rade` + FARGAN/Opus C targets.
+3. Vendor the model: ship `rade_enc_data.c`/`rade_dec_data.c` (compiled-in) OR a
+   binary blob distributed via the existing `FreeDvNativeInstaller` download
+   affordance (codec2 already does this). ~2 MB total.
+4. Build native binaries in CI (`build-native-libs.yml`) for win-x64/arm64,
+   linux-x64/arm64, osx-arm64/x64; emit `rade.dll` / `librade.{so,dylib}` next to
+   `codec2.*`. Reference freedv-gui's CMake for the cross-platform recipe.
+
+## Zeus-side architecture
+
+RADE is **NOT** a `freedv_open` submode — different API, complex IO, FARGAN, 16 kHz.
+Already in place (Phase 1, committed):
+- `FreeDvSubmode.RadeV1` (byte 5). `FreeDvModem.OpenLocked` short-circuits it to a
+  clean passthrough so a classic decoder is never mis-opened on a RADE signal.
+- `FreeDvModem.RadeAvailable` / `FreeDvStatusDto.RadeAvailable` (false today).
+- Panel: RADEV1 shown (matching freedv-gui), gated with a "decoder not installed"
+  notice. Mode list = RADEV1/700D/700E/1600; 700C/800XA stay backend-valid.
+
+To build (the native phase):
+- `native/radae/CMakeLists.txt` + `VENDORING.md` (mirror `native/codec2/`).
+- `Zeus.Dsp.FreeDv/RadeNativeMethods.cs` + `RadeNativeLoader.cs` (own
+  `SetDllImportResolver` for `rade`, mirror the codec2 ones) — P/Invoke `rade_api.h`
+  + the `fargan_*` synth.
+- `Zeus.Dsp.FreeDv/RadeModem.cs` — the streaming decode (48k→8k, real→complex,
+  `rade_rx`→features→FARGAN→16k, 16k→48k). Same realtime discipline as
+  `FreeDvModem` (lock-free hot path, Dekker-fenced handle handoff).
+- `FreeDvResampler`: add 48k↔16k (3:1) + a real→complex helper.
+- Route `FreeDvSubmode.RadeV1` in `FreeDvService`/`FreeDvModem` to `RadeModem`;
+  flip `RadeAvailable` to a real `RadeNativeLoader.TryProbe()`.
+- `FreeDvNativeInstaller`: add the RADE model (and lib, if not bundled) to the
+  download/stage path so RADEV1 lights up live like codec2 does.
+
+## Phases & status
+
+| Phase | Work | Status |
+|------|------|--------|
+| 0 | Diagnose (RADE on-air, classic modes fail), scope, research API/build | ✅ done |
+| 1 | UI/contract groundwork: `RadeV1` submode, gated panel, `RadeAvailable` | ✅ done (committed) |
+| 2 | `native/radae/` vendoring: build `rade`+FARGAN cross-platform, CI binaries | ⏳ next (the hard one) |
+| 3 | Model weights export + bundling/install | ⏳ |
+| 4 | `RadeModem` + P/Invoke + complex IO + FARGAN + 48k↔16k resample; flip `RadeAvailable` | ⏳ |
+| 5 | On-air validation vs a live RADEV1 station | ⏳ |
+
+## Open questions for Phase 2
+- Exact FARGAN C entry points + state struct (Opus `spl_fargan` branch) and how
+  freedv-gui drives features→PCM. Read freedv-gui's RADE RX path as the reference.
+- Compiled-in weights vs. downloaded blob (size vs. update story). Lean: download
+  via `FreeDvNativeInstaller` to keep the repo/binary lean.
+- clang-cl + arm build of Opus/FARGAN — expect codec2-style `if(NOT MSVC)` patches.
+- Real→complex front end: does `rade_rx` want an analytic (Hilbert) signal or the
+  real SSB audio packed as `{re=x, im=0}`? Confirm against freedv-gui.

--- a/docs/designs/rade-v1-integration.md
+++ b/docs/designs/rade-v1-integration.md
@@ -216,7 +216,23 @@ To build (the native phase):
 | 0 | Diagnose (RADE on-air, classic modes fail), scope, research API/build | ✅ done |
 | 1 | UI/contract groundwork: `RadeV1` submode, gated panel, `RadeAvailable` | ✅ done (committed) |
 | 2a | Prove the dependency-free decoder (build radae_nopy, decode off-air sample) | ✅ done (WSL, 2026-06-23) |
-| 2b | `native/radae/` vendoring: build `rade`+Opus/FARGAN cross-platform (Win MinGW+autotools, arm), CI binaries | ⏳ next (the hard one) |
+| 2b | **`zeus_rade` shim** — one C lib: complex IQ → `rade_rx` → FARGAN → 16 kHz PCM | ✅ done + validated (WSL: 2628 synced ticks, 14 dB, 5:14 speech out) |
+| 2c | `native/radae/` vendoring CMake: fetch radae_nopy + build Opus/FARGAN + shim into one shared lib, cross-platform (Win MinGW+autotools, arm `--disable-rtcd`), CI binaries | ⏳ next (the hard one) |
+| 4 | `RadeModem` P/Invoke the shim (`zeus_rade_*`) + 48k↔16k resample + real→complex; flip `RadeAvailable` | ⏳ (no model files; weights compiled in) |
+
+### zeus_rade shim (PROVEN 2026-06-23)
+`native/radae/shim/{zeus_rade.h,zeus_rade.c,zeus_rade_test.c,build_test_wsl.sh}` —
+a thin C wrapper giving Zeus a single P/Invoke surface instead of binding both
+`rade_api.h` and Opus's FARGAN. Verified by compiling against the radae_nopy +
+Opus build and decoding `FDV_offair.wav` through `zeus_rade_rx()` alone:
+`pcm_samples=5033280, synced=2628/2717, last_snr=14 dB`, 5:14 of real speech.
+
+Concrete dims learned at runtime: `rade_n_features_in_out=432` (= 12 × 36-float
+frames per `rade_rx`), `Nmf=960`, `n_eoo_bits=180`. FARGAN: prime 5 frames
+(`fargan_cont`) then `fargan_synthesize` 160 samples/frame; weights built in.
+Known issue: EOO callsign decode returns garbage — revisit (likely the EOO
+soft-bit handoff). Both RADE and FARGAN weights are compiled in → **no model
+files to ship**. The shim re-primes FARGAN on each sync re-acquire.
 | 3 | Model weights export + bundling/install | ⏳ |
 | 4 | `RadeModem` + P/Invoke + complex IO + FARGAN + 48k↔16k resample; flip `RadeAvailable` | ⏳ |
 | 5 | On-air validation vs a live RADEV1 station | ⏳ |

--- a/docs/designs/rade-v1-integration.md
+++ b/docs/designs/rade-v1-integration.md
@@ -70,7 +70,48 @@ int           rade_snrdB_3k_est(struct rade *r);
 `RADE_COMP` is a `{float real; float imag;}` pair. FARGAN synthesis is a separate
 call (Opus/LPCNet `fargan_*` API) consuming `features_out` → 16 kHz PCM.
 
-## Build — the hard part
+## ⚠ Phase 2 build investigation — VERIFIED BLOCKER (2026-06-23)
+
+A real build attempt (clone + read the actual CMake/source, toolchain present:
+cmake 4.3, gcc/MinGW, clang, Python 3.12) found that **upstream `drowe67/radae`
+`librade` cannot be vendored dependency-free.** Concretely:
+
+- `src/rade_api.c` **unconditionally** `#include <Python.h>` + `numpy/arrayobject.h`
+  (no compile guard). `rade_open()` imports Python modules `radae_txe`/`radae_rxe`
+  and instantiates PyTorch classes pointing at a `.pth` checkpoint.
+- `src/CMakeLists.txt` always `target_link_libraries(rade Python3::Python ...)`.
+- The `RADE_USE_C_ENCODER/DECODER` flags only move the **neural core** to C
+  (`rade_enc.c`/`rade_dec.c` with committed weights `rade_*_data.c`); the **OFDM
+  modem + sync still run in embedded Python** (`radae_rxe.py`). So the flags do
+  NOT yield a Python-free decoder.
+- Confirmation: even **freedv-gui's official Windows release ships an embedded
+  Python and downloads the PyTorch modules from the internet at install time.**
+
+Embedding CPython + PyTorch + a `.pth` is antithetical to Zeus's
+cross-platform/arm/Pi, dependency-free design. So the "vendor librade like
+codec2" plan below is **not possible against upstream main today.**
+
+### The only dependency-free candidates
+1. **`peterbmarks/radae_nopy`** — a *pure-C* port (no Python.h, no interpreter;
+   OFDM modem + sync + neural core all in C; weights compiled in from
+   `rade_enc_data.c`/`rade_dec_data.c`; BSD-2). **This is the viable base.** But:
+   tested Linux/macOS only (no Windows/arm), and **the repo says "no longer
+   recommended"** — FreeDV is consolidating future work into a `freedv-backend`
+   repo.
+2. **Upstream C port (`freedv-backend` / future librade V2)** — the *supported*
+   long-term path, "planned… eventually negate the need for Python." Not ready.
+
+### Revised recommendation
+RADE-into-Zeus today = fork/adopt **`radae_nopy`** as the native base and port it
+to Windows (clang-cl, exactly like the codec2 MSVC patch) + arm, OR **wait/track**
+the upstream C port (`freedv-backend`). Both are real multi-day efforts; the first
+builds on a deprecated base, the second isn't available yet. **This is a maintainer
+decision** — pick the base before any native CMake work. The original codec2-style
+"FetchContent drowe67/radae" approach is a dead end (drags in Python).
+
+---
+
+## Build — the hard part (assumes a Python-free base per the box above)
 
 The native build is the bulk of the effort and the reason this is multi-day:
 

--- a/native/radae/CMakeLists.txt
+++ b/native/radae/CMakeLists.txt
@@ -91,6 +91,16 @@ set(RADAE_C_SOURCES
     "${RADAE_C}/src/rade_dec_data.c"   # ~24 MB compiled-in decoder weights
     "${RADAE_C}/src/rade_enc_data.c")  # ~24 MB compiled-in encoder weights
 
+# The two compiled-in weight tables are ~24 MB each of generated data — at -O2/-O3
+# they cost minutes and gigabytes of RAM to compile for zero runtime benefit (they
+# are data, not hot code). Pin them to -O1. (GCC / Clang / MinGW; MSVC ignores.)
+if(NOT MSVC)
+  set_source_files_properties(
+    "${RADAE_C}/src/rade_enc_data.c"
+    "${RADAE_C}/src/rade_dec_data.c"
+    PROPERTIES COMPILE_OPTIONS "-O1")
+endif()
+
 # ---------------------------------------------------------------------------
 # 3. zeus_rade shim
 # ---------------------------------------------------------------------------
@@ -136,6 +146,20 @@ set_target_properties(zeus_rade PROPERTIES
     OUTPUT_NAME zeus_rade
     VERSION 1.0
     SOVERSION 1)
+
+# Windows: emit `zeus_rade.dll` (drop MinGW's "lib" prefix) so the file name
+# matches what the .NET loader probes (FreeDvNativeLoader.RadeNativeFileName).
+# Linux/macOS keep the conventional lib<name>.so / .dylib.
+if(WIN32)
+  set_target_properties(zeus_rade PROPERTIES PREFIX "")
+endif()
+
+# MinGW: statically link the GCC + winpthread runtimes so the DLL depends only on
+# system libraries (KERNEL32 + UCRT) — never libgcc_s_seh-1.dll / libwinpthread-1.dll.
+# PROVEN: yields a standalone zeus_rade.dll that decoded off-air RADE on Windows.
+if(MINGW)
+  target_link_options(zeus_rade PRIVATE -static -static-libgcc -Wl,-Bstatic)
+endif()
 
 # ---------------------------------------------------------------------------
 # Optional: standalone decode-validation harness (proves the lib end-to-end).

--- a/native/radae/CMakeLists.txt
+++ b/native/radae/CMakeLists.txt
@@ -1,0 +1,151 @@
+# native/radae/CMakeLists.txt
+#
+# Builds ONE shared library, `zeus_rade`, that decodes RADE V1 (Radio Autoencoder)
+# off-air IQ to 16 kHz PCM. It is the cross-platform native base for Zeus's RADE
+# support and is P/Invoked from the .NET side as a single library.
+#
+# Composition (all statically linked into the one .so/.dll/.dylib):
+#   1. opus_dnn   — Xiph Opus + the DNN/FARGAN vocoder (built here via CMake with
+#                   OPUS_DEEP_PLC=ON; provides fargan_synthesize / nnet).
+#   2. radae_c    — David Rowe's pure-C, Python-free RADE modem (IQ -> 36-float
+#                   feature frames). Weights are compiled in (rade_enc_data.c /
+#                   rade_dec_data.c, ~24 MB each). No model files at runtime.
+#   3. zeus_rade  — Zeus's thin shim (shim/zeus_rade.c): rade_rx() -> accumulate
+#                   NB_TOTAL_FEATURES -> fargan_synthesize(), behind one streaming
+#                   "complex IQ in -> int16 PCM out" surface.
+#
+# The three upstream slices are NOT committed to the Zeus git tree (~95 MB of
+# weight sources). CI (build-native-libs.yml) vendors them into ${ZEUS_RADE_VENDOR}
+# from the SHAs recorded in vendor/PROVENANCE.md before configuring this project.
+#
+# PROVEN: this exact composition decoded a 5-minute off-air RADE recording in WSL
+# (Ubuntu-24.04) — 2620 synced ticks, 14 dB SNR, max amplitude 0.999969
+# (full-scale real speech). See vendor/PROVENANCE.md.
+
+cmake_minimum_required(VERSION 3.16)
+project(zeus_rade C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# ---------------------------------------------------------------------------
+# Options
+# ---------------------------------------------------------------------------
+# Root of the vendored upstream slices. CI populates this; for a local build,
+# point it at a checkout of sv1eia/Thetis-RADE's "Project Files/lib" (see
+# vendor/PROVENANCE.md for the pinned SHA and the exact sub-paths).
+set(ZEUS_RADE_VENDOR "${CMAKE_CURRENT_SOURCE_DIR}/vendor"
+    CACHE PATH "Directory containing radae_c/, opus_dnn/, freedv_text/ slices")
+
+# Generic / Raspberry Pi fallback: disable all SIMD intrinsics. Also required on
+# any host where the vendored opus_dnn tree is the MSVC-only slice (its arm/ and
+# x86/ SIMD subtrees are stripped; see PROVENANCE.md). Default ON for portability.
+option(OPUS_DISABLE_INTRINSICS "Disable Opus SIMD intrinsics (generic/RPi build)" ON)
+
+set(RADAE_C   "${ZEUS_RADE_VENDOR}/radae_c")
+set(OPUS_DNN  "${ZEUS_RADE_VENDOR}/opus_dnn")
+set(FREEDV_TXT "${ZEUS_RADE_VENDOR}/freedv_text")
+
+if(NOT EXISTS "${OPUS_DNN}/CMakeLists.txt")
+  message(FATAL_ERROR
+    "opus_dnn not found at ${OPUS_DNN}. Vendor the slices listed in "
+    "native/radae/vendor/PROVENANCE.md (CI does this automatically).")
+endif()
+
+# ---------------------------------------------------------------------------
+# 1. opus_dnn — static Opus + DNN/FARGAN. OPUS_DEEP_PLC pulls in the FARGAN
+#    vocoder + nnet sources (dnn/fargan.c, dnn/fargan_data.c, dnn/nnet.c, ...).
+#    Build as a static lib; we whole-archive it into zeus_rade so the FARGAN
+#    symbols survive into the final shared object.
+# ---------------------------------------------------------------------------
+set(OPUS_BUILD_SHARED_LIBRARY OFF CACHE BOOL "" FORCE)
+set(OPUS_BUILD_PROGRAMS       OFF CACHE BOOL "" FORCE)
+set(OPUS_BUILD_TESTING        OFF CACHE BOOL "" FORCE)
+set(OPUS_DEEP_PLC             ON  CACHE BOOL "" FORCE)  # FARGAN vocoder + nnet
+# OPUS_DRED / OPUS_OSCE are NOT required for the V1 decode path (DEEP_PLC alone
+# yielded full-scale decode in the proven WSL run); enable only if a future
+# inference path needs them.
+add_subdirectory("${OPUS_DNN}" "${CMAKE_CURRENT_BINARY_DIR}/opus_dnn" EXCLUDE_FROM_ALL)
+
+set(OPUS_INCLUDE_DIRS
+    "${OPUS_DNN}/include"
+    "${OPUS_DNN}/dnn"
+    "${OPUS_DNN}/celt"
+    "${OPUS_DNN}/silk")
+
+# ---------------------------------------------------------------------------
+# 2. radae_c — Python-free RADE modem (IQ -> features) + compiled-in weights.
+#    radc_api.c exposes the canonical rade_api.h surface the shim links against.
+# ---------------------------------------------------------------------------
+set(RADAE_C_SOURCES
+    "${RADAE_C}/src/radc_acq.c"
+    "${RADAE_C}/src/radc_api.c"
+    "${RADAE_C}/src/radc_bpf.c"
+    "${RADAE_C}/src/radc_dec.c"
+    "${RADAE_C}/src/radc_demod.c"
+    "${RADAE_C}/src/radc_enc.c"
+    "${RADAE_C}/src/radc_mod.c"
+    "${RADAE_C}/src/radc_modem.c"
+    "${RADAE_C}/src/radc_rx.c"
+    "${RADAE_C}/src/radc_tx.c"
+    "${RADAE_C}/src/rade_dec_data.c"   # ~24 MB compiled-in decoder weights
+    "${RADAE_C}/src/rade_enc_data.c")  # ~24 MB compiled-in encoder weights
+
+# ---------------------------------------------------------------------------
+# 3. zeus_rade shim
+# ---------------------------------------------------------------------------
+set(SHIM_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/shim/zeus_rade.c")
+
+# ---------------------------------------------------------------------------
+# The one shared library
+# ---------------------------------------------------------------------------
+add_library(zeus_rade SHARED ${RADAE_C_SOURCES} ${SHIM_SOURCES})
+
+target_include_directories(zeus_rade PRIVATE
+    "${RADAE_C}/src"
+    "${CMAKE_CURRENT_SOURCE_DIR}/shim"
+    ${OPUS_INCLUDE_DIRS})
+
+# RADE_STATIC neutralises the DLL import/export + __stdcall decoration in
+# rade_api.h (Thetis-RADE static-build patch); RADE_PYTHON_FREE selects the C
+# encoder/decoder; IS_BUILDING_RADE_API matches the upstream vcxproj defines.
+target_compile_definitions(zeus_rade PRIVATE
+    RADE_STATIC
+    RADE_PYTHON_FREE=1
+    IS_BUILDING_RADE_API=1)
+
+if(OPUS_DISABLE_INTRINSICS)
+  target_compile_definitions(zeus_rade PRIVATE OPUS_DISABLE_INTRINSICS)
+endif()
+
+# Whole-archive the static opus so fargan_* / nnet symbols are retained even
+# though only the shim references them transitively.
+if(APPLE)
+  target_link_libraries(zeus_rade PRIVATE
+    -Wl,-force_load,$<TARGET_FILE:opus> m)
+elseif(MSVC)
+  target_link_libraries(zeus_rade PRIVATE opus)
+  set_target_properties(zeus_rade PROPERTIES LINK_FLAGS "/WHOLEARCHIVE:opus")
+else() # GNU/Clang ld
+  target_link_libraries(zeus_rade PRIVATE
+    -Wl,--whole-archive opus -Wl,--no-whole-archive m)
+endif()
+
+set_target_properties(zeus_rade PROPERTIES
+    C_VISIBILITY_PRESET default
+    OUTPUT_NAME zeus_rade
+    VERSION 1.0
+    SOVERSION 1)
+
+# ---------------------------------------------------------------------------
+# Optional: standalone decode-validation harness (proves the lib end-to-end).
+# ---------------------------------------------------------------------------
+option(ZEUS_RADE_BUILD_TEST "Build the zeus_rade_test decode harness" OFF)
+if(ZEUS_RADE_BUILD_TEST)
+  add_executable(zeus_rade_test "${CMAKE_CURRENT_SOURCE_DIR}/shim/zeus_rade_test.c")
+  target_include_directories(zeus_rade_test PRIVATE
+      "${RADAE_C}/src"
+      "${CMAKE_CURRENT_SOURCE_DIR}/shim"
+      ${OPUS_INCLUDE_DIRS})
+  target_link_libraries(zeus_rade_test PRIVATE zeus_rade)
+endif()

--- a/native/radae/VENDORING.md
+++ b/native/radae/VENDORING.md
@@ -2,9 +2,17 @@
 
 > **STATUS: SCAFFOLD ONLY. THE NATIVE BUILD IS NOT IMPLEMENTED YET.**
 > RADEV1 is surfaced + gated in the UI (Phase 1, landed). This directory is the
-> starting point for Phase 2 (the native build). The `CMakeLists.txt` here is a
-> **DRAFT** that does not yet produce a working `rade` library — see the blockers
-> below. Full design + plan: `docs/designs/rade-v1-integration.md`.
+> starting point for Phase 2 (the native build).
+>
+> **⚠ VERIFIED 2026-06-23 — do NOT FetchContent `drowe67/radae`.** A real build
+> investigation found upstream `librade` embeds CPython + PyTorch at runtime
+> (`rade_api.c` unconditionally includes `Python.h`; the OFDM modem/sync run in
+> Python; even freedv-gui ships embedded Python + downloads PyTorch). It cannot be
+> vendored dependency-free. The viable Python-free base is **`peterbmarks/radae_nopy`**
+> (pure C, weights compiled in, BSD-2 — but Linux/macOS only, no Windows/arm, and
+> upstream-deprecated in favour of a future `freedv-backend`). Pick the base
+> (radae_nopy now vs. waiting for the upstream C port) before writing CMake.
+> Full analysis: `docs/designs/rade-v1-integration.md` → "Phase 2 build investigation".
 
 ## What this will produce (target)
 

--- a/native/radae/VENDORING.md
+++ b/native/radae/VENDORING.md
@@ -1,0 +1,66 @@
+# native/radae — RADE V1 (Radio Autoencoder) vendoring
+
+> **STATUS: SCAFFOLD ONLY. THE NATIVE BUILD IS NOT IMPLEMENTED YET.**
+> RADEV1 is surfaced + gated in the UI (Phase 1, landed). This directory is the
+> starting point for Phase 2 (the native build). The `CMakeLists.txt` here is a
+> **DRAFT** that does not yet produce a working `rade` library — see the blockers
+> below. Full design + plan: `docs/designs/rade-v1-integration.md`.
+
+## What this will produce (target)
+
+```
+macOS   : librade.dylib   (arm64, x86_64)
+Linux   : librade.so      (x86_64, arm64, Raspberry Pi)
+Windows : rade.dll        (x64, arm64) — no "lib" prefix
+```
+
+…plus the FARGAN vocoder (from Opus's `spl_fargan` branch) and the RADE model
+weights, so Zeus can P/Invoke `rade_api.h` + the `fargan_*` synth.
+
+## Upstream
+
+| | |
+|---|---|
+| Repo | `drowe67/radae` |
+| License | BSD-2-clause |
+| Pin | **TBD** — pick a release tag, never moving HEAD (cf. codec2's `1.2.0` pin) |
+| FARGAN/Opus | Opus `spl_fargan` branch, pulled by radae's `cmake/BuildOpus.cmake` |
+| Model | `.pth` checkpoint → C (`rade_enc_data.c`/`rade_dec_data.c`) via repo export, or runtime blob |
+
+## Known build blockers (why this isn't a copy of native/codec2)
+
+1. **Python at configure time.** radae's root `CMakeLists.txt` requires
+   `Python3` (Interpreter + Development + NumPy); even the cross-compile path
+   wants `-DPython3_ROOT_DIR`. We must drive only the C decoder + FARGAN targets
+   and supply pre-exported C weights so Python isn't needed to *build the lib we
+   ship*. Reference freedv-gui's build, which does exactly this for distribution.
+2. **Custom Opus/FARGAN build.** Not `find_package(Opus)` — radae includes
+   `cmake/BuildOpus.cmake` to fetch+configure the `spl_fargan` Opus branch with
+   FARGAN. That sub-build must succeed under each toolchain.
+3. **MSVC can't compile the C99 `_Complex` DSP** (same as codec2). Windows builds
+   via **clang-cl**; expect an `if(NOT MSVC)` patch like
+   `native/codec2/patch-codec2-msvc.cmake`, applied to both radae and the Opus
+   sub-build.
+4. **arm/Pi.** RADE runs on arm (TI AM625, Librem 5) but the AVX option must be
+   off there; ensure the Opus/FARGAN SIMD selection is correct per arch.
+5. **Reverses `LPCNET=OFF`.** This is the deliberate dependency-free decision in
+   `native/codec2/VENDORING.md`. Accepted for RADE (maintainer, 2026-06-23):
+   bigger binaries + more CPU. Keep the FARGAN dependency contained to `librade`;
+   do NOT let it leak back into the codec2 build.
+
+## Plan (Phase 2)
+
+1. Pin a radae release tag; FetchContent radae + (via its cmake) Opus `spl_fargan`.
+2. Force the C decoder path; provide exported model weights as C so no Python is
+   needed to build the shipped library.
+3. Apply clang-cl / arm patches until `rade` + FARGAN link on win/linux/mac × x64/arm.
+4. Name outputs `rade.dll` / `librade.{so,dylib}` (PREFIX "" on WIN32, like codec2).
+5. Wire into `build-native-libs.yml`; emit binaries next to `codec2.*`.
+6. Then Phase 4: `RadeNativeMethods`/`RadeNativeLoader`/`RadeModem` P/Invoke +
+   the 48k↔16k resampler + real→complex front end; flip `RadeAvailable` true.
+
+## Update procedure (once it builds)
+
+Bump the radae pin → rebuild on all platforms via CI → re-export weights if the
+model changed → verify `rade_version()` + an on-air decode. Mirror the codec2
+VENDORING update discipline.

--- a/native/radae/shim/build_test_wsl.sh
+++ b/native/radae/shim/build_test_wsl.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Build + validate the zeus_rade shim against a real off-air RADE sample, using
+# a prior radae_nopy build in $HOME/rade-build. Linux/WSL only (validation harness).
+set -e
+SHIM="$(cd "$(dirname "$0")" && pwd)"
+B="$HOME/rade-build"
+RSRC="$B/src"
+BUILD="$B/build"
+
+OPUS="$(find "$BUILD" -type d -name build_opus | head -1)"
+LIBOPUS="$(find "$BUILD" -name libopus.a | head -1)"
+mapfile -t RADE_OBJ < <(find "$BUILD" -path '*rade.dir*' -name '*.o')
+REAL2IQ="$(find "$BUILD" -name real2iq -type f | head -1)"
+
+echo "opus=$OPUS"
+echo "libopus=$LIBOPUS"
+echo "rade objs=${#RADE_OBJ[@]}"
+echo "real2iq=$REAL2IQ"
+
+mkdir -p "$B/zeus" && cd "$B/zeus"
+echo "### compile shim + test"
+gcc -O2 -I"$SHIM" -I"$RSRC" -I"$OPUS/dnn" -I"$OPUS/celt" -I"$OPUS/include" -I"$OPUS" \
+    "$SHIM/zeus_rade.c" "$SHIM/zeus_rade_test.c" "${RADE_OBJ[@]}" "$LIBOPUS" -lm \
+    -o zeus_rade_test
+
+echo "### decode off-air sample through the shim's single IQ->PCM API"
+sox "$B/FDV_offair.wav" -r 8000 -e float -b 32 -c 1 -t raw - 2>/dev/null \
+  | "$REAL2IQ" 2>/dev/null \
+  | ./zeus_rade_test > zeus_out.pcm
+sox -t .s16 -r 16000 -c 1 zeus_out.pcm zeus_decoded.wav 2>/dev/null
+echo "### output audio stats (proof of real speech)"
+sox zeus_decoded.wav -n stat 2>&1 | grep -iE "samples read|length|maximum amplitude|rms amplitude"

--- a/native/radae/shim/zeus_rade.c
+++ b/native/radae/shim/zeus_rade.c
@@ -1,0 +1,145 @@
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * zeus_rade — single-entry RADE V1 decode shim (see zeus_rade.h).
+ *
+ * Combines radae_nopy's `rade` modem (IQ -> feature frames) with Opus's FARGAN
+ * vocoder (feature frames -> 16 kHz PCM) into one streaming call. Mirrors the
+ * verified reference flow from radae_nopy's lpcnet_demo.c (-fargan-synthesis):
+ * FARGAN is primed with the first 5 feature frames, then synthesizes 160 PCM
+ * samples per subsequent frame. RADE + FARGAN weights are compiled in.
+ *
+ * Frame constants (from the Opus DNN build): a feature frame is
+ * NB_TOTAL_FEATURES(36) floats; FARGAN consumes the first NB_FEATURES(20) and
+ * emits LPCNET_FRAME_SIZE(160) samples at 16 kHz.
+ */
+#include "zeus_rade.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+/* Opus FARGAN vocoder. */
+#include "fargan.h"
+#include "freq.h"      /* NB_TOTAL_FEATURES, NB_FEATURES */
+#include "lpcnet.h"    /* LPCNET_FRAME_SIZE */
+
+#define ZR_PRIME_FRAMES 5
+/* A RADE modem frame yields a bounded number of feature frames; this caps the
+ * PCM produced per rx call. Generous — guards the output buffer against any
+ * upstream change without truncating real output. */
+#define ZR_MAX_FRAMES_PER_RX 64
+
+struct zeus_rade {
+    struct rade *r;
+    FARGANState  fargan;
+    int   n_features;     /* rade_n_features_in_out (feature floats per RADE frame group) */
+    int   n_eoo_bits;
+    int   primed;         /* FARGAN continuation done */
+    int   prime_have;     /* feature frames collected toward priming */
+    float prime_buf[ZR_PRIME_FRAMES * NB_TOTAL_FEATURES];
+    float feat_scratch[ZR_MAX_FRAMES_PER_RX * NB_TOTAL_FEATURES];
+    float eoo_scratch[1024];
+    int   have_callsign;
+    char  callsign[RADE_EOO_CALLSIGN_MAX + 1];
+};
+
+void zeus_rade_global_init(void)     { rade_initialize(); }
+void zeus_rade_global_shutdown(void) { rade_finalize(); }
+
+zeus_rade *zeus_rade_open(void)
+{
+    zeus_rade *z = (zeus_rade *)calloc(1, sizeof(*z));
+    if (!z) return NULL;
+
+    /* radae_nopy compiles the weights in, so the model path is unused; the C
+     * encoder/decoder paths are what make this Python-free. */
+    z->r = rade_open("", RADE_USE_C_ENCODER | RADE_USE_C_DECODER | RADE_VERBOSE_0);
+    if (!z->r) { free(z); return NULL; }
+
+    z->n_features  = rade_n_features_in_out(z->r);
+    z->n_eoo_bits  = rade_n_eoo_bits(z->r);
+    fargan_init(&z->fargan);
+    z->primed = 0;
+    z->prime_have = 0;
+    z->have_callsign = 0;
+    z->callsign[0] = '\0';
+    return z;
+}
+
+void zeus_rade_close(zeus_rade *z)
+{
+    if (!z) return;
+    if (z->r) rade_close(z->r);
+    free(z);
+}
+
+int zeus_rade_nin(zeus_rade *z)            { return rade_nin(z->r); }
+int zeus_rade_nin_max(zeus_rade *z)        { return rade_nin_max(z->r); }
+int zeus_rade_max_pcm_per_rx(zeus_rade *z) { (void)z; return ZR_MAX_FRAMES_PER_RX * LPCNET_FRAME_SIZE; }
+int zeus_rade_sync(zeus_rade *z)           { return rade_sync(z->r); }
+float zeus_rade_freq_offset(zeus_rade *z)  { return rade_freq_offset(z->r); }
+int zeus_rade_snr_db(zeus_rade *z)         { return rade_snrdB_3k_est(z->r); }
+
+int zeus_rade_get_eoo_callsign(zeus_rade *z, char *callsign_out)
+{
+    if (!z->have_callsign) { if (callsign_out) callsign_out[0] = '\0'; return 0; }
+    int n = (int)strlen(z->callsign);
+    if (callsign_out) memcpy(callsign_out, z->callsign, (size_t)n + 1);
+    z->have_callsign = 0; /* consume */
+    return n;
+}
+
+/* Prime FARGAN exactly as the reference does: 5 frames of NB_TOTAL_FEATURES read
+ * into NB_FEATURES-strided slots, with 2 frames of zero PCM history. */
+static void zr_try_prime(zeus_rade *z, const float *frame36)
+{
+    memcpy(&z->prime_buf[z->prime_have * NB_FEATURES], frame36,
+           NB_TOTAL_FEATURES * sizeof(float));
+    z->prime_have++;
+    if (z->prime_have == ZR_PRIME_FRAMES) {
+        float zeros[2 * LPCNET_FRAME_SIZE];
+        memset(zeros, 0, sizeof(zeros));
+        fargan_cont(&z->fargan, zeros, z->prime_buf);
+        z->primed = 1;
+    }
+}
+
+int zeus_rade_rx(zeus_rade *z, const RADE_COMP *rx_in, short *pcm_out)
+{
+    int has_eoo = 0;
+    int nfloats = rade_rx(z->r, z->feat_scratch, &has_eoo, z->eoo_scratch,
+                          (RADE_COMP *)rx_in);
+
+    /* On loss of sync, drop the priming so we re-prime cleanly on re-acquire. */
+    if (!rade_sync(z->r)) { z->primed = 0; z->prime_have = 0; }
+
+    if (has_eoo) {
+        char cs[RADE_EOO_CALLSIGN_MAX + 1];
+        int n = rade_rx_get_eoo_callsign(z->eoo_scratch, z->n_eoo_bits, cs);
+        if (n > 0) { memcpy(z->callsign, cs, (size_t)n + 1); z->have_callsign = 1; }
+    }
+
+    if (nfloats <= 0) return 0;
+
+    int n_pcm = 0;
+    int frames = nfloats / NB_TOTAL_FEATURES;
+    if (frames > ZR_MAX_FRAMES_PER_RX) frames = ZR_MAX_FRAMES_PER_RX;
+    for (int f = 0; f < frames; f++) {
+        const float *frame36 = &z->feat_scratch[f * NB_TOTAL_FEATURES];
+        if (!z->primed) {
+            zr_try_prime(z, frame36);
+            continue; /* priming frames produce no audio (matches reference) */
+        }
+        float feats[NB_FEATURES];
+        float fpcm[LPCNET_FRAME_SIZE];
+        memcpy(feats, frame36, NB_FEATURES * sizeof(float)); /* OPUS_COPY first 20 */
+        fargan_synthesize(&z->fargan, fpcm, feats);
+        for (int i = 0; i < LPCNET_FRAME_SIZE; i++) {
+            float s = 32768.0f * fpcm[i];
+            if (s >  32767.0f) s =  32767.0f;
+            if (s < -32767.0f) s = -32767.0f;
+            pcm_out[n_pcm++] = (short)floorf(0.5f + s);
+        }
+    }
+    return n_pcm;
+}

--- a/native/radae/shim/zeus_rade.h
+++ b/native/radae/shim/zeus_rade.h
@@ -1,0 +1,66 @@
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * zeus_rade — a thin single-entry shim over RADE V1 (radae_nopy) + the FARGAN
+ * vocoder (Opus), packaged for Zeus. It hides RADE's two-stage decode behind one
+ * streaming "complex IQ in -> 16 kHz PCM out" surface so the .NET side P/Invokes
+ * a single library instead of binding both rade_api.h AND the Opus FARGAN API.
+ *
+ * Pipeline (per the verified radae_nopy reference, 2026-06-23):
+ *   rade_rx(IQ@8kHz) -> vocoder feature frames (36 floats/frame)
+ *   FARGAN: prime with the first 5 frames, then synthesize 160 PCM@16kHz / frame.
+ * Both RADE and FARGAN weights are compiled in — no model files at runtime.
+ *
+ * All sample rates / buffer sizes come from the underlying rade_api.h:
+ *   modem IQ  = RADE_MODEM_SAMPLE_RATE  (8000)
+ *   speech    = RADE_SPEECH_SAMPLE_RATE (16000)
+ */
+#ifndef ZEUS_RADE_H
+#define ZEUS_RADE_H
+
+#include "rade_api.h"   /* RADE_COMP, RADE_MODEM_SAMPLE_RATE, RADE_SPEECH_SAMPLE_RATE */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef _WIN32
+#  define ZEUS_RADE_EXPORT __declspec(dllexport)
+#else
+#  define ZEUS_RADE_EXPORT __attribute__((visibility("default")))
+#endif
+
+typedef struct zeus_rade zeus_rade;
+
+/* Library lifecycle (wrap rade_initialize/finalize; call once per process). */
+ZEUS_RADE_EXPORT void        zeus_rade_global_init(void);
+ZEUS_RADE_EXPORT void        zeus_rade_global_shutdown(void);
+
+/* Open/close a decoder context. Returns NULL on failure. */
+ZEUS_RADE_EXPORT zeus_rade  *zeus_rade_open(void);
+ZEUS_RADE_EXPORT void        zeus_rade_close(zeus_rade *z);
+
+/* Buffer-sizing helpers (call after open). */
+ZEUS_RADE_EXPORT int  zeus_rade_nin(zeus_rade *z);       /* IQ samples for the NEXT rx call (varies) */
+ZEUS_RADE_EXPORT int  zeus_rade_nin_max(zeus_rade *z);   /* max ever — size rx_in[] with this */
+ZEUS_RADE_EXPORT int  zeus_rade_max_pcm_per_rx(zeus_rade *z); /* upper bound on PCM produced per rx call */
+
+/* Decode one block of IQ to 16 kHz PCM.
+ *   rx_in   : zeus_rade_nin(z) complex (interleaved real,imag) samples @ 8 kHz
+ *   pcm_out : caller buffer, >= zeus_rade_max_pcm_per_rx(z) int16 samples @ 16 kHz
+ * Returns the number of int16 PCM samples written (0 while unsynced / priming). */
+ZEUS_RADE_EXPORT int  zeus_rade_rx(zeus_rade *z, const RADE_COMP *rx_in, short *pcm_out);
+
+/* Telemetry (valid when synced). */
+ZEUS_RADE_EXPORT int   zeus_rade_sync(zeus_rade *z);
+ZEUS_RADE_EXPORT float zeus_rade_freq_offset(zeus_rade *z);
+ZEUS_RADE_EXPORT int   zeus_rade_snr_db(zeus_rade *z);
+
+/* Last decoded End-of-Over callsign (RADE carries up to 8 chars in the EOO
+ * frame). Copies into callsign_out (>= 9 bytes); returns chars written, 0 if
+ * none since the last over. Maps to the existing FreeDV RX-text UI. */
+ZEUS_RADE_EXPORT int   zeus_rade_get_eoo_callsign(zeus_rade *z, char *callsign_out);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* ZEUS_RADE_H */

--- a/native/radae/shim/zeus_rade_test.c
+++ b/native/radae/shim/zeus_rade_test.c
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * zeus_rade_test — validates the zeus_rade shim end-to-end against a real
+ * off-air RADE recording. Reads interleaved complex IQ (RADE_COMP) @ 8 kHz from
+ * stdin, decodes via the single shim API, writes int16 PCM @ 16 kHz to stdout.
+ *
+ *   sox FDV_offair.wav -r 8000 -e float -b 32 -c 1 -t raw - \
+ *     | real2iq | zeus_rade_test > out.pcm
+ *   sox -t .s16 -r 16000 -c 1 out.pcm decoded.wav   # listen / measure
+ */
+#include "zeus_rade.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(void)
+{
+    zeus_rade_global_init();
+    zeus_rade *z = zeus_rade_open();
+    if (!z) { fprintf(stderr, "zeus_rade_open failed\n"); return 1; }
+
+    int nin_max = zeus_rade_nin_max(z);
+    int max_pcm = zeus_rade_max_pcm_per_rx(z);
+    RADE_COMP *iq  = (RADE_COMP *)malloc(sizeof(RADE_COMP) * (size_t)nin_max);
+    short     *pcm = (short *)malloc(sizeof(short) * (size_t)max_pcm);
+
+    long total_pcm = 0;
+    int  synced_ticks = 0, ticks = 0, last_snr = 0;
+    for (;;) {
+        int nin = zeus_rade_nin(z);
+        if (nin <= 0 || nin > nin_max) break;
+        size_t got = fread(iq, sizeof(RADE_COMP), (size_t)nin, stdin);
+        if (got != (size_t)nin) break;
+        int n = zeus_rade_rx(z, iq, pcm);
+        if (n > 0) { fwrite(pcm, sizeof(short), (size_t)n, stdout); total_pcm += n; }
+        ticks++;
+        if (zeus_rade_sync(z)) { synced_ticks++; last_snr = zeus_rade_snr_db(z); }
+    }
+
+    char cs[RADE_EOO_CALLSIGN_MAX + 1];
+    int csn = zeus_rade_get_eoo_callsign(z, cs);
+    fprintf(stderr,
+            "zeus_rade_test: pcm_samples=%ld ticks=%d synced=%d last_snr=%ddB callsign=%s\n",
+            total_pcm, ticks, synced_ticks, last_snr, csn > 0 ? cs : "(none)");
+
+    free(iq); free(pcm);
+    zeus_rade_close(z);
+    zeus_rade_global_shutdown();
+    return 0;
+}

--- a/native/radae/shim/zeus_rade_test.c
+++ b/native/radae/shim/zeus_rade_test.c
@@ -12,9 +12,19 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef _WIN32
+#  include <io.h>
+#  include <fcntl.h>
+#endif
 
 int main(void)
 {
+#ifdef _WIN32
+    /* Windows opens stdin/stdout in text mode by default, which mangles binary
+     * IQ/PCM (a 0x0A byte ends a read early). Force binary mode. */
+    _setmode(_fileno(stdin),  _O_BINARY);
+    _setmode(_fileno(stdout), _O_BINARY);
+#endif
     zeus_rade_global_init();
     zeus_rade *z = zeus_rade_open();
     if (!z) { fprintf(stderr, "zeus_rade_open failed\n"); return 1; }

--- a/native/radae/vendor/PROVENANCE.md
+++ b/native/radae/vendor/PROVENANCE.md
@@ -1,0 +1,111 @@
+# native/radae/vendor — RADE V1 vendored source provenance
+
+Zeus builds its RADE V1 decoder (`libzeus_rade`, see `../CMakeLists.txt`) from three
+upstream C slices. They are **not committed to the Zeus git tree** — together they are
+~95 MB, almost all of it compiled-in neural-network weight tables. CI
+(`build-native-libs.yml`) vendors them into this `vendor/` directory before
+configuring the CMake project. This file is the single source of truth for *what* to
+vendor, *from where*, and *under which license*.
+
+## Upstream
+
+All three slices are vendored from a single upstream repository:
+
+| field        | value |
+|--------------|-------|
+| Upstream     | https://github.com/sv1eia/Thetis-RADE |
+| Pinned SHA   | `f7605a46bd21275ab8b9edd00d4a1b6fae6eabe8` |
+| HEAD subject | *"Remove vendored radae_nopy; build rade.lib from in-repo radae_c and update credits/docs"* |
+
+(That HEAD commit is the one that switched Thetis-RADE itself from `radae_nopy` to the
+in-repo `radae_c` + co-vendored `opus_dnn` model — i.e. exactly the composition Zeus
+adopts here.)
+
+## Slices to vendor
+
+Copy these three directories from the pinned checkout into `native/radae/vendor/`,
+preserving the directory name (drop the `Project Files/lib/` prefix):
+
+| vendor/ target | upstream path (under the SHA above)        | license       |
+|----------------|--------------------------------------------|---------------|
+| `radae_c/`     | `Project Files/lib/radae_c/`               | BSD-2-Clause  |
+| `opus_dnn/`    | `Project Files/lib/opus_dnn/`              | BSD-3-Clause  |
+| `freedv_text/` | `Project Files/lib/freedv_text/`           | mixed: see below |
+
+### `radae_c/` — BSD-2-Clause (David Rowe, © 2024)
+Pure-C, Python-free RADE modem. IQ → 36-float feature frames; encoder/decoder weights
+compiled in (`src/rade_enc_data.c`, `src/rade_dec_data.c`, ~24 MB each). The public API
+(`src/rade_api.h`, implemented by `src/radc_api.c`) is byte-for-byte compatible with the
+reference `rade_api.h`. Only the **decode** path is used by Zeus, but the whole `src/`
+tree is vendored (the tx files are tiny and the data tables are shared).
+
+### `opus_dnn/` — BSD-3-Clause (Xiph.Org / Skype / Jean-Marc Valin et al.)
+Xiph Opus pinned at upstream `xiph/opus` commit
+`940d4e5af64351ca8ba8390df3f555484c567fbb` (per `opus_dnn/commit_pin.txt`), carrying the
+DNN/FARGAN vocoder. Built via its own CMake with **`OPUS_DEEP_PLC=ON`**, which compiles
+`dnn/fargan.c`, `dnn/fargan_data.c`, `dnn/nnet.c`, `dnn/freq.c`, etc. — providing
+`fargan_synthesize()` (the 36-float-feature → 160-sample @ 16 kHz vocoder) that the shim
+calls. (`OPUS_DRED`/`OPUS_OSCE` are **not** required for the V1 decode path.)
+
+> **CI caveat — stripped SIMD subtrees.** The Thetis-RADE `opus_dnn` slice is the
+> MSVC-x64 scalar build: its `silk/x86/`, `silk/arm/`, `celt/x86/`, `celt/arm/`,
+> `dnn/x86/`, `dnn/arm/` directories are **absent**, but the CMake `*_headers.mk` /
+> `*_sources.mk` lists still reference ~65 of those files. With
+> `OPUS_DISABLE_INTRINSICS=ON` those SIMD *sources* are not compiled, but CMake's
+> `target_sources()` still validates that the referenced *header* entries exist.
+> CI must create empty placeholder files for every missing referenced path before
+> configuring (one-liner: for each `silk|celt|dnn|src/...\.[ch]` token in the `.mk`
+> files that does not exist on disk, `mkdir -p $(dirname) && : > $file`). This was the
+> only patch needed to make `opus_dnn` configure on Linux/CMake.
+
+### `freedv_text/` — mixed license (vendored but NOT yet wired)
+Not needed to **decode audio**. It is the FreeDV-GUI reliable-text (LDPC) codec that
+decodes the on-air **EOO callsign** frame. radae_c's built-in
+`rade_rx_get_eoo_callsign()` uses a simple 7-bit-MSB packing that is *not* the
+FreeDV-GUI on-air format, so callsigns decoded through the shim today are garbled. Wiring
+`freedv_text/src/rade_text.c` into the shim is a known follow-up (see
+"Decode-test result" below). Licenses within the slice:
+- `freedv_text/src/rade_text.{c,h}` — BSD-2/3-Clause (Mooneer Salem)
+- `freedv_text/codec2/*` (LDPC: `mpdecode_core.c`, `gp_interleaver.c`, `ldpc_codes.c`,
+  `HRA_56_56.c`, `phi0.c`) — **LGPL-2.1** (David Rowe / codec2)
+
+## License roll-up
+
+| component   | license      | copyleft? |
+|-------------|--------------|-----------|
+| radae_c     | BSD-2-Clause | no |
+| opus_dnn    | BSD-3-Clause | no |
+| freedv_text/src (rade_text) | BSD | no |
+| freedv_text/codec2 (LDPC) | LGPL-2.1 | weak (dynamic-link OK) |
+
+The audio-decode build (`radae_c` + `opus_dnn` + Zeus shim) is **BSD-only**. The
+LGPL-2.1 codec2 LDPC code is pulled in **only** if/when the EOO-callsign path is wired,
+and `libzeus_rade` is already a shared library (dynamic linking satisfies LGPL-2.1).
+
+## Proven build + decode (WSL Ubuntu-24.04, 2026-06-24)
+
+The one-shared-library composition above was built and validated end-to-end:
+
+- **opus_dnn** built static via CMake: `-DOPUS_DEEP_PLC=ON -DOPUS_DISABLE_INTRINSICS=ON`
+  (+ the placeholder-stub step). FARGAN symbols present in `libopus.a`.
+- **radae_c** compiled with `-DRADE_STATIC -DRADE_PYTHON_FREE=1 -DIS_BUILDING_RADE_API=1`.
+- Linked **radae_c objects + shim + whole-archived opus_dnn** into one
+  `libzeus_rade.so` (11 MB). All `zeus_rade_*` symbols exported.
+- **Decode test** on a 5'26" off-air RADE recording (`FDV_offair.wav`, 48 kHz mono),
+  fed as **real samples** (`RADE_COMP.real = s, .imag = 0` — radae_c's modem expects a
+  real 8 kHz signal; this is the reference feed in `ChannelMaster/radae.c`, *not* a
+  Hilbert IQ front-end like radae_nopy's `real2iq`):
+
+  ```
+  zeus_rade_test: pcm_samples=5017920 ticks=2717 synced=2620 last_snr=14dB
+  out.wav stat: Maximum amplitude 0.999969  RMS 0.116568  (313.6 s of real speech)
+  ```
+
+  **2620 synced ticks, 14 dB SNR, near-full-scale audio** — matches the prior
+  radae_nopy reference run (~2628 ticks / 14 dB / 0.9999 max-amp). RADE V1 decode from
+  the radae_c + opus_dnn base is PROVEN.
+
+- **Known follow-up:** EOO callsign decoded garbled (`8}sRy`) — expected, because the
+  shim still uses radae_c's 7-bit `rade_rx_get_eoo_callsign`. Correct callsigns require
+  wiring `freedv_text/src/rade_text.c` (LGPL-2.1 codec2 LDPC). Out of scope for the
+  audio-decode base decision; tracked separately.

--- a/native/radae/vendor/PROVENANCE.md
+++ b/native/radae/vendor/PROVENANCE.md
@@ -109,3 +109,23 @@ The one-shared-library composition above was built and validated end-to-end:
   shim still uses radae_c's 7-bit `rade_rx_get_eoo_callsign`. Correct callsigns require
   wiring `freedv_text/src/rade_text.c` (LGPL-2.1 codec2 LDPC). Out of scope for the
   audio-decode base decision; tracked separately.
+
+## Proven build + decode (Windows / MinGW, 2026-06-24)
+
+The same composition was then PROVEN on native Windows with MinGW UCRT64 gcc 16.1
+(Ninja, `OPUS_DISABLE_INTRINSICS=ON`):
+
+- `zeus_rade.dll` (11.0 MB) linked clean; all 12 `zeus_rade_*` symbols exported.
+- **Standalone** — `objdump -p` shows deps only on `KERNEL32` + `ADVAPI32` +
+  system UCRT (`api-ms-win-crt-*`); NO `libgcc_s_seh-1.dll` / `libwinpthread-1.dll`
+  / `libstdc++`. The static-link flags are now in `../CMakeLists.txt` (`if(MINGW)`).
+- Decoded `FDV_offair.wav` (Windows exe): `synced=2620 last_snr=14dB`,
+  decoded audio max-amp `0.999969` — **byte-for-byte identical to the Linux run**.
+
+Windows build notes now folded into `../CMakeLists.txt`:
+- `if(WIN32) PREFIX ""` so MinGW emits `zeus_rade.dll`, not `libzeus_rade.dll`
+  (matches the .NET loader's probe name).
+- `if(MINGW)` static-runtime link (`-static -static-libgcc -Wl,-Bstatic`).
+- `-O1` on the two ~24 MB weight `.c` files (compile-time/RAM; they are data).
+- The `shim/zeus_rade_test.c` harness needs `_setmode(_O_BINARY)` on Windows (stdio
+  binary mode) — added there; the production P/Invoke path doesn't use stdio.

--- a/tests/Zeus.Dsp.FreeDv.Tests/FreeDvAutoScannerTests.cs
+++ b/tests/Zeus.Dsp.FreeDv.Tests/FreeDvAutoScannerTests.cs
@@ -25,7 +25,7 @@ public class FreeDvAutoScannerTests
     [Fact]
     public void Unsynced_HoldsForDwell_ThenAdvancesInOrder()
     {
-        var s = new FreeDvAutoScanner(dwellMs: 1000, reacquireMs: 2000);
+        var s = new FreeDvAutoScanner(dwellMs: 1000, lockConfirmMs: 1500, unlockMs: 4000);
         Assert.Null(s.Tick(0, synced: false, FreeDvSubmode.Mode700D));   // seeds timebase
         Assert.Null(s.Tick(999, synced: false, FreeDvSubmode.Mode700D)); // still dwelling
         Assert.Equal(FreeDvSubmode.Mode700E, s.Tick(1000, synced: false, FreeDvSubmode.Mode700D));
@@ -37,36 +37,47 @@ public class FreeDvAutoScannerTests
     [Fact]
     public void Advance_WrapsPastLastMode()
     {
-        var s = new FreeDvAutoScanner(dwellMs: 1000, reacquireMs: 2000);
+        var s = new FreeDvAutoScanner(dwellMs: 1000, lockConfirmMs: 1500, unlockMs: 4000);
         s.Tick(0, synced: false, FreeDvSubmode.Mode800XA);
         Assert.Equal(FreeDvSubmode.Mode700D, s.Tick(1000, synced: false, FreeDvSubmode.Mode800XA));
     }
 
     [Fact]
-    public void Synced_HoldsIndefinitely_NeverAdvances()
+    public void BriefSyncFlicker_DoesNotLock_AndStillAdvances()
     {
-        var s = new FreeDvAutoScanner(dwellMs: 1000, reacquireMs: 2000);
-        Assert.Null(s.Tick(0, synced: true, FreeDvSubmode.Mode700D));
-        // Far past any dwell, but locked — must not move.
-        Assert.Null(s.Tick(100_000, synced: true, FreeDvSubmode.Mode700D));
+        // The marginal-signal chatter case: a sub-lockConfirm sync blip must NOT
+        // camp the scanner, and must NOT reset the dwell — the mode still advances.
+        var s = new FreeDvAutoScanner(dwellMs: 1000, lockConfirmMs: 1500, unlockMs: 4000);
+        Assert.Null(s.Tick(0, synced: false, FreeDvSubmode.Mode700D));
+        Assert.Null(s.Tick(400, synced: true, FreeDvSubmode.Mode700D));   // flicker up (300 ms)
+        Assert.Null(s.Tick(700, synced: false, FreeDvSubmode.Mode700D));  // back to noise
+        Assert.False(s.Locked);
+        Assert.Equal(FreeDvSubmode.Mode700E, s.Tick(1000, synced: false, FreeDvSubmode.Mode700D));
     }
 
     [Fact]
-    public void AfterLock_LosesSync_HoldsThroughReacquireGrace_ThenResumes()
+    public void SustainedSync_Locks_AndCampsThroughFadesUntilUnlock()
     {
-        var s = new FreeDvAutoScanner(dwellMs: 1000, reacquireMs: 2000);
-        s.Tick(0, synced: true, FreeDvSubmode.Mode700D); // lock
-        // Sync drops; within the re-acquire grace the locked mode is held even
-        // though the dwell has long since elapsed (covers QSO overs / fades).
-        Assert.Null(s.Tick(1999, synced: false, FreeDvSubmode.Mode700D));
-        // Grace expired and dwell elapsed — resume scanning from the locked mode.
-        Assert.Equal(FreeDvSubmode.Mode700E, s.Tick(2000, synced: false, FreeDvSubmode.Mode700D));
+        var s = new FreeDvAutoScanner(dwellMs: 1000, lockConfirmMs: 1500, unlockMs: 4000);
+        Assert.Null(s.Tick(0, synced: true, FreeDvSubmode.Mode700D));
+        Assert.Null(s.Tick(1500, synced: true, FreeDvSubmode.Mode700D)); // 1.5 s continuous → lock
+        Assert.True(s.Locked);
+        // Lose sync; camped mode is held through the unlock window (overs/fades).
+        Assert.Null(s.Tick(10_000, synced: false, FreeDvSubmode.Mode700D));
+        Assert.True(s.Locked);
+        Assert.Null(s.Tick(13_999, synced: false, FreeDvSubmode.Mode700D)); // still within unlock grace
+        Assert.True(s.Locked);
+        // Continuous loss exceeds unlock → release (this tick just unlocks)…
+        Assert.Null(s.Tick(14_000, synced: false, FreeDvSubmode.Mode700D));
+        Assert.False(s.Locked);
+        // …then the resumed scan advances after a fresh dwell.
+        Assert.Equal(FreeDvSubmode.Mode700E, s.Tick(15_000, synced: false, FreeDvSubmode.Mode700D));
     }
 
     [Fact]
     public void Reset_ReseedsDwell()
     {
-        var s = new FreeDvAutoScanner(dwellMs: 1000, reacquireMs: 2000);
+        var s = new FreeDvAutoScanner(dwellMs: 1000, lockConfirmMs: 1500, unlockMs: 4000);
         s.Tick(0, synced: false, FreeDvSubmode.Mode700D);
         Assert.Equal(FreeDvSubmode.Mode700E, s.Tick(1000, synced: false, FreeDvSubmode.Mode700D));
         s.Reset(5000);

--- a/tests/Zeus.Dsp.FreeDv.Tests/FreeDvAutoScannerTests.cs
+++ b/tests/Zeus.Dsp.FreeDv.Tests/FreeDvAutoScannerTests.cs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using Zeus.Contracts;
+using Zeus.Dsp.FreeDv;
+
+namespace Zeus.Dsp.FreeDv.Tests;
+
+/// <summary>
+/// Deterministic tests for the auto submode scanner. It owns no clock, so we
+/// drive it with explicit timestamps — no native modem, no real time, no flakiness.
+/// </summary>
+public class FreeDvAutoScannerTests
+{
+    [Fact]
+    public void Order_StartsWith700D_AndCoversAllFiveModes()
+    {
+        var s = new FreeDvAutoScanner();
+        Assert.Equal(5, s.Order.Count);
+        Assert.Equal(FreeDvSubmode.Mode700D, s.Order[0]);
+        Assert.Contains(FreeDvSubmode.Mode700E, s.Order);
+        Assert.Contains(FreeDvSubmode.Mode700C, s.Order);
+        Assert.Contains(FreeDvSubmode.Mode1600, s.Order);
+        Assert.Contains(FreeDvSubmode.Mode800XA, s.Order);
+    }
+
+    [Fact]
+    public void Unsynced_HoldsForDwell_ThenAdvancesInOrder()
+    {
+        var s = new FreeDvAutoScanner(dwellMs: 1000, reacquireMs: 2000);
+        Assert.Null(s.Tick(0, synced: false, FreeDvSubmode.Mode700D));   // seeds timebase
+        Assert.Null(s.Tick(999, synced: false, FreeDvSubmode.Mode700D)); // still dwelling
+        Assert.Equal(FreeDvSubmode.Mode700E, s.Tick(1000, synced: false, FreeDvSubmode.Mode700D));
+        // Caller applies 700E; dwell restarts at 1000.
+        Assert.Null(s.Tick(1999, synced: false, FreeDvSubmode.Mode700E));
+        Assert.Equal(FreeDvSubmode.Mode700C, s.Tick(2000, synced: false, FreeDvSubmode.Mode700E));
+    }
+
+    [Fact]
+    public void Advance_WrapsPastLastMode()
+    {
+        var s = new FreeDvAutoScanner(dwellMs: 1000, reacquireMs: 2000);
+        s.Tick(0, synced: false, FreeDvSubmode.Mode800XA);
+        Assert.Equal(FreeDvSubmode.Mode700D, s.Tick(1000, synced: false, FreeDvSubmode.Mode800XA));
+    }
+
+    [Fact]
+    public void Synced_HoldsIndefinitely_NeverAdvances()
+    {
+        var s = new FreeDvAutoScanner(dwellMs: 1000, reacquireMs: 2000);
+        Assert.Null(s.Tick(0, synced: true, FreeDvSubmode.Mode700D));
+        // Far past any dwell, but locked — must not move.
+        Assert.Null(s.Tick(100_000, synced: true, FreeDvSubmode.Mode700D));
+    }
+
+    [Fact]
+    public void AfterLock_LosesSync_HoldsThroughReacquireGrace_ThenResumes()
+    {
+        var s = new FreeDvAutoScanner(dwellMs: 1000, reacquireMs: 2000);
+        s.Tick(0, synced: true, FreeDvSubmode.Mode700D); // lock
+        // Sync drops; within the re-acquire grace the locked mode is held even
+        // though the dwell has long since elapsed (covers QSO overs / fades).
+        Assert.Null(s.Tick(1999, synced: false, FreeDvSubmode.Mode700D));
+        // Grace expired and dwell elapsed — resume scanning from the locked mode.
+        Assert.Equal(FreeDvSubmode.Mode700E, s.Tick(2000, synced: false, FreeDvSubmode.Mode700D));
+    }
+
+    [Fact]
+    public void Reset_ReseedsDwell()
+    {
+        var s = new FreeDvAutoScanner(dwellMs: 1000, reacquireMs: 2000);
+        s.Tick(0, synced: false, FreeDvSubmode.Mode700D);
+        Assert.Equal(FreeDvSubmode.Mode700E, s.Tick(1000, synced: false, FreeDvSubmode.Mode700D));
+        s.Reset(5000);
+        Assert.Null(s.Tick(5000, synced: false, FreeDvSubmode.Mode700E));      // fresh dwell
+        Assert.Null(s.Tick(5999, synced: false, FreeDvSubmode.Mode700E));
+        Assert.Equal(FreeDvSubmode.Mode700C, s.Tick(6000, synced: false, FreeDvSubmode.Mode700E));
+    }
+}

--- a/tests/Zeus.Dsp.FreeDv.Tests/FreeDvLoopbackTests.cs
+++ b/tests/Zeus.Dsp.FreeDv.Tests/FreeDvLoopbackTests.cs
@@ -20,6 +20,9 @@ public class FreeDvLoopbackTests
     [SkippableTheory]
     [InlineData(FreeDvSubmode.Mode700D)]
     [InlineData(FreeDvSubmode.Mode700E)]
+    [InlineData(FreeDvSubmode.Mode700C)]
+    [InlineData(FreeDvSubmode.Mode1600)]
+    [InlineData(FreeDvSubmode.Mode800XA)]
     public void NativeLoopback_TxToRx_AchievesSync(FreeDvSubmode submode)
     {
         using var tx = new FreeDvModem();
@@ -35,7 +38,7 @@ public class FreeDvLoopbackTests
         rx.Activate();
 
         const int blockSize = 960;   // 20 ms @ 48 kHz
-        const int txBlocks = 250;    // ~5 s of transmit — ample for OFDM acquisition
+        const int txBlocks = 500;    // ~10 s of transmit — ample acquisition for every mode
 
         // 1) Run a speech-like signal through TX, collecting the 48 kHz modem audio.
         var modemAudio = new List<float>(txBlocks * blockSize);
@@ -128,6 +131,117 @@ public class FreeDvLoopbackTests
         Assert.Equal(8000, m.SpeechSampleRateHz);
         Assert.Equal(8000, m.ModemSampleRateHz);
         Assert.StartsWith("codec2", m.LibraryVersion);
+    }
+
+    /// <summary>
+    /// The RX hot path must run far faster than real time — it is one of several
+    /// inserts on the DSP tick and cannot be the bottleneck. We feed real synced
+    /// modem audio (so freedv_rx does full decode work, not just sync search) and
+    /// assert the decode wall-clock is a small fraction of the audio duration.
+    /// Conservative threshold (>=10x) to stay green on a loaded CI box; in
+    /// practice the margin is far larger.
+    /// </summary>
+    [SkippableFact]
+    public void NativeLoopback_RxHotPath_RunsFasterThanRealTime()
+    {
+        using var tx = new FreeDvModem();
+        Skip.IfNot(tx.NativeAvailable, "codec2 native library not present — perf test skipped.");
+        using var rx = new FreeDvModem();
+        tx.SetSubmode(FreeDvSubmode.Mode700E);
+        rx.SetSubmode(FreeDvSubmode.Mode700E);
+        rx.SetSquelch(enabled: false, threshDb: null);
+        tx.Activate();
+        rx.Activate();
+
+        const int blockSize = 960;   // 20 ms @ 48 kHz
+        const int txBlocks = 500;    // ~10 s of modem audio
+        var modemAudio = GenerateModemAudio(tx, blockSize, txBlocks);
+
+        var rxBlock = new float[blockSize];
+        int total = modemAudio.Count;
+
+        // Warm up (JIT + sync acquisition) so the timed region is steady-state decode.
+        for (int i = 0; i + blockSize <= total; i += blockSize)
+        {
+            modemAudio.CopyTo(i, rxBlock, 0, blockSize);
+            rx.ProcessRxInPlace(rxBlock);
+        }
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        int processed = 0;
+        for (int i = 0; i + blockSize <= total; i += blockSize)
+        {
+            modemAudio.CopyTo(i, rxBlock, 0, blockSize);
+            rx.ProcessRxInPlace(rxBlock);
+            processed += blockSize;
+        }
+        sw.Stop();
+
+        double audioSeconds = processed / (double)FreeDvResampler.FsHigh;
+        double wallSeconds = sw.Elapsed.TotalSeconds;
+        double realtimeFactor = audioSeconds / wallSeconds;
+        Assert.True(
+            realtimeFactor >= 10.0,
+            $"FreeDV RX hot path too slow: {realtimeFactor:F1}x real time " +
+            $"({wallSeconds * 1000:F1} ms to decode {audioSeconds:F1} s of audio). " +
+            "Must be well above 1x — it is one insert among many on the DSP tick.");
+    }
+
+    /// <summary>
+    /// The RX hot path is contractually zero-allocation (matches the realtime
+    /// discipline of the Zeus audio bus). After warmup, processing a long run of
+    /// blocks must allocate nothing on the calling thread — any per-block alloc
+    /// would invite GC pauses on the audio tick.
+    /// </summary>
+    [SkippableFact]
+    public void RxHotPath_SteadyState_DoesNotAllocate()
+    {
+        using var tx = new FreeDvModem();
+        Skip.IfNot(tx.NativeAvailable, "codec2 native library not present — alloc test skipped.");
+        using var rx = new FreeDvModem();
+        tx.SetSubmode(FreeDvSubmode.Mode700D);
+        rx.SetSubmode(FreeDvSubmode.Mode700D);
+        rx.SetSquelch(enabled: false, threshDb: null);
+        tx.Activate();
+        rx.Activate();
+
+        const int blockSize = 960;
+        const int txBlocks = 300;
+        var modemAudio = GenerateModemAudio(tx, blockSize, txBlocks);
+        var rxBlock = new float[blockSize];
+        int total = modemAudio.Count;
+
+        // Warm up: drive to sync and JIT every branch of the hot path.
+        for (int i = 0; i + blockSize <= total; i += blockSize)
+        {
+            modemAudio.CopyTo(i, rxBlock, 0, blockSize);
+            rx.ProcessRxInPlace(rxBlock);
+        }
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int rep = 0; rep < 3; rep++)
+            for (int i = 0; i + blockSize <= total; i += blockSize)
+            {
+                modemAudio.CopyTo(i, rxBlock, 0, blockSize);
+                rx.ProcessRxInPlace(rxBlock);
+            }
+        long after = GC.GetAllocatedBytesForCurrentThread();
+
+        Assert.Equal(0, after - before);
+    }
+
+    // Run the TX modem over speech-like input and collect the 48 kHz modem audio.
+    private static List<float> GenerateModemAudio(FreeDvModem tx, int blockSize, int txBlocks)
+    {
+        var modemAudio = new List<float>(txBlocks * blockSize);
+        var block = new float[blockSize];
+        for (int b = 0; b < txBlocks; b++)
+        {
+            FillSpeechLike(block, b);
+            tx.ProcessTxInPlace(block);
+            modemAudio.AddRange(block);
+        }
+        return modemAudio;
     }
 
     // A crude voiced-speech-like excitation: a low-frequency "pitch" fundamental

--- a/tests/Zeus.Dsp.FreeDv.Tests/FreeDvModemTests.cs
+++ b/tests/Zeus.Dsp.FreeDv.Tests/FreeDvModemTests.cs
@@ -73,4 +73,27 @@ public class FreeDvModemTests
         modem.Activate();
         modem.FlushTx();
     }
+
+    [Fact]
+    public void RadeV1_ReportsUnavailable_AndPassesThrough()
+    {
+        // RADE V1 has no native decoder yet. Selecting it must NOT mis-open a
+        // classic codec2 handle (which would emit garbage on a RADE signal) — it
+        // runs as a clean passthrough and reports RadeAvailable=false so the UI
+        // can gate it. This holds whether or not codec2 native is present.
+        using var modem = new FreeDvModem();
+        modem.SetSubmode(FreeDvSubmode.RadeV1);
+        Assert.Equal(FreeDvSubmode.RadeV1, modem.Submode);
+        Assert.False(modem.RadeAvailable);
+
+        modem.Activate();
+        Assert.True(modem.Active);
+        Assert.False(modem.Synced);
+
+        var block = new float[480];
+        for (int i = 0; i < block.Length; i++) block[i] = MathF.Sin(i * 0.1f);
+        var expected = (float[])block.Clone();
+        modem.ProcessRxInPlace(block);
+        Assert.Equal(expected, block); // passthrough — no decode, buffer untouched
+    }
 }

--- a/tests/Zeus.Server.Tests/FreeDvServiceTxGateTests.cs
+++ b/tests/Zeus.Server.Tests/FreeDvServiceTxGateTests.cs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Guards the FreeDV auto-detect TX-pause gate. The scanner must keep cycling
+/// submodes while receiving, and pause only briefly around real transmit blocks.
+/// A regression here (integer overflow on the never-transmitted sentinel) silently
+/// disabled scanning entirely, so the sentinel case is pinned explicitly.
+/// </summary>
+public sealed class FreeDvServiceTxGateTests
+{
+    private const long Quiet = 400;
+
+    [Fact]
+    public void NeverTransmitted_IsNotActive()
+    {
+        // The sentinel must read as "not transmitting" no matter how large `now`
+        // is — the bug was `now - long.MinValue` overflowing to a negative value
+        // that compared < quiet and pinned scanning off forever.
+        Assert.False(FreeDvService.IsTxActive(0, long.MinValue, Quiet));
+        Assert.False(FreeDvService.IsTxActive(1_000_000, long.MinValue, Quiet));
+        Assert.False(FreeDvService.IsTxActive(long.MaxValue, long.MinValue, Quiet));
+    }
+
+    [Fact]
+    public void WithinQuietWindow_IsActive()
+    {
+        Assert.True(FreeDvService.IsTxActive(nowMs: 10_000, lastTxMs: 9_900, quietMs: Quiet));   // 100 ms ago
+        Assert.True(FreeDvService.IsTxActive(nowMs: 10_000, lastTxMs: 10_000, quietMs: Quiet));  // this tick
+    }
+
+    [Fact]
+    public void PastQuietWindow_IsNotActive()
+    {
+        Assert.False(FreeDvService.IsTxActive(nowMs: 10_000, lastTxMs: 9_600, quietMs: Quiet));  // exactly quiet → not active
+        Assert.False(FreeDvService.IsTxActive(nowMs: 10_000, lastTxMs: 9_000, quietMs: Quiet));  // 1 s ago
+    }
+}

--- a/tests/Zeus.Server.Tests/FreeDvSidebandConventionTests.cs
+++ b/tests/Zeus.Server.Tests/FreeDvSidebandConventionTests.cs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+// Lock in the FreeDV band-convention sideband. FreeDV adopted the SSB voice-mode
+// convention — LSB below 10 MHz, USB at/above — so every station on a band shares
+// one OFDM-carrier orientation; a mismatch mirror-images the spectrum in RF and
+// nothing decodes. WDSP has no FreeDv sideband of its own, so
+// RadioService.EffectiveEngineMode resolves it from the dial at the engine-apply
+// seam (DspPipelineService). RxMode.FreeDv stays the radio's mode everywhere else.
+public class FreeDvSidebandConventionTests
+{
+    [Theory]
+    [InlineData(1_800_000, RxMode.LSB)]    // 160 m
+    [InlineData(3_573_000, RxMode.LSB)]    // 80 m
+    [InlineData(7_177_000, RxMode.LSB)]    // 40 m — the band that bit us
+    [InlineData(9_999_999, RxMode.LSB)]    // just below the threshold
+    [InlineData(10_000_000, RxMode.USB)]   // exactly 10 MHz → USB
+    [InlineData(14_236_000, RxMode.USB)]   // 20 m
+    [InlineData(28_330_000, RxMode.USB)]   // 10 m
+    public void FreeDv_resolves_sideband_from_dial(long dialHz, RxMode expected)
+    {
+        Assert.Equal(expected, RadioService.EffectiveEngineMode(RxMode.FreeDv, dialHz));
+    }
+
+    [Theory]
+    [InlineData(RxMode.USB)]
+    [InlineData(RxMode.LSB)]
+    [InlineData(RxMode.DIGU)]
+    [InlineData(RxMode.DIGL)]
+    [InlineData(RxMode.AM)]
+    [InlineData(RxMode.FM)]
+    [InlineData(RxMode.CWU)]
+    [InlineData(RxMode.CWL)]
+    public void Non_FreeDv_modes_pass_through_unchanged(RxMode mode)
+    {
+        // Every other mode is dial-independent — the convention must never touch it,
+        // on either side of the 10 MHz threshold.
+        Assert.Equal(mode, RadioService.EffectiveEngineMode(mode, 7_177_000));
+        Assert.Equal(mode, RadioService.EffectiveEngineMode(mode, 14_236_000));
+    }
+
+    [Fact]
+    public void FreeDv_sub_10MHz_signs_the_bandpass_negative_for_LSB()
+    {
+        // End-to-end: the FreeDV spec passband (300..2700 stored USB-positive) must
+        // come out NEGATIVE once resolved through the convention on 40 m, so WDSP
+        // keys/demods on the lower sideband like every other 40 m FreeDV station.
+        var engineMode = RadioService.EffectiveEngineMode(RxMode.FreeDv, 7_177_000);
+        var (low, high) = RadioService.SignedFilterForMode(engineMode, 300, 2700);
+
+        Assert.Equal(RxMode.LSB, engineMode);
+        Assert.True(low < 0 && high < 0, "sub-10 MHz FreeDV must sign the passband negative (LSB)");
+        Assert.Equal(-2700, low);
+        Assert.Equal(-300, high);
+    }
+
+    [Fact]
+    public void FreeDv_at_or_above_10MHz_keeps_the_bandpass_positive_for_USB()
+    {
+        // ≥10 MHz is byte-identical to the legacy FreeDv→USB behaviour.
+        var engineMode = RadioService.EffectiveEngineMode(RxMode.FreeDv, 14_236_000);
+        var (low, high) = RadioService.SignedFilterForMode(engineMode, 300, 2700);
+
+        Assert.Equal(RxMode.USB, engineMode);
+        Assert.Equal(300, low);
+        Assert.Equal(2700, high);
+    }
+}

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -7074,7 +7074,30 @@ export type FreeDvStationsResponseDto = {
   connectionState: string; // "Disconnected"|"Connecting"|"Connected"|"Reconnecting"
   enabled: boolean;
   stations: FreeDvStationDto[];
+  reporting: boolean;      // true when on the public map ("report" role)
+  mySid: string | null;    // operator's own session id while reporting
 };
+
+// ---- FreeDV Reporter "report mode" settings (GET/POST /api/freedv/reporter/settings) ----
+// Mirrors the server-side FreeDvReporterSettings record. Strictly opt-in:
+// reportEnabled defaults false and the backend only joins the public map in
+// "report" role when enabled AND callsign + grid are present.
+export type FreeDvReporterSettings = {
+  reportEnabled: boolean;
+  callsign: string;
+  gridSquare: string;
+  message: string;
+};
+
+function normalizeFreeDvReporterSettings(raw: unknown): FreeDvReporterSettings {
+  const r = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+  return {
+    reportEnabled: r.reportEnabled === true,
+    callsign: typeof r.callsign === 'string' ? r.callsign : '',
+    gridSquare: typeof r.gridSquare === 'string' ? r.gridSquare : '',
+    message: typeof r.message === 'string' ? r.message : '',
+  };
+}
 
 function normalizeFreeDvStation(raw: unknown): FreeDvStationDto {
   const r = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
@@ -7104,10 +7127,51 @@ function normalizeFreeDvStationsResponse(raw: unknown): FreeDvStationsResponseDt
     connectionState: typeof r.connectionState === 'string' ? r.connectionState : 'Disconnected',
     enabled: r.enabled === true,
     stations: Array.isArray(r.stations) ? (r.stations as unknown[]).map(normalizeFreeDvStation) : [],
+    reporting: r.reporting === true,
+    mySid: typeof r.mySid === 'string' ? r.mySid : null,
   };
 }
 
 // GET /api/freedv/stations — live FreeDV Reporter station list.
 export function fetchFreeDvStations(signal?: AbortSignal): Promise<FreeDvStationsResponseDto> {
   return jsonFetch('/api/freedv/stations', { signal }, normalizeFreeDvStationsResponse);
+}
+
+// GET /api/freedv/reporter/settings — current report-mode opt-in settings.
+export function getFreeDvReporterSettings(signal?: AbortSignal): Promise<FreeDvReporterSettings> {
+  return jsonFetch('/api/freedv/reporter/settings', { signal }, normalizeFreeDvReporterSettings);
+}
+
+// POST /api/freedv/reporter/settings — save report-mode settings (the backend
+// normalizes, persists, and reconnects in the new role). Returns what was saved.
+export function setFreeDvReporterSettings(
+  settings: FreeDvReporterSettings,
+  signal?: AbortSignal,
+): Promise<FreeDvReporterSettings> {
+  return jsonFetch(
+    '/api/freedv/reporter/settings',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        reportEnabled: settings.reportEnabled,
+        callsign: settings.callsign,
+        gridSquare: settings.gridSquare,
+        message: settings.message,
+      }),
+      signal,
+    },
+    normalizeFreeDvReporterSettings,
+  );
+}
+
+// POST /api/freedv/stations/{sid}/qsy — ask that station to QSY to my current
+// VFO frequency. Resolves on success; rejects (jsonFetch throws on non-2xx) when
+// not reporting or the sid is unknown.
+export function freeDvStationQsy(sid: string, signal?: AbortSignal): Promise<void> {
+  return jsonFetch(
+    `/api/freedv/stations/${encodeURIComponent(sid)}/qsy`,
+    { method: 'POST', signal },
+    () => undefined,
+  );
 }

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -7048,3 +7048,66 @@ export function getFreeDvInstallStatus(signal?: AbortSignal): Promise<FreeDvInst
 export function startFreeDvInstall(signal?: AbortSignal): Promise<FreeDvInstallStatusDto> {
   return jsonFetch('/api/freedv/install', { method: 'POST', signal }, normalizeFreeDvInstallStatus);
 }
+
+// ---- FreeDV Reporter — live station list (GET /api/freedv/stations) ----
+// Mirrors the server-side FreeDvStationDto / FreeDvStationsResponseDto records
+// (System.Text.Json camelCase serialisation).
+
+export type FreeDvStationDto = {
+  sid: string;
+  callsign: string;
+  gridSquare: string | null;
+  freqHz: number;
+  mode: string;          // FreeDV submode as advertised, e.g. "1600","700D","700E","RADEV1"
+  transmitting: boolean;
+  rxOnly: boolean;
+  message: string | null;
+  version: string | null;
+  lastRxSnr: number | null;
+  lastRxCallsign: string | null;
+  lastRxMode: string | null;
+  lastUpdate: string;    // ISO-8601 UTC
+  connectTime: string | null;
+};
+
+export type FreeDvStationsResponseDto = {
+  connectionState: string; // "Disconnected"|"Connecting"|"Connected"|"Reconnecting"
+  enabled: boolean;
+  stations: FreeDvStationDto[];
+};
+
+function normalizeFreeDvStation(raw: unknown): FreeDvStationDto {
+  const r = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+  const str = (v: unknown): string | null => (typeof v === 'string' ? v : null);
+  const num = (v: unknown): number | null => (typeof v === 'number' && Number.isFinite(v) ? v : null);
+  return {
+    sid: typeof r.sid === 'string' ? r.sid : '',
+    callsign: typeof r.callsign === 'string' ? r.callsign : '',
+    gridSquare: str(r.gridSquare),
+    freqHz: typeof r.freqHz === 'number' ? r.freqHz : 0,
+    mode: typeof r.mode === 'string' ? r.mode : '',
+    transmitting: r.transmitting === true,
+    rxOnly: r.rxOnly === true,
+    message: str(r.message),
+    version: str(r.version),
+    lastRxSnr: num(r.lastRxSnr),
+    lastRxCallsign: str(r.lastRxCallsign),
+    lastRxMode: str(r.lastRxMode),
+    lastUpdate: typeof r.lastUpdate === 'string' ? r.lastUpdate : '',
+    connectTime: str(r.connectTime),
+  };
+}
+
+function normalizeFreeDvStationsResponse(raw: unknown): FreeDvStationsResponseDto {
+  const r = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+  return {
+    connectionState: typeof r.connectionState === 'string' ? r.connectionState : 'Disconnected',
+    enabled: r.enabled === true,
+    stations: Array.isArray(r.stations) ? (r.stations as unknown[]).map(normalizeFreeDvStation) : [],
+  };
+}
+
+// GET /api/freedv/stations — live FreeDV Reporter station list.
+export function fetchFreeDvStations(signal?: AbortSignal): Promise<FreeDvStationsResponseDto> {
+  return jsonFetch('/api/freedv/stations', { signal }, normalizeFreeDvStationsResponse);
+}

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -6864,19 +6864,26 @@ export function setMicGain(
 // config that drive the native FreeDV panel — they are NOT part of StateDto.
 
 export type FreeDvSubmode =
+  | 'RadeV1'
   | 'Mode700D'
   | 'Mode700E'
   | 'Mode700C'
   | 'Mode1600'
   | 'Mode800XA';
 
-// Panel-facing submode order + short labels (matches freedv-gui's selector).
-export const FREEDV_SUBMODES: ReadonlyArray<{ value: FreeDvSubmode; label: string }> = [
+// Panel-facing submode order + short labels, matching freedv-gui 2.1.0's
+// selector (RADEV1, 700D, 700E, 1600). 700C/800XA remain valid on the backend
+// and in auto-detect's scan set, but freedv-gui retired them from its UI so we
+// mirror that here. `rade` marks the submode that needs the native RADE library.
+export const FREEDV_SUBMODES: ReadonlyArray<{
+  value: FreeDvSubmode;
+  label: string;
+  rade?: boolean;
+}> = [
+  { value: 'RadeV1', label: 'RADEV1', rade: true },
   { value: 'Mode700D', label: '700D' },
   { value: 'Mode700E', label: '700E' },
-  { value: 'Mode700C', label: '700C' },
   { value: 'Mode1600', label: '1600' },
-  { value: 'Mode800XA', label: '800XA' },
 ];
 
 // Mirrors the server-side FreeDvStatusDto (GET /api/freedv/status).
@@ -6896,6 +6903,9 @@ export type FreeDvStatusDto = {
   // Auto submode detection: while unsynced the modem cycles submodes until one
   // locks. `submode` reflects the live (possibly scanner-chosen) mode.
   autoDetect: boolean;
+  // True when the native RADE modem is available. False until librade is
+  // integrated — RADEV1 then runs no decoder and the panel shows a gated state.
+  radeAvailable: boolean;
 };
 
 // PUT /api/freedv/config body — all fields optional, null = leave unchanged.
@@ -6907,16 +6917,35 @@ export type FreeDvConfigRequest = {
   autoDetect?: boolean;
 };
 
-const FREEDV_SUBMODE_ORDER: readonly FreeDvSubmode[] = FREEDV_SUBMODES.map(
-  (s) => s.value,
-);
+// Every valid submode name — a SUPERSET of the panel list. The backend can
+// report 700C/800XA (auto-detect still scans them) even though they're not shown
+// as buttons, so the normalizer must accept them or it would mislabel them.
+const FREEDV_SUBMODE_NAMES: readonly FreeDvSubmode[] = [
+  'Mode700D',
+  'Mode700E',
+  'Mode700C',
+  'Mode1600',
+  'Mode800XA',
+  'RadeV1',
+];
+
+// Indexed by the C# FreeDvSubmode byte value (700D=0 … 800XA=4, RadeV1=5) for the
+// defensive numeric path. Order here is the wire byte order, NOT the panel order.
+const FREEDV_SUBMODE_BY_BYTE: readonly FreeDvSubmode[] = [
+  'Mode700D',
+  'Mode700E',
+  'Mode700C',
+  'Mode1600',
+  'Mode800XA',
+  'RadeV1',
+];
 
 function normalizeFreeDvSubmode(v: unknown): FreeDvSubmode {
-  if (typeof v === 'string' && (FREEDV_SUBMODE_ORDER as readonly string[]).includes(v)) {
+  if (typeof v === 'string' && (FREEDV_SUBMODE_NAMES as readonly string[]).includes(v)) {
     return v as FreeDvSubmode;
   }
   if (typeof v === 'number' && Number.isInteger(v)) {
-    return FREEDV_SUBMODE_ORDER[v] ?? 'Mode700D';
+    return FREEDV_SUBMODE_BY_BYTE[v] ?? 'Mode700D';
   }
   return 'Mode700D';
 }
@@ -6943,6 +6972,7 @@ function normalizeFreeDvStatus(raw: unknown): FreeDvStatusDto {
     txText: str(r.txText),
     libraryVersion: str(r.libraryVersion),
     autoDetect: bool(r.autoDetect),
+    radeAvailable: bool(r.radeAvailable),
   };
 }
 

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -6893,6 +6893,9 @@ export type FreeDvStatusDto = {
   rxText: string | null;
   txText: string | null;
   libraryVersion: string | null;
+  // Auto submode detection: while unsynced the modem cycles submodes until one
+  // locks. `submode` reflects the live (possibly scanner-chosen) mode.
+  autoDetect: boolean;
 };
 
 // PUT /api/freedv/config body — all fields optional, null = leave unchanged.
@@ -6901,6 +6904,7 @@ export type FreeDvConfigRequest = {
   squelchEnabled?: boolean;
   snrSquelchThreshDb?: number;
   txText?: string;
+  autoDetect?: boolean;
 };
 
 const FREEDV_SUBMODE_ORDER: readonly FreeDvSubmode[] = FREEDV_SUBMODES.map(
@@ -6938,6 +6942,7 @@ function normalizeFreeDvStatus(raw: unknown): FreeDvStatusDto {
     rxText: str(r.rxText),
     txText: str(r.txText),
     libraryVersion: str(r.libraryVersion),
+    autoDetect: bool(r.autoDetect),
   };
 }
 

--- a/zeus-web/src/layout/panels.ts
+++ b/zeus-web/src/layout/panels.ts
@@ -70,6 +70,7 @@ import { AnalogMeterPanel } from './panels/AnalogMeterPanel';
 import { WavRecorderPanel } from './panels/WavRecorderPanel';
 import { HamClockPanel } from './panels/HamClockPanel';
 import { SpotsPanel } from './panels/SpotsPanel';
+import { FreeDvStationsPanel } from './panels/FreeDvStationsPanel';
 import { SpaceWeatherPanel } from './panels/SpaceWeatherPanel';
 import { UrlEmbedPanel } from './panels/UrlEmbedPanel';
 import { ChatPanel } from './panels/ChatPanel';
@@ -492,6 +493,15 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'tools',
     tags: ['spots', 'pota', 'sota', 'activation', 'dx', 'cluster', 'tune', 'park', 'summit'],
     component: SpotsPanel,
+    minW: 6,
+    minH: 8,
+  },
+  freedvstations: {
+    id: 'freedvstations',
+    name: 'FreeDV Stations',
+    category: 'tools',
+    tags: ['freedv', 'stations', 'reporter', 'qso', 'spots', 'digital voice', 'tune', 'rade'],
+    component: FreeDvStationsPanel,
     minW: 6,
     minH: 8,
   },

--- a/zeus-web/src/layout/panels/FreeDvPanel.tsx
+++ b/zeus-web/src/layout/panels/FreeDvPanel.tsx
@@ -42,7 +42,6 @@ const SNR_SQUELCH_MAX = 10;
 
 export function FreeDvPanel() {
   const mode = useConnectionStore((s) => s.mode);
-  const connected = useConnectionStore((s) => s.status === 'Connected');
   const inFreeDvMode = mode === 'FREEDV';
 
   // Operator's own callsign from the QRZ session — used to seed the FreeDV TX
@@ -175,7 +174,13 @@ export function FreeDvPanel() {
     );
   }
 
-  const ctrlsDisabled = !connected || !reachable;
+  // This panel is entirely REST-driven (getFreeDvStatus / setFreeDvConfig), so
+  // the controls only need the backend to be reachable — NOT a live SignalR hub
+  // connection to a radio. Gating on the hub status locked AUTO/submode/squelch
+  // whenever the hub wasn't 'Connected' (e.g. just after a backend restart) even
+  // though the modem service was fully reachable. The FreeDV modem config is
+  // independent of the radio link, so reachability is the correct gate.
+  const ctrlsDisabled = !reachable;
   const snrThreshDisabled = ctrlsDisabled || !status.squelchEnabled;
 
   return (

--- a/zeus-web/src/layout/panels/FreeDvPanel.tsx
+++ b/zeus-web/src/layout/panels/FreeDvPanel.tsx
@@ -18,8 +18,9 @@
 // submode selector, SYNC lamp + SNR readout, SNR squelch, and the RX/TX text
 // sidechannel — driven by GET /api/freedv/status (polled ~4 Hz) and
 // PUT /api/freedv/config. FreeDV is a normal RxMode ('FREEDV'); selecting it
-// from the mode row engages the modem (backend forces USB underneath). This
-// panel is telemetry/config only — it does NOT select the mode itself.
+// from the mode row engages the modem (backend runs the SSB demod underneath on
+// the FreeDV band-convention sideband — LSB < 10 MHz, USB ≥). This panel is
+// telemetry/config only — it does NOT select the mode itself.
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
@@ -448,7 +449,8 @@ export function FreeDvPanel() {
         style={{ color: 'var(--fg-3)', lineHeight: 1.4, marginTop: 2 }}
       >
         FreeDV requires the radio in <strong>FreeDV</strong> mode — pick it from
-        the mode row. The modem runs USB underneath automatically.
+        the mode row. The modem rides the band-convention sideband automatically
+        (LSB below 10&nbsp;MHz, USB at/above).
       </div>
     </div>
   );

--- a/zeus-web/src/layout/panels/FreeDvPanel.tsx
+++ b/zeus-web/src/layout/panels/FreeDvPanel.tsx
@@ -35,13 +35,27 @@ import {
 } from '../../api/client';
 import { useConnectionStore } from '../../state/connection-store';
 import { useQrzStore } from '../../state/qrz-store';
+import { freqHzToBand } from '../../state/spots-store';
 
 const POLL_MS = 250; // ~4 Hz, matches the brief.
 const SNR_SQUELCH_MIN = -2;
 const SNR_SQUELCH_MAX = 10;
 
+// FreeDV community sideband convention: LSB below 10 MHz, USB at/above 10 MHz —
+// FreeDV adopted the SSB voice-mode convention so every station on a band shares
+// one spectral orientation. Zeus runs the FreeDV modem on this sideband
+// underneath; a mismatch would invert the OFDM carriers in RF and nothing would
+// decode. This mirrors freedv-gui's "current mode" readout (which shows the rig
+// sideband, red when it's unexpected for the band).
+const FREEDV_USB_THRESHOLD_HZ = 10_000_000;
+function freedvSidebandForFreq(hz: number): 'LSB' | 'USB' {
+  return hz < FREEDV_USB_THRESHOLD_HZ ? 'LSB' : 'USB';
+}
+
 export function FreeDvPanel() {
   const mode = useConnectionStore((s) => s.mode);
+  const vfoHz = useConnectionStore((s) => s.vfoHz);
+  const connected = useConnectionStore((s) => s.status === 'Connected');
   const inFreeDvMode = mode === 'FREEDV';
 
   // Operator's own callsign from the QRZ session — used to seed the FreeDV TX
@@ -186,6 +200,12 @@ export function FreeDvPanel() {
   return (
     <div className="dsp-cfg" style={{ gap: 8, padding: '10px 12px', overflowY: 'auto' }}>
       <FreeDvHeader status={status} reachable={reachable} inFreeDvMode={inFreeDvMode} />
+
+      <FreeDvBandModeIndicator
+        connected={connected}
+        inFreeDvMode={inFreeDvMode}
+        vfoHz={vfoHz}
+      />
 
       {/* SYNC lamp + SNR readout. */}
       <div className="dsp-cfg-row">
@@ -478,6 +498,66 @@ function FreeDvHeader({
               ? 'engaging…'
               : 'idle'}
         {status?.libraryVersion ? ` · ${status.libraryVersion}` : ''}
+      </span>
+    </div>
+  );
+}
+
+// Band / sideband readout — Zeus's analogue of freedv-gui's "current mode"
+// indicator. FreeDV follows the SSB convention (LSB < 10 MHz, USB ≥ 10 MHz), so
+// the operator wants to see, at a glance, which sideband the modem is riding for
+// the current dial. When the radio isn't connected (no dial to read) we show a
+// grayed "unk", exactly like freedv-gui does when CAT can't report the mode.
+function FreeDvBandModeIndicator({
+  connected,
+  inFreeDvMode,
+  vfoHz,
+}: {
+  connected: boolean;
+  inFreeDvMode: boolean;
+  vfoHz: number;
+}) {
+  const haveDial = connected && vfoHz > 0;
+  const band = haveDial ? freqHzToBand(vfoHz) : null;
+  const sideband = haveDial ? freedvSidebandForFreq(vfoHz) : null;
+  const freqMhz = haveDial ? (vfoHz / 1e6).toFixed(3) : null;
+
+  // freedv-gui semantics: gray "unk" when the mode can't be determined (no CAT /
+  // here: no radio). When we do know the dial, the convention sideband is what
+  // Zeus rides underneath — show it confidently in the accent colour while
+  // FreeDV is the active mode, muted otherwise (advisory of what it *would* use).
+  const valueColor = !haveDial
+    ? 'var(--fg-3)'
+    : inFreeDvMode
+      ? 'var(--accent)'
+      : 'var(--fg-2)';
+
+  return (
+    <div className="dsp-cfg-row">
+      <span className="dsp-cfg-label">
+        Band
+        <span className="dsp-cfg-hint"> FreeDV sideband</span>
+      </span>
+      <span
+        className="mono dsp-cfg-unit"
+        title={
+          haveDial
+            ? `FreeDV uses ${sideband} ${
+                sideband === 'LSB' ? 'below' : 'at/above'
+              } 10 MHz — Zeus rides this sideband so its carriers line up with other FreeDV stations on the band.`
+            : 'Connect a radio so the dial frequency can be read (freedv-gui shows "unk" here without CAT).'
+        }
+        style={{ color: valueColor, display: 'flex', alignItems: 'center', gap: 6 }}
+      >
+        {haveDial ? (
+          <>
+            <span>{freqMhz} MHz</span>
+            {band && <span style={{ color: 'var(--fg-3)' }}>{band}</span>}
+            <span style={{ fontWeight: 600 }}>{sideband}</span>
+          </>
+        ) : (
+          'unk'
+        )}
       </span>
     </div>
   );

--- a/zeus-web/src/layout/panels/FreeDvPanel.tsx
+++ b/zeus-web/src/layout/panels/FreeDvPanel.tsx
@@ -249,6 +249,10 @@ export function FreeDvPanel() {
           </button>
           {FREEDV_SUBMODES.map((m) => {
             const isCurrent = status.submode === m.value;
+            // RADEV1 needs the native RADE library, which isn't integrated yet —
+            // mark it as not-ready but still selectable so the operator sees the
+            // explanatory notice rather than a silently dead button.
+            const radeUnavailable = m.rade === true && !status.radeAvailable;
             // When scanning, dim the 'active' look on the tried mode so AUTO is
             // visually the engaged control, not the transient submode.
             const cls =
@@ -262,19 +266,48 @@ export function FreeDvPanel() {
                   sendConfig({ submode: m.value as FreeDvSubmode, autoDetect: false })
                 }
                 className={`btn sm ${cls}`}
-                title={`FreeDV ${m.label}${isCurrent && status.autoDetect && !status.synced ? ' (scanning)' : ''}`}
+                title={
+                  radeUnavailable
+                    ? 'RADEV1 — neural Radio Autoencoder (decoder not installed yet)'
+                    : `FreeDV ${m.label}${isCurrent && status.autoDetect && !status.synced ? ' (scanning)' : ''}`
+                }
                 style={
                   isCurrent && status.autoDetect && !status.synced
                     ? { outline: '1px dashed var(--accent)', outlineOffset: -1 }
-                    : undefined
+                    : radeUnavailable
+                      ? { opacity: 0.7 }
+                      : undefined
                 }
               >
                 {m.label}
+                {radeUnavailable ? ' •' : ''}
               </button>
             );
           })}
         </div>
       </div>
+
+      {/* RADEV1 selected but the native RADE library isn't integrated yet — be
+          explicit so the operator understands why it won't decode, instead of
+          chasing a "silent" mode the way a missing codec2 would look. */}
+      {status.submode === 'RadeV1' && !status.radeAvailable && (
+        <div
+          className="label-xs"
+          style={{
+            padding: '8px 10px',
+            border: '1px solid var(--line)',
+            borderRadius: 'var(--r-sm)',
+            background: 'var(--bg-1)',
+            color: 'var(--fg-2)',
+            lineHeight: 1.45,
+          }}
+        >
+          <strong>RADEV1</strong> is FreeDV's neural (Radio Autoencoder) mode. Its
+          decoder isn't built into Zeus yet, so this mode won't produce audio.
+          Use <strong>700D / 700E / 1600</strong> for now — RADE support is in
+          progress.
+        </div>
+      )}
 
       {/* SNR squelch toggle. */}
       <div className="dsp-cfg-row">

--- a/zeus-web/src/layout/panels/FreeDvPanel.tsx
+++ b/zeus-web/src/layout/panels/FreeDvPanel.tsx
@@ -222,24 +222,57 @@ export function FreeDvPanel() {
         </span>
       </div>
 
-      {/* Submode selector. */}
+      {/* Submode selector + auto-detect. AUTO scans submodes until one locks;
+          picking a specific mode asserts it and turns AUTO off (backend does the
+          same implicitly). While scanning, the active button is the mode the
+          scanner is currently trying. */}
       <div className="dsp-cfg-row">
-        <span className="dsp-cfg-label">Submode</span>
+        <span className="dsp-cfg-label">
+          Submode
+          {status.autoDetect && (
+            <span className="dsp-cfg-hint">
+              {' '}
+              {status.synced ? 'auto · locked' : 'auto · scanning…'}
+            </span>
+          )}
+        </span>
         <div className="dsp-cfg-btns">
-          {FREEDV_SUBMODES.map((m) => (
-            <button
-              key={m.value}
-              type="button"
-              disabled={ctrlsDisabled}
-              onClick={() =>
-                m.value !== status.submode && sendConfig({ submode: m.value as FreeDvSubmode })
-              }
-              className={`btn sm ${status.submode === m.value ? 'active' : ''}`}
-              title={`FreeDV ${m.label}`}
-            >
-              {m.label}
-            </button>
-          ))}
+          <button
+            type="button"
+            disabled={ctrlsDisabled}
+            aria-pressed={status.autoDetect}
+            onClick={() => sendConfig({ autoDetect: !status.autoDetect })}
+            className={`btn sm ${status.autoDetect ? 'active' : ''}`}
+            title="Auto-detect: cycle submodes until the modem locks onto the received signal"
+          >
+            AUTO
+          </button>
+          {FREEDV_SUBMODES.map((m) => {
+            const isCurrent = status.submode === m.value;
+            // When scanning, dim the 'active' look on the tried mode so AUTO is
+            // visually the engaged control, not the transient submode.
+            const cls =
+              isCurrent && (!status.autoDetect || status.synced) ? 'active' : '';
+            return (
+              <button
+                key={m.value}
+                type="button"
+                disabled={ctrlsDisabled}
+                onClick={() =>
+                  sendConfig({ submode: m.value as FreeDvSubmode, autoDetect: false })
+                }
+                className={`btn sm ${cls}`}
+                title={`FreeDV ${m.label}${isCurrent && status.autoDetect && !status.synced ? ' (scanning)' : ''}`}
+                style={
+                  isCurrent && status.autoDetect && !status.synced
+                    ? { outline: '1px dashed var(--accent)', outlineOffset: -1 }
+                    : undefined
+                }
+              >
+                {m.label}
+              </button>
+            );
+          })}
         </div>
       </div>
 

--- a/zeus-web/src/layout/panels/FreeDvStationsPanel.tsx
+++ b/zeus-web/src/layout/panels/FreeDvStationsPanel.tsx
@@ -10,7 +10,9 @@ import {
   useFreeDvStationsStore,
   stationMatchesQuery,
   freqHzToBand,
+  type FreeDvReporterSettings,
 } from '../../state/freedv-stations-store';
+import { useQrzStore } from '../../state/qrz-store';
 import type { FreeDvStationDto } from '../../api/client';
 
 const POLL_MS = 5_000;
@@ -97,6 +99,17 @@ export function FreeDvStationsPanel() {
   const loadStations = useFreeDvStationsStore((s) => s.loadStations);
   const tuneToStation = useFreeDvStationsStore((s) => s.tuneToStation);
 
+  const reporting = useFreeDvStationsStore((s) => s.reporting);
+  const mySid = useFreeDvStationsStore((s) => s.mySid);
+  const reporterSettings = useFreeDvStationsStore((s) => s.reporterSettings);
+  const reporterError = useFreeDvStationsStore((s) => s.reporterError);
+  const reporterSaving = useFreeDvStationsStore((s) => s.reporterSaving);
+  const loadReporterSettings = useFreeDvStationsStore((s) => s.loadReporterSettings);
+  const saveReporterSettings = useFreeDvStationsStore((s) => s.saveReporterSettings);
+  const requestQsy = useFreeDvStationsStore((s) => s.requestQsy);
+
+  const qrzHome = useQrzStore((s) => s.home);
+
   const [sortKey, setSortKey] = useState<SortKey>('age');
   const [sortDir, setSortDir] = useState<SortDir>('asc');
 
@@ -114,12 +127,13 @@ export function FreeDvStationsPanel() {
   useEffect(() => {
     const ac = new AbortController();
     void loadStations();
+    void loadReporterSettings();
     const id = window.setInterval(() => void loadStations(), POLL_MS);
     return () => {
       window.clearInterval(id);
       ac.abort();
     };
-  }, [loadStations]);
+  }, [loadStations, loadReporterSettings]);
 
   const filtered = useMemo(
     () => stations.filter((st) => stationMatchesQuery(st, query)),
@@ -202,6 +216,17 @@ export function FreeDvStationsPanel() {
         </button>
       </div>
 
+      {/* Report-me section — opt-in onto the public FreeDV Reporter map. */}
+      <ReportSection
+        reporting={reporting}
+        settings={reporterSettings}
+        error={reporterError}
+        saving={reporterSaving}
+        qrzCall={qrzHome?.callsign ?? ''}
+        qrzGrid={qrzHome?.grid ?? ''}
+        onSave={saveReporterSettings}
+      />
+
       {/* Tune error banner */}
       {tuneError && (
         <div
@@ -253,7 +278,14 @@ export function FreeDvStationsPanel() {
             </thead>
             <tbody>
               {visible.map((st) => (
-                <StationRow key={st.sid || `${st.callsign}|${st.freqHz}`} station={st} onTune={() => void tuneToStation(st)} />
+                <StationRow
+                  key={st.sid || `${st.callsign}|${st.freqHz}`}
+                  station={st}
+                  isSelf={!!mySid && st.sid === mySid}
+                  canQsy={reporting && !!st.sid && st.sid !== mySid}
+                  onTune={() => void tuneToStation(st)}
+                  onQsy={() => void requestQsy(st.sid)}
+                />
               ))}
             </tbody>
           </table>
@@ -281,10 +313,16 @@ export function FreeDvStationsPanel() {
 
 function StationRow({
   station,
+  isSelf,
+  canQsy,
   onTune,
+  onQsy,
 }: {
   station: FreeDvStationDto;
+  isSelf: boolean;
+  canQsy: boolean;
   onTune: () => void;
+  onQsy: () => void;
 }) {
   const band = freqHzToBand(station.freqHz);
   const [hovered, setHovered] = useState(false);
@@ -329,11 +367,15 @@ function StationRow({
   return (
     <tr
       onClick={onTune}
-      title={`Tune ${fmtFreq(station.freqHz)} MHz FreeDV ${station.mode}${title ? ` — ${title}` : ''}`}
+      title={`Tune ${fmtFreq(station.freqHz)} MHz FreeDV ${station.mode}${title ? ` — ${title}` : ''}${
+        isSelf ? ' — this is you' : ''
+      }`}
       style={{
         cursor: 'pointer',
         borderBottom: '1px solid var(--panel-border)',
-        background: hovered ? 'var(--accent-soft)' : '',
+        background: isSelf ? 'var(--accent-soft)' : hovered ? 'var(--accent-soft)' : '',
+        // Subtle left accent marks the operator's own row on the map.
+        boxShadow: isSelf ? 'inset 3px 0 0 var(--accent)' : undefined,
       }}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
@@ -354,16 +396,170 @@ function StationRow({
       </td>
       {/* Status */}
       <td style={tdStyle}>
-        {statusBadge}
-        {heardLine && !station.transmitting && (
-          <span style={{ fontSize: 10, color: 'var(--fg-3)' }}>{heardLine}</span>
-        )}
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+          {statusBadge}
+          {heardLine && !station.transmitting && (
+            <span style={{ fontSize: 10, color: 'var(--fg-3)' }}>{heardLine}</span>
+          )}
+          {canQsy && (
+            <button
+              type="button"
+              className="btn sm"
+              title="Ask this station to QSY to my current frequency"
+              onClick={(e) => {
+                e.stopPropagation();
+                onQsy();
+              }}
+              style={{ fontSize: 10, padding: '0 5px', lineHeight: '16px' }}
+            >
+              QSY→me
+            </button>
+          )}
+        </span>
       </td>
       {/* Age */}
       <td style={{ ...tdStyle, textAlign: 'right', color: 'var(--fg-2)' }}>
         {fmtAge(station.lastUpdate)}
       </td>
     </tr>
+  );
+}
+
+// Opt-in "Report me" controls. Default OFF; when enabled, Zeus connects to the
+// FreeDV Reporter in "report" role and broadcasts the operator's callsign /
+// grid / freq / TX activity to the public map. Callsign + grid pre-fill from QRZ
+// home (editable). Reporting only engages when toggled on AND both fields set.
+function ReportSection({
+  reporting,
+  settings,
+  error,
+  saving,
+  qrzCall,
+  qrzGrid,
+  onSave,
+}: {
+  reporting: boolean;
+  settings: FreeDvReporterSettings | null;
+  error: string | null;
+  saving: boolean;
+  qrzCall: string;
+  qrzGrid: string;
+  onSave: (settings: FreeDvReporterSettings) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [call, setCall] = useState('');
+  const [grid, setGrid] = useState('');
+  const [message, setMessage] = useState('');
+  const [seeded, setSeeded] = useState(false);
+
+  // Seed the editable fields once from the persisted settings, falling back to
+  // the QRZ home station for any blank field so a fresh operator sees their call.
+  useEffect(() => {
+    if (seeded || !settings) return;
+    setCall(settings.callsign || qrzCall || '');
+    setGrid(settings.gridSquare || qrzGrid || '');
+    setMessage(settings.message || '');
+    setSeeded(true);
+  }, [seeded, settings, qrzCall, qrzGrid]);
+
+  const enabled = settings?.reportEnabled ?? false;
+  const canEnable = call.trim().length > 0 && grid.trim().length > 0;
+
+  const persist = (next: Partial<FreeDvReporterSettings>) => {
+    onSave({
+      reportEnabled: next.reportEnabled ?? enabled,
+      callsign: next.callsign ?? call,
+      gridSquare: next.gridSquare ?? grid,
+      message: next.message ?? message,
+    });
+  };
+
+  return (
+    <div
+      style={{
+        borderBottom: '1px solid var(--panel-border)',
+        padding: '4px 8px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 4,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <button
+          type="button"
+          className="btn sm"
+          onClick={() => setOpen((o) => !o)}
+          title="Report my station onto the FreeDV Reporter map"
+          style={{ fontSize: 10 }}
+        >
+          {open ? '▾' : '▸'} Report me
+        </button>
+
+        {/* Enable toggle — disabled until call + grid are present. */}
+        <label
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 4,
+            fontSize: 11,
+            color: canEnable ? 'var(--fg-1)' : 'var(--fg-3)',
+            cursor: canEnable ? 'pointer' : 'not-allowed',
+          }}
+          title={canEnable ? 'Broadcast my station publicly' : 'Enter callsign + grid first'}
+        >
+          <input
+            type="checkbox"
+            checked={enabled}
+            disabled={!canEnable || saving}
+            onChange={(e) => persist({ reportEnabled: e.target.checked })}
+          />
+          On the map
+        </label>
+
+        {reporting && (
+          <span
+            style={{ fontSize: 10, color: 'var(--accent)', whiteSpace: 'nowrap' }}
+            title="Your station is live on qso.freedv.org"
+          >
+            ● on the map
+          </span>
+        )}
+      </div>
+
+      {open && (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, alignItems: 'center' }}>
+          <input
+            className="cs-input mono"
+            value={call}
+            onChange={(e) => setCall(e.target.value)}
+            onBlur={() => persist({ callsign: call })}
+            placeholder="Callsign"
+            spellCheck={false}
+            style={{ width: 90 }}
+          />
+          <input
+            className="cs-input mono"
+            value={grid}
+            onChange={(e) => setGrid(e.target.value)}
+            onBlur={() => persist({ gridSquare: grid })}
+            placeholder="Grid"
+            spellCheck={false}
+            style={{ width: 70 }}
+          />
+          <input
+            className="cs-input"
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            onBlur={() => persist({ message })}
+            placeholder="Status message (optional)"
+            maxLength={80}
+            style={{ flex: 1, minWidth: 110 }}
+          />
+        </div>
+      )}
+
+      {error && <span style={{ fontSize: 10, color: 'var(--tx)' }}>{error}</span>}
+    </div>
   );
 }
 

--- a/zeus-web/src/layout/panels/FreeDvStationsPanel.tsx
+++ b/zeus-web/src/layout/panels/FreeDvStationsPanel.tsx
@@ -1,0 +1,381 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// FreeDvStationsPanel — workspace tile listing live FreeDV stations from the
+// FreeDV Reporter network (qso.freedv.org), with click-to-tune into the Zeus
+// VFO. Backed by freedv-stations-store, which polls GET /api/freedv/stations
+// and tunes via setVfo + setMode + setFreeDvConfig.
+
+import { useEffect, useMemo, useState } from 'react';
+import {
+  useFreeDvStationsStore,
+  stationMatchesQuery,
+  freqHzToBand,
+} from '../../state/freedv-stations-store';
+import type { FreeDvStationDto } from '../../api/client';
+
+const POLL_MS = 5_000;
+
+type SortKey = 'call' | 'freq' | 'band' | 'mode' | 'grid' | 'snr' | 'status' | 'age';
+type SortDir = 'asc' | 'desc';
+
+const COLUMNS: ReadonlyArray<{ key: SortKey; label: string; align?: 'right' }> = [
+  { key: 'call', label: 'Call' },
+  { key: 'freq', label: 'Freq' },
+  { key: 'band', label: 'Band' },
+  { key: 'mode', label: 'Mode' },
+  { key: 'grid', label: 'Grid' },
+  { key: 'snr', label: 'SNR', align: 'right' },
+  { key: 'status', label: 'Status' },
+  { key: 'age', label: 'Age', align: 'right' },
+];
+
+function fmtFreq(hz: number): string {
+  return (hz / 1_000_000).toFixed(3);
+}
+
+function stationAgeSeconds(lastUpdate: string, nowMs: number = Date.now()): number | null {
+  const t = Date.parse(lastUpdate);
+  if (Number.isNaN(t)) return null;
+  return Math.max(0, Math.round((nowMs - t) / 1000));
+}
+
+function fmtAge(lastUpdate: string): string {
+  const secs = stationAgeSeconds(lastUpdate);
+  if (secs === null) return '';
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.round(secs / 60);
+  if (mins < 60) return `${mins}m`;
+  return `${Math.round(mins / 60)}h`;
+}
+
+function compareStations(a: FreeDvStationDto, b: FreeDvStationDto, key: SortKey): number {
+  let d = 0;
+  switch (key) {
+    case 'call':
+      d = a.callsign.localeCompare(b.callsign);
+      break;
+    case 'freq':
+    case 'band':
+      d = a.freqHz - b.freqHz;
+      break;
+    case 'mode':
+      d = (a.mode || '').localeCompare(b.mode || '');
+      break;
+    case 'grid':
+      d = (a.gridSquare ?? '').localeCompare(b.gridSquare ?? '');
+      break;
+    case 'snr':
+      d = (a.lastRxSnr ?? -Infinity) - (b.lastRxSnr ?? -Infinity);
+      break;
+    case 'status': {
+      // TX first, then RX-only, then idle
+      const rank = (st: FreeDvStationDto) => (st.transmitting ? 0 : st.rxOnly ? 1 : 2);
+      d = rank(a) - rank(b);
+      break;
+    }
+    case 'age':
+      d = (stationAgeSeconds(a.lastUpdate) ?? Infinity) - (stationAgeSeconds(b.lastUpdate) ?? Infinity);
+      break;
+  }
+  if (d !== 0) return d;
+  if (a.freqHz !== b.freqHz) return a.freqHz - b.freqHz;
+  return a.callsign.localeCompare(b.callsign);
+}
+
+function connectionStateColor(state: string): string {
+  return state === 'Connected' ? 'var(--accent)' : 'var(--fg-3)';
+}
+
+export function FreeDvStationsPanel() {
+  const stations = useFreeDvStationsStore((s) => s.stations);
+  const connectionState = useFreeDvStationsStore((s) => s.connectionState);
+  const loading = useFreeDvStationsStore((s) => s.loading);
+  const error = useFreeDvStationsStore((s) => s.error);
+  const tuneError = useFreeDvStationsStore((s) => s.tuneError);
+  const query = useFreeDvStationsStore((s) => s.query);
+  const setQuery = useFreeDvStationsStore((s) => s.setQuery);
+  const loadStations = useFreeDvStationsStore((s) => s.loadStations);
+  const tuneToStation = useFreeDvStationsStore((s) => s.tuneToStation);
+
+  const [sortKey, setSortKey] = useState<SortKey>('age');
+  const [sortDir, setSortDir] = useState<SortDir>('asc');
+
+  const toggleSort = (key: SortKey) => {
+    if (key === sortKey) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortDir('asc');
+    }
+  };
+
+  // Poll on mount + every POLL_MS. AbortController so in-flight fetches are
+  // cancelled if the panel unmounts mid-request.
+  useEffect(() => {
+    const ac = new AbortController();
+    void loadStations();
+    const id = window.setInterval(() => void loadStations(), POLL_MS);
+    return () => {
+      window.clearInterval(id);
+      ac.abort();
+    };
+  }, [loadStations]);
+
+  const filtered = useMemo(
+    () => stations.filter((st) => stationMatchesQuery(st, query)),
+    [stations, query],
+  );
+
+  const visible = useMemo(() => {
+    const sorted = [...filtered].sort((a, b) => compareStations(a, b, sortKey));
+    if (sortDir === 'desc') sorted.reverse();
+    return sorted;
+  }, [filtered, sortKey, sortDir]);
+
+  const emptyMessage =
+    connectionState !== 'Connected'
+      ? 'Connecting to FreeDV Reporter…'
+      : 'No active FreeDV stations.';
+
+  return (
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', position: 'relative' }}>
+      {/* Header toolbar */}
+      <div
+        style={{
+          padding: '4px 8px',
+          borderBottom: '1px solid var(--panel-border)',
+          display: 'flex',
+          gap: 6,
+          alignItems: 'center',
+          flexWrap: 'wrap',
+        }}
+      >
+        <span
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+            color: 'var(--fg-1)',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          FreeDV Stations
+        </span>
+
+        {/* Connection-state lamp */}
+        <span
+          title={`Reporter: ${connectionState}`}
+          style={{
+            width: 7,
+            height: 7,
+            borderRadius: '50%',
+            background: connectionStateColor(connectionState),
+            flexShrink: 0,
+            display: 'inline-block',
+          }}
+        />
+        <span style={{ fontSize: 10, color: connectionStateColor(connectionState), whiteSpace: 'nowrap' }}>
+          {connectionState}
+        </span>
+
+        <span style={{ fontSize: 10, color: 'var(--fg-3)', whiteSpace: 'nowrap' }}>
+          {stations.length} station{stations.length !== 1 ? 's' : ''}
+        </span>
+
+        <input
+          className="cs-input mono"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Filter call / grid / mode / band…"
+          style={{ flex: 1, minWidth: 90 }}
+        />
+
+        <button
+          type="button"
+          className="btn sm"
+          disabled={loading}
+          onClick={() => void loadStations()}
+          title="Refresh now"
+        >
+          {loading ? '…' : '⟳'}
+        </button>
+      </div>
+
+      {/* Tune error banner */}
+      {tuneError && (
+        <div
+          style={{
+            padding: '4px 8px',
+            fontSize: 11,
+            color: 'var(--tx)',
+            borderBottom: '1px solid var(--panel-border)',
+          }}
+        >
+          {tuneError}
+        </div>
+      )}
+
+      {/* Table / empty state */}
+      <div style={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
+        {error ? (
+          <div style={{ padding: 12, fontSize: 12, color: 'var(--tx)' }}>{error}</div>
+        ) : visible.length === 0 ? (
+          <div style={{ padding: 12, fontSize: 12, color: 'var(--fg-2)' }}>{emptyMessage}</div>
+        ) : (
+          <table className="mono" style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}>
+            <thead>
+              <tr style={{ color: 'var(--fg-2)', textAlign: 'left' }}>
+                {COLUMNS.map((col) => {
+                  const active = sortKey === col.key;
+                  return (
+                    <th
+                      key={col.key}
+                      onClick={() => toggleSort(col.key)}
+                      title={`Sort by ${col.label}`}
+                      aria-sort={active ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
+                      style={{
+                        ...thStyle,
+                        textAlign: col.align ?? 'left',
+                        cursor: 'pointer',
+                        userSelect: 'none',
+                        color: active ? 'var(--accent)' : undefined,
+                      }}
+                    >
+                      {col.label}
+                      <span style={{ opacity: active ? 1 : 0.25, marginLeft: 3 }}>
+                        {active ? (sortDir === 'asc' ? '▲' : '▼') : '↕'}
+                      </span>
+                    </th>
+                  );
+                })}
+              </tr>
+            </thead>
+            <tbody>
+              {visible.map((st) => (
+                <StationRow key={st.sid || `${st.callsign}|${st.freqHz}`} station={st} onTune={() => void tuneToStation(st)} />
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {/* Footer */}
+      <div
+        style={{
+          padding: '3px 8px',
+          borderTop: '1px solid var(--panel-border)',
+          fontSize: 10,
+          color: 'var(--fg-3)',
+          display: 'flex',
+          justifyContent: 'space-between',
+          gap: 8,
+        }}
+      >
+        <span>{visible.length} shown</span>
+        <span>{stations.length} total</span>
+      </div>
+    </div>
+  );
+}
+
+function StationRow({
+  station,
+  onTune,
+}: {
+  station: FreeDvStationDto;
+  onTune: () => void;
+}) {
+  const band = freqHzToBand(station.freqHz);
+  const [hovered, setHovered] = useState(false);
+
+  const statusBadge = (() => {
+    if (station.transmitting) {
+      return (
+        <span
+          style={{
+            fontSize: 10,
+            fontWeight: 700,
+            letterSpacing: '0.04em',
+            color: 'var(--tx)',
+            padding: '1px 4px',
+            border: '1px solid var(--tx)',
+            borderRadius: 'var(--r-sm, 3px)',
+          }}
+        >
+          TX
+        </span>
+      );
+    }
+    if (station.rxOnly) {
+      return <span style={{ fontSize: 10, color: 'var(--fg-3)' }}>RX-only</span>;
+    }
+    return null;
+  })();
+
+  const heardLine =
+    station.lastRxCallsign
+      ? `hears ${station.lastRxCallsign}${station.lastRxSnr !== null ? ` ${station.lastRxSnr}dB` : ''}`
+      : null;
+
+  const title = [
+    station.message,
+    station.version ? `v${station.version}` : null,
+    heardLine,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+
+  return (
+    <tr
+      onClick={onTune}
+      title={`Tune ${fmtFreq(station.freqHz)} MHz FreeDV ${station.mode}${title ? ` — ${title}` : ''}`}
+      style={{
+        cursor: 'pointer',
+        borderBottom: '1px solid var(--panel-border)',
+        background: hovered ? 'var(--accent-soft)' : '',
+      }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      {/* Call */}
+      <td style={{ ...tdStyle, fontWeight: 700 }}>{station.callsign}</td>
+      {/* Freq */}
+      <td style={tdStyle}>{fmtFreq(station.freqHz)}</td>
+      {/* Band */}
+      <td style={{ ...tdStyle, color: 'var(--fg-2)' }}>{band ?? '—'}</td>
+      {/* Mode */}
+      <td style={tdStyle}>{station.mode || '—'}</td>
+      {/* Grid */}
+      <td style={{ ...tdStyle, color: 'var(--fg-2)' }}>{station.gridSquare ?? '—'}</td>
+      {/* SNR */}
+      <td style={{ ...tdStyle, textAlign: 'right', color: 'var(--fg-2)' }}>
+        {station.lastRxSnr !== null ? `${station.lastRxSnr}` : '—'}
+      </td>
+      {/* Status */}
+      <td style={tdStyle}>
+        {statusBadge}
+        {heardLine && !station.transmitting && (
+          <span style={{ fontSize: 10, color: 'var(--fg-3)' }}>{heardLine}</span>
+        )}
+      </td>
+      {/* Age */}
+      <td style={{ ...tdStyle, textAlign: 'right', color: 'var(--fg-2)' }}>
+        {fmtAge(station.lastUpdate)}
+      </td>
+    </tr>
+  );
+}
+
+const thStyle: React.CSSProperties = {
+  padding: '3px 8px',
+  position: 'sticky',
+  top: 0,
+  background: 'var(--panel-top)',
+  fontWeight: 600,
+};
+
+const tdStyle: React.CSSProperties = {
+  padding: '3px 8px',
+  whiteSpace: 'nowrap',
+};

--- a/zeus-web/src/state/freedv-stations-store.ts
+++ b/zeus-web/src/state/freedv-stations-store.ts
@@ -8,16 +8,21 @@
 import { create } from 'zustand';
 import {
   fetchFreeDvStations,
+  getFreeDvReporterSettings,
+  setFreeDvReporterSettings,
+  freeDvStationQsy,
   setMode,
   setVfo,
   setFreeDvConfig,
   type FreeDvStationDto,
+  type FreeDvReporterSettings,
   type FreeDvSubmode,
 } from '../api/client';
 import { useConnectionStore } from './connection-store';
 import { freqHzToBand } from './spots-store';
 
 export { freqHzToBand };
+export type { FreeDvReporterSettings };
 
 interface FreeDvStationsState {
   stations: FreeDvStationDto[];
@@ -25,6 +30,17 @@ interface FreeDvStationsState {
   loading: boolean;
   error: string | null;
   lastUpdated: number | null;
+
+  /** True when Zeus is connected in "report" role (on the public map). */
+  reporting: boolean;
+  /** Operator's own session id while reporting (highlights own row). */
+  mySid: string | null;
+
+  /** Report-mode settings (opt-in toggle + callsign/grid/message). */
+  reporterSettings: FreeDvReporterSettings | null;
+  /** Transient feedback from the last report-settings save / QSY. */
+  reporterError: string | null;
+  reporterSaving: boolean;
 
   /** Free-text filter (callsign / grid / mode / band). */
   query: string;
@@ -35,6 +51,10 @@ interface FreeDvStationsState {
   setQuery: (query: string) => void;
   loadStations: () => Promise<void>;
   tuneToStation: (station: FreeDvStationDto) => Promise<void>;
+
+  loadReporterSettings: () => Promise<void>;
+  saveReporterSettings: (settings: FreeDvReporterSettings) => Promise<void>;
+  requestQsy: (sid: string) => Promise<void>;
 }
 
 /** Map a FreeDV Reporter mode string to a FreeDvSubmode enum value.
@@ -73,12 +93,17 @@ export function stationMatchesQuery(station: FreeDvStationDto, query: string): b
   );
 }
 
-export const useFreeDvStationsStore = create<FreeDvStationsState>()((set) => ({
+export const useFreeDvStationsStore = create<FreeDvStationsState>()((set, get) => ({
   stations: [],
   connectionState: 'Disconnected',
   loading: false,
   error: null,
   lastUpdated: null,
+  reporting: false,
+  mySid: null,
+  reporterSettings: null,
+  reporterError: null,
+  reporterSaving: false,
   query: '',
   tuneError: null,
 
@@ -91,6 +116,8 @@ export const useFreeDvStationsStore = create<FreeDvStationsState>()((set) => ({
       set({
         stations: resp.stations,
         connectionState: resp.connectionState,
+        reporting: resp.reporting,
+        mySid: resp.mySid,
         error: null,
         loading: false,
         lastUpdated: Date.now(),
@@ -100,6 +127,41 @@ export const useFreeDvStationsStore = create<FreeDvStationsState>()((set) => ({
         error: err instanceof Error ? err.message : 'Failed to load FreeDV stations',
         loading: false,
       });
+    }
+  },
+
+  loadReporterSettings: async () => {
+    try {
+      const settings = await getFreeDvReporterSettings();
+      set({ reporterSettings: settings, reporterError: null });
+    } catch (err) {
+      set({
+        reporterError: err instanceof Error ? err.message : 'Failed to load report settings',
+      });
+    }
+  },
+
+  saveReporterSettings: async (settings) => {
+    set({ reporterSaving: true, reporterError: null });
+    try {
+      const saved = await setFreeDvReporterSettings(settings);
+      set({ reporterSettings: saved, reporterSaving: false });
+      // Reconnect takes a moment server-side; refresh the roster + reporting flag.
+      void get().loadStations();
+    } catch (err) {
+      set({
+        reporterError: err instanceof Error ? err.message : 'Failed to save report settings',
+        reporterSaving: false,
+      });
+    }
+  },
+
+  requestQsy: async (sid) => {
+    set({ reporterError: null });
+    try {
+      await freeDvStationQsy(sid);
+    } catch (err) {
+      set({ reporterError: err instanceof Error ? err.message : 'QSY request failed' });
     }
   },
 

--- a/zeus-web/src/state/freedv-stations-store.ts
+++ b/zeus-web/src/state/freedv-stations-store.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// freedv-stations-store — client state for the FreeDV Stations panel.
+// Polls GET /api/freedv/stations (served by the backend FreeDvReporterService),
+// holds the live station list and implements click-to-tune by driving the Zeus
+// VFO (setVfo + setMode + setFreeDvConfig) over the native radio connection.
+
+import { create } from 'zustand';
+import {
+  fetchFreeDvStations,
+  setMode,
+  setVfo,
+  setFreeDvConfig,
+  type FreeDvStationDto,
+  type FreeDvSubmode,
+} from '../api/client';
+import { useConnectionStore } from './connection-store';
+import { freqHzToBand } from './spots-store';
+
+export { freqHzToBand };
+
+interface FreeDvStationsState {
+  stations: FreeDvStationDto[];
+  connectionState: string;
+  loading: boolean;
+  error: string | null;
+  lastUpdated: number | null;
+
+  /** Free-text filter (callsign / grid / mode / band). */
+  query: string;
+
+  /** Transient feedback from the last tune attempt. */
+  tuneError: string | null;
+
+  setQuery: (query: string) => void;
+  loadStations: () => Promise<void>;
+  tuneToStation: (station: FreeDvStationDto) => Promise<void>;
+}
+
+/** Map a FreeDV Reporter mode string to a FreeDvSubmode enum value.
+ *  Returns null when the mapping is unknown — callers skip the submode call. */
+function reporterModeToSubmode(mode: string): FreeDvSubmode | null {
+  switch (mode.trim().toUpperCase()) {
+    case '1600':
+      return 'Mode1600';
+    case '700C':
+      return 'Mode700C';
+    case '700D':
+      return 'Mode700D';
+    case '700E':
+      return 'Mode700E';
+    case '800XA':
+      return 'Mode800XA';
+    case 'RADEV1':
+    case 'RADE':
+      return 'RadeV1';
+    default:
+      return null;
+  }
+}
+
+/** True when `station` matches the free-text `query` (callsign / grid / mode / band). */
+export function stationMatchesQuery(station: FreeDvStationDto, query: string): boolean {
+  const q = query.trim().toUpperCase();
+  if (q.length === 0) return true;
+  const band = freqHzToBand(station.freqHz);
+  return (
+    station.callsign.toUpperCase().includes(q) ||
+    (station.gridSquare ?? '').toUpperCase().includes(q) ||
+    station.mode.toUpperCase().includes(q) ||
+    (band !== null && band.toUpperCase() === q) ||
+    (band !== null && band.toUpperCase().replace('M', '').startsWith(q.replace('M', '')))
+  );
+}
+
+export const useFreeDvStationsStore = create<FreeDvStationsState>()((set) => ({
+  stations: [],
+  connectionState: 'Disconnected',
+  loading: false,
+  error: null,
+  lastUpdated: null,
+  query: '',
+  tuneError: null,
+
+  setQuery: (query) => set({ query }),
+
+  loadStations: async () => {
+    set({ loading: true });
+    try {
+      const resp = await fetchFreeDvStations();
+      set({
+        stations: resp.stations,
+        connectionState: resp.connectionState,
+        error: null,
+        loading: false,
+        lastUpdated: Date.now(),
+      });
+    } catch (err) {
+      set({
+        error: err instanceof Error ? err.message : 'Failed to load FreeDV stations',
+        loading: false,
+      });
+    }
+  },
+
+  tuneToStation: async (station) => {
+    if (useConnectionStore.getState().status !== 'Connected') {
+      set({ tuneError: 'No radio connected — connect first.' });
+      return;
+    }
+    set({ tuneError: null });
+    try {
+      await setVfo(station.freqHz);
+      await setMode('FREEDV');
+      const submode = reporterModeToSubmode(station.mode);
+      if (submode !== null) {
+        await setFreeDvConfig({ submode });
+      }
+    } catch (err) {
+      set({ tuneError: err instanceof Error ? err.message : 'Tune failed' });
+    }
+  },
+}));


### PR DESCRIPTION
Builds the FreeDV digital-voice feature set out across three fronts. All commits build clean on Zeus.Dsp.FreeDv + Zeus.Server.Hosting; FreeDV unit tests pass (36) plus 11 new sideband-convention tests.

## FreeDV Reporter — live stations channel (qso.freedv.org)
- Backend `SocketIoReporterClient`: dependency-free clean-room Engine.IO v4 / Socket.IO client over `ClientWebSocket` (no NuGet). Connects read-only (`view` role); `FreeDvReporterService` mirrors the live roster and serves `GET /api/freedv/stations`. **Live-validated** against the real server (274-station snapshot, field decode).
- Frontend `FreeDvStationsPanel` (registered, picker-selectable): sortable Call/Freq/Band/Mode/Grid/SNR/Status/Age table, connection lamp, **click-to-tune** (VFO + FreeDV mode + matching submode) — the POTA/SOTA pattern for FreeDV.
- **Opt-in report-mode** (default OFF): when enabled with a callsign+grid the single connection switches to `report` role — you appear on the map, your freq/mode/TX publish live (read-only taps on `StateChanged`/`MoxChanged`, every emit wrapped so it can't disturb TX), and each row gets a "QSY→me" button. Pre-fills from the QRZ home station.

## FreeDV band-convention sideband (LSB < 10 MHz, USB ≥)
WDSP demod/mod'd FreeDV as USB on every band, so on 40 m and below the OFDM carriers were mirror-imaged versus the rest of the FreeDV world (a real decode bug). `RadioService.EffectiveEngineMode` now resolves the sideband from the dial (single source of truth, no-op for non-FreeDv modes) and `DspPipelineService` applies it at the engine-push seams + re-signs the bandpass. ≥10 MHz is byte-identical to before; only the previously-non-decoding <10 MHz path changes. The panel gains a freedv-gui-style band/sideband indicator.

> ⚠ The sub-10 MHz path changes the on-air sideband — worth a bench check of a 40 m FreeDV decode/transmit on a real radio.

## RADE V1 (neural Radio Autoencoder) decode
- Native base: `radae_c` + co-vendored `opus_dnn`/FARGAN (BSD), weights compiled in, no model files. One shared lib `zeus_rade` (`native/radae/CMakeLists.txt`); upstream slices vendored at a pinned SHA (see `vendor/PROVENANCE.md`), not committed.
- `RadeModem` mirrors `FreeDvModem`'s lock-free realtime discipline (decimate 48→8k → complex front-end → `zeus_rade_rx` → wideband 16→48k interp). `FreeDvService` routes `RadeV1` to it; passthrough-safe with no binary.
- **win-x64 `zeus_rade.dll` shipped** (`runtimes/win-x64/native/`, standalone — KERNEL32/UCRT only). **Decode PROVEN** on Linux and Windows against a real off-air recording: 2620 synced ticks, 14 dB, 0.999969 max amplitude (identical both platforms). Selecting RADEV1 decodes after a rebuild.
- `build-rade.yml` (manual-dispatch + artifact-upload) builds the lib per RID.

RADE follow-ups (not blocking RX decode): RADE TX (TX silences for now), EOO callsign via `freedv_text`, on-air test, and `build-rade` dispatch for the arm64/macOS binaries.

## Also
- Auto submode detection (camp-on-sustained-sync scanner), all-mode RX verification, and the panel-control gating fix (REST-driven, not gated on the SignalR hub).