### PR TITLE
fix(rx-audio): RX2+ silent when persisted Rx2AudioMode=Rx1 — make per-RX mute the sole audibility control

### DIFF
--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -5060,50 +5060,31 @@ public class DspPipelineService : BackgroundService,
         engine.Dispose();
     }
 
-    internal static int SelectRxAudio(
-        Rx2AudioMode mode,
-        Span<float> rx1,
-        int rx1Count,
-        ReadOnlySpan<float> rx2,
-        int rx2Count)
-    {
-        rx1Count = Math.Clamp(rx1Count, 0, rx1.Length);
-        rx2Count = Math.Clamp(rx2Count, 0, rx2.Length);
-        return mode switch
-        {
-            Rx2AudioMode.Rx2 => rx2Count > 0 ? CopyRx2Audio(rx1, rx2, rx2Count) : rx1Count,
-            Rx2AudioMode.Both => MixRxAudioN(rx1, rx1Count, new[]
-            {
-                new RxAudioSlice(rx2.Length == 0 ? Array.Empty<float>() : rx2.ToArray(), rx2Count),
-            }),
-            _ => rx1Count,
-        };
-    }
-
-    private static int CopyRx2Audio(Span<float> output, ReadOnlySpan<float> rx2, int rx2Count)
-    {
-        int count = Math.Min(output.Length, rx2Count);
-        rx2[..count].CopyTo(output);
-        return count;
-    }
-
     // N-receiver generalisation of the old 2-RX 0.5*(rx1+rx2) mix. The output
     // block runs at the longest contributor; each output sample is the average
     // of the contributors PRESENT at that index (a contributor "present" means
     // its index is within its own sample count). The divisor is the number of
-    // streams that produced any samples — RX1 (when rx1Count>0) plus every slice
-    // with Count>0 — so a stalled stream never dilutes the others, and a single
-    // contributor passes through at full amplitude. With exactly one non-empty
-    // slice this is byte-identical to the original MixRxAudio (RX1+RX2 → /2; RX2
-    // only when rx1Count==0 → passthrough; no RX2 → rx1 untouched).
+    // streams that produced any samples — RX1 (when unmuted and rx1Count>0) plus
+    // every slice with Count>0 — so a stalled or muted stream never dilutes the
+    // others, and a single contributor passes through at full amplitude. With
+    // exactly one non-empty slice and an unmuted RX1 this is byte-identical to
+    // the original MixRxAudio (RX1+RX2 → /2; RX2 only when rx1Count==0 →
+    // passthrough; no RX2 → rx1 untouched).
+    //
+    // <paramref name="rx1Muted"/>: RX1's samples are dropped from both the sum
+    // and the divisor (the caller has already zeroed them), but rx1Count still
+    // sets the block length so the secondaries stay clocked to RX1. This lets the
+    // per-RX mute model express "RX2 only" (mute RX1) without halving RX2.
     internal static int MixRxAudioN(
         Span<float> rx1,
         int rx1Count,
-        ReadOnlySpan<RxAudioSlice> slices)
+        ReadOnlySpan<RxAudioSlice> slices,
+        bool rx1Muted = false)
     {
         rx1Count = Math.Clamp(rx1Count, 0, rx1.Length);
 
-        int contributors = rx1Count > 0 ? 1 : 0;
+        bool rx1Contributes = !rx1Muted && rx1Count > 0;
+        int contributors = rx1Contributes ? 1 : 0;
         int count = rx1Count;
         foreach (var s in slices)
         {
@@ -5117,7 +5098,7 @@ public class DspPipelineService : BackgroundService,
 
         for (int i = 0; i < count; i++)
         {
-            float sum = i < rx1Count ? rx1[i] : 0f;
+            float sum = (rx1Contributes && i < rx1Count) ? rx1[i] : 0f;
             foreach (var s in slices)
             {
                 int sc = Math.Clamp(s.Count, 0, s.Buffer.Length);
@@ -5474,18 +5455,20 @@ public class DspPipelineService : BackgroundService,
         if (IsReceiverMuted(state, 0) && audioSampleCount > 0)
             audioBuf.AsSpan(0, audioSampleCount).Clear();
 
-        // Secondary-receiver audio. Drain EVERY enabled secondary RX ring this
-        // tick so none can back up: RX3+ used to be computed-and-discarded, so
-        // their WDSP audio rings overran and tripped the rx-ingest "audio
-        // consumer behind" selfcheck warn (IQ ingest itself stays lossless).
-        // What we do with the drained audio follows Rx2AudioMode, generalised
-        // across N receivers:
-        //   Rx1  → secondaries drained & discarded (RX1 only).
-        //   Rx2  → RX2 drained fully and output; RX3+ drained & discarded.
-        //   Both → RX1 + every enabled secondary mixed (each clocked to RX1).
-        var rxAudioMode = state.Rx2AudioMode;
+        // Secondary-receiver audio. Per-receiver mute is the sole audibility
+        // control (Thetis chkMUT, the #894 model): every enabled secondary is
+        // mixed into the RX1-clocked output bus, and muting a receiver — RX1
+        // (above) or any secondary (here) — removes its contribution. This
+        // subsumes the old Rx2AudioMode (Both/RX1/RX2) routing:
+        //   hear both → nothing muted;  RX1 only → mute the secondaries;
+        //   RX2 only  → mute RX1.
+        // The legacy Rx2AudioMode field is retained for wire compatibility but no
+        // longer gates audio: its UI control was removed in #894, so a stale
+        // persisted Rx2AudioMode=Rx1/Rx2 used to strand every enabled secondary
+        // silent with no way to recover. Drain EVERY enabled secondary each tick
+        // (incl. muted) so no WDSP audio ring can back up and trip the rx-ingest
+        // "consumer behind" selfcheck (IQ ingest stays lossless regardless).
         int mixSliceCount = 0;
-        int rx2OnlyCount = 0;
         for (int ri = 1; ri < MaxReceivers; ri++)
         {
             if (!SecondaryReceiverEnabled(ri, state)) continue;
@@ -5493,51 +5476,31 @@ public class DspPipelineService : BackgroundService,
             int secChan = Volatile.Read(ref sec.ChannelId);
             if (secChan < 0) continue;
 
-            if (rxAudioMode == Rx2AudioMode.Both)
-            {
-                // RX1 is the audio clock-master when receivers are mixed: read at
-                // most rx1Count samples from each secondary so the mixed stream
-                // is fed at exactly the RX sample rate. Draining fully and mixing
-                // max() over-feeds the sink — per-tick counts jitter
-                // independently, so E[max] exceeds the true rate (~5% on a G2),
-                // saturating the output ring → overrun → dual-RX clicking (#787).
-                // The unread remainder stays buffered for the next tick, so no
-                // secondary audio is dropped. With RX1 silent (rx1Count==0) read
-                // nothing this tick, matching the original RX2 Both behaviour.
-                int want = Math.Min(audioSampleCount, sec.AudioBuf.Length);
-                int n = want > 0 ? engine.ReadAudio(secChan, sec.AudioBuf.AsSpan(0, want)) : 0;
-                // Muted secondary: drained (so its ring can't back up) but zeroed
-                // so it contributes silence to the mix.
-                if (n > 0 && IsReceiverMuted(state, ri))
-                    sec.AudioBuf.AsSpan(0, n).Clear();
-                _mixSlices[mixSliceCount++] = new RxAudioSlice(sec.AudioBuf, n);
-            }
-            else if (rxAudioMode == Rx2AudioMode.Rx2 && ri == 1)
-            {
-                // RX2 is the audio master in RX2-only mode: drain its ring fully.
-                rx2OnlyCount = engine.ReadAudio(secChan, sec.AudioBuf.AsSpan());
-                if (rx2OnlyCount > 0 && IsReceiverMuted(state, ri))
-                    sec.AudioBuf.AsSpan(0, rx2OnlyCount).Clear();
-            }
-            else
-            {
-                // Not contributing to the output — drain fully and discard so the
-                // ring can't back up.
-                engine.ReadAudio(secChan, sec.AudioBuf.AsSpan());
-            }
+            // RX1 is the audio clock-master: read at most audioSampleCount samples
+            // from each secondary so the mixed stream is fed at exactly the RX
+            // sample rate. Draining fully and mixing max() over-feeds the sink —
+            // per-tick counts jitter independently, so E[max] exceeds the true
+            // rate (~5% on a G2), saturating the output ring → overrun → dual-RX
+            // clicking (#787). The unread remainder stays buffered for the next
+            // tick, so no secondary audio is dropped. With RX1 silent
+            // (audioSampleCount==0) read nothing this tick.
+            int want = Math.Min(audioSampleCount, sec.AudioBuf.Length);
+            int n = want > 0 ? engine.ReadAudio(secChan, sec.AudioBuf.AsSpan(0, want)) : 0;
+            // A muted secondary is still drained above (so its ring can't back up)
+            // but excluded from the mix entirely — it must neither add signal nor
+            // count toward the MixRxAudioN divisor (which would attenuate the
+            // receivers you can still hear).
+            if (IsReceiverMuted(state, ri)) continue;
+            _mixSlices[mixSliceCount++] = new RxAudioSlice(sec.AudioBuf, n);
         }
 
-        if (rxAudioMode == Rx2AudioMode.Both)
-        {
-            audioSampleCount = MixRxAudioN(audioBuf, audioSampleCount, _mixSlices.AsSpan(0, mixSliceCount));
-        }
-        else if (rxAudioMode == Rx2AudioMode.Rx2 && rx2OnlyCount > 0)
-        {
-            int n = Math.Min(audioBuf.Length, rx2OnlyCount);
-            _secondaryRx[1].AudioBuf.AsSpan(0, n).CopyTo(audioBuf);
-            audioSampleCount = n;
-        }
-        // Rx1 (default): audioSampleCount unchanged — RX1 only.
+        // RX1's own samples were already zeroed above when it's muted; tell the
+        // mixer to drop RX1 from the divisor too, so an unmuted secondary plays at
+        // full amplitude (RX2-only = mute RX1). With nothing audible the mixer
+        // returns silence.
+        audioSampleCount = MixRxAudioN(
+            audioBuf, audioSampleCount, _mixSlices.AsSpan(0, mixSliceCount),
+            rx1Muted: IsReceiverMuted(state, 0));
         if (audioSampleCount > 0)
         {
             SanitizeAudioBuffer(audioBuf.AsSpan(0, audioSampleCount));

--- a/tests/Zeus.Server.Tests/DspPipelineRx2RoutingTests.cs
+++ b/tests/Zeus.Server.Tests/DspPipelineRx2RoutingTests.cs
@@ -86,36 +86,62 @@ public class DspPipelineRx2RoutingTests
     }
 
     [Fact]
-    public void SelectRxAudio_Rx2ModeWithNoRx2Samples_FallsBackToRx1()
+    public void MixRxAudioN_Rx1Muted_PlaysSecondaryAtFullAmplitude()
     {
-        float[] rx1 = [0.10f, -0.20f, 0.30f, 9.0f];
+        // "RX2 only" in the per-RX mute model = mute RX1. RX1's samples are
+        // already zeroed by the caller; rx1Muted drops it from the divisor so the
+        // single unmuted secondary passes through at full amplitude (NOT halved).
+        float[] rx1 = new float[3];                  // RX1 muted → pre-zeroed
+        float[] rx2 = [0.40f, -0.50f, 0.30f];
 
-        int count = DspPipelineService.SelectRxAudio(
-            Rx2AudioMode.Rx2,
+        int count = DspPipelineService.MixRxAudioN(
             rx1,
             rx1Count: 3,
-            rx2: [],
-            rx2Count: 0);
+            new[] { new DspPipelineService.RxAudioSlice(rx2, rx2.Length) },
+            rx1Muted: true);
 
         Assert.Equal(3, count);
-        Assert.Equal([0.10f, -0.20f, 0.30f], rx1[..count]);
+        Assert.Equal(0.40f, rx1[0], 5);
+        Assert.Equal(-0.50f, rx1[1], 5);
+        Assert.Equal(0.30f, rx1[2], 5);
     }
 
     [Fact]
-    public void SelectRxAudio_Rx2ModeWithRx2Samples_UsesRx2()
+    public void MixRxAudioN_Rx1Muted_TwoSecondaries_AveragesOnlyThem()
     {
-        float[] rx1 = [0.10f, -0.20f, 0.30f];
-        float[] rx2 = [0.40f, -0.50f];
+        // RX1 muted, two unmuted secondaries → divide by 2 (RX1 excluded).
+        float[] rx1 = new float[2];
+        float[] rx2 = [0.40f, 0.20f];
+        float[] rx3 = [0.20f, 0.40f];
 
-        int count = DspPipelineService.SelectRxAudio(
-            Rx2AudioMode.Rx2,
+        int count = DspPipelineService.MixRxAudioN(
             rx1,
-            rx1Count: rx1.Length,
-            rx2,
-            rx2Count: rx2.Length);
+            rx1Count: 2,
+            new[]
+            {
+                new DspPipelineService.RxAudioSlice(rx2, rx2.Length),
+                new DspPipelineService.RxAudioSlice(rx3, rx3.Length),
+            },
+            rx1Muted: true);
 
         Assert.Equal(2, count);
-        Assert.Equal([0.40f, -0.50f], rx1[..count]);
+        Assert.Equal(0.30f, rx1[0], 5);   // (0.40+0.20)/2 — RX1 not in divisor
+        Assert.Equal(0.30f, rx1[1], 5);   // (0.20+0.40)/2
+    }
+
+    [Fact]
+    public void MixRxAudioN_Rx1Muted_NoUnmutedReceivers_ReturnsSilence()
+    {
+        // Everything muted (RX1 muted, no contributing slices) → silence.
+        float[] rx1 = new float[3];
+
+        int count = DspPipelineService.MixRxAudioN(
+            rx1,
+            rx1Count: 3,
+            System.ReadOnlySpan<DspPipelineService.RxAudioSlice>.Empty,
+            rx1Muted: true);
+
+        Assert.Equal(0, count);
     }
 
     [Fact]


### PR DESCRIPTION
## What operators see

Turning on RX2 (or any receiver past RX1) produces **no audio** — RX1 keeps working, the RX2 panadapter/waterfall update normally, but you hear nothing from RX2. Same for RX3–RX8. Some operators never hit it; others can't get RX2 audio at all.

## Root cause (proven on the wire)

Zeus mixes all receivers into **one** audio output bus. Whether a secondary receiver is included was gated on a single legacy field, `Rx2AudioMode` (`Both` / `RX1` / `RX2`). On an affected client `/api/state` shows:

```
rx2AudioMode = Rx1      ← "RX1 only" → every secondary drained & DISCARDED
rx2Enabled  = True
rx2Muted    = False
```

In the `Rx1` branch (`DspPipelineService.cs`) every secondary receiver is drained and thrown away — so RX2's audio is computed (WDSP channel open, ring draining) and then discarded. Because it's one shared field, **all** secondaries go silent at once (hence RX3+ too).

**Why it regressed:** #894 replaced the old Both/RX1/RX2 audio switch with a **per-receiver mute** model and removed the only UI control that wrote `Rx2AudioMode`. The backend kept gating audio on that field. So anyone left with a stale non-`Both` value has permanently silent secondaries **with no way to recover** — the control that could fix it is gone. Operators whose value happened to be the `Both` default were unaffected, which made it look platform-specific (it isn't — it's persisted state).

## The fix (backend only)

Finish #894's intent: **per-receiver mute is the sole audibility control.** Every enabled, unmuted secondary is mixed into the RX1-clocked bus, reusing the proven #787 clock-master timing. The mute model fully subsumes the old routing:

| Old mode | New equivalent |
|---|---|
| Both | nothing muted |
| RX1 only | mute the secondaries |
| RX2 only | mute RX1 |

`Rx2AudioMode` is **retained on the wire** (DTO/enum/store unchanged) for compatibility but no longer affects audio routing.

Also fixes a **latent divisor bug** that this surfaces: a muted receiver used to be zeroed but still counted in `MixRxAudioN`'s average, quietly attenuating the receivers you could still hear. Muted secondaries are now excluded entirely, and a new `rx1Muted` flag drops a muted RX1 from the divisor so an unmuted secondary plays at full amplitude (correct "RX2-only").

## Why this is Windows-safe

The `Both` + all-unmuted path is **byte-identical** to before — locked down by the existing `MixRxAudioN_SingleSlice_MatchesLegacyHalfMix` test. Operators already on `Both` (incl. the Windows testers who never saw the bug) get exactly the same audio. Affected clients (stale `Rx1`/`Rx2`) now hear their secondaries.

## Tests

- `dotnet build Zeus.slnx` — clean, 0 warnings.
- Zeus.Server.Tests **1745 passed** / 0 failed; Zeus.Dsp.Tests **178 passed**.
- Removed the dead mode-based `SelectRxAudio`/`CopyRx2Audio` helpers + their tests; added 3 tests for the muted-divisor behaviour (`MixRxAudioN_Rx1Muted_*`).

## Bench verification needed before merge

- [ ] **G2 (Doug):** enable RX2 on a different band, confirm audio; mute/unmute RX1 and RX2 and confirm "both / RX1-only / RX2-only" all work via mute, with no volume drop on the receivers you keep.
- [ ] HL2 sanity (dual-RX where applicable).
- [ ] Confirm no dual-RX clicking/overrun (the #787 regression class) under sustained dual-RX.

## Follow-up (not in this PR — flagged for review)

The frontend still has an orphaned `rx2AudioMode` store field that `FilterMiniPan` reads to decide which filter panes to show. With audio routing now mute-based, that field is display-only with no UI. A stale `rx1` there can also limit which filter panes render. Cleaning that up (and optionally one-time normalizing persisted `Rx2AudioMode` → `Both`) is a small **frontend/UX** change — left out here to keep this fix backend-focused and avoid touching the in-flight A/B-collapse work. Visual/UX call for Brian/Doug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)