### PR TITLE
fix(workspace): latch grid column pitch on a settled width, not the first measurement

### DIFF
--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -282,15 +282,29 @@ function WorkspaceCanvas({
   // so an operator can expand a panel as far as they like and a smaller window
   // simply scrolls to the content instead of squashing or clipping it.
   //
-  // The column pixel pitch is captured ONCE — from the first valid width at the
-  // base 24-column count — and then held constant. RGL derives a column width of
+  // The column pixel pitch is captured ONCE — from a SETTLED width at the base
+  // 24-column count — and then held constant. RGL derives a column width of
   // (containerWidth - margin*(cols-1)) / cols, so we invert that to recover the
   // per-column pitch and feed RGL an exact width for `cols` columns, pinning the
   // rendered column width to baseColWidth with no sub-pixel rescale on resize.
+  //
+  // The latch must wait for the width to STOP changing, not grab the first
+  // non-zero value. During connect/mount the container can report a too-small
+  // intermediate width (notably in the Photino desktop webview) before the flex
+  // pass settles. Freezing on that transient yields a tiny baseColWidth, which
+  // inflates `cols` to fill the real window, which crams every tile (placed in
+  // columns 0..24) into a narrow strip on the left — the "panels stacked on the
+  // left" bug. So debounce: only latch a width that survives a frame without
+  // changing, so a later, larger settled width supersedes an early narrow one.
+  // (While frozenWidth is still 0 the render falls back to baseColWidth=0 →
+  // cols=24 → gridWidth=live width, which already renders correctly; the latch
+  // only fixes the pitch held constant across subsequent window resizes.)
   const [frozenWidth, setFrozenWidth] = useState(0);
   useEffect(() => {
     if (frozenWidth > 0) return;
-    if (mounted && width > 0) setFrozenWidth(width);
+    if (!mounted || !(width > 0)) return;
+    const id = window.setTimeout(() => setFrozenWidth(width), 150);
+    return () => window.clearTimeout(id);
   }, [frozenWidth, mounted, width]);
   const baseColWidth =
     frozenWidth > 0


### PR DESCRIPTION
## Symptom

On startup the workspace panels come up **stacked under each other in a narrow strip on the left**, with the rest of the grid empty — reproducibly, every launch (seen in the Photino desktop app). Resizing the window doesn't fix it.

## Root cause

The fixed-cell workspace (introduced in #828) captures the per-column pixel pitch **once**, from the *first* non-zero container width, and holds it constant for the session — [`FlexWorkspace.tsx`](../blob/develop/zeus-web/src/layout/FlexWorkspace.tsx#L290):

```ts
const [frozenWidth, setFrozenWidth] = useState(0);
useEffect(() => {
  if (frozenWidth > 0) return;            // latches ONCE, never re-evaluated
  if (mounted && width > 0) setFrozenWidth(width);
}, [frozenWidth, mounted, width]);
```

Everything downstream derives from it:

```ts
const baseColWidth = (frozenWidth - margins) / 24;
const cols = max(occupiedCols, floor(liveWidth / baseColWidth));
```

During connect/mount the container can briefly report a too-small intermediate width before the flex pass settles. If the latch grabs that transient (e.g. 380px instead of ~1900px):

1. `baseColWidth` becomes tiny (~14px vs ~78px),
2. `cols` balloons (~110 instead of 24) to fill the real window,
3. tiles live in columns 0–24, so they occupy only the leftmost ~340px and overlap, while ~100 phantom columns sit empty.

Because the latch is captured once and never corrected, every startup reproduces it.

## Fix

Debounce the latch — only freeze a width that survives 150ms without changing, so an early narrow transient is superseded by the later settled width.

- **Fixed-cell invariant preserved:** once latched the pitch stays constant, so growing the window still *adds columns* rather than rescaling panels.
- **No visible delay:** while `frozenWidth` is still 0 the render falls back to `baseColWidth=0 → cols=24 → gridWidth=live width`, which already lays out correctly.
- **Render-only fix:** saved layouts were never corrupted (idle compactor is the identity, render is a straight passthrough of stored geometry), so no layout reset is needed.

## Testing

- `npm run typecheck` — green.
- Runtime: the bug only manifests in the real desktop webview mount transient (headless preview can't render the WebGL panadapter), so this needs a desktop-app launch to confirm panels come up in their saved positions on every start.

Targets `develop`; `main` does not yet carry the fixed-cell rewrite, so the bug doesn't exist there.