### PR TITLE
refactor(server): remove flat VFO-B StateDto fields — finish A/B wire collapse

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -1152,14 +1152,14 @@ public sealed record StateDto(
     // RX1/RX2 inside the captured bandwidth immediately; future protocol
     // work can map this same state onto a second hardware DDC for wider
     // splits without changing the UI contract.
+    //
+    // RX2's *tuning* (VFO / mode / filter / AF gain) now lives in the canonical
+    // <see cref="Receivers"/> array at index 1 — the flat VFO-B fields
+    // (VfoBHz / ModeB / Filter*B / Rx2AfGainDb) were retired in the A/B wire
+    // collapse. Only the RX2 *control* fields below remain flat: the enable
+    // toggle, audio-routing mode, and per-RX mute.
     bool Rx2Enabled = false,
-    long VfoBHz = 14_200_000,
-    RxMode ModeB = RxMode.USB,
-    int FilterLowHzB = 100,
-    int FilterHighHzB = 2850,
-    string? FilterPresetNameB = "VAR1",
     Zeus.Contracts.Rx2AudioMode Rx2AudioMode = Zeus.Contracts.Rx2AudioMode.Both,
-    double Rx2AfGainDb = 0.0,
     Zeus.Contracts.TxVfo TxVfo = Zeus.Contracts.TxVfo.A,
 
     // CW sidetone pitch in Hz. Currently a baked-in constant
@@ -1194,13 +1194,14 @@ public sealed record StateDto(
 
     // ---- Multi-DDC receivers array (wire v2) ----
     // Canonical per-receiver list: index 0 = RX1, index 1 = RX2, index ≥ 2 =
-    // additional DDCs. The flat RX1 fields (VfoHz/Mode/Filter*/RxAfGainDb) and
-    // the RX2 / VFO-B fields (VfoBHz/ModeB/Filter*B/Rx2AfGainDb) remain the
-    // authoritative source for indices 0/1; RadioService projects them into
-    // this array on every state change (Mutate + Snapshot), so the array is
-    // never stale. Null only on a pre-projection seed — every wire-bound path
-    // populates it. The frontend migrates to this array (multi-DDC UI); the
-    // flat dupes are retired once that lands.
+    // additional DDCs. RX1 (index 0) is still projected from the flat RX1 fields
+    // (VfoHz/Mode/Filter*/RxAfGainDb). RX2 (index 1) and every extra DDC are
+    // AUTHORITATIVE in this array — RX2's old flat VFO-B dupes were removed in
+    // the A/B wire collapse, so RadioService.ProjectReceivers carries index 1's
+    // tuning forward and only overlays the flat RX2 control fields (Rx2Enabled/
+    // Rx2Muted) + shared SampleRate. RadioService re-projects on every state
+    // change (Mutate + Snapshot), so the array is never stale. Null only on a
+    // pre-seed construction — every wire-bound path populates it.
     IReadOnlyList<ReceiverDto>? Receivers = null,
 
     // Wire contract version (WireContract.Version) so the frontend can

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -3885,13 +3885,13 @@ public class DspPipelineService : BackgroundService,
     private static bool IsReceiverMuted(StateDto s, int rxIndex) =>
         s.Receivers is { } rs && rxIndex >= 0 && rxIndex < rs.Count && rs[rxIndex].Muted;
 
-    // Per-secondary-receiver tuning params. RX2 reads the flat RX2/VFO-B fields
-    // (byte-exact); RX3+ read the per-receiver StateDto.Receivers[] entry.
+    // Per-secondary-receiver tuning params, read from the canonical Receivers[]
+    // entry (RX2 = index 1, RX3+ = index N). RadioService keeps the array
+    // current on every Mutate; RX2's flat VFO-B fields were retired in the A/B
+    // wire collapse, so every secondary receiver now flows through one path.
     private static (RxMode mode, long vfoHz, int filterLow, int filterHigh, double afGainDb)
         SecondaryRxParams(StateDto s, int rxIndex)
     {
-        if (rxIndex == 1)
-            return (s.ModeB, s.VfoBHz, s.FilterLowHzB, s.FilterHighHzB, s.Rx2AfGainDb);
         var r = s.Receivers is { } rs && rxIndex >= 0 && rxIndex < rs.Count ? rs[rxIndex] : null;
         return r is null
             ? (RxMode.USB, 0L, 100, 2850, 0.0)
@@ -3929,7 +3929,7 @@ public class DspPipelineService : BackgroundService,
                 rxIndex + 1,
                 opened,
                 rateHz,
-                s.VfoBHz);
+                s.Rx2().VfoHz);
             return opened;
         }
         catch
@@ -3993,14 +3993,15 @@ public class DspPipelineService : BackgroundService,
         long rx2LoHz,
         bool protocol2)
     {
-        long effectiveVfoBHz = CwOffset.EffectiveLoHz(s.ModeB, s.VfoBHz);
+        var rx2 = s.Rx2();
+        long effectiveVfoBHz = CwOffset.EffectiveLoHz(rx2.Mode, rx2.VfoHz);
         return protocol2
             ? (int)(effectiveVfoBHz - rx2LoHz)
             : (int)(effectiveVfoBHz - s.RadioLoHz);
     }
 
     // N-receiver generalization of ComputeRx2CtunShiftHz: the WDSP shift for any
-    // secondary, from its own mode/VFO. For RX2 (mode=ModeB, vfo=VfoBHz) this
+    // secondary, from its own mode/VFO. For RX2 (Receivers[1].Mode/VfoHz) this
     // returns the same value as ComputeRx2CtunShiftHz, keeping RX2 byte-exact.
     private static int ComputeSecondaryCtunShiftHz(
         StateDto s, RxMode mode, long vfoHz, long rxLoHz, bool protocol2)
@@ -5168,7 +5169,7 @@ public class DspPipelineService : BackgroundService,
         engine.SetVfoHz(channel, state.VfoHz);
         int rx2Channel = Volatile.Read(ref _secondaryRx[1].ChannelId);
         if (state.Rx2Enabled && rx2Channel >= 0)
-            engine.SetVfoHz(rx2Channel, state.VfoBHz);
+            engine.SetVfoHz(rx2Channel, state.Rx2().VfoHz);
 
         // Skip the entire display pipeline unless at least one client has a
         // mounted spectrum consumer. Saves: 2× engine.TryGet*DisplayPixels

--- a/Zeus.Server.Hosting/FrontPanel/G2PanelActionRouter.cs
+++ b/Zeus.Server.Hosting/FrontPanel/G2PanelActionRouter.cs
@@ -242,7 +242,7 @@ public sealed class G2PanelActionRouter
     {
         var s = _radio.Snapshot();
         _radio.SetRx2(new Rx2SetRequest(
-            AfGainDb: Math.Clamp(s.Rx2AfGainDb + ticks * AfGainStepDb, -50.0, 20.0)));
+            AfGainDb: Math.Clamp(s.Rx2().AfGainDb + ticks * AfGainStepDb, -50.0, 20.0)));
     }
 
     private void AdjustAgcRx1(int ticks)
@@ -406,7 +406,7 @@ public sealed class G2PanelActionRouter
     }
 
     private void CopyAtoB() { var s = _radio.Snapshot(); _radio.SetVfoB(s.VfoHz); }
-    private void CopyBtoA() { var s = _radio.Snapshot(); _radio.SetVfo(s.VfoBHz); }
+    private void CopyBtoA() { var s = _radio.Snapshot(); _radio.SetVfo(s.Rx2().VfoHz); }
 
     private void StepMode(int dir)
     {

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -516,6 +516,17 @@ public sealed class RadioService : IDisposable
                 ps?.MoxDelaySec ?? 0.2);
         }
 
+        // RX2 (VFO-B) tuning is hydrated into the canonical Receivers[1] entry —
+        // the flat VFO-B StateDto fields were retired in the A/B wire collapse.
+        // Legacy rows that never stored RX2 fall back to the RX1 values, exactly
+        // as the old flat-field hydration did.
+        long hydVfoB = (rsSnap?.VfoBHz ?? 0L) != 0L ? rsSnap!.VfoBHz : (rsSnap?.VfoHz ?? 14_200_000);
+        RxMode hydModeB = rsSnap?.ModeB ?? rsSnap?.Mode ?? RxMode.USB;
+        int hydFilterLowB = rsSnap?.FilterLowHzB ?? rsSnap?.FilterLowHz ?? 100;
+        int hydFilterHighB = rsSnap?.FilterHighHzB ?? rsSnap?.FilterHighHz ?? 2850;
+        string? hydPresetB = rsSnap?.FilterPresetNameB ?? rsSnap?.FilterPresetName ?? "VAR1";
+        double hydAfGainB = Math.Clamp(rsSnap?.Rx2AfGainDb ?? 0.0, -50.0, 20.0);
+
         _state = new(
             Status: ConnectionStatus.Disconnected,
             Endpoint: null,
@@ -601,19 +612,32 @@ public sealed class RadioService : IDisposable
                 ? rsSnap!.RadioLoHz
                 : (rsSnap?.VfoHz ?? 14_200_000),
             Rx2Enabled: rsSnap?.Rx2Enabled ?? false,
-            VfoBHz: (rsSnap?.VfoBHz ?? 0L) != 0L
-                ? rsSnap!.VfoBHz
-                : (rsSnap?.VfoHz ?? 14_200_000),
-            ModeB: rsSnap?.ModeB ?? rsSnap?.Mode ?? RxMode.USB,
-            FilterLowHzB: rsSnap?.FilterLowHzB ?? rsSnap?.FilterLowHz ?? 100,
-            FilterHighHzB: rsSnap?.FilterHighHzB ?? rsSnap?.FilterHighHz ?? 2850,
-            FilterPresetNameB: rsSnap?.FilterPresetNameB ?? rsSnap?.FilterPresetName ?? "VAR1",
             Rx2AudioMode: rsSnap?.Rx2AudioMode ?? Zeus.Contracts.Rx2AudioMode.Both,
-            Rx2AfGainDb: Math.Clamp(rsSnap?.Rx2AfGainDb ?? 0.0, -50.0, 20.0),
             TxVfo: rsSnap?.TxVfo ?? TxVfo.A,
             CwPitchHz: CwOffset.CwPitchHz,
             CtunEnabled: rsSnap?.CtunEnabled ?? false,
             PreampOn: rsSnap?.PreampOn ?? false);
+
+        // Seed the canonical Receivers[] so RX2's hydrated tuning is the live
+        // source of truth from the very first snapshot. RX1 (index 0) is rebuilt
+        // from the flat RX1 fields by ProjectReceivers on every later Mutate;
+        // index 1's tuning is carried forward (the flat VFO-B fields are gone).
+        _state = _state with
+        {
+            Receivers = new ReceiverDto[]
+            {
+                new(Index: 0, Enabled: true, AdcSource: 0,
+                    VfoHz: _state.VfoHz, Mode: _state.Mode,
+                    FilterLowHz: _state.FilterLowHz, FilterHighHz: _state.FilterHighHz,
+                    FilterPresetName: _state.FilterPresetName, AfGainDb: _state.RxAfGainDb,
+                    SampleRateHz: _state.SampleRate, Muted: _state.Rx1Muted),
+                new(Index: 1, Enabled: _state.Rx2Enabled, AdcSource: 0,
+                    VfoHz: hydVfoB, Mode: hydModeB,
+                    FilterLowHz: hydFilterLowB, FilterHighHz: hydFilterHighB,
+                    FilterPresetName: hydPresetB, AfGainDb: hydAfGainB,
+                    SampleRateHz: _state.SampleRate, Muted: _state.Rx2Muted),
+            },
+        };
 
         // Kick off the debounce flush timer. Fires every 1 s; only writes to
         // LiteDB when _stateDirty is set (i.e., at least one Mutate() has fired
@@ -1021,7 +1045,7 @@ public sealed class RadioService : IDisposable
         lock (_sync) { if (_state.VfoLocked) return Snapshot(); }
         long previousTx;
         lock (_sync) previousTx = TxFrequencyHzLocked(_state);
-        Mutate(s => s with { VfoBHz = clamped });
+        Mutate(s => WithRx2(s, r => r with { VfoHz = clamped }));
         if (BandUtils.FreqToBand(previousTx) != BandUtils.FreqToBand(TxFrequencyHz(Snapshot())))
         {
             RecomputePaAndPush();
@@ -1083,8 +1107,8 @@ public sealed class RadioService : IDisposable
             if (filterLowHz is not null || filterHighHz is not null || filterPresetName is not null)
             {
                 var cur = Snapshot();
-                int lo = filterLowHz ?? (index == 1 ? cur.FilterLowHzB : cur.FilterLowHz);
-                int hi = filterHighHz ?? (index == 1 ? cur.FilterHighHzB : cur.FilterHighHz);
+                int lo = filterLowHz ?? (index == 1 ? cur.Rx2().FilterLowHz : cur.FilterLowHz);
+                int hi = filterHighHz ?? (index == 1 ? cur.Rx2().FilterHighHz : cur.FilterHighHz);
                 SetFilter(lo, hi, filterPresetName, receiver);
             }
             if (afGainDb is double af)
@@ -1145,23 +1169,20 @@ public sealed class RadioService : IDisposable
         lock (_sync) previousTx = TxFrequencyHzLocked(_state);
         Mutate(s =>
         {
+            var rx2 = s.Rx2();
             long nextVfoB = req.VfoBHz.HasValue
                 ? Math.Clamp(req.VfoBHz.Value, 0L, 60_000_000L)
-                : s.VfoBHz > 0
-                    ? s.VfoBHz
+                : rx2.VfoHz > 0
+                    ? rx2.VfoHz
                     : s.VfoHz;
             var nextMode = req.AudioMode ?? s.Rx2AudioMode;
             double nextGain = req.AfGainDb.HasValue
                 ? Math.Clamp(req.AfGainDb.Value, -50.0, 20.0)
-                : s.Rx2AfGainDb;
+                : rx2.AfGainDb;
             bool nextEnabled = req.Enabled ?? s.Rx2Enabled;
-            return s with
-            {
-                Rx2Enabled = nextEnabled,
-                VfoBHz = nextVfoB,
-                Rx2AudioMode = nextMode,
-                Rx2AfGainDb = nextGain,
-            };
+            return WithRx2(
+                s with { Rx2Enabled = nextEnabled, Rx2AudioMode = nextMode },
+                r => r with { VfoHz = nextVfoB, AfGainDb = nextGain });
         });
         if (BandUtils.FreqToBand(previousTx) != BandUtils.FreqToBand(TxFrequencyHz(Snapshot())))
         {
@@ -1224,7 +1245,7 @@ public sealed class RadioService : IDisposable
     public static long TxFrequencyHz(StateDto state) => state.TxReceiverIndex switch
     {
         <= 0 => state.VfoHz,
-        1 => state.VfoBHz,
+        1 => state.Rx2().VfoHz,
         int i => state.Receivers is { } rs && i < rs.Count ? rs[i].VfoHz : state.VfoHz,
     };
 
@@ -1234,7 +1255,7 @@ public sealed class RadioService : IDisposable
     private long TxFrequencyHzLocked(StateDto state) => state.TxReceiverIndex switch
     {
         <= 0 => state.VfoHz,
-        1 => state.VfoBHz,
+        1 => state.Rx2().VfoHz,
         int i => i < _extraReceivers.Length && _extraReceivers[i] is { } e ? e.VfoHz : state.VfoHz,
     };
 
@@ -1255,14 +1276,16 @@ public sealed class RadioService : IDisposable
         Mutate(s =>
         {
             previousTx = TxFrequencyHzLocked(s);
-            newA = Math.Clamp(s.VfoBHz, 0L, 60_000_000L);
+            newA = Math.Clamp(s.Rx2().VfoHz, 0L, 60_000_000L);
             mode = s.Mode;
-            return s with
-            {
-                VfoHz = newA,
-                VfoBHz = Math.Clamp(s.VfoHz, 0L, 60_000_000L),
-                RadioLoHz = CwOffset.EffectiveLoHz(mode, newA),
-            };
+            long oldA = Math.Clamp(s.VfoHz, 0L, 60_000_000L);
+            return WithRx2(
+                s with
+                {
+                    VfoHz = newA,
+                    RadioLoHz = CwOffset.EffectiveLoHz(mode, newA),
+                },
+                r => r with { VfoHz = oldA });
         });
         ActiveClient?.SetVfoAHz(CwOffset.EffectiveLoHz(mode, newA));
         if (BandUtils.FreqToBand(previousTx) != BandUtils.FreqToBand(TxFrequencyHz(Snapshot())))
@@ -1714,10 +1737,11 @@ public sealed class RadioService : IDisposable
         {
             bool targetB = receiver == TxVfo.B && s.Rx2Enabled;
             targetBAtSet = targetB;
-            var currentMode = targetB ? s.ModeB : s.Mode;
-            var currentPreset = targetB ? s.FilterPresetNameB : s.FilterPresetName;
-            var currentFilterLow = targetB ? s.FilterLowHzB : s.FilterLowHz;
-            var currentFilterHigh = targetB ? s.FilterHighHzB : s.FilterHighHz;
+            var rx2 = s.Rx2();
+            var currentMode = targetB ? rx2.Mode : s.Mode;
+            var currentPreset = targetB ? rx2.FilterPresetName : s.FilterPresetName;
+            var currentFilterLow = targetB ? rx2.FilterLowHz : s.FilterLowHz;
+            var currentFilterHigh = targetB ? rx2.FilterHighHz : s.FilterHighHz;
 
             departingMode = currentMode;
             departingPreset = currentPreset;
@@ -1755,29 +1779,30 @@ public sealed class RadioService : IDisposable
             //    behaviour is unchanged.
             long bump = CwOffset.DialBumpForModeTransition(currentMode, mode);
             long nextVfoA = targetB ? s.VfoHz : Math.Clamp(s.VfoHz + bump, 0L, 60_000_000L);
-            long nextVfoB = targetB ? Math.Clamp(s.VfoBHz + bump, 0L, 60_000_000L) : s.VfoBHz;
+            long nextVfoB = targetB ? Math.Clamp(rx2.VfoHz + bump, 0L, 60_000_000L) : rx2.VfoHz;
             newVfoAHz = nextVfoA;
 
             if (targetB)
             {
-                return s with
+                return WithRx2(s, r => r with
                 {
-                    ModeB = mode,
-                    VfoBHz = nextVfoB,
-                    FilterLowHzB = lo,
-                    FilterHighHzB = hi,
-                    FilterPresetNameB = restoredPreset,
-                };
+                    Mode = mode,
+                    VfoHz = nextVfoB,
+                    FilterLowHz = lo,
+                    FilterHighHz = hi,
+                    FilterPresetName = restoredPreset,
+                });
             }
 
             var txFam = TxFamilyFilterFor(mode);
             var (txLo, txHi) = SignedFilterForMode(mode, txFam.LoAbs, txFam.HiAbs);
 
+            // RX2 is untouched on an RX1 mode change — ProjectReceivers carries
+            // Receivers[1] forward (nextVfoB == rx2.VfoHz here).
             return s with
             {
                 Mode = mode,
                 VfoHz = nextVfoA,
-                VfoBHz = nextVfoB,
                 FilterLowHz = lo, FilterHighHz = hi,
                 TxFilterLowHz = txLo, TxFilterHighHz = txHi,
                 FilterPresetName = restoredPreset,
@@ -1813,7 +1838,7 @@ public sealed class RadioService : IDisposable
         {
             bool targetB = receiver == TxVfo.B && s.Rx2Enabled;
             targetBAtSet = targetB;
-            modeAtSet = targetB ? s.ModeB : s.Mode;
+            modeAtSet = targetB ? s.Rx2().Mode : s.Mode;
             // Normalize the slot name: if (low,high) exactly matches a non-VAR
             // preset for this mode, use that slot's name regardless of what the
             // caller passed. Prevents dual selection where a stored VAR happens
@@ -1830,7 +1855,7 @@ public sealed class RadioService : IDisposable
             int hiAbs = Math.Max(Math.Abs(lowHz), Math.Abs(highHz));
             StoreFamilyFilter(modeAtSet, loAbs, hiAbs, targetB ? TxVfo.B : TxVfo.A);
             if (targetB)
-                return s with { FilterLowHzB = lowHz, FilterHighHzB = highHz, FilterPresetNameB = resolvedName };
+                return WithRx2(s, r => r with { FilterLowHz = lowHz, FilterHighHz = highHz, FilterPresetName = resolvedName });
             return s with { FilterLowHz = lowHz, FilterHighHz = highHz, FilterPresetName = resolvedName };
         });
         if (resolvedName != null && !targetBAtSet)
@@ -3615,8 +3640,32 @@ public sealed class RadioService : IDisposable
         StateChanged?.Invoke(next);
     }
 
-    // Build the canonical per-receiver array (wire v2) from the flat RX1/RX2
-    // fields. Index 0 = RX1 (always present); index 1 = RX2 with Enabled
+    // Patch the authoritative RX2 (index 1) entry inside a StateDto's Receivers
+    // array, returning a new StateDto. Callers set only RX2's tuning fields
+    // (VFO / mode / filter / AF gain) here — the subsequent Mutate /
+    // ProjectReceivers pass re-overlays the flat control fields. This is the
+    // write counterpart to ReceiverProjection.Rx2 (the read accessor). Off the
+    // audio thread (operator setters), so the small list copy is fine.
+    private static StateDto WithRx2(StateDto s, Func<ReceiverDto, ReceiverDto> patch)
+    {
+        var next = patch(s.Rx2());
+        var src = s.Receivers;
+        if (src is null)
+            return s with { Receivers = new[] { next } };
+        var list = new List<ReceiverDto>(src.Count);
+        bool replaced = false;
+        foreach (var r in src)
+        {
+            if (r.Index == 1) { list.Add(next); replaced = true; }
+            else list.Add(r);
+        }
+        if (!replaced) list.Add(next);
+        return s with { Receivers = list };
+    }
+
+    // Build the canonical per-receiver array (wire v2). Index 0 = RX1 is rebuilt
+    // from the flat RX1 fields; index 1 = RX2 is carried forward from the array
+    // (authoritative) with Enabled
     // tracking Rx2Enabled so the frontend has the VFO-B config even when RX2 is
     // off. AdcSource defaults to ADC0 until the multi-DDC UI assigns per-DDC
     // ADCs; SampleRateHz is the shared capture rate. Additional DDCs (index ≥ 2)
@@ -3634,13 +3683,20 @@ public sealed class RadioService : IDisposable
                 FilterPresetName: s.FilterPresetName,
                 AfGainDb: s.RxAfGainDb, SampleRateHz: s.SampleRate,
                 Muted: s.Rx1Muted),
-            new ReceiverDto(
-                Index: 1, Enabled: s.Rx2Enabled, AdcSource: 0,
-                VfoHz: s.VfoBHz, Mode: s.ModeB,
-                FilterLowHz: s.FilterLowHzB, FilterHighHz: s.FilterHighHzB,
-                FilterPresetName: s.FilterPresetNameB,
-                AfGainDb: s.Rx2AfGainDb, SampleRateHz: s.SampleRate,
-                Muted: s.Rx2Muted),
+            // index 1 = RX2: its VFO / mode / filter / AF gain are authoritative
+            // in the array itself (the flat VFO-B fields are gone). Carry the
+            // existing tuning forward and overlay the flat RX2 control fields
+            // (Enabled / Muted) + the shared capture rate. RX2 writes patch
+            // Receivers[1] (see WithRx2) before this runs, so the latest tuning
+            // is what gets carried.
+            s.Rx2() with
+            {
+                Index = 1,
+                Enabled = s.Rx2Enabled,
+                AdcSource = 0,
+                SampleRateHz = s.SampleRate,
+                Muted = s.Rx2Muted,
+            },
         };
         // Extra DDC receivers (RX3+). Appended contiguously while enabled — the
         // P2 multi-DDC path requires no DDC gaps, so the first disabled slot
@@ -3681,6 +3737,7 @@ public sealed class RadioService : IDisposable
             notches = _notches.ToList();
         }
 
+        var rx2Snap = snap.Rx2();
         try
         {
             _radioStateStore.Save(new RadioStateEntry
@@ -3720,14 +3777,17 @@ public sealed class RadioService : IDisposable
                 TunePct = snap.TunePct,
                 TxMoxPreKeyDelayMs = snap.TxMoxPreKeyDelayMs,
                 RadioLoHz = snap.RadioLoHz,
+                // RX2 tuning persists from the canonical Receivers[1] entry (the
+                // flat VFO-B StateDto fields are gone); the RadioStateEntry schema
+                // is unchanged so older/newer DBs round-trip identically.
                 Rx2Enabled = snap.Rx2Enabled,
-                VfoBHz = snap.VfoBHz,
-                ModeB = snap.ModeB,
-                FilterLowHzB = snap.FilterLowHzB,
-                FilterHighHzB = snap.FilterHighHzB,
-                FilterPresetNameB = snap.FilterPresetNameB,
+                VfoBHz = rx2Snap.VfoHz,
+                ModeB = rx2Snap.Mode,
+                FilterLowHzB = rx2Snap.FilterLowHz,
+                FilterHighHzB = rx2Snap.FilterHighHz,
+                FilterPresetNameB = rx2Snap.FilterPresetName,
                 Rx2AudioMode = snap.Rx2AudioMode,
-                Rx2AfGainDb = snap.Rx2AfGainDb,
+                Rx2AfGainDb = rx2Snap.AfGainDb,
                 TxVfo = snap.TxVfo,
                 CtunEnabled = snap.CtunEnabled,
                 Notches = notches.Select(n => new RadioStateNotchEntry

--- a/Zeus.Server.Hosting/ReceiverProjection.cs
+++ b/Zeus.Server.Hosting/ReceiverProjection.cs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Collections.Generic;
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Canonical RX2 accessor over the unified <see cref="StateDto.Receivers"/>
+/// model. RX2's tuning state (VFO / mode / filter / AF gain) lives
+/// authoritatively in the receivers array at index 1 — the flat VFO-B fields
+/// (VfoBHz / ModeB / Filter*B / Rx2AfGainDb) were retired in the A/B wire
+/// collapse. The flat RX2 *control* fields that remain (Rx2Enabled / Rx2Muted /
+/// Rx2AudioMode / shared SampleRate) are overlaid onto the projected entry by
+/// <c>RadioService.ProjectReceivers</c>, so this accessor returns the live
+/// tuning while those callers re-source the control bits themselves.
+/// </summary>
+public static class ReceiverProjection
+{
+    /// <summary>Default RX2 entry used only before the array is first seeded
+    /// (construction / hydration). Mirrors the old flat VFO-B defaults so a
+    /// pre-seed read is byte-identical to the legacy behaviour.</summary>
+    public static readonly ReceiverDto Rx2Seed = new(
+        Index: 1, Enabled: false, AdcSource: 0,
+        VfoHz: 14_200_000, Mode: RxMode.USB,
+        FilterLowHz: 100, FilterHighHz: 2850, FilterPresetName: "VAR1",
+        AfGainDb: 0.0, SampleRateHz: 192_000, Muted: false);
+
+    /// <summary>The authoritative RX2 (index 1) receiver entry. Alloc-free (no
+    /// LINQ, no enumerator) so realtime callers — the per-tick RX2
+    /// <c>SetVfoHz</c> and the CTUN shift computation — stay zero-alloc on the
+    /// audio/pipeline thread. Returns <see cref="Rx2Seed"/> if the array is not
+    /// yet seeded (should not happen after construction).</summary>
+    public static ReceiverDto Rx2(this StateDto s)
+    {
+        var r = s.Receivers;
+        if (r is not null)
+        {
+            for (int i = 0; i < r.Count; i++)
+                if (r[i].Index == 1) return r[i];
+        }
+        return Rx2Seed;
+    }
+}

--- a/tests/Zeus.Server.Tests/ControlSurfaceBackendTests.cs
+++ b/tests/Zeus.Server.Tests/ControlSurfaceBackendTests.cs
@@ -60,7 +60,7 @@ public sealed class ControlSurfaceBackendTests : IDisposable
         radio.SetVfoB(7_100_000);
         radio.SetVfoLock(true);
         var after = radio.SetVfoB(7_200_000);
-        Assert.Equal(7_100_000, after.VfoBHz);
+        Assert.Equal(7_100_000, after.Rx2().VfoHz);
     }
 
     [Fact]

--- a/tests/Zeus.Server.Tests/DspPipelineRx2RoutingTests.cs
+++ b/tests/Zeus.Server.Tests/DspPipelineRx2RoutingTests.cs
@@ -15,9 +15,17 @@ public class DspPipelineRx2RoutingTests
         FilterLowHz: 300,
         FilterHighHz: 2600,
         SampleRate: 384_000,
-        VfoBHz: 14_250_000,
-        ModeB: mode,
-        RadioLoHz: 14_200_000);
+        RadioLoHz: 14_200_000,
+        // RX2 tuning lives in the canonical Receivers[1] entry (VFO-B fields gone).
+        Receivers: new ReceiverDto[]
+        {
+            new(Index: 0, Enabled: true, AdcSource: 0, VfoHz: 14_200_000, Mode: mode,
+                FilterLowHz: 300, FilterHighHz: 2600, FilterPresetName: "VAR1", AfGainDb: 0,
+                SampleRateHz: 384_000, Muted: false),
+            new(Index: 1, Enabled: true, AdcSource: 0, VfoHz: 14_250_000, Mode: mode,
+                FilterLowHz: 300, FilterHighHz: 2600, FilterPresetName: "VAR1", AfGainDb: 0,
+                SampleRateHz: 384_000, Muted: false),
+        });
 
     [Fact]
     public void Rx2CtunShift_Protocol2TrueDdc_UsesRx2DdcCenter()

--- a/tests/Zeus.Server.Tests/RadioServiceModeTargetTests.cs
+++ b/tests/Zeus.Server.Tests/RadioServiceModeTargetTests.cs
@@ -42,7 +42,7 @@ public sealed class RadioServiceModeTargetTests : IDisposable
 
         Assert.Equal(RxMode.CWU, after.Mode);
         Assert.Equal(14_200_600, after.VfoHz);
-        Assert.Equal(7_100_000, after.VfoBHz);
+        Assert.Equal(7_100_000, after.Rx2().VfoHz);
     }
 
     [Fact]
@@ -56,9 +56,9 @@ public sealed class RadioServiceModeTargetTests : IDisposable
         var after = radio.SetMode(RxMode.CWU, TxVfo.B);
 
         Assert.Equal(RxMode.USB, after.Mode);
-        Assert.Equal(RxMode.CWU, after.ModeB);
+        Assert.Equal(RxMode.CWU, after.Rx2().Mode);
         Assert.Equal(14_200_000, after.VfoHz);
-        Assert.Equal(7_100_600, after.VfoBHz);
+        Assert.Equal(7_100_600, after.Rx2().VfoHz);
     }
 
     [Fact]
@@ -74,9 +74,9 @@ public sealed class RadioServiceModeTargetTests : IDisposable
         Assert.Equal(150, after.FilterLowHz);
         Assert.Equal(2850, after.FilterHighHz);
         Assert.Equal("VAR1", after.FilterPresetName);
-        Assert.Equal(300, after.FilterLowHzB);
-        Assert.Equal(2400, after.FilterHighHzB);
-        Assert.Equal("F6", after.FilterPresetNameB);
+        Assert.Equal(300, after.Rx2().FilterLowHz);
+        Assert.Equal(2400, after.Rx2().FilterHighHz);
+        Assert.Equal("F6", after.Rx2().FilterPresetName);
     }
 
     [Fact]
@@ -94,8 +94,8 @@ public sealed class RadioServiceModeTargetTests : IDisposable
         Assert.Equal(RxMode.USB, after.Mode);
         Assert.Equal(150, after.FilterLowHz);
         Assert.Equal(2850, after.FilterHighHz);
-        Assert.Equal(300, after.FilterLowHzB);
-        Assert.Equal(2400, after.FilterHighHzB);
+        Assert.Equal(300, after.Rx2().FilterLowHz);
+        Assert.Equal(2400, after.Rx2().FilterHighHz);
     }
 
     [Fact]
@@ -111,10 +111,10 @@ public sealed class RadioServiceModeTargetTests : IDisposable
         var after = radio.SetMode(RxMode.USB, TxVfo.B);
 
         Assert.Equal(RxMode.USB, after.Mode);
-        Assert.Equal(RxMode.USB, after.ModeB);
+        Assert.Equal(RxMode.USB, after.Rx2().Mode);
         Assert.Equal(150, after.FilterLowHz);
         Assert.Equal(2850, after.FilterHighHz);
-        Assert.Equal(300, after.FilterLowHzB);
-        Assert.Equal(2400, after.FilterHighHzB);
+        Assert.Equal(300, after.Rx2().FilterLowHz);
+        Assert.Equal(2400, after.Rx2().FilterHighHz);
     }
 }

--- a/tests/Zeus.Server.Tests/RadioServiceUnifiedReceiverWriteTests.cs
+++ b/tests/Zeus.Server.Tests/RadioServiceUnifiedReceiverWriteTests.cs
@@ -73,14 +73,9 @@ public sealed class RadioServiceUnifiedReceiverWriteTests : IDisposable
         radio.SetReceiver(1, filterLowHz: -2850, filterHighHz: -100, filterPresetName: "VAR1");
         var s = radio.SetReceiver(1, afGainDb: -3.0);
 
-        // Flat RX2 (*B) fields and the projected receivers[1] entry agree.
+        // RX2's tuning is authoritative in the projected receivers[1] entry
+        // (the flat VFO-B fields were retired in the A/B wire collapse).
         Assert.True(s.Rx2Enabled);
-        Assert.Equal(7_074_000, s.VfoBHz);
-        Assert.Equal(RxMode.LSB, s.ModeB);
-        Assert.Equal(-2850, s.FilterLowHzB);
-        Assert.Equal(-100, s.FilterHighHzB);
-        Assert.Equal("VAR1", s.FilterPresetNameB);
-        Assert.Equal(-3.0, s.Rx2AfGainDb);
 
         var rx2 = Rx(s, 1);
         Assert.True(rx2.Enabled);

--- a/tests/Zeus.Server.Tests/RotctldServiceTests.cs
+++ b/tests/Zeus.Server.Tests/RotctldServiceTests.cs
@@ -52,7 +52,17 @@ public class RotctldServiceTests : IDisposable
             FilterHighHz: 2850,
             SampleRate: 192_000,
             TxReceiverIndex: txRxIndex,
-            VfoBHz: vfoBHz);
+            // RX2's VFO is the canonical Receivers[1] entry (TX targets it when
+            // TxReceiverIndex == 1); the flat VFO-B field was retired.
+            Receivers: new ReceiverDto[]
+            {
+                new(Index: 0, Enabled: true, AdcSource: 0, VfoHz: vfoHz, Mode: RxMode.USB,
+                    FilterLowHz: 150, FilterHighHz: 2850, FilterPresetName: "VAR1", AfGainDb: 0,
+                    SampleRateHz: 192_000, Muted: false),
+                new(Index: 1, Enabled: true, AdcSource: 0, VfoHz: vfoBHz, Mode: RxMode.USB,
+                    FilterLowHz: 150, FilterHighHz: 2850, FilterPresetName: "VAR1", AfGainDb: 0,
+                    SampleRateHz: 192_000, Muted: false),
+            });
 
     private static RotctldSlot Slot(int id, bool enabled, params string[] bands) =>
         new RotctldSlot(id, $"Rotator {id}", enabled, "127.0.0.1", 4533, bands, 100);


### PR DESCRIPTION
Finishes the A/B → numeric-receivers collapse on the **server**, the back half of the work whose client side landed in #929. The six flat RX2 / VFO-B fields are removed from `StateDto`; RX2's tuning is now authoritative in the canonical `Receivers[]` array at index 1, matching both the client and the RX3+ model.

## What changed
Removed from `StateDto`: `VfoBHz`, `ModeB`, `FilterLowHzB`, `FilterHighHzB`, `FilterPresetNameB`, `Rx2AfGainDb`. (`Rx2Enabled` / `Rx2AudioMode` / `Rx2Muted` stay — they're RX2 *control*, not tuning.)

- **`ReceiverProjection.Rx2(StateDto)`** — new alloc-free accessor (no LINQ, manual loop) so the realtime per-tick `SetVfoHz` and CTUN-shift stay zero-alloc on the audio thread.
- **`RadioService`** — `WithRx2()` write helper; `SetVfoB` / `SetRx2` / `SetMode(B)` / `SetFilter(B)` / `SwapVfos` / `SetReceiver` patch `Receivers[1]`; `TxFrequencyHz`/`Locked`, hydration, and `FlushState` read it. `ProjectReceivers` now carries index 1 forward (authoritative) and overlays the surviving flat control fields + shared `SampleRate`; RX1 (index 0) is still rebuilt from the flat RX1 fields.
- **`DspPipelineService`** — `SecondaryRxParams` collapses RX2 into the generic `Receivers[]` path (RX2 == RX3+ now); CTUN shift + per-tick `SetVfoHz` read `Receivers[1]`.
- **`G2PanelActionRouter`** — `AdjustAfRx2` / `CopyBtoA` read `Receivers[1]`.

## Persistence — schema unchanged
`RadioStateEntry` keeps its VFO-B columns. Hydration seeds `Receivers[1]` from them; `FlushState` writes them back from `Receivers[1]`. So `zeus-prefs.db` round-trips identically across versions — no migration, no decouple.

## Deployment ordering
Safe to land now: #929 (client stops reading the flat fields) is already merged to develop, so client + server ship together — no old-client/new-server window.

## Verification
- **Build:** full solution green.
- **Tests:** 258 affected server tests pass (mode/filter targeting, unified-receiver writes, RX2 DSP routing, TX-frequency resolution, swap, rotctld, control-surface, persistence round-trip, multi-DDC).
- **On-air, real ANAN G2 (P2, dual DDC):**
  - Flat `vfoBHz`/`modeB`/`rx2AfGainDb` confirmed **absent** from every `/api/state`.
  - RX2 tuned independently (7.074 MHz DIGU, 150/2700, −4 dB) while RX1 stayed put (14.2 MHz USB) — via `receivers[1]`.
  - rx-ingest-health selfcheck **pass**: 0 dropped / 0 overrun across 2 active channels (RX2 decodes on its slice).
  - TX target → RX2 resolves the carrier to `receivers[1].VfoHz` (7.074, not RX1). Resolution verified; **no key-down** performed on the live band (actual on-air TX keying deferred to a deliberate bench test).