### PR TITLE
fix(rx-audio): debounce zoom POST so multi-RX zoom drags stop clicking

### DIFF
--- a/zeus-web/src/util/use-pan-tune-gesture.test.tsx
+++ b/zeus-web/src/util/use-pan-tune-gesture.test.tsx
@@ -140,6 +140,11 @@ async function flush(): Promise<void> {
   drainRafs();
   await Promise.resolve();
   drainRafs();
+  // Step past the zoom POST debounce (ZOOM_DEBOUNCE_MS = 80) so a settled zoom
+  // gesture fires its single trailing setZoom() within the test's flush window.
+  await vi.advanceTimersByTimeAsync(100);
+  drainRafs();
+  await Promise.resolve();
 }
 
 function drainRafs(maxFrames = 1000): void {
@@ -175,6 +180,10 @@ function rx2Vfo(): number | undefined {
 describe('usePanTuneGesture mobile touch mode', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Fake only the timer functions the zoom debounce uses, so flush() can step
+    // past ZOOM_DEBOUNCE_MS deterministically. requestAnimationFrame stays under
+    // the manual stub below (drainRafs drives it), not the fake clock.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
     viewCenter._resetForTest();
     rafNowMs = 0;
     nextRafHandle = 1;
@@ -253,6 +262,7 @@ describe('usePanTuneGesture mobile touch mode', () => {
       impulseRejectEnabled: true,
     });
     useSignalEnhanceStore.getState().resetSignalEnhanceTuning();
+    vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
@@ -597,6 +607,99 @@ describe('usePanTuneGesture mobile touch mode', () => {
 
     expect(setRadioLoMock).not.toHaveBeenCalled();
     expect(setVfoMock).toHaveBeenCalledWith(14_205_000, undefined);
+
+    unmount();
+  });
+
+  it('debounces a multi-step zoom drag into a single settled setZoom POST', async () => {
+    useConnectionStore.setState({ ctunEnabled: false, zoomLevel: 4 });
+
+    const { container, unmount } = render(createElement(GestureProbe, { touchMode: 'normal' }));
+    const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+
+    // Six rapid zoom-out wheel notches (one nudgeZoom step each) — the
+    // optimistic store update must fire on every step so the panadapter span
+    // tracks the drag, but the server POST is deferred behind the debounce.
+    await act(async () => {
+      for (let k = 0; k < 6; k++) wheel(canvas, { deltaY: 40, shiftKey: true });
+      drainRafs();
+      await Promise.resolve();
+    });
+
+    // Optimistic store stepped all the way down (4 → 3 → … but ZOOM_MIN clamps;
+    // simply assert it moved every step before the trailing flush).
+    const optimisticLevel = useConnectionStore.getState().zoomLevel;
+    expect(setZoomMock).not.toHaveBeenCalled();
+
+    // Trailing debounce fires once with the final settled level only.
+    await act(async () => {
+      await flush();
+    });
+
+    expect(setZoomMock).toHaveBeenCalledTimes(1);
+    expect(setZoomMock).toHaveBeenCalledWith(optimisticLevel, expect.any(AbortSignal));
+
+    unmount();
+  });
+
+  it('force-flushes the settled zoom level when a pinch ends', async () => {
+    useConnectionStore.setState({ ctunEnabled: false, zoomLevel: 4 });
+
+    const { container, unmount } = render(createElement(GestureProbe, { touchMode: 'normal' }));
+    const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+
+    await act(async () => {
+      // Pinch out → optimistic store tracks the spread; POST stays deferred.
+      pointer(canvas, 'pointerdown', { pointerId: 1, clientX: 100, clientY: 0 });
+      pointer(canvas, 'pointerdown', { pointerId: 2, clientX: 140, clientY: 0 });
+      pointer(canvas, 'pointermove', { pointerId: 2, clientX: 180, clientY: 0 });
+      drainRafs();
+      await Promise.resolve();
+    });
+
+    const settledLevel = useConnectionStore.getState().zoomLevel;
+    expect(setZoomMock).not.toHaveBeenCalled();
+
+    // Lifting a finger ends the pinch — the settled level commits immediately,
+    // without waiting out the trailing debounce window.
+    await act(async () => {
+      pointer(canvas, 'pointerup', { pointerId: 2, clientX: 180, clientY: 0 });
+      drainRafs();
+      await Promise.resolve();
+    });
+
+    expect(setZoomMock).toHaveBeenCalledTimes(1);
+    expect(setZoomMock).toHaveBeenCalledWith(settledLevel, expect.any(AbortSignal));
+
+    unmount();
+  });
+
+  it('supersedes an in-flight zoom POST when a newer settled level arrives', async () => {
+    useConnectionStore.setState({ ctunEnabled: false, zoomLevel: 4 });
+
+    const { container, unmount } = render(createElement(GestureProbe, { touchMode: 'normal' }));
+    const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+
+    // First zoom gesture settles and posts.
+    await act(async () => {
+      wheel(canvas, { deltaY: 40, shiftKey: true });
+      await flush();
+    });
+    expect(setZoomMock).toHaveBeenCalledTimes(1);
+    const firstSignal = setZoomMock.mock.calls[0]![1] as AbortSignal;
+    expect(firstSignal.aborted).toBe(false);
+
+    // A second gesture in the opposite direction settles to a new level — its
+    // flush aborts the prior in-flight request before posting the latest.
+    await act(async () => {
+      wheel(canvas, { deltaY: -40, shiftKey: true });
+      await flush();
+    });
+
+    expect(setZoomMock).toHaveBeenCalledTimes(2);
+    expect(firstSignal.aborted).toBe(true);
+    const finalLevel = useConnectionStore.getState().zoomLevel;
+    expect(setZoomMock).toHaveBeenLastCalledWith(finalLevel, expect.any(AbortSignal));
 
     unmount();
   });

--- a/zeus-web/src/util/use-pan-tune-gesture.ts
+++ b/zeus-web/src/util/use-pan-tune-gesture.ts
@@ -406,6 +406,19 @@ export function usePanTuneGesture(
     // notch on a mouse wheel should be one tune/zoom step, not three.
     let wheelAccum = 0;
     let zoomInflight: AbortController | null = null;
+    // Zoom POST debounce: the optimistic store update (setZoomLevel) fires on
+    // every step so the panadapter span tracks the drag in real time, but the
+    // actual setZoom() POST is deferred behind a short trailing timer that only
+    // commits the final settled level. A single zoom drag fires nudgeZoom many
+    // times across N receivers; without this each step held state.AnalyzerLock
+    // across a native SetAnalyzer rebuild on the HTTP thread while the audio
+    // Tick blocked on the same lock — one stalled tick underran the ring and
+    // clicked. One settled POST per drag = one rebuild, so the Tick almost
+    // never collides with a lock-held reallocation.
+    const ZOOM_DEBOUNCE_MS = 80;
+    let zoomDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+    let pendingZoomLevel: ZoomLevel | null = null;
+    let pendingZoomFromLevel: number | null = null;
 
     // The commanded-frequency chain: pendingHz when a POST is queued, else
     // the optimistic store value. All view-center nudges are DELTAS against
@@ -569,19 +582,27 @@ export function usePanTuneGesture(
       scheduleFlush();
     };
 
-    const nudgeZoom = (delta: number) => {
-      if (delta === 0) return;
-      const state = useConnectionStore.getState();
-      const cur = state.zoomLevel;
-      const next = clampZoom(cur + delta);
-      if (next === cur) return;
-      useConnectionStore.getState().setZoomLevel(next);
+    // Commit the latest settled zoom level to the server. CTUN recentre spans
+    // the whole drag — from the level when this debounce window opened
+    // (pendingZoomFromLevel) to the settled level — so a multi-step zoom-in
+    // recenters once, on the net change, not per intermediate step.
+    const flushZoom = () => {
+      if (zoomDebounceTimer !== null) {
+        clearTimeout(zoomDebounceTimer);
+        zoomDebounceTimer = null;
+      }
+      const next = pendingZoomLevel;
+      const from = pendingZoomFromLevel;
+      pendingZoomLevel = null;
+      pendingZoomFromLevel = null;
+      if (next == null || from == null) return;
+      if (next === from) return;
       zoomInflight?.abort();
       const ctrl = new AbortController();
       zoomInflight = ctrl;
       const centeredLoHz =
         rxIndexOf(receiver) === 0 && rxIndexOf(tuneReceiver) === 0
-          ? centerCtunForZoomIn(cur, next, ctrl.signal)
+          ? centerCtunForZoomIn(from, next, ctrl.signal)
           : null;
       setZoom(next, ctrl.signal)
         .then((s) => {
@@ -591,6 +612,23 @@ export function usePanTuneGesture(
           }
         })
         .catch(() => {});
+    };
+
+    const nudgeZoom = (delta: number) => {
+      if (delta === 0) return;
+      const state = useConnectionStore.getState();
+      const cur = state.zoomLevel;
+      const next = clampZoom(cur + delta);
+      if (next === cur) return;
+      // Optimistic store update fires every step — the panadapter span tracks
+      // the drag immediately. The server POST is deferred to flushZoom.
+      useConnectionStore.getState().setZoomLevel(next);
+      // Capture the from-level when the debounce window first opens so the CTUN
+      // recentre and the "did anything change" guard span the whole gesture.
+      if (pendingZoomFromLevel === null) pendingZoomFromLevel = cur;
+      pendingZoomLevel = next;
+      if (zoomDebounceTimer !== null) clearTimeout(zoomDebounceTimer);
+      zoomDebounceTimer = setTimeout(flushZoom, ZOOM_DEBOUNCE_MS);
     };
 
     const onPointerDown = (e: PointerEvent) => {
@@ -791,6 +829,9 @@ export function usePanTuneGesture(
           cancelPinchRaf();
           pinch = null;
           canvas.style.cursor = idleCursor();
+          // Settle the final pinch level immediately rather than waiting out
+          // the trailing debounce after the fingers lift.
+          flushZoom();
         }
         return;
       }
@@ -906,6 +947,7 @@ export function usePanTuneGesture(
       if (pendingRaf !== 0) cancelAnimationFrame(pendingRaf);
       if (pendingPanRaf !== 0) cancelAnimationFrame(pendingPanRaf);
       cancelPinchRaf();
+      if (zoomDebounceTimer !== null) clearTimeout(zoomDebounceTimer);
       pendingAbort?.abort();
       pendingPanAbort?.abort();
       zoomInflight?.abort();


### PR DESCRIPTION
## What

Under multiple receivers, dragging the panadapter **zoom** produced intermittent RX audio **clicks**. This fixes the zoom source with a client-side debounce. Two *other* click sources (AF-gain slider, AGC-T slider) were also found and confirmed but are **deferred** — see the linked issue.

## Root cause (zoom) — confirmed against source + live telemetry

It's lock contention, not the DSP:

- `SetZoom` holds the per-channel `AnalyzerLock` on the HTTP/state thread while running a heavy native `SetAnalyzer` rebuild (`WdspDspEngine.cs:883`).
- The audio-producing pipeline **tick** blocks on that **same** `AnalyzerLock` inside `GetPixels` (`WdspDspEngine.cs:1568`), *before* it refills the native output ring (`DspPipelineService.cs:5619`).
- One zoom drag fired **~6 POSTs**, fanned across **every active receiver** → the tick stalled repeatedly → the native ring (running ~24–90 ms of headroom against a 33 ms tick) **underran → click**.

**Live proof:** with 3 RX, `GET /api/audio/native` showed `underrunSamplesTotal` and `rebufferEvents` (1→3) climbing **only during zoom drags**. (The AF/AGC-T clicks showed `under/s = 0` — gain-step discontinuities, not buffer events. Multi-RX mixing was cleared: `overrunSamplesTotal = 0`, #787 clock-master invariant correctly generalized.)

## Fix — pure client dispatch cadence (no DSP/feel/latency change)

`nudgeZoom` keeps firing the optimistic `setZoomLevel` store update every step (panadapter span still tracks the drag in real time), but defers the actual `setZoom()` POST behind an **80 ms trailing debounce** committing only the final settled level. One drag → **one `SetAnalyzer` rebuild per channel** instead of ~6, so the audio tick almost never collides with a lock-held native reallocation.

- CTUN recentre spans the gesture's net `from→to` level
- pinch-end / wheel-idle force-flush the latest level
- a newer settled level aborts the in-flight request

Steady-state behaviour is unchanged (no AGC/AF/ring/latency/prebuffer touched). Cross-platform safe (pure TypeScript).

## Tests

3 new vitest cases in `use-pan-tune-gesture.test.tsx`: multi-step drag → single settled POST; pinch-end force-flush; supersede-in-flight on a newer level. Full file passes (29/29).

## Gates
- `dotnet build Zeus.slnx` ✅ &nbsp; `npm --prefix zeus-web run build` ✅ (tsc clean)
- `Zeus.Dsp.Tests` 178 ✅ &nbsp; `Zeus.Server.Tests` 1745 ✅
- The ~17 local-vitest fails are the known `localStorage` env quirk (pre-existing, pass in CI).

## Why draft
Zoom fix is the only confirmed ring-underrun and is steady-state-safe, but bench-confirm on the **G2 with 3 RX** that a zoom drag is now click-free and the 80 ms debounce doesn't make zoom feel laggy.

## Deferred (separate, RED-LIGHT)
AF-gain and AGC-T de-step ramps — feel-sensitive (gain feel / AGC curve), ramp durations need tuning by ear, AGC-T interacts with Auto-AGC-T. To be coded live at the G2. Tracking issue linked below.