### PR TITLE
feat(chat): live ban-list unban + persistent ban management

### DIFF
--- a/Zeus.Contracts/ChatEventFrame.cs
+++ b/Zeus.Contracts/ChatEventFrame.cs
@@ -23,6 +23,7 @@ namespace Zeus.Contracts;
 /// {"kind":"banned","message":"..."}
 /// {"kind":"cleared","room":"lobby"}
 /// {"kind":"notice","from":"N9WAR","text":"...","ts":123}
+/// {"kind":"bans","bans":["N0CALL", ...]}
 /// </code>
 ///
 /// JSON (rather than fixed binary) because the payload is small, low-rate, and
@@ -73,6 +74,10 @@ public static class ChatEventFrame
     /// <summary>Encodes a global admin announcement into a 0x35 frame.</summary>
     public static byte[] Notice(string from, string text, long ts) =>
         Encode(new NoticeEnvelope(from, text, ts));
+
+    /// <summary>Encodes the current ban list (admins only) into a 0x35 frame.</summary>
+    public static byte[] Bans(IReadOnlyList<string> bans) =>
+        Encode(new BansEnvelope(bans));
 
     /// <summary>Serialises <paramref name="envelope"/> to UTF-8 JSON and
     /// prefixes the ChatEvent type byte.</summary>
@@ -143,5 +148,10 @@ public static class ChatEventFrame
     public sealed record NoticeEnvelope(string From, string Text, long Ts)
     {
         public string Kind => "notice";
+    }
+
+    public sealed record BansEnvelope(IReadOnlyList<string> Bans)
+    {
+        public string Kind => "bans";
     }
 }

--- a/Zeus.Server.Hosting/ChatService.cs
+++ b/Zeus.Server.Hosting/ChatService.cs
@@ -251,6 +251,12 @@ public sealed class ChatService : BackgroundService
     public Task UnbanAsync(string callsign, CancellationToken ct) =>
         SendFriendActionAsync("admin_unban", "callsign", callsign, ct);
 
+    /// <summary>Admin: asks the relay for the current ban list (pushed back as a
+    /// 0x35 <c>bans</c> frame). The relay ignores this unless the caller is an
+    /// admin.</summary>
+    public Task ListBansAsync(CancellationToken ct) =>
+        SendFrameAsync(RequireSocket(), new { t = "admin_list_bans" }, ct);
+
     /// <summary>Admin: clears a room's history (defaults to the public lobby).</summary>
     public Task ClearRoomAsync(string? room, CancellationToken ct)
     {
@@ -567,6 +573,9 @@ public sealed class ChatService : BackgroundService
                         ReadString(root, "from") ?? string.Empty,
                         ReadString(root, "text") ?? string.Empty,
                         ReadLong(root, "ts") ?? DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()));
+                    break;
+                case "bans":
+                    _hub.BroadcastChatEvent(ChatEventFrame.Bans(ReadStringArray(root, "bans")));
                     break;
                 case "error":
                     var code = ReadString(root, "code");

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -3088,6 +3088,8 @@ public static class ZeusEndpoints
             Run(() => chat.ClearRoomAsync(req.Room, ctx.RequestAborted)));
         app.MapPost("/api/chat/admin/broadcast", (ChatBroadcastRequest req, ChatService chat, HttpContext ctx) =>
             Run(() => chat.BroadcastAsync(req.Text, ctx.RequestAborted)));
+        app.MapPost("/api/chat/admin/bans", (ChatService chat, HttpContext ctx) =>
+            Run(() => chat.ListBansAsync(ctx.RequestAborted)));
 
         // Point-to-point propagation (DE → DX). Proxies the HamClock sidecar's
         // ITU-R P.533-14 engine; always returns 200 with an {available:false}

--- a/cloud/zeuschat-relay/src/chat-room.ts
+++ b/cloud/zeuschat-relay/src/chat-room.ts
@@ -172,6 +172,7 @@ export class ChatRoom extends DurableObject<Env> {
         this.notify(callsign); // friend graph
         this.send(ws, { t: 'rooms', rooms: this.roomsFor(callsign) });
         await this.sendHistory(ws, callsign, PUBLIC_ROOM); // instant public scrollback
+        if (this.admins.has(callsign)) this.sendBans(ws); // admins get the ban list up front
         return;
       }
 
@@ -260,6 +261,9 @@ export class ChatRoom extends DurableObject<Env> {
         return;
       case 'admin_broadcast':
         if (this.isAdmin(me)) this.broadcastNotice(me, (msg.text ?? '').slice(0, MAX_MESSAGE_LEN));
+        return;
+      case 'admin_list_bans':
+        if (this.isAdmin(me)) this.sendBans(ws);
         return;
 
       case 'ping':
@@ -511,6 +515,20 @@ export class ChatRoom extends DurableObject<Env> {
     return !!callsign && this.admins.has(callsign);
   }
 
+  /** Send the current ban list to a single admin socket. */
+  private sendBans(ws: WebSocket): void {
+    this.send(ws, { t: 'bans', bans: [...this.bans].sort() });
+  }
+
+  /** Push the current ban list to every connected admin (after a ban/unban). */
+  private broadcastBans(): void {
+    const bans = [...this.bans].sort();
+    for (const ws of this.ctx.getWebSockets()) {
+      const att = ws.deserializeAttachment() as Attachment | null;
+      if (att?.callsign && this.admins.has(att.callsign)) this.send(ws, { t: 'bans', bans });
+    }
+  }
+
   private async banUser(admin: string, callsign: string): Promise<void> {
     if (!callsign || this.admins.has(callsign)) return; // never ban an admin
     this.bans.add(callsign);
@@ -524,12 +542,14 @@ export class ChatRoom extends DurableObject<Env> {
       }
     }
     this.broadcastRoster();
+    this.broadcastBans();
   }
 
   private async unbanUser(callsign: string): Promise<void> {
     if (!callsign || !this.bans.has(callsign)) return;
     this.bans.delete(callsign);
     await this.ctx.storage.delete(`ban:${callsign}`);
+    this.broadcastBans();
   }
 
   // --- friendship graph ------------------------------------------------------

--- a/cloud/zeuschat-relay/src/protocol.ts
+++ b/cloud/zeuschat-relay/src/protocol.ts
@@ -102,6 +102,8 @@ export type ClientToRelay =
   | { t: 'admin_clear_room'; room?: string }
   // Push a one-off global announcement to every connected operator.
   | { t: 'admin_broadcast'; text: string }
+  // Ask the relay for the current ban list (relay replies with a `bans` frame).
+  | { t: 'admin_list_bans' }
   // Keepalive. The relay auto-responds with {t:"pong"} without waking (see
   // setWebSocketAutoResponse in chat-room.ts) — send this EXACT string:
   // '{"t":"ping"}'.
@@ -130,6 +132,9 @@ export type RelayToClient =
   | { t: 'friends'; accepted: string[]; incoming: string[]; outgoing: string[] }
   // The operator has been banned/kicked; the socket is about to close.
   | { t: 'banned'; message: string }
+  // The current ban list, sent to admins on hello, on every ban/unban, and in
+  // response to `admin_list_bans`. Non-admins never receive this.
+  | { t: 'bans'; bans: string[] }
   // Protocol/validation error. Non-fatal unless the socket is also closed.
   | { t: 'error'; code: string; message: string }
   // Keepalive response.

--- a/zeus-web/src/api/chat.ts
+++ b/zeus-web/src/api/chat.ts
@@ -309,3 +309,6 @@ export const chatClearRoom = (room?: string, signal?: AbortSignal) =>
 /** Admin: broadcast a one-off global announcement to every connected operator. */
 export const chatBroadcast = (text: string, signal?: AbortSignal) =>
   postOk('/api/chat/admin/broadcast', { text }, signal);
+/** Admin: request the current ban list (relay replies with a `bans` push frame). */
+export const chatListBans = (signal?: AbortSignal) =>
+  postOk('/api/chat/admin/bans', {}, signal);

--- a/zeus-web/src/layout/panels/ChatPanel.tsx
+++ b/zeus-web/src/layout/panels/ChatPanel.tsx
@@ -1129,6 +1129,95 @@ function AdminAction({
 }
 
 /**
+ * The unban surface: a live list of every currently-banned callsign (relay-
+ * authoritative, persisted across relay restarts). Each row lifts that ban; the
+ * relay echoes the updated list back so the dialog updates in place and stays
+ * open for unbanning several at once.
+ */
+function BanListDialog({
+  bans,
+  onUnban,
+  onClose,
+}: {
+  bans: string[];
+  onUnban: (callsign: string) => void;
+  onClose: () => void;
+}) {
+  return (
+    <ConfirmDialog
+      title="Banned operators"
+      confirmLabel="Done"
+      cancelLabel="Close"
+      intent="primary"
+      onConfirm={onClose}
+      onCancel={onClose}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8, minWidth: 248 }}>
+        <div style={{ fontSize: 11, color: 'var(--fg-3)', lineHeight: 1.4 }}>
+          Bans are stored on the relay and persist across restarts. Lift one to let
+          that callsign reconnect to ZeusChat.
+        </div>
+        {bans.length === 0 ? (
+          <div
+            style={{
+              padding: '12px 8px',
+              textAlign: 'center',
+              fontSize: 12,
+              color: 'var(--fg-3)',
+              border: '1px dashed var(--line)',
+              borderRadius: 'var(--r-sm)',
+            }}
+          >
+            No operators are currently banned.
+          </div>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4, maxHeight: 260, overflowY: 'auto' }}>
+            {bans.map((call) => (
+              <div
+                key={call}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  padding: '5px 8px',
+                  borderRadius: 'var(--r-sm)',
+                  background: 'var(--bg-2)',
+                  border: '1px solid var(--line)',
+                }}
+              >
+                <span
+                  className="mono"
+                  style={{
+                    flex: 1,
+                    fontWeight: 700,
+                    fontSize: 12.5,
+                    color: 'var(--fg-0)',
+                    letterSpacing: '0.04em',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                  }}
+                >
+                  {call}
+                </span>
+                <button
+                  type="button"
+                  className="btn sm"
+                  onClick={() => onUnban(call)}
+                  title={`Unban ${call}`}
+                  style={{ flexShrink: 0, color: 'var(--power)', borderColor: 'var(--power)' }}
+                >
+                  Unban
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </ConfirmDialog>
+  );
+}
+
+/**
  * Collapsible strip of network-wide moderator tools, shown only to operators the
  * relay flagged as admins (N9WAR / KB2UKA). Gathers the actions that aren't tied
  * to a single roster row or room: global announcement, clear the public lobby,
@@ -1140,7 +1229,17 @@ function AdminConsole() {
   const broadcast = useChatStore((s) => s.broadcast);
   const clearRoom = useChatStore((s) => s.clearRoom);
   const unban = useChatStore((s) => s.unban);
+  const listBans = useChatStore((s) => s.listBans);
+  const bannedUsers = useChatStore((s) => s.bannedUsers);
   const ownCall = useChatStore((s) => s.callsign);
+
+  // Refresh the ban list whenever the console is opened, so the count + list are
+  // current without waiting for the next ban/unban push.
+  useEffect(() => {
+    if (open) void listBans();
+  }, [open, listBans]);
+
+  const banCount = bannedUsers.length;
 
   return (
     <div
@@ -1218,9 +1317,16 @@ function AdminConsole() {
           <AdminAction
             icon={<UnbanIcon />}
             title="Unban operator"
-            description="Lift a ban so a callsign can reconnect to ZeusChat."
-            actionLabel="Unban…"
-            onClick={() => setDialog('unban')}
+            description={
+              banCount === 0
+                ? 'No operators are currently banned.'
+                : `${banCount} operator${banCount === 1 ? '' : 's'} banned — open the list to lift a ban.`
+            }
+            actionLabel="Manage"
+            onClick={() => {
+              void listBans();
+              setDialog('unban');
+            }}
           />
           <AdminAction
             icon={<ClearIcon />}
@@ -1247,16 +1353,10 @@ function AdminConsole() {
         />
       )}
       {dialog === 'unban' && (
-        <PromptDialog
-          title="Unban operator"
-          label="Callsign"
-          placeholder="e.g. N0CALL"
-          confirmLabel="Unban"
-          onSubmit={(v) => {
-            void unban(v.toUpperCase());
-            setDialog(null);
-          }}
-          onCancel={() => setDialog(null)}
+        <BanListDialog
+          bans={bannedUsers}
+          onUnban={(call) => void unban(call)}
+          onClose={() => setDialog(null)}
         />
       )}
       {dialog === 'clear' && (

--- a/zeus-web/src/state/chat-store.ts
+++ b/zeus-web/src/state/chat-store.ts
@@ -47,6 +47,7 @@ import {
   chatUnban,
   chatClearRoom,
   chatBroadcast,
+  chatListBans,
   normalizeStatus,
   normalizeOperator,
   normalizeMessage,
@@ -93,7 +94,8 @@ export type ChatEnvelope =
   | { kind: 'rooms'; rooms: unknown }
   | { kind: 'banned'; message?: unknown }
   | { kind: 'cleared'; room?: unknown }
-  | { kind: 'notice'; from?: unknown; text?: unknown; ts?: unknown };
+  | { kind: 'notice'; from?: unknown; text?: unknown; ts?: unknown }
+  | { kind: 'bans'; bans?: unknown };
 
 /** A one-off global announcement pushed by an admin (shown as a banner). */
 export type ChatAnnouncement = { from: string; text: string; ts: number };
@@ -125,6 +127,10 @@ export type ChatStoreState = {
   // The latest global admin announcement, shown as a dismissible banner.
   announcement: ChatAnnouncement | null;
 
+  // Currently-banned callsigns (admins only; relay-authoritative). Pushed on
+  // connect, on every ban/unban, and in reply to listBans().
+  bannedUsers: string[];
+
   refreshStatus: () => Promise<void>;
   setEnabled: (enabled: boolean) => Promise<void>;
   /** Report whether the Chat panel is currently displayed (gates presence). */
@@ -150,6 +156,8 @@ export type ChatStoreState = {
   removeMember: (room: string, callsign: string) => Promise<void>;
   ban: (callsign: string) => Promise<void>;
   unban: (callsign: string) => Promise<void>;
+  /** Refresh the ban list from the relay (admins only). */
+  listBans: () => Promise<void>;
   clearRoom: (room?: string) => Promise<void>;
   broadcast: (text: string) => Promise<void>;
   dismissAnnouncement: () => void;
@@ -215,6 +223,7 @@ export const useChatStore = create<ChatStoreState>((set, get) => ({
   incomingRequests: [],
   outgoingRequests: [],
   announcement: null,
+  bannedUsers: [],
 
   refreshStatus: async () => {
     try {
@@ -381,6 +390,9 @@ export const useChatStore = create<ChatStoreState>((set, get) => ({
   unban: async (callsign) => {
     try { await chatUnban(callsign); } catch (err) { set({ relayError: errMsg(err) }); }
   },
+  listBans: async () => {
+    try { await chatListBans(); } catch (err) { set({ relayError: errMsg(err) }); }
+  },
   clearRoom: async (room) => {
     try { await chatClearRoom(room); } catch (err) { set({ relayError: errMsg(err) }); }
   },
@@ -456,6 +468,16 @@ export const useChatStore = create<ChatStoreState>((set, get) => ({
         const from = typeof envelope.from === 'string' ? envelope.from : '';
         const ts = typeof envelope.ts === 'number' && Number.isFinite(envelope.ts) ? envelope.ts : Date.now();
         set({ announcement: { from, text, ts } });
+        return;
+      }
+      case 'bans': {
+        const bans = Array.isArray(envelope.bans)
+          ? envelope.bans
+              .filter((b): b is string => typeof b === 'string' && b.length > 0)
+              .map((b) => b.toUpperCase())
+              .sort()
+          : [];
+        set({ bannedUsers: bans });
         return;
       }
       default:


### PR DESCRIPTION
Follow-up to the admin console (#900, #911). Replaces the free-text unban prompt with a live, relay-authoritative list of currently-banned operators, and removes the trailing ellipsis from the action.

## Changes
- **Unban is now a list, not a text prompt.** The admin console's Unban action opens a **Banned operators** dialog listing every currently-banned callsign; each row has its own Unban button. The relay echoes the updated list after each unban, so the dialog updates in place and stays open for unbanning several at once.
- **Ban count surfaced.** The Unban action shows the live count (e.g. "3 operators banned — open the list to lift a ban"). Action label is now **Manage** (no "…").
- **Bans persist** — they were already stored in the relay's Durable Object storage (`ban:*` keys, rehydrated in `ensureLoaded`); this PR just makes that state visible and manageable. Survives relay restarts/hibernation.

## Wire / plumbing
- Relay: `admin_list_bans` (client→relay) and `bans` (relay→client). Bans pushed to admins on `hello`, on every ban/unban (`broadcastBans`), and on request. Non-admins never receive it.
- Backend: `ChatEventFrame.Bans`, `ChatService.ListBansAsync`, `POST /api/chat/admin/bans` (relay enforces admin; backend just forwards).
- Frontend: `chatListBans`, `chat-store` `bannedUsers` + `listBans`, `BanListDialog` in `ChatPanel`.

## Verification
- `tsc --noEmit` clean (frontend + relay), `dotnet build Zeus.Server.Hosting` succeeds.

## Deploy note
Like #900, the relay half needs a `wrangler deploy` of `cloud/zeuschat-relay` to go live (the `bans`/`admin_list_bans` handlers). Deploying as part of landing this.