### PR TITLE
feat(freedv): RADE V1 RX/TX + Reporter + band sideband + AUTO submode detection

### DIFF
--- a/Zeus.Dsp.FreeDv/FreeDvAutoScanner.cs
+++ b/Zeus.Dsp.FreeDv/FreeDvAutoScanner.cs
@@ -22,19 +22,22 @@ namespace Zeus.Dsp.FreeDv;
 
 public sealed class FreeDvAutoScanner
 {
-    // Scan order: the on-air-common OFDM voice modes first (700D is the global
-    // FreeDV default), then the legacy interop modes. Matches the panel order.
+    // Scan order matches the submodes the panel exposes, so the panel's
+    // "scanning…" highlight always lands on a visible button. RADE V1 leads — it
+    // is the modern FreeDV default and is what most stations on the calling
+    // frequencies now run; the classic OFDM voice modes follow. (700C / 800XA are
+    // not exposed by the panel and so are not scanned.)
     private static readonly FreeDvSubmode[] DefaultOrder =
     {
+        FreeDvSubmode.RadeV1,
         FreeDvSubmode.Mode700D,
         FreeDvSubmode.Mode700E,
-        FreeDvSubmode.Mode700C,
         FreeDvSubmode.Mode1600,
-        FreeDvSubmode.Mode800XA,
     };
 
     private readonly FreeDvSubmode[] _order;
-    private readonly long _dwellMs;        // time given to each candidate to acquire while scanning
+    private readonly long _dwellMs;        // time given to each classic candidate to acquire while scanning
+    private readonly long _radeDwellMs;    // RADE V1 acquires more slowly — give it a longer scan dwell
     private readonly long _lockConfirmMs;  // continuous sync needed to declare LOCKED and stop scanning
     private readonly long _unlockMs;       // continuous loss-of-sync needed to give up a lock and resume
 
@@ -62,17 +65,28 @@ public sealed class FreeDvAutoScanner
     /// Continuous loss-of-sync required to give up a lock and resume scanning. Long
     /// (8 s) so QSO overs and deep fades don't bump the operator off the right mode.
     /// </param>
+    /// <param name="radeDwellMs">
+    /// Scan dwell for RADE V1 specifically. The neural autoencoder takes longer to
+    /// acquire than the classic OFDM modems, so it gets a longer window (6 s) before
+    /// the scan advances — otherwise AUTO would walk past a decodable RADE signal.
+    /// </param>
     public FreeDvAutoScanner(
         long dwellMs = 3000,
         long lockConfirmMs = 1500,
         long unlockMs = 8000,
+        long radeDwellMs = 6000,
         FreeDvSubmode[]? order = null)
     {
         _order = order is { Length: > 0 } ? order : DefaultOrder;
         _dwellMs = dwellMs;
+        _radeDwellMs = radeDwellMs;
         _lockConfirmMs = lockConfirmMs;
         _unlockMs = unlockMs;
     }
+
+    // Per-candidate scan dwell: RADE V1 gets the longer window, the classic OFDM
+    // modes the shorter one.
+    private long DwellFor(FreeDvSubmode m) => m == FreeDvSubmode.RadeV1 ? _radeDwellMs : _dwellMs;
 
     /// <summary>Submodes this scanner cycles through, in scan order.</summary>
     public IReadOnlyList<FreeDvSubmode> Order => _order;
@@ -136,7 +150,8 @@ public sealed class FreeDvAutoScanner
         }
 
         // Unsynced: stay on this candidate until its dwell elapses, then advance.
-        if (nowMs - _dwellStartMs < _dwellMs)
+        // RADE V1 gets a longer dwell than the classic modes (DwellFor).
+        if (nowMs - _dwellStartMs < DwellFor(current))
             return null;
 
         int idx = Array.IndexOf(_order, current);

--- a/Zeus.Server.Hosting/FreeDvService.cs
+++ b/Zeus.Server.Hosting/FreeDvService.cs
@@ -39,6 +39,14 @@ public sealed class FreeDvService : IDisposable
     // modems' active state.
     private volatile bool _radeActive;
 
+    // Serialises the routing-state mutators (SyncMode / ApplySubmode /
+    // ApplyEngagedRouting / ReloadNative). Without it the DSP tick (SyncMode), the
+    // auto-detect scan loop and the API thread (ApplyConfig) interleave and leave
+    // _radeActive out of sync with _rade.Active — routing RX to the inactive
+    // classic modem so RADE audio passes through undecoded ("sounds like USB").
+    // Hot-path ProcessRx/ProcessTx read _radeActive (volatile) without this lock.
+    private readonly object _routingGate = new();
+
     // Auto submode detection. The scanner is a pure state machine; this service
     // ticks it on a lightweight control loop and applies its submode decisions.
     // Scanning pauses while transmitting (ProcessTx stamps _lastTxActivityMs) so
@@ -67,8 +75,14 @@ public sealed class FreeDvService : IDisposable
     /// </summary>
     private bool RadeSelected => _modem.Submode == FreeDvSubmode.RadeV1;
 
-    /// <summary>True when FreeDV is engaged and the modem is processing audio.</summary>
-    public bool Active => _modem.Active;
+    /// <summary>
+    /// True when FreeDV is engaged and a decoder is processing audio. Must check
+    /// BOTH modems: when RADE V1 is selected the classic <see cref="_modem"/> is
+    /// deactivated and only <see cref="_rade"/> is active, so checking _modem alone
+    /// made the DSP pipeline skip ProcessRx for RADE — RX passed through as plain
+    /// SSB ("sounds like USB") and the RADE decoder never ran.
+    /// </summary>
+    public bool Active => _modem.Active || _rade.Active;
 
     /// <summary>True when the codec2 native library is loadable and FreeDV can run.</summary>
     public bool NativeAvailable => _modem.NativeAvailable;
@@ -94,21 +108,29 @@ public sealed class FreeDvService : IDisposable
         // Rebuild RADE too so a newly-installed zeus_rade lib re-probes and goes
         // live. Capture engaged state BEFORE disposing the old modems (Dispose
         // clears their active flags).
-        bool wasEngaged = _modem.Active || _rade.Active;
-        _radeActive = false;
         var freshRade = new RadeModem(_loggerFactory.CreateLogger<RadeModem>());
         freshRade.SetTxText(_txText); // carry the EOO callsign across the swap
 
-        var old = _modem;
-        var oldRade = _rade;
-        _modem = fresh;
-        _rade = freshRade;
-        old.Dispose();
-        oldRade.Dispose();
+        // Swap + re-route under the routing lock so a concurrent SyncMode /
+        // ApplySubmode can't observe a half-swapped pair or desynced _radeActive.
+        lock (_routingGate)
+        {
+            // Capture engaged state BEFORE disposing the old modems (Dispose
+            // clears their active flags).
+            bool wasEngaged = _modem.Active || _rade.Active;
+            _radeActive = false;
 
-        // Re-engage whichever modem the selected submode calls for, if FreeDV was
-        // active before the reload.
-        if (wasEngaged) ApplyEngagedRouting();
+            var old = _modem;
+            var oldRade = _rade;
+            _modem = fresh;
+            _rade = freshRade;
+            old.Dispose();
+            oldRade.Dispose();
+
+            // Re-engage whichever modem the selected submode calls for, if FreeDV
+            // was active before the reload.
+            if (wasEngaged) ApplyEngagedRouting();
+        }
 
         _log.LogInformation(
             "FreeDV: native reload — codec2 {State}, RADE {RadeState}",
@@ -124,19 +146,22 @@ public sealed class FreeDvService : IDisposable
     /// </summary>
     public void SyncMode(RxMode mode)
     {
-        bool want = mode == RxMode.FreeDv;
-        bool engaged = _modem.Active || _rade.Active;
-        if (want && !engaged)
+        lock (_routingGate)
         {
-            _log.LogInformation("FreeDV: engaging (mode=FreeDv, submode={Submode})", _modem.Submode);
-            ApplyEngagedRouting();
-        }
-        else if (!want && engaged)
-        {
-            _log.LogInformation("FreeDV: disengaging (mode={Mode})", mode);
-            _modem.Deactivate();
-            _rade.Deactivate();
-            _radeActive = false;
+            bool want = mode == RxMode.FreeDv;
+            bool engaged = _modem.Active || _rade.Active;
+            if (want && !engaged)
+            {
+                _log.LogInformation("FreeDV: engaging (mode=FreeDv, submode={Submode})", _modem.Submode);
+                ApplyEngagedRouting();
+            }
+            else if (!want && engaged)
+            {
+                _log.LogInformation("FreeDV: disengaging (mode={Mode})", mode);
+                _modem.Deactivate();
+                _rade.Deactivate();
+                _radeActive = false;
+            }
         }
     }
 
@@ -159,6 +184,23 @@ public sealed class FreeDvService : IDisposable
             _rade.Deactivate();
             _radeActive = false;
             _modem.Activate();
+        }
+    }
+
+    /// <summary>
+    /// Set the selected submode and, when FreeDV is engaged, route audio to the
+    /// decoder that submode calls for (RADE V1 -> _rade, otherwise -> _modem).
+    /// _modem remains the single source of truth for the selected submode even
+    /// when RADE is the active decoder. Used by both the operator's manual pick
+    /// (ApplyConfig) and the auto-detect scan loop, so AUTO can move into and out
+    /// of RADE exactly like a manual pick.
+    /// </summary>
+    private void ApplySubmode(FreeDvSubmode submode)
+    {
+        lock (_routingGate)
+        {
+            _modem.SetSubmode(submode);
+            if (_modem.Active || _rade.Active) ApplyEngagedRouting();
         }
     }
 
@@ -226,13 +268,9 @@ public sealed class FreeDvService : IDisposable
         {
             if (_autoDetect && (!req.AutoDetect.HasValue || !req.AutoDetect.Value))
                 _autoDetect = false;
-            // _modem stays the record of the selected submode even for RADE V1,
-            // mirroring today; RadeSelected then keys off it.
-            _modem.SetSubmode(req.Submode.Value);
-            // If FreeDV is engaged, swap the active modem to match the new submode
-            // (into/out of RADE). No-op when the routing already matches.
-            bool engaged = _modem.Active || _rade.Active;
-            if (engaged) ApplyEngagedRouting();
+            // _modem stays the record of the selected submode even for RADE V1;
+            // ApplySubmode swaps the active decoder to match (into/out of RADE).
+            ApplySubmode(req.Submode.Value);
         }
         if (req.SquelchEnabled.HasValue || req.SnrSquelchThreshDb.HasValue)
             _modem.SetSquelch(req.SquelchEnabled, req.SnrSquelchThreshDb);
@@ -285,18 +323,28 @@ public sealed class FreeDvService : IDisposable
                 await Task.Delay(ScanTickMs, ct).ConfigureAwait(false);
 
                 var modem = _modem; // may be swapped by ReloadNative; read once per tick
+                var rade = _rade;
                 long now = Environment.TickCount64;
                 bool transmitting = IsTxActive(now, Volatile.Read(ref _lastTxActivityMs), TxQuietMs);
-                bool scanning = _autoDetect && modem.Active && modem.NativeAvailable && !transmitting;
+                // FreeDV is engaged when EITHER decoder is active (the selected
+                // submode decides which). Scan whenever a decoder we can run is
+                // engaged — RADE counts, so AUTO works while parked on RADE V1.
+                bool engaged = modem.Active || rade.Active;
+                bool canDecode = modem.NativeAvailable || rade.RadeAvailable;
+                bool scanning = _autoDetect && engaged && canDecode && !transmitting;
 
                 if (!scanning) { wasScanning = false; continue; }
                 if (!wasScanning) { _scanner.Reset(now); wasScanning = true; }
 
-                var next = _scanner.Tick(now, modem.Synced, modem.Submode);
-                if (next is { } m && m != modem.Submode)
+                // Sync comes from whichever decoder the current submode routes to.
+                bool synced = _radeActive ? rade.Synced : modem.Synced;
+                var current = modem.Submode;
+
+                var next = _scanner.Tick(now, synced, current);
+                if (next is { } m && m != current)
                 {
                     _log.LogInformation("FreeDV: auto-detect — no lock, trying submode {Submode}", m);
-                    modem.SetSubmode(m);
+                    ApplySubmode(m); // routes RADE <-> classic, not just _modem.SetSubmode
                 }
             }
         }

--- a/tests/Zeus.Dsp.FreeDv.Tests/FreeDvAutoScannerTests.cs
+++ b/tests/Zeus.Dsp.FreeDv.Tests/FreeDvAutoScannerTests.cs
@@ -11,15 +11,15 @@ namespace Zeus.Dsp.FreeDv.Tests;
 public class FreeDvAutoScannerTests
 {
     [Fact]
-    public void Order_StartsWith700D_AndCoversAllFiveModes()
+    public void Order_StartsWithRade_AndCoversPanelModes()
     {
         var s = new FreeDvAutoScanner();
-        Assert.Equal(5, s.Order.Count);
-        Assert.Equal(FreeDvSubmode.Mode700D, s.Order[0]);
+        // Scan order = the panel's exposed submodes, RADE V1 first.
+        Assert.Equal(4, s.Order.Count);
+        Assert.Equal(FreeDvSubmode.RadeV1, s.Order[0]);
+        Assert.Contains(FreeDvSubmode.Mode700D, s.Order);
         Assert.Contains(FreeDvSubmode.Mode700E, s.Order);
-        Assert.Contains(FreeDvSubmode.Mode700C, s.Order);
         Assert.Contains(FreeDvSubmode.Mode1600, s.Order);
-        Assert.Contains(FreeDvSubmode.Mode800XA, s.Order);
     }
 
     [Fact]
@@ -29,17 +29,32 @@ public class FreeDvAutoScannerTests
         Assert.Null(s.Tick(0, synced: false, FreeDvSubmode.Mode700D));   // seeds timebase
         Assert.Null(s.Tick(999, synced: false, FreeDvSubmode.Mode700D)); // still dwelling
         Assert.Equal(FreeDvSubmode.Mode700E, s.Tick(1000, synced: false, FreeDvSubmode.Mode700D));
-        // Caller applies 700E; dwell restarts at 1000.
+        // Caller applies 700E; dwell restarts at 1000. Order is [RADE,700D,700E,1600],
+        // so 700E advances to 1600.
         Assert.Null(s.Tick(1999, synced: false, FreeDvSubmode.Mode700E));
-        Assert.Equal(FreeDvSubmode.Mode700C, s.Tick(2000, synced: false, FreeDvSubmode.Mode700E));
+        Assert.Equal(FreeDvSubmode.Mode1600, s.Tick(2000, synced: false, FreeDvSubmode.Mode700E));
     }
 
     [Fact]
-    public void Advance_WrapsPastLastMode()
+    public void RadeV1_GetsLongerDwell_ThenAdvancesToClassic()
+    {
+        // RADE acquires slowly, so it dwells longer (3 s here) than the classic
+        // modes (1 s) before AUTO gives up and advances.
+        var s = new FreeDvAutoScanner(dwellMs: 1000, lockConfirmMs: 1500, unlockMs: 4000, radeDwellMs: 3000);
+        Assert.Null(s.Tick(0, synced: false, FreeDvSubmode.RadeV1));      // seeds timebase on RADE
+        Assert.Null(s.Tick(2999, synced: false, FreeDvSubmode.RadeV1));   // still within RADE dwell
+        Assert.Equal(FreeDvSubmode.Mode700D, s.Tick(3000, synced: false, FreeDvSubmode.RadeV1));
+        // Now on 700D — the shorter classic dwell applies.
+        Assert.Null(s.Tick(3999, synced: false, FreeDvSubmode.Mode700D));
+        Assert.Equal(FreeDvSubmode.Mode700E, s.Tick(4000, synced: false, FreeDvSubmode.Mode700D));
+    }
+
+    [Fact]
+    public void Advance_WrapsPastLastMode_ToRade()
     {
         var s = new FreeDvAutoScanner(dwellMs: 1000, lockConfirmMs: 1500, unlockMs: 4000);
-        s.Tick(0, synced: false, FreeDvSubmode.Mode800XA);
-        Assert.Equal(FreeDvSubmode.Mode700D, s.Tick(1000, synced: false, FreeDvSubmode.Mode800XA));
+        s.Tick(0, synced: false, FreeDvSubmode.Mode1600);
+        Assert.Equal(FreeDvSubmode.RadeV1, s.Tick(1000, synced: false, FreeDvSubmode.Mode1600));
     }
 
     [Fact]
@@ -83,6 +98,6 @@ public class FreeDvAutoScannerTests
         s.Reset(5000);
         Assert.Null(s.Tick(5000, synced: false, FreeDvSubmode.Mode700E));      // fresh dwell
         Assert.Null(s.Tick(5999, synced: false, FreeDvSubmode.Mode700E));
-        Assert.Equal(FreeDvSubmode.Mode700C, s.Tick(6000, synced: false, FreeDvSubmode.Mode700E));
+        Assert.Equal(FreeDvSubmode.Mode1600, s.Tick(6000, synced: false, FreeDvSubmode.Mode700E));
     }
 }

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -6972,6 +6972,7 @@ export function setFreeDvConfig(
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
         submode: req.submode ?? null,
+        autoDetect: req.autoDetect ?? null,
         squelchEnabled: req.squelchEnabled ?? null,
         snrSquelchThreshDb: req.snrSquelchThreshDb ?? null,
         txText: req.txText ?? null,


### PR DESCRIPTION
End-to-end FreeDV for Zeus: classic codec2 modes, RADE V1 (neural) RX **and** TX,
the FreeDV Reporter stations channel, the band-convention sideband, and AUTO
submode detection. Built and verified live on an ANAN G2.

## What lands
- **RADE V1 RX + TX** — native `zeus_rade` shim (radae_c + opus_dnn FARGAN + LPCNet),
  win-x64 dll shipped; RadeModem P/Invoke with lock-free Dekker-fenced handoff.
  LDPC EOO callsign (FreeDV-GUI reliable-text wire format).
- **Classic FreeDV** — 700C/700D/700E/1600/800XA RX+TX via codec2.
- **FreeDV Reporter** — live stations channel (Engine.IO/Socket.IO) + opt-in report-mode.
- **Band-convention sideband** — LSB < 10 MHz, USB >= 10 MHz, re-flips on a 10 MHz
  dial crossing (`RadioService.EffectiveEngineMode`).
- **AUTO submode detection** — scans the panel submodes until the modem locks.

## Fixes in this session (found live on the G2)
- **AUTO button was dead** — the web `setFreeDvConfig` PUT body dropped the
  `autoDetect` field, so clicks never reached the backend.
- **RADE never engaged for RX or TX** — `FreeDvService.Active` checked only the
  classic modem; with RADE selected the classic modem is deactivated, so the DSP
  pipeline gate skipped `ProcessRx`/`ProcessTx` entirely. RX passed through as plain
  SSB ("sounds like USB") and TX transmitted SSB instead of RADE. Now checks both.
- **AUTO never tried RADE** — scan order excluded RadeV1 and included two modes the
  panel doesn't expose. Now scans RadeV1 + 700D/700E/1600, RADE first with a longer
  acquisition dwell, and the scan loop drives RADE<->classic routing + reads sync
  from the active decoder.
- **Routing race** — serialised the routing-state mutators with a lock so
  `_radeActive` can't desync from `_rade.Active`.

## Verified live
AUTO cycles RadeV1->700D->700E->1600; classic decode produces audio (SNR squelch
off for weak signals); the RADE RX decoder is finally invoked. TX routes RADEV1 ->
`rade_tx`, classic -> `freedv_tx` at the selected submode.

## Not in this PR / follow-ups
- **On-air RX decode + TX interop** with a real FreeDV-GUI station (needs a live
  signal / bench QSO).
- **Auto-EOO callsign on un-key** — needs a TX-tail (hold MOX past un-key + pump the
  EOO frame), a real subsystem touching the live PTT/MOX path; to be bench-verified
  into a dummy load.
- osx-arm64 / other-RID `zeus_rade` binaries.