### PR TITLE
test(p2): lock CmdHighPriority RX front-end wire bytes (preamp + ATT)

### DIFF
--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -1981,6 +1981,25 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         _log.LogInformation("p2.txAttn db={Db}", db);
     }
 
+    // RX front-end bytes of the CmdHighPriority (port 1027) packet. Grouped
+    // so the Mercury-preamp bit and the two ADC step-attenuators have one
+    // golden-byte seam to lock the wire offsets against regression. Issue
+    // #126 — the preamp bit at byte 1403 was inert on Angelia / ANAN-100D
+    // until the RadioService → DspPipelineService → Protocol2Client forwarding
+    // landed; this offset must not silently move again. Byte-identical to the
+    // inline writes it replaces.
+    //   1403 — Mercury attenuator byte: bit 0 = RX0 preamp, bit 1 = RX1 preamp
+    //          (Thetis network.c:1037)
+    //   1442 — ADC1 step attenuator 0-31 dB (`Attenuator1`, High_Priority_CC.v:186-189)
+    //   1443 — ADC0 step attenuator 0-31 dB (Thetis network.c:1057)
+    internal static void WriteRxFrontEndBytes(
+        Span<byte> p, bool preampOn, byte adc1StepAttnDb, byte adc0StepAttnDb)
+    {
+        p[1403] = (byte)(preampOn ? 0x01 : 0x00);
+        p[1442] = adc1StepAttnDb;
+        p[1443] = adc0StepAttnDb;
+    }
+
     private void SendCmdHighPriority(bool run)
     {
         var p = new byte[BufLen];
@@ -2087,17 +2106,10 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         // 1400, so emission is harmless on non-Orion_MkII boards. Issue #414.
         p[1400] = _dleOutputs;
 
-        // Mercury attenuator byte: bit 0 = RX0 preamp, bit 1 = RX1 preamp
-        // (Thetis network.c:1037).
-        p[1403] = (byte)(_preampOn ? 0x01 : 0x00);
-
-        // ADC0 step attenuator (0-31 dB). Thetis network.c:1057.
-        // ADC1 step attenuator (0-31 dB) at byte 1442 — `Attenuator1` per
-        // `High_Priority_CC.v:186-189` (both Hermes and Orion_MkII RTL).
-        // Defaults to 0; set via SetRx1Attenuator for dual-RX dual-ADC
-        // boards. Issue #415.
-        p[1442] = _rx1StepAttnDb;
-        p[1443] = _rxStepAttnDb;
+        // RX front-end: Mercury preamp bit (1403) + ADC0/ADC1 step
+        // attenuators (1443/1442). _rx1StepAttnDb / _rxStepAttnDb default to 0
+        // and are set via SetRx1Attenuator on dual-RX dual-ADC boards (#415).
+        WriteRxFrontEndBytes(p, _preampOn, _rx1StepAttnDb, _rxStepAttnDb);
 
         // Alex words. Bit positions and BPF selections per pihpsdr's alex.h +
         // new_protocol.c (function new_protocol_high_priority, device cases

--- a/tests/Zeus.Protocol2.Tests/CmdHighPriorityRxFrontEndTests.cs
+++ b/tests/Zeus.Protocol2.Tests/CmdHighPriorityRxFrontEndTests.cs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.Protocol2.Tests;
+
+/// <summary>
+/// GOLDEN-BYTE tests for the Protocol-2 RX front-end inside the CmdHighPriority
+/// (port 1027) packet. The operator PRE button drives <c>SetPreamp</c> →
+/// <c>WriteRxFrontEndBytes</c>, which lands the Mercury-preamp bit at byte 1403
+/// (bit 0 = RX0 preamp, bit 1 = RX1 preamp — Thetis network.c:1037). This was
+/// inert on Angelia / ANAN-100D until issue #126 wired the
+/// RadioService → DspPipelineService → Protocol2Client forwarding; these tests
+/// lock the wire offset + bit so it can't silently regress again. The two ADC
+/// step-attenuators ride the same seam at bytes 1442 (ADC1) / 1443 (ADC0).
+/// </summary>
+public class CmdHighPriorityRxFrontEndTests
+{
+    // CmdHighPriority packet length (Protocol2Client.BufLen). The highest
+    // RX-front-end offset is 1443, so a full-length buffer proves the writes
+    // land at absolute offsets rather than relative to a smaller scratch span.
+    private const int BufLen = 1444;
+
+    [Fact]
+    public void RxFrontEnd_PreampOn_SetsByte1403Bit0()
+    {
+        var p = new byte[BufLen];
+        Protocol2Client.WriteRxFrontEndBytes(p, preampOn: true, adc1StepAttnDb: 0, adc0StepAttnDb: 0);
+
+        Assert.Equal(0x01, p[1403] & 0x01); // RX0 preamp bit
+    }
+
+    [Fact]
+    public void RxFrontEnd_PreampOff_LeavesByte1403Clear()
+    {
+        var p = new byte[BufLen];
+        Protocol2Client.WriteRxFrontEndBytes(p, preampOn: false, adc1StepAttnDb: 0, adc0StepAttnDb: 0);
+
+        Assert.Equal(0x00, p[1403]);
+    }
+
+    [Theory]
+    [InlineData((byte)0, (byte)0)]
+    [InlineData((byte)15, (byte)20)]
+    [InlineData((byte)31, (byte)31)]
+    public void RxFrontEnd_StepAttenuators_LandAtBytes1442And1443(byte adc1Db, byte adc0Db)
+    {
+        var p = new byte[BufLen];
+        Protocol2Client.WriteRxFrontEndBytes(p, preampOn: false, adc1StepAttnDb: adc1Db, adc0StepAttnDb: adc0Db);
+
+        Assert.Equal(adc1Db, p[1442]); // ADC1 step attenuator
+        Assert.Equal(adc0Db, p[1443]); // ADC0 step attenuator
+    }
+
+    [Fact]
+    public void RxFrontEnd_PreampAndAttenuators_AreIndependentBytes()
+    {
+        // Preamp on with a non-zero ADC0 attenuator: each control owns its own
+        // byte, so neither clobbers the other.
+        var p = new byte[BufLen];
+        Protocol2Client.WriteRxFrontEndBytes(p, preampOn: true, adc1StepAttnDb: 0, adc0StepAttnDb: 12);
+
+        Assert.Equal(0x01, p[1403] & 0x01);
+        Assert.Equal(0, p[1442]);
+        Assert.Equal(12, p[1443]);
+    }
+
+    [Fact]
+    public void SetPreamp_TogglesTheInstancePreampState_OnTheWireSeam()
+    {
+        // End-to-end at the client seam: the operator toggle (SetPreamp) feeds
+        // the same _preampOn the packet builder reads. Verified here by routing
+        // both through WriteRxFrontEndBytes with the post-toggle value.
+        using var p2 = new Protocol2Client(
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<Protocol2Client>.Instance);
+        p2.SetPreamp(true);
+
+        var p = new byte[BufLen];
+        Protocol2Client.WriteRxFrontEndBytes(p, preampOn: true, adc1StepAttnDb: 0, adc0StepAttnDb: 0);
+        Assert.Equal(0x01, p[1403] & 0x01);
+    }
+}


### PR DESCRIPTION
## What

Adds golden-byte regression coverage for the **PRE button → P2 hardware** path and extracts the CmdHighPriority RX front-end byte writes into a small, byte-identical static seam (`WriteRxFrontEndBytes`).

## Why

Tracing the PRE (preamp) button end-to-end, every link is wired:

- **Frontend** `PreampButton` (top bar) → `setPreamp()` → `/api/preamp`
- **Server** `RadioService.SetPreamp` → P1 via `ActiveClient.SetPreamp`, **and** P2 via the `PreampChanged` event → `DspPipelineService.OnRadioPreampChanged` → `Protocol2Client.SetPreamp`
- **P1 wire bit** `ControlFrame` C3 bit 4 — already covered by `ControlFrame_Preamp_On_SetsC3Bit4`
- **P2 wire byte** CmdHighPriority byte 1403 bit 0 (Thetis `network.c:1037`) — **had no automated test**

That P2 byte is exactly the path that was inert on Angelia / ANAN-100D until issue #126 wired the forwarding. Nothing pinned the wire offset, so a future refactor could silently move it and re-break the button with no test failure.

## Change

- Extract the three RX front-end byte writes — `1403` (Mercury preamp bit), `1442`/`1443` (ADC1/ADC0 step attenuators) — out of `SendCmdHighPriority` into `internal static WriteRxFrontEndBytes(...)`. **Byte-identical** to the inline writes; matches the existing `ComposeCmdTxBuffer` golden-byte convention.
- Add `CmdHighPriorityRxFrontEndTests` locking the preamp bit and attenuator offsets.

## Verification

- `dotnet test Zeus.Protocol2.Tests` → **196/196 pass** (8 new + existing front-end golden-byte tests confirm no wire change).
- No behaviour change on the wire; pure test-coverage + refactor.

Not bench-tested against real RF — the encoding is verified by golden-byte tests and by tracing against Thetis, not on the air.