### PR TITLE
feat(web): gang band selection across all selected receivers

### DIFF
--- a/zeus-web/src/components/toolbar/BandFavorites.test.tsx
+++ b/zeus-web/src/components/toolbar/BandFavorites.test.tsx
@@ -233,4 +233,37 @@ describe('BandFavorites', () => {
 
     unmount();
   });
+
+  it('gangs a band selection across every selected receiver', async () => {
+    // RX1 + RX2 both selected, RX1 focused. A band click must retune BOTH.
+    useConnectionStore.setState({
+      vfoHz: 14_200_000,
+      vfoBHz: 14_200_000,
+      mode: 'USB',
+      modeB: 'USB',
+      rx2Enabled: true,
+      focusedRxIndex: 0,
+      rxFocus: 'A',
+      selectedRxIndices: [0, 1],
+    });
+
+    const { container, unmount } = render(createElement(BandFavorites));
+    const fortyMeters = Array.from(container.querySelectorAll<HTMLButtonElement>('button'))
+      .find((button) => button.textContent === '40m');
+
+    await act(async () => {
+      fortyMeters?.click();
+      await Promise.resolve();
+    });
+
+    // Both receivers were commanded to the 40m centre (the ganged contract).
+    // The focused receiver (RX1) reconciles the store from its own response;
+    // RX2's committed value lands on the next state poll, so we assert the
+    // posts rather than the transiently-reconciled sibling field.
+    expect(setVfo).toHaveBeenCalledWith(7_074_000, undefined);
+    expect(setVfoB).toHaveBeenCalledWith(7_074_000, undefined);
+    expect(useConnectionStore.getState().vfoHz).toBe(7_074_000);
+
+    unmount();
+  });
 });

--- a/zeus-web/src/components/toolbar/BandFavorites.tsx
+++ b/zeus-web/src/components/toolbar/BandFavorites.tsx
@@ -69,7 +69,6 @@ export function BandFavorites() {
   // whichever receiver the operator is working in.
   const focusedRxIndex = useConnectionStore((s) => s.focusedRxIndex);
   const activeVfoHz = useConnectionStore((s) => getReceiverVfoHz(s, focusedRxIndex));
-  const activeMode = useConnectionStore((s) => getReceiverMode(s, focusedRxIndex));
   const applyState = useConnectionStore((s) => s.applyState);
 
   const [currentBand, setCurrentBand] = useState<string>(() => bandOf(activeVfoHz));
@@ -156,39 +155,54 @@ export function BandFavorites() {
       const targetHz = stored?.hz ?? band.centerHz;
       const targetMode: RxMode | null = stored?.mode ?? null;
 
-      viewCenterFor(focusedRxIndex).markOptimisticTune();
-      optimisticSetReceiverVfo(focusedRxIndex, targetHz);
-      if (targetMode && targetMode !== activeMode) {
-        optimisticSetReceiverMode(focusedRxIndex, targetMode);
-      }
+      // Ganged: a band selection retunes EVERY selected receiver to the
+      // remembered (hz, mode) for that band; the store is reconciled only from
+      // the focused receiver's responses (the others' are ignored so they can't
+      // clobber the focused view — the next state poll reconciles them). With a
+      // single-receiver selection this is identical to the focused-only path.
+      const { selectedRxIndices, focusedRxIndex: focused } = useConnectionStore.getState();
 
-      void (async () => {
-        let modeRestored = !targetMode || targetMode === activeMode;
-        if (targetMode && targetMode !== activeMode) {
+      for (const idx of selectedRxIndices) {
+        const curMode = getReceiverMode(useConnectionStore.getState(), idx);
+        const isFocused = idx === focused;
+
+        viewCenterFor(idx).markOptimisticTune();
+        optimisticSetReceiverVfo(idx, targetHz);
+        if (targetMode && targetMode !== curMode) {
+          optimisticSetReceiverMode(idx, targetMode);
+        }
+
+        void (async () => {
+          let modeRestored = !targetMode || targetMode === curMode;
+          if (targetMode && targetMode !== curMode) {
+            try {
+              const res = withRestoredMode(
+                await postReceiverMode(idx, targetMode),
+                idx,
+                targetMode,
+              );
+              if (isFocused) applyState(res);
+              modeRestored = true;
+            } catch {
+              /* next state poll reconciles */
+            }
+          }
           try {
-            applyState(withRestoredMode(
-              await postReceiverMode(focusedRxIndex, targetMode),
-              focusedRxIndex,
-              targetMode,
-            ));
-            modeRestored = true;
+            const next = await postReceiverVfo(idx, targetHz);
+            if (isFocused) {
+              applyState(
+                targetMode && modeRestored
+                  ? withRestoredMode(next, idx, targetMode)
+                  : next,
+              );
+            }
           } catch {
             /* next state poll reconciles */
           }
-        }
-        try {
-          const next = await postReceiverVfo(focusedRxIndex, targetHz);
-          applyState(
-            targetMode && modeRestored
-              ? withRestoredMode(next, focusedRxIndex, targetMode)
-              : next,
-          );
-        } catch {
-          /* next state poll reconciles */
-        }
-      })();
+        })();
+      }
     },
-    [focusedRxIndex, activeMode, applyState, currentBand, flushPendingSave],
+    [applyState, currentBand, flushPendingSave],
   );
 
   return (


### PR DESCRIPTION
## Summary

Follow-up to #924. `BandFavorites` was the last focused-only toolbar control after the ganged-multi-select work landed — every other control (mode, bandwidth, mode favourites, AF gain, filter panel/ribbon) already acts on the whole selection. This makes a **band selection gang across every selected receiver**, retuning each to the remembered `(hz, mode)` for that band.

## Details
- `onSelect` now iterates the live `selectedRxIndices` instead of only `focusedRxIndex`. Each selected receiver gets its optimistic VFO/mode update plus the REST posts; the store is reconciled only from the **focused** receiver's responses (siblings' committed state lands on the next 1 Hz poll), matching the established ganged-control pattern.
- Per-receiver current mode is read fresh so the mode-restore decision is correct for each receiver, not just the focused one.
- **Band-memory persistence stays focused-only** — one writer, so multi-select doesn't fan out N writes for the same band.
- Single-receiver selection is byte-identical to the old focused-only path (all 5 existing tests unchanged + green).

## Tests
- `+1` test: a band click with RX1+RX2 selected commands both receivers (`setVfo` **and** `setVfoB`).
- Full `BandFavorites.test.tsx` green (6/6); typecheck clean.

## Safety
No backend, wire, or persistence changes. No PureSignal surface touched.
