### PR TITLE
refactor(web): collapse A/B — RX2 reads/writes via receivers[] (client side)

### DIFF
--- a/zeus-web/src/state/receiver-state.inversion.test.ts
+++ b/zeus-web/src/state/receiver-state.inversion.test.ts
@@ -1,0 +1,115 @@
+/** @vitest-environment jsdom */
+
+// RX2 source-of-truth inversion: the `receivers[]` array is canonical for
+// every receiver including RX2 (index 1). Reads prefer `receivers[1]` and fall
+// back to the flat *B fields only when the array entry is absent; the optimistic
+// writers keep BOTH in sync during the migration off the flat dupes.
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useConnectionStore } from './connection-store';
+import type { ReceiverDto } from '../api/client';
+import {
+  getReceiverAfGainDb,
+  getReceiverFilterHighHz,
+  getReceiverFilterLowHz,
+  getReceiverFilterPresetName,
+  getReceiverMode,
+  getReceiverVfoHz,
+  optimisticSetReceiverFilter,
+  optimisticSetReceiverMode,
+  optimisticSetReceiverPreset,
+  optimisticSetReceiverVfo,
+} from './receiver-state';
+
+function rx(index: number, patch: Partial<ReceiverDto> = {}): ReceiverDto {
+  return {
+    index,
+    enabled: true,
+    adcSource: 0,
+    vfoHz: 14_000_000,
+    mode: 'USB',
+    filterLowHz: 100,
+    filterHighHz: 2800,
+    filterPresetName: 'VAR1',
+    afGainDb: 0,
+    sampleRateHz: 192_000,
+    muted: false,
+    ...patch,
+  };
+}
+
+describe('receiver-state RX2 inversion', () => {
+  beforeEach(() => {
+    useConnectionStore.setState({
+      // Flat *B fields hold STALE values so we can prove reads come from the
+      // array, not these.
+      vfoBHz: 7_000_000,
+      modeB: 'LSB',
+      filterLowHzB: -2850,
+      filterHighHzB: -100,
+      filterPresetNameB: 'VAR1',
+      rx2AfGainDb: -12,
+      receivers: [
+        rx(0, { vfoHz: 14_074_000, mode: 'DIGU' }),
+        rx(1, {
+          vfoHz: 21_074_000,
+          mode: 'CWU',
+          filterLowHz: 300,
+          filterHighHz: 700,
+          filterPresetName: 'VAR2',
+          afGainDb: -3,
+        }),
+      ],
+    });
+  });
+
+  it('reads RX2 from receivers[1], not the flat *B fields', () => {
+    const s = useConnectionStore.getState();
+    expect(getReceiverVfoHz(s, 1)).toBe(21_074_000);
+    expect(getReceiverMode(s, 1)).toBe('CWU');
+    expect(getReceiverFilterLowHz(s, 1)).toBe(300);
+    expect(getReceiverFilterHighHz(s, 1)).toBe(700);
+    expect(getReceiverFilterPresetName(s, 1)).toBe('VAR2');
+    expect(getReceiverAfGainDb(s, 1)).toBe(-3);
+    // 'B' is the legacy alias for index 1 — same routing.
+    expect(getReceiverVfoHz(s, 'B')).toBe(21_074_000);
+  });
+
+  it('falls back to the flat *B fields when receivers[1] is absent', () => {
+    useConnectionStore.setState({ receivers: [rx(0, { vfoHz: 14_074_000 })] });
+    const s = useConnectionStore.getState();
+    expect(getReceiverVfoHz(s, 1)).toBe(7_000_000);
+    expect(getReceiverMode(s, 1)).toBe('LSB');
+    expect(getReceiverFilterLowHz(s, 1)).toBe(-2850);
+    expect(getReceiverAfGainDb(s, 1)).toBe(-12);
+  });
+
+  it('optimistic RX2 writes update BOTH receivers[1] and the flat *B mirror', () => {
+    optimisticSetReceiverVfo(1, 28_074_000);
+    optimisticSetReceiverMode(1, 'DIGL');
+    optimisticSetReceiverFilter(1, 250, 3050);
+    optimisticSetReceiverPreset(1, 'F5');
+
+    const s = useConnectionStore.getState();
+    const entry = s.receivers.find((r) => r.index === 1)!;
+    expect(entry.vfoHz).toBe(28_074_000);
+    expect(entry.mode).toBe('DIGL');
+    expect(entry.filterLowHz).toBe(250);
+    expect(entry.filterHighHz).toBe(3050);
+    expect(entry.filterPresetName).toBe('F5');
+
+    // Flat mirror stayed in lock-step for the not-yet-migrated direct readers.
+    expect(s.vfoBHz).toBe(28_074_000);
+    expect(s.modeB).toBe('DIGL');
+    expect(s.filterLowHzB).toBe(250);
+    expect(s.filterHighHzB).toBe(3050);
+    expect(s.filterPresetNameB).toBe('F5');
+  });
+
+  it('keeps RX1 (index 0) on the flat primary fields', () => {
+    optimisticSetReceiverVfo(0, 18_100_000);
+    const s = useConnectionStore.getState();
+    expect(s.vfoHz).toBe(18_100_000);
+    expect(getReceiverVfoHz(s, 0)).toBe(18_100_000);
+  });
+});

--- a/zeus-web/src/state/receiver-state.ts
+++ b/zeus-web/src/state/receiver-state.ts
@@ -27,8 +27,15 @@
 //
 // Field routing by receiver INDEX:
 //   - index 0 (RX1)  → the connection-store primary fields (vfoHz, mode, …)
-//   - index 1 (RX2)  → the *B fields (vfoBHz, modeB, …)
-//   - index >= 2     → the matching `receivers[]` entry, found by `.index`
+//   - index >= 1     → the matching `receivers[]` entry, found by `.index`,
+//                      falling back to the flat *B fields (vfoBHz, modeB, …) for
+//                      index 1 only when the array entry is absent
+//
+// The `receivers[]` array is the canonical per-receiver source of truth. RX2
+// (index 1) is being migrated off the flat *B fields onto `receivers[1]`: reads
+// prefer the array entry and the optimistic writers keep BOTH in sync (the flat
+// *B fields stay populated for the components that still read them directly,
+// until that migration completes and the flat dupes are retired).
 //
 // RX2 and RX3+ are the same class of "secondary receiver" (the VFO is the DDC
 // center); only RX1 (index 0) gets radioLo pan, CTUN sweep, snap history /
@@ -70,6 +77,17 @@ function receiverEntry(state: ConnState, idx: number): ReceiverDto | undefined {
   return state.receivers.find((r) => r.index === idx);
 }
 
+/** Immutably patch the `receivers[]` entry with the given index, leaving the
+ *  rest of the array untouched. Used by the optimistic writers so RX2 (index 1)
+ *  and RX3+ live in the canonical array even before the server round-trips. */
+function patchReceiverEntry(
+  receivers: ReceiverDto[],
+  idx: number,
+  patch: Partial<ReceiverDto>,
+): ReceiverDto[] {
+  return receivers.map((r) => (r.index === idx ? { ...r, ...patch } : r));
+}
+
 // ---------------------------------------------------------------------------
 // Pure selectors over connection-store state. Usable directly as zustand
 // selectors (`useConnectionStore((s) => getReceiverVfoHz(s, key))`). For
@@ -79,29 +97,33 @@ function receiverEntry(state: ConnState, idx: number): ReceiverDto | undefined {
 export function getReceiverVfoHz(state: ConnState, key: ReceiverKey): number {
   const idx = rxIndexOf(key);
   if (idx === 0) return state.vfoHz;
-  if (idx === 1) return state.vfoBHz;
-  return receiverEntry(state, idx)?.vfoHz ?? state.vfoHz;
+  const entry = receiverEntry(state, idx);
+  if (entry) return entry.vfoHz;
+  return idx === 1 ? state.vfoBHz : state.vfoHz;
 }
 
 export function getReceiverMode(state: ConnState, key: ReceiverKey) {
   const idx = rxIndexOf(key);
   if (idx === 0) return state.mode;
-  if (idx === 1) return state.modeB;
-  return receiverEntry(state, idx)?.mode ?? state.mode;
+  const entry = receiverEntry(state, idx);
+  if (entry) return entry.mode;
+  return idx === 1 ? state.modeB : state.mode;
 }
 
 export function getReceiverFilterLowHz(state: ConnState, key: ReceiverKey): number {
   const idx = rxIndexOf(key);
   if (idx === 0) return state.filterLowHz;
-  if (idx === 1) return state.filterLowHzB;
-  return receiverEntry(state, idx)?.filterLowHz ?? state.filterLowHz;
+  const entry = receiverEntry(state, idx);
+  if (entry) return entry.filterLowHz;
+  return idx === 1 ? state.filterLowHzB : state.filterLowHz;
 }
 
 export function getReceiverFilterHighHz(state: ConnState, key: ReceiverKey): number {
   const idx = rxIndexOf(key);
   if (idx === 0) return state.filterHighHz;
-  if (idx === 1) return state.filterHighHzB;
-  return receiverEntry(state, idx)?.filterHighHz ?? state.filterHighHz;
+  const entry = receiverEntry(state, idx);
+  if (entry) return entry.filterHighHz;
+  return idx === 1 ? state.filterHighHzB : state.filterHighHz;
 }
 
 /** Read a receiver's VFO out of a server RadioStateDto (e.g. to reconcile the
@@ -113,15 +135,17 @@ export function getReceiverVfoFromState(
 ): number {
   const idx = rxIndexOf(key);
   if (idx === 0) return state.vfoHz;
-  if (idx === 1) return state.vfoBHz;
-  return state.receivers?.find((r) => r.index === idx)?.vfoHz ?? state.vfoHz;
+  const entry = state.receivers?.find((r) => r.index === idx);
+  if (entry) return entry.vfoHz;
+  return idx === 1 ? state.vfoBHz : state.vfoHz;
 }
 
 export function getReceiverAfGainDb(state: ConnState, key: ReceiverKey): number {
   const idx = rxIndexOf(key);
   if (idx === 0) return state.rxAfGainDb;
-  if (idx === 1) return state.rx2AfGainDb;
-  return receiverEntry(state, idx)?.afGainDb ?? state.rxAfGainDb;
+  const entry = receiverEntry(state, idx);
+  if (entry) return entry.afGainDb;
+  return idx === 1 ? state.rx2AfGainDb : state.rxAfGainDb;
 }
 
 export function getReceiverFilterPresetName(
@@ -130,8 +154,9 @@ export function getReceiverFilterPresetName(
 ): string | null {
   const idx = rxIndexOf(key);
   if (idx === 0) return state.filterPresetName;
-  if (idx === 1) return state.filterPresetNameB;
-  return receiverEntry(state, idx)?.filterPresetName ?? state.filterPresetName;
+  const entry = receiverEntry(state, idx);
+  if (entry) return entry.filterPresetName;
+  return idx === 1 ? state.filterPresetNameB : state.filterPresetName;
 }
 
 // ---------------------------------------------------------------------------
@@ -143,11 +168,12 @@ export function optimisticSetReceiverVfo(key: ReceiverKey, hz: number): void {
   const idx = rxIndexOf(key);
   if (idx === 0) {
     useConnectionStore.setState({ vfoHz: hz });
-  } else if (idx === 1) {
-    useConnectionStore.setState({ vfoBHz: hz });
   } else {
+    // index >= 1: update the canonical receivers[] entry; for RX2 (index 1)
+    // also keep the flat vfoBHz mirror in sync until its direct readers migrate.
     useConnectionStore.setState((s) => ({
-      receivers: s.receivers.map((r) => (r.index === idx ? { ...r, vfoHz: hz } : r)),
+      receivers: patchReceiverEntry(s.receivers, idx, { vfoHz: hz }),
+      ...(idx === 1 ? { vfoBHz: hz } : {}),
     }));
   }
 }
@@ -160,13 +186,10 @@ export function optimisticSetReceiverFilter(
   const idx = rxIndexOf(key);
   if (idx === 0) {
     useConnectionStore.setState({ filterLowHz: lo, filterHighHz: hi });
-  } else if (idx === 1) {
-    useConnectionStore.setState({ filterLowHzB: lo, filterHighHzB: hi });
   } else {
     useConnectionStore.setState((s) => ({
-      receivers: s.receivers.map((r) =>
-        r.index === idx ? { ...r, filterLowHz: lo, filterHighHz: hi } : r,
-      ),
+      receivers: patchReceiverEntry(s.receivers, idx, { filterLowHz: lo, filterHighHz: hi }),
+      ...(idx === 1 ? { filterLowHzB: lo, filterHighHzB: hi } : {}),
     }));
   }
 }
@@ -175,11 +198,10 @@ export function optimisticSetReceiverMode(key: ReceiverKey, mode: RxMode): void 
   const idx = rxIndexOf(key);
   if (idx === 0) {
     useConnectionStore.setState({ mode });
-  } else if (idx === 1) {
-    useConnectionStore.setState({ modeB: mode });
   } else {
     useConnectionStore.setState((s) => ({
-      receivers: s.receivers.map((r) => (r.index === idx ? { ...r, mode } : r)),
+      receivers: patchReceiverEntry(s.receivers, idx, { mode }),
+      ...(idx === 1 ? { modeB: mode } : {}),
     }));
   }
 }
@@ -188,13 +210,10 @@ export function optimisticSetReceiverPreset(key: ReceiverKey, slot: string): voi
   const idx = rxIndexOf(key);
   if (idx === 0) {
     useConnectionStore.setState({ filterPresetName: slot });
-  } else if (idx === 1) {
-    useConnectionStore.setState({ filterPresetNameB: slot });
   } else {
     useConnectionStore.setState((s) => ({
-      receivers: s.receivers.map((r) =>
-        r.index === idx ? { ...r, filterPresetName: slot } : r,
-      ),
+      receivers: patchReceiverEntry(s.receivers, idx, { filterPresetName: slot }),
+      ...(idx === 1 ? { filterPresetNameB: slot } : {}),
     }));
   }
 }

--- a/zeus-web/src/util/band-memory.ts
+++ b/zeus-web/src/util/band-memory.ts
@@ -2,6 +2,7 @@
 
 import {
   saveBandMemory,
+  type ReceiverDto,
   type RxMode,
   type TxVfo,
 } from '../api/client';
@@ -10,12 +11,15 @@ import { useConnectionStore } from '../state/connection-store';
 
 export const BAND_MEMORY_UPDATED_EVENT = 'zeus-band-memory-updated';
 
+// Accepts both the live connection store and a server RadioStateDto. RX2 reads
+// prefer the canonical receivers[] entry and fall back to the flat *B fields.
 type BandMemoryState = {
   vfoHz: number;
   vfoBHz: number;
   rx2Enabled: boolean;
   mode: RxMode;
   modeB: RxMode;
+  receivers?: readonly ReceiverDto[];
 };
 
 export type BandMemoryUpdatedDetail = {
@@ -50,7 +54,8 @@ export function saveReceiverBandModeMemory(
   state: BandMemoryState = useConnectionStore.getState(),
 ): void {
   const targetB = receiver === 'B' && state.rx2Enabled;
-  const hz = targetB ? state.vfoBHz : state.vfoHz;
-  const mode = modeOverride ?? (targetB ? state.modeB : state.mode);
+  const entry = targetB ? state.receivers?.find((r) => r.index === 1) : undefined;
+  const hz = entry?.vfoHz ?? (targetB ? state.vfoBHz : state.vfoHz);
+  const mode = modeOverride ?? entry?.mode ?? (targetB ? state.modeB : state.mode);
   saveBandModeMemory(hz, mode);
 }


### PR DESCRIPTION
## Summary

Collapses the A/B model on the **client**: RX2 is now read and written exclusively through the canonical per-receiver `receivers[]` array (RX2 = index 1), the same path RX3+ use. This is the client half of retiring the flat `*B` wire fields (`vfoBHz`/`modeB`/`filter*B`/`rx2AfGainDb`/`filterPresetNameB`).

Deliberately **behaviour-neutral, wire-neutral, backend-neutral** — nothing is deleted from the wire or the server yet, and the flat `*B` fields stay populated (dual-written) as a fallback. This is the safe, correctly-ordered first contraction: the client must stop *depending on* the flat fields **before** the server stops sending them (old-client/new-server safety).

## What changed (4 commits)
1. **Invert RX2 source-of-truth** — `getReceiver*` selectors prefer the `receivers[]` entry for every index ≥ 1; optimistic writers dual-write `receivers[1]` + the flat mirror. (+`receiver-state.inversion.test.ts`, 4)
2. **Band memory** reads RX2 from `receivers[1]`.
3. **Remaining readers** — spectrum redraw triggers (`Panadapter`/`Waterfall`/`FreqAxis`/`WaterfallHeightfield`/`PassbandOverlay`/`FilterCursorOverlay`) key off `s.receivers`; `VfoDisplay`/`VfoPanel`/`App` route RX2 vfo/mode/AF through the selectors (+`optimisticSetReceiverAfGain`).
4. **FilterMiniPan** — its `miniPanFilterForReceiver`/`setSelectedFilterState`/redraw subscribe delegate to the selectors (keeps its A/B interface; removes the last component-level flat reads).

After this PR the **only** references to the flat `*B` fields on the client are the definition plumbing (`StateDto`/`normalizeState`/`applyState`) and the selector fallbacks.

## Tests
- Full frontend suite green: **959/959** (105 files; the sole intermittent failure is the pre-existing `display-settings-store` timer-leak flake). Typecheck clean. Production SPA build clean.

## Safety
No backend, wire, or persistence change. No PureSignal surface touched. The live RX2 data path is byte-identical to the already-live-validated #924 (server still projects `receivers[]` from its `*B` storage).

## Follow-up (the final contraction — bench-gated)
Delete the flat `*B` fields from the wire `StateDto` + the backend `_state`, sourcing RX2 from the receivers model in `RadioService`/`DspPipelineService`. That touches the realtime RX2 DSP + TX path, so per the repo's hardware-safety discipline it needs **on-air RX2/TX verification on a real G2** before merge. Filed as `zeus-sc0j`. Persistence is already decoupled (`RadioStateEntry`), so it won't touch the prefs schema.
