### PR TITLE
fix(desktop): open main window at saved size without panel reflow

### DIFF
--- a/OpenhpsdrZeus/Program.cs
+++ b/OpenhpsdrZeus/Program.cs
@@ -413,7 +413,13 @@ public partial class Program
                 if (TryReadOpenExternalRequest(msg, out var externalUrl))
                     OpenExternalUrl(externalUrl);
             })
-            .Load(new Uri(startUrl));
+            // Deliberately load a dark placeholder, NOT the SPA, as the startup
+            // content. The real SPA navigation is deferred to the WindowCreated
+            // handler below so it happens AFTER the frame is resized to the saved
+            // geometry — see the comment there. The placeholder matches --bg-app
+            // (#0a0a0c) so the brief pre-size frame is invisible against the dark
+            // chrome instead of flashing white.
+            .LoadRawString("<!doctype html><meta name=\"color-scheme\" content=\"dark\"><body style=\"margin:0;height:100vh;background:#0a0a0c\">");
 
         // Remember the last NORMAL (non-maximized) frame size as resize events
         // arrive. This is only needed for the maximized-at-close case: when the
@@ -459,6 +465,20 @@ public partial class Program
             catch (Exception ex)
             {
                 Console.Error.WriteLine($"window.geometry.restore failed: {ex.Message}");
+            }
+            finally
+            {
+                // Navigate to the SPA only NOW — after the frame has been resized
+                // to the saved geometry. Loading it in the builder chain made
+                // WebView2 paint the SPA at the min-size opening frame (Photino
+                // frequently opens at SetMinWidth/Height and the resize lands a
+                // frame later), so React's first layout measured the small
+                // viewport and the panels visibly reflowed when the window grew.
+                // Deferring the load means React's first measurement is the final
+                // size and the panels don't jump. In a finally so a failed resize
+                // above can never strand the window on the dark placeholder.
+                try { window.Load(new Uri(startUrl)); }
+                catch (Exception ex) { Console.Error.WriteLine($"window.spa.load failed: {ex.Message}"); }
             }
         });
 


### PR DESCRIPTION
## Problem

The desktop (Photino) main window already persists and restores its size/maximized state, but the restore was **visible on every launch**: the frame opened at the minimum size (1280×800), the SPA laid out its panels for that small viewport, and the `WindowCreated` resize to the saved (larger) size then forced React to reflow — so the panels visibly jumped. Reported as *"if I make the main window larger, on startup it opens smaller then moves my panels over."*

Root cause: Photino/WebView2 opens the frame at `SetMinWidth`/`SetMinHeight` first, and the `.SetSize(...)` startup parameter is unreliable on Windows. The SPA was loaded in the builder chain, so its first layout pass measured the min-size frame.

## Fix

Defer the SPA navigation until **after** the `WindowCreated` resize:

- The builder chain now loads a dark placeholder matching `--bg-app` (`#0a0a0c`) instead of the SPA, so the brief pre-size frame is invisible against the dark chrome rather than flashing.
- `window.Load(startUrl)` runs at the end of the `WindowCreated` handler, once the saved size/maximized state is applied. React's first layout measurement is then the final viewport and the panels render in place — no jump.
- The load sits in a `finally` so a failed resize can never strand the window on the placeholder.

Maximized-restore and the Ctrl-C / close-save paths are unchanged. Persistence logic (`WindowGeometryStore`) is untouched — this is purely the startup render order.

## Scope / testing

- One file changed: `OpenhpsdrZeus/Program.cs` (desktop host only; no effect on web/headless modes).
- Compiles clean (`Csc` succeeds; `LoadRawString`/`Load(Uri)` resolve on Photino.NET 4.0.16).
- Desktop GUI needs a manual bench check on launch: close + relaunch should open straight at the saved size with panels already positioned.