### PR TITLE
refactor(web): remove the orphaned Rx2AudioMode from the client (follow-up to #932)

### DIFF
--- a/zeus-web/src/api/client.test.ts
+++ b/zeus-web/src/api/client.test.ts
@@ -87,7 +87,6 @@ import {
   normalizeNbMode,
   normalizeNr,
   normalizeNrMode,
-  normalizeRx2AudioMode,
   normalizeSquelch,
   normalizeState,
   normalizeStatus,
@@ -161,20 +160,6 @@ describe('normalizeMode', () => {
   });
 });
 
-describe('normalizeRx2AudioMode', () => {
-  it('accepts numeric and string enum values', () => {
-    expect(normalizeRx2AudioMode(0)).toBe('both');
-    expect(normalizeRx2AudioMode(1)).toBe('rx1');
-    expect(normalizeRx2AudioMode(2)).toBe('rx2');
-    expect(normalizeRx2AudioMode('Both')).toBe('both');
-    expect(normalizeRx2AudioMode('Rx2')).toBe('rx2');
-  });
-  it('falls back to both on garbage', () => {
-    expect(normalizeRx2AudioMode(42)).toBe('both');
-    expect(normalizeRx2AudioMode('nope')).toBe('both');
-  });
-});
-
 describe('normalizeTxVfo', () => {
   it('accepts numeric and string enum values', () => {
     expect(normalizeTxVfo(0)).toBe('A');
@@ -196,7 +181,6 @@ describe('normalizeState', () => {
       vfoHz: 14_200_000,
       vfoBHz: 14_250_000,
       rx2Enabled: true,
-      rx2AudioMode: 2,
       rx2AfGainDb: -3,
       txVfo: 1,
       mode: 1,
@@ -215,7 +199,6 @@ describe('normalizeState', () => {
     // RX2 (*B) fields no longer surface on RadioStateDto — they live in
     // receivers[1]. The server may still send them; normalizeState ignores them.
     expect(s.rx2Enabled).toBe(true);
-    expect(s.rx2AudioMode).toBe('rx2');
     expect(s.txVfo).toBe('B');
     expect(s.sampleRate).toBe(192_000);
     expect(s.preampOn).toBe(false);
@@ -240,7 +223,6 @@ describe('normalizeState', () => {
     expect(s.endpoint).toBe(null);
     expect(s.vfoHz).toBe(0);
     expect(s.rx2Enabled).toBe(false);
-    expect(s.rx2AudioMode).toBe('both');
     expect(s.txVfo).toBe('A');
     expect(s.mode).toBe('USB');
     expect(s.nr).toEqual(NR_CONFIG_DEFAULT);

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -68,7 +68,6 @@ export type RxMode =
   | 'DIGU'
   | 'FREEDV';
 
-export type Rx2AudioMode = 'both' | 'rx1' | 'rx2';
 export type TxVfo = 'A' | 'B';
 
 export type NrMode = 'Off' | 'Anr' | 'Emnr' | 'Sbnr' | 'Rnnr';
@@ -289,7 +288,6 @@ export type RadioStateDto = {
   // (RX2 = index 1); the client no longer carries the flat *B fields. The server
   // still accepts the legacy A/B write endpoints (setVfoB/setMode?receiver=B/…).
   rx2Enabled: boolean;
-  rx2AudioMode: Rx2AudioMode;
   txVfo: TxVfo;
   // Authoritative TX target as a receiver index (0=RX1/VFO A, 1=RX2/VFO B,
   // >=2 extra DDC). txVfo stays the legacy A/B projection. Optional until a v2
@@ -2040,7 +2038,6 @@ const MODE_ORDER: readonly RxMode[] = [
   'FREEDV',
 ];
 
-const RX2_AUDIO_MODE_ORDER: readonly Rx2AudioMode[] = ['both', 'rx1', 'rx2'];
 const NR_MODE_ORDER: readonly NrMode[] = ['Off', 'Anr', 'Emnr', 'Sbnr', 'Rnnr'];
 const NB_MODE_ORDER: readonly NbMode[] = ['Off', 'Nb1', 'Nb2'];
 
@@ -2077,19 +2074,6 @@ function modeFromWire(v: unknown): RxMode | null {
 
 export function normalizeMode(v: unknown): RxMode {
   return modeFromWire(v) ?? 'USB';
-}
-
-export function normalizeRx2AudioMode(v: unknown): Rx2AudioMode {
-  if (typeof v === 'string') {
-    const lowered = v.toLowerCase();
-    return (RX2_AUDIO_MODE_ORDER as readonly string[]).includes(lowered)
-      ? (lowered as Rx2AudioMode)
-      : 'both';
-  }
-  if (typeof v === 'number' && Number.isInteger(v)) {
-    return RX2_AUDIO_MODE_ORDER[v] ?? 'both';
-  }
-  return 'both';
 }
 
 export function normalizeTxVfo(v: unknown): TxVfo {
@@ -2364,7 +2348,6 @@ export function normalizeState(raw: unknown): RadioStateDto {
     // RX2 (and RX3+) state comes from the receivers[] array below — the flat *B
     // fields the server may still send are ignored.
     rx2Enabled: typeof r.rx2Enabled === 'boolean' ? r.rx2Enabled : false,
-    rx2AudioMode: normalizeRx2AudioMode(r.rx2AudioMode),
     txVfo: normalizeTxVfo(r.txVfo),
     txReceiverIndex:
       typeof r.txReceiverIndex === 'number' ? r.txReceiverIndex : undefined,
@@ -5523,10 +5506,6 @@ export function setVfo(
   );
 }
 
-function rx2AudioModeToWire(mode: Rx2AudioMode): number {
-  return RX2_AUDIO_MODE_ORDER.indexOf(mode);
-}
-
 export function setVfoB(
   hz: number,
   signal?: AbortSignal,
@@ -5564,7 +5543,6 @@ export function setRx2(
   req: {
     enabled?: boolean;
     vfoBHz?: number;
-    audioMode?: Rx2AudioMode;
     afGainDb?: number;
   },
   signal?: AbortSignal,
@@ -5577,10 +5555,6 @@ export function setRx2(
       body: JSON.stringify({
         enabled: req.enabled,
         vfoBHz: req.vfoBHz,
-        audioMode:
-          req.audioMode === undefined
-            ? undefined
-            : rx2AudioModeToWire(req.audioMode),
         afGainDb: req.afGainDb,
       }),
       signal,

--- a/zeus-web/src/components/SmartNrController.test.tsx
+++ b/zeus-web/src/components/SmartNrController.test.tsx
@@ -76,7 +76,6 @@ function mockState(nr: NrConfigDto): RadioStateDto {
     endpoint: conn.endpoint,
     vfoHz: conn.vfoHz,
     rx2Enabled: false,
-    rx2AudioMode: 'both',
     txVfo: 'A',
     mode: conn.mode,
     filterLowHz: conn.filterLowHz,

--- a/zeus-web/src/components/filter/FilterMiniPan.tsx
+++ b/zeus-web/src/components/filter/FilterMiniPan.tsx
@@ -68,7 +68,7 @@ import {
 } from '../../state/receiver-state';
 import { formatCutOffset, formatFilterWidth, nudgeStepHz } from './filterPresets';
 import { MeterGlass } from '../meters/render/MeterGlass';
-import type { Rx2AudioMode, RxMode, TxVfo } from '../../api/client';
+import type { RxMode } from '../../api/client';
 import {
   DB_FLOOR,
   MINI_NOISE_GATE_DB,
@@ -232,14 +232,12 @@ type ActiveMiniPanFilter = {
   filterPresetName: string | null;
 };
 
-function filterMiniPanReceivers(
-  rx2Enabled: boolean,
-  rx2AudioMode: Rx2AudioMode,
-  rxFocus: TxVfo,
-): SpectrumReceiver[] {
-  if (!rx2Enabled) return ['A'];
-  if (rx2AudioMode === 'both') return ['A', 'B'];
-  return [rxFocus];
+function filterMiniPanReceivers(rx2Enabled: boolean): SpectrumReceiver[] {
+  // Filter panes follow which receivers are ENABLED. RX2 audio routing is now
+  // governed solely by per-RX mute (the legacy Rx2AudioMode was retired in
+  // PR #932), so when RX2 is on we show both filter panes — you may be
+  // listening to either, and a muted receiver is still tunable/filterable.
+  return rx2Enabled ? ['A', 'B'] : ['A'];
 }
 
 // All per-receiver reads/writes go through the canonical receivers[] selectors
@@ -1964,9 +1962,7 @@ function FilterMiniPanSurface({
 
 export function FilterMiniPan() {
   const rx2Enabled = useConnectionStore((s) => s.rx2Enabled);
-  const rx2AudioMode = useConnectionStore((s) => s.rx2AudioMode);
-  const rxFocus = useConnectionStore((s) => s.rxFocus);
-  const receivers = filterMiniPanReceivers(rx2Enabled, rx2AudioMode, rxFocus);
+  const receivers = filterMiniPanReceivers(rx2Enabled);
   const split = receivers.length > 1;
 
   return (

--- a/zeus-web/src/state/connection-store.ts
+++ b/zeus-web/src/state/connection-store.ts
@@ -55,7 +55,6 @@ import {
   type ConnectionStatus,
   type NrConfigDto,
   type RadioStateDto,
-  type Rx2AudioMode,
   type RxMode,
   type SquelchConfigDto,
   type TxVfo,
@@ -78,7 +77,6 @@ export type ConnectionState = {
   // RX2+ per-receiver state (VFO/mode/filter/AF) lives in `receivers[]` (RX2 =
   // index 1), not flat *B fields. RX1 keeps its flat primary fields below.
   rx2Enabled: boolean;
-  rx2AudioMode: Rx2AudioMode;
   txVfo: TxVfo;
   // Authoritative TX target as a receiver index (0=RX1, 1=RX2, >=2 extra DDC);
   // txVfo stays the legacy A/B projection. Driven by the VFO panel TX-select.
@@ -210,7 +208,6 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
   endpoint: null,
   vfoHz: 14_200_000,
   rx2Enabled: false,
-  rx2AudioMode: 'both',
   receivers: [],
   maxReceivers: 8,
   txVfo: 'A',
@@ -266,7 +263,6 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
             ? s.vfoHz
             : prev.vfoHz,
         rx2Enabled: s.rx2Enabled,
-        rx2AudioMode: s.rx2AudioMode,
         // Secondary-receiver poll-guard: RX2 (index 1) and RX3+ live in the
         // receivers[] array. While the operator is mid-tune, a 1 Hz /api/state
         // poll generated just before the gesture would rubber-band that


### PR DESCRIPTION
## Why

Follow-up to #932. That PR made **per-receiver mute** the sole RX audio audibility control and retired the legacy `Rx2AudioMode` (Both/RX1/RX2) routing on the backend. #894 had already removed the only UI that wrote `Rx2AudioMode`, so on the client the field was dead weight — the exact "orphaned field left behind after its UI was removed" pattern that *caused* the RX2-silent bug in the first place. This removes it so it can't strand anything again.

## What

Frontend-only, display + wire-plumbing — **no audio-path code touched.**

Removed:
- `Rx2AudioMode` type, `RX2_AUDIO_MODE_ORDER`, `normalizeRx2AudioMode`, `rx2AudioModeToWire` (`client.ts`)
- `rx2AudioMode` from the `RadioStateDto` and its parse in `normalizeState`
- the `setRx2({ audioMode })` parameter + wire body (no caller passed it)
- `rx2AudioMode` field/default/hydration in `connection-store.ts`

Changed the last reader, `FilterMiniPan`:
- It used `Rx2AudioMode` to pick which filter panes to show. Now panes follow which receivers are **enabled** — RX2 on → both panes (you may be listening to either; a muted RX is still tunable/filterable), RX2 off → RX1 only. Matches the post-#932 mute-based model. (Bonus: previously a stale `rx2AudioMode=rx1` could hide the RX2 filter pane; that's gone.)

The server still accepts/sends `Rx2AudioMode` on the wire (unchanged) — the client simply no longer tracks or sends it.

## No audio regression

This PR does not touch any audio-routing, mixing, or playback code (backend DSP or `audio-client.ts`). It only removes a client field that no longer influenced audio after #932 and repoints filter-pane display from that dead field to receiver-enabled state.

## Tests / build

- Frontend `tsc -b && vite build` — clean.
- `client.test.ts` — passes (removed the dead `normalizeRx2AudioMode` describe block + `rx2AudioMode` assertions).
- `SmartNrController.test.tsx` mock updated. Note: this suite fails locally with a pre-existing `root.unmount()` jsdom/env issue **identical on develop's own version** (verified) — CI is the source of truth here.
- Backend untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)