### PR TITLE
ci(nightly): pin reusable release.yml to @develop (fix pipeline/source skew)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,7 +33,16 @@ concurrency:
 jobs:
   nightly:
     name: Build + publish nightly
-    uses: ./.github/workflows/release.yml
+    # Pin the reusable workflow to @develop, NOT a local `./` path. A local path
+    # resolves release.yml at the CALLER's commit — which for a scheduled run is
+    # always the default branch (main). That loaded main's (older) build pipeline
+    # while `ref: develop` below checked out develop's SOURCE, so any build-step
+    # divergence between main and develop broke the nightly (e.g. develop's
+    # zeus-windows.iss requires MicrosoftEdgeWebview2Setup.exe but main's
+    # release.yml had no step to download it → installer compile aborted).
+    # Pinning to @develop builds develop's source with develop's pipeline, so the
+    # two stay in lockstep and the nightly self-heals as develop evolves.
+    uses: OpenHPSDR-Zeus-org/openhpsdr-zeus/.github/workflows/release.yml@develop
     with:
       mode: nightly
       ref: develop


### PR DESCRIPTION
## Why

The nightly builds **develop's source** but ran **main's** `release.yml`. With a local `./` reusable-workflow path, GitHub loads the pipeline from the caller's commit — and a scheduled run always fires from the default branch (main). So the nightly has always run *main's build steps against develop's code*.

That works only while both pipelines stay in sync. On 2026-06-20, commit `38e01538` (develop-only) made develop's Windows installer require `MicrosoftEdgeWebview2Setup.exe` **and** added the workflow step to download it — atomically. main never got that step, so today's nightly failed: Inno Setup couldn't find the file.

## Fix

Pin the reusable call to `release.yml@develop` so the nightly builds develop's source **with develop's pipeline**. They can't drift again — no cross-branch cherry-pick discipline required.

## Scope / safety
- Workflow-only, one line (plus comment). **Not** a content merge of develop→main.
- Does not touch website-publish gating: nightly still sets `is-release=false`, so `publish-downloads` stays skipped.
- macOS notarization (Apple agreement 403) is a separate issue, handled out-of-band.
- A sibling PR puts the same line on develop so future dev→main release merges keep it.