### PR TITLE
feat(freedv): open FreeDV controls as a popup on mode select

### DIFF
--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -50,8 +50,8 @@ import { FlexWorkspace } from './layout/FlexWorkspace';
 import { WorkspaceErrorBoundary } from './layout/WorkspaceErrorBoundary';
 import { AppErrorBoundary } from './layout/AppErrorBoundary';
 import { currentDetachedWorkspaceLayoutId } from './layout/workspace-windows';
-import { placeTileInPage } from './layout/workspace';
 import { ConfirmDialog } from './layout/ConfirmDialog';
+import { FreeDvWindow } from './components/FreeDvWindow';
 import { AfGainSlider } from './components/AfGainSlider';
 import { AgcSlider } from './components/AgcSlider';
 import { SquelchSlider } from './components/SquelchSlider';
@@ -99,6 +99,7 @@ import { useMicUplink } from './audio/use-mic-uplink';
 import { fetchState, fetchUpdateStatus, type RepoUpdateStatus } from './api/client';
 import { useConnectionStore } from './state/connection-store';
 import { getReceiverMode } from './state/receiver-state';
+import { useFreeDvWindowStore } from './state/freedv-window-store';
 import { useRadioStore } from './state/radio-store';
 import { useQrzStore } from './state/qrz-store';
 import { useRotatorStore } from './state/rotator-store';
@@ -361,22 +362,21 @@ export default function App() {
     });
   }, []);
 
-  // Selecting FreeDV mode surfaces the FreeDV panel (submode / SYNC / SNR /
+  // Selecting FreeDV mode pops the FreeDV window open (submode / SYNC / SNR /
   // TX-text sidechannel) so the operator gets immediate feedback and the modem
   // controls — without it the mode runs USB underneath with no visible change,
-  // which reads as "nothing happened". Fires on the transition into FreeDV on
-  // either VFO and is idempotent: it won't add a second tile if the panel is
-  // already in the active layout, and it won't re-add a tile the operator
-  // removed unless they switch away from FreeDV and back. We only place it when
-  // it fits the CURRENT page — never spill onto a freshly-minted page and yank
-  // the operator's console out from under them. On a full page the panel stays
-  // a manual Add-Panel action.
+  // which reads as "nothing happened". It comes up as a draggable popup overlay
+  // rather than a docked workspace tile, so engaging FreeDV never rearranges the
+  // operator's console. Fires only on the false→true edge into FreeDV on either
+  // VFO (tracked via a ref) so closing the window while still in FreeDV doesn't
+  // immediately reopen it.
+  const wasInFreeDv = useRef(false);
   useEffect(() => {
-    if (mode !== 'FREEDV' && modeB !== 'FREEDV') return;
-    const ls = useLayoutStore.getState();
-    if (ls.workspace.tiles.some((t) => t.panelId === 'freedv')) return;
-    const fits = placeTileInPage('freedv', ls.workspace.tiles, ls.viewportCols, ls.viewportRows);
-    if (fits) ls.addTile('freedv');
+    const inFreeDv = mode === 'FREEDV' || modeB === 'FREEDV';
+    if (inFreeDv && !wasInFreeDv.current) {
+      useFreeDvWindowStore.getState().open();
+    }
+    wasInFreeDv.current = inFreeDv;
   }, [mode, modeB]);
 
   useEffect(() => {
@@ -912,6 +912,7 @@ export default function App() {
           </WorkspaceErrorBoundary>
         </div>
         {disconnectedOverlay}
+        <FreeDvWindow />
       </div>
       </SpectrumWheelActionsContext.Provider>
       </WorkspaceContext.Provider>
@@ -1101,6 +1102,12 @@ export default function App() {
           state in the store is the single source of truth. */}
       <AudioSuiteWindow route="tx" />
       <AudioSuiteWindow route="rx" />
+
+      {/* FreeDV modem popup — floating overlay that opens when the operator
+          selects FreeDV mode (see the mode-transition effect above). Mounted
+          unconditionally; renders null when closed, so the store's isOpen flag
+          is the single source of truth. */}
+      <FreeDvWindow />
 
       {/* Transport — MOX/TUN + audio + mic + macro buttons on the left,
           PA/PRE chips, then the per-radio status (radio IP, rotator, QRZ)

--- a/zeus-web/src/components/FreeDvWindow.tsx
+++ b/zeus-web/src/components/FreeDvWindow.tsx
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// FreeDvWindow — draggable, resizable floating popup that hosts the FreeDV
+// modem controls (the FreeDvPanel body). Selecting FreeDV mode pops this open
+// (see App.tsx) instead of injecting a workspace tile, so the operator gets the
+// submode / SYNC / SNR / TX-text sidechannel as an overlay they can drag aside
+// rather than something that rearranges their console.
+//
+// Drag + resize use Pointer Events with capture, mirroring AudioSuiteWindow.
+// All chrome is in Zeus tokens — no raw hex per docs/lessons/dev-conventions.md.
+
+import { useCallback, useEffect, useRef } from 'react';
+import { FreeDvPanel } from '../layout/panels/FreeDvPanel';
+import {
+  FREEDV_WINDOW_MIN_WIDTH,
+  FREEDV_WINDOW_MIN_HEIGHT,
+  useFreeDvWindowStore,
+} from '../state/freedv-window-store';
+
+/** Edge codes for the resize handles — 4 edges + 4 corners. */
+type ResizeEdge = 'n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw';
+const RESIZE_EDGES: ResizeEdge[] = ['n', 's', 'e', 'w', 'ne', 'nw', 'se', 'sw'];
+const RESIZE_HANDLE_PX = 6;
+
+const CURSOR_FOR_EDGE: Record<ResizeEdge, string> = {
+  n: 'ns-resize',
+  s: 'ns-resize',
+  e: 'ew-resize',
+  w: 'ew-resize',
+  ne: 'nesw-resize',
+  sw: 'nesw-resize',
+  nw: 'nwse-resize',
+  se: 'nwse-resize',
+};
+
+function handleStyleFor(edge: ResizeEdge): React.CSSProperties {
+  const base: React.CSSProperties = {
+    position: 'absolute',
+    zIndex: 1,
+    cursor: CURSOR_FOR_EDGE[edge],
+    touchAction: 'none',
+  };
+  const cornerBorder = '1px solid var(--fg-3)';
+  switch (edge) {
+    case 'n':  return { ...base, top: 0, left: RESIZE_HANDLE_PX, right: RESIZE_HANDLE_PX, height: RESIZE_HANDLE_PX };
+    case 's':  return { ...base, bottom: 0, left: RESIZE_HANDLE_PX, right: RESIZE_HANDLE_PX, height: RESIZE_HANDLE_PX };
+    case 'e':  return { ...base, top: RESIZE_HANDLE_PX, bottom: RESIZE_HANDLE_PX, right: 0, width: RESIZE_HANDLE_PX };
+    case 'w':  return { ...base, top: RESIZE_HANDLE_PX, bottom: RESIZE_HANDLE_PX, left: 0, width: RESIZE_HANDLE_PX };
+    case 'ne': return { ...base, top: 0, right: 0, width: RESIZE_HANDLE_PX, height: RESIZE_HANDLE_PX,
+                        borderTop: cornerBorder, borderRight: cornerBorder, opacity: 0.6 };
+    case 'nw': return { ...base, top: 0, left: 0, width: RESIZE_HANDLE_PX, height: RESIZE_HANDLE_PX,
+                        borderTop: cornerBorder, borderLeft: cornerBorder, opacity: 0.6 };
+    case 'se': return { ...base, bottom: 0, right: 0, width: RESIZE_HANDLE_PX, height: RESIZE_HANDLE_PX,
+                        borderBottom: cornerBorder, borderRight: cornerBorder, opacity: 0.6 };
+    case 'sw': return { ...base, bottom: 0, left: 0, width: RESIZE_HANDLE_PX, height: RESIZE_HANDLE_PX,
+                        borderBottom: cornerBorder, borderLeft: cornerBorder, opacity: 0.6 };
+  }
+}
+
+function ResizeHandle({ edge }: { edge: ResizeEdge }) {
+  const x = useFreeDvWindowStore((s) => s.x);
+  const y = useFreeDvWindowStore((s) => s.y);
+  const width = useFreeDvWindowStore((s) => s.width);
+  const height = useFreeDvWindowStore((s) => s.height);
+  const setPosition = useFreeDvWindowStore((s) => s.setPosition);
+  const setSize = useFreeDvWindowStore((s) => s.setSize);
+
+  const dragRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    origX: number;
+    origY: number;
+    origW: number;
+    origH: number;
+  } | null>(null);
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      e.stopPropagation();
+      e.preventDefault();
+      e.currentTarget.setPointerCapture(e.pointerId);
+      dragRef.current = {
+        pointerId: e.pointerId,
+        startX: e.clientX,
+        startY: e.clientY,
+        origX: x, origY: y,
+        origW: width, origH: height,
+      };
+    },
+    [x, y, width, height],
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const d = dragRef.current;
+      if (!d || d.pointerId !== e.pointerId) return;
+      const dx = e.clientX - d.startX;
+      const dy = e.clientY - d.startY;
+      let nX = d.origX;
+      let nY = d.origY;
+      let nW = d.origW;
+      let nH = d.origH;
+      if (edge.includes('e')) nW = d.origW + dx;
+      if (edge.includes('s')) nH = d.origH + dy;
+      if (edge.includes('w')) { nX = d.origX + dx; nW = d.origW - dx; }
+      if (edge.includes('n')) { nY = d.origY + dy; nH = d.origH - dy; }
+
+      if (nW < FREEDV_WINDOW_MIN_WIDTH) {
+        if (edge.includes('w')) nX = d.origX + d.origW - FREEDV_WINDOW_MIN_WIDTH;
+        nW = FREEDV_WINDOW_MIN_WIDTH;
+      }
+      if (nH < FREEDV_WINDOW_MIN_HEIGHT) {
+        if (edge.includes('n')) nY = d.origY + d.origH - FREEDV_WINDOW_MIN_HEIGHT;
+        nH = FREEDV_WINDOW_MIN_HEIGHT;
+      }
+
+      setPosition(nX, nY);
+      setSize(nW, nH);
+    },
+    [edge, setPosition, setSize],
+  );
+
+  const onPointerUp = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const d = dragRef.current;
+      if (!d || d.pointerId !== e.pointerId) return;
+      try { e.currentTarget.releasePointerCapture(e.pointerId); } catch { /* best-effort */ }
+      dragRef.current = null;
+    },
+    [],
+  );
+
+  return (
+    <div
+      data-no-drag
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerUp}
+      style={handleStyleFor(edge)}
+    />
+  );
+}
+
+export function FreeDvWindow() {
+  const isOpen = useFreeDvWindowStore((s) => s.isOpen);
+  const close = useFreeDvWindowStore((s) => s.close);
+  const x = useFreeDvWindowStore((s) => s.x);
+  const y = useFreeDvWindowStore((s) => s.y);
+  const width = useFreeDvWindowStore((s) => s.width);
+  const height = useFreeDvWindowStore((s) => s.height);
+  const setPosition = useFreeDvWindowStore((s) => s.setPosition);
+
+  // Escape closes the popup — standard modal/popup keyboard affordance.
+  // Attached only while open so it doesn't fight other Escape handlers.
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [isOpen, close]);
+
+  // Viewport-resize clamp — keep the window grabbable if the browser shrinks.
+  useEffect(() => {
+    if (!isOpen) return;
+    const onResize = () => {
+      const minX = -width + 80;
+      const minY = 64;
+      const maxX = window.innerWidth - 80;
+      const maxY = window.innerHeight - 40;
+      const nextX = Math.min(maxX, Math.max(minX, x));
+      const nextY = Math.min(maxY, Math.max(minY, y));
+      if (nextX !== x || nextY !== y) setPosition(nextX, nextY);
+    };
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, [isOpen, x, y, width, setPosition]);
+
+  // --- Window dragging via Pointer Events --------------------------
+  const dragStateRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    offsetX: number;
+    offsetY: number;
+  } | null>(null);
+
+  const onHeaderPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const target = e.target as HTMLElement;
+      if (target.closest('[data-no-drag]')) return;
+      e.currentTarget.setPointerCapture(e.pointerId);
+      dragStateRef.current = {
+        pointerId: e.pointerId,
+        startX: e.clientX,
+        startY: e.clientY,
+        offsetX: x,
+        offsetY: y,
+      };
+    },
+    [x, y],
+  );
+
+  const onHeaderPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const ds = dragStateRef.current;
+      if (!ds || ds.pointerId !== e.pointerId) return;
+      const dx = e.clientX - ds.startX;
+      const dy = e.clientY - ds.startY;
+      const minX = -width + 80;
+      const minY = 64;
+      const maxX = window.innerWidth - 80;
+      const maxY = window.innerHeight - 40;
+      const nextX = Math.min(maxX, Math.max(minX, ds.offsetX + dx));
+      const nextY = Math.min(maxY, Math.max(minY, ds.offsetY + dy));
+      setPosition(nextX, nextY);
+    },
+    [width, setPosition],
+  );
+
+  const onHeaderPointerUp = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const ds = dragStateRef.current;
+      if (!ds || ds.pointerId !== e.pointerId) return;
+      try { e.currentTarget.releasePointerCapture(e.pointerId); } catch { /* best-effort */ }
+      dragStateRef.current = null;
+    },
+    [],
+  );
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-label="FreeDV"
+      style={{
+        position: 'fixed',
+        left: x,
+        // Render-time clamp so a stale persisted y can't ship under the topbar.
+        top: Math.max(64, y),
+        width,
+        height,
+        // Above the Zeus topbar (zIndex 300), below modal dialogs (10000).
+        zIndex: 420,
+        display: 'flex',
+        flexDirection: 'column',
+        background: 'linear-gradient(180deg, var(--panel-top), var(--panel-bot))',
+        border: '1px solid var(--line)',
+        borderRadius: 8,
+        boxShadow: '0 12px 32px rgba(0, 0, 0, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.04)',
+        color: 'var(--fg-0)',
+        fontFamily: 'var(--font-sans, Inter, system-ui, sans-serif)',
+        overflow: 'hidden',
+      }}
+    >
+      {RESIZE_EDGES.map((e) => <ResizeHandle key={e} edge={e} />)}
+
+      {/* Header — drag handle + close. */}
+      <div
+        onPointerDown={onHeaderPointerDown}
+        onPointerMove={onHeaderPointerMove}
+        onPointerUp={onHeaderPointerUp}
+        onPointerCancel={onHeaderPointerUp}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          padding: '8px 12px',
+          background: 'linear-gradient(180deg, var(--panel-top), var(--panel-bot))',
+          borderBottom: '1px solid var(--line)',
+          cursor: 'grab',
+          userSelect: 'none',
+        }}
+      >
+        <span
+          style={{
+            color: 'var(--fg-1)',
+            fontSize: 12,
+            fontWeight: 600,
+            letterSpacing: 1.4,
+            textTransform: 'uppercase',
+          }}
+        >
+          FreeDV
+        </span>
+        <button
+          type="button"
+          data-no-drag
+          onClick={close}
+          aria-label="Close FreeDV window"
+          title="Close"
+          style={{
+            marginLeft: 'auto',
+            padding: '2px 10px',
+            borderRadius: 4,
+            border: '1px solid var(--line)',
+            background: 'var(--bg-2)',
+            color: 'var(--fg-2)',
+            cursor: 'pointer',
+            fontSize: 14,
+            fontWeight: 600,
+            fontFamily: 'inherit',
+            lineHeight: 1,
+          }}
+        >
+          ×
+        </button>
+      </div>
+
+      {/* Body — the FreeDV modem controls. FreeDvPanel already manages its own
+          scrolling (overflowY:auto on the .dsp-cfg root); the flex:1 min-height:0
+          wrapper gives it a bounded height to scroll within. */}
+      <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+        <FreeDvPanel />
+      </div>
+    </div>
+  );
+}

--- a/zeus-web/src/state/freedv-window-store.ts
+++ b/zeus-web/src/state/freedv-window-store.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// freedv-window-store — open/close + position state for the floating FreeDV
+// popup window. Selecting FreeDV mode pops this window open (see App.tsx);
+// it carries the same FreeDvPanel body the workspace tile used to, but as a
+// draggable overlay instead of a docked panel. Position is persisted to
+// localStorage so the window reopens where the operator last left it.
+
+import { create } from 'zustand';
+
+export const FREEDV_WINDOW_MIN_WIDTH = 300;
+export const FREEDV_WINDOW_MIN_HEIGHT = 360;
+const DEFAULT_WIDTH = 340;
+const DEFAULT_HEIGHT = 520;
+
+const POS_KEY = 'zeus.freedvWindow.pos';
+
+function loadPos(): { x: number; y: number; width: number; height: number } {
+  // Default near the top-right so the popup doesn't cover the panadapter.
+  const fallback = {
+    x: typeof window !== 'undefined' ? Math.max(80, window.innerWidth - DEFAULT_WIDTH - 40) : 120,
+    y: 96,
+    width: DEFAULT_WIDTH,
+    height: DEFAULT_HEIGHT,
+  };
+  try {
+    const raw = localStorage.getItem(POS_KEY);
+    if (!raw) return fallback;
+    const parsed = JSON.parse(raw) as Partial<typeof fallback>;
+    return {
+      x: typeof parsed.x === 'number' ? parsed.x : fallback.x,
+      y: typeof parsed.y === 'number' ? parsed.y : fallback.y,
+      width: typeof parsed.width === 'number' ? parsed.width : fallback.width,
+      height: typeof parsed.height === 'number' ? parsed.height : fallback.height,
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+function savePos(pos: { x: number; y: number; width: number; height: number }) {
+  try {
+    localStorage.setItem(POS_KEY, JSON.stringify(pos));
+  } catch {
+    /* private-mode / quota — position just isn't persisted */
+  }
+}
+
+interface FreeDvWindowState {
+  isOpen: boolean;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+  setPosition: (x: number, y: number) => void;
+  setSize: (width: number, height: number) => void;
+}
+
+export const useFreeDvWindowStore = create<FreeDvWindowState>((set, get) => {
+  const initial = loadPos();
+  return {
+    isOpen: false,
+    x: initial.x,
+    y: initial.y,
+    width: initial.width,
+    height: initial.height,
+    open: () => set({ isOpen: true }),
+    close: () => set({ isOpen: false }),
+    toggle: () => set({ isOpen: !get().isOpen }),
+    setPosition: (x, y) => {
+      set({ x, y });
+      const s = get();
+      savePos({ x, y, width: s.width, height: s.height });
+    },
+    setSize: (width, height) => {
+      const w = Math.max(FREEDV_WINDOW_MIN_WIDTH, width);
+      const h = Math.max(FREEDV_WINDOW_MIN_HEIGHT, height);
+      set({ width: w, height: h });
+      const s = get();
+      savePos({ x: s.x, y: s.y, width: w, height: h });
+    },
+  };
+});


### PR DESCRIPTION
## What

Selecting **FreeDV** mode now opens the FreeDV modem controls as a draggable, resizable **floating popup window** instead of injecting a docked workspace tile.

Previously, picking FreeDV auto-added a `freedv` panel tile to the active layout (`addTile('freedv')`), which rearranged the operator's console. Now it pops a self-contained overlay carrying the same `FreeDvPanel` body (submode / SYNC / SNR / SNR-squelch / RX+TX text sidechannel).

## Behavior

- Opens on the **false→true edge** into FreeDV on either VFO (tracked via a ref) — so closing the window while still in FreeDV doesn't immediately reopen it; switching away and back does.
- **Drag** by the header, **resize** from any edge/corner (8 handles), **Escape** or the **×** button closes it.
- Window position/size **persist to `localStorage`** so it reopens where the operator left it.
- Mounted in both the main console and the detached-workspace tree.

## Files

- `zeus-web/src/state/freedv-window-store.ts` (new) — Zustand store: `isOpen` + persisted geometry, `open`/`close`/`toggle`/`setPosition`/`setSize`.
- `zeus-web/src/components/FreeDvWindow.tsx` (new) — `position:fixed` overlay (zIndex 420: above the topbar, below modals) reusing the existing `FreeDvPanel`. Pointer-event drag + resize mirror the proven `AudioSuiteWindow` pattern. Chrome uses only Zeus tokens — no raw hex.
- `zeus-web/src/App.tsx` — the mode-transition effect now opens the popup instead of `addTile('freedv')`; `<FreeDvWindow />` mounted in the main + detached trees; removed the now-unused `placeTileInPage` import.

The `freedv` entry stays in the panel registry, so existing saved layouts that reference a docked FreeDV tile still resolve and it remains addable via Add Panel — only the auto-on-mode-select behavior changed to a popup.

## Verification

Vite dev (desktop 1440×900), via DOM inspection:
- Selecting FreeDV → popup renders (`position:fixed`, `zIndex:420`, 340×520, top-right) with the panel body + close button.
- **No** docked `freedv` workspace tile is added (old behavior removed).
- Close button dismisses it; USB→FreeDV reopens; closing while staying in FreeDV does **not** reopen.
- No console errors. Changed files typecheck (`tsc -b`) and lint (`eslint`) clean.

## Notes

This touches UX (how engaging FreeDV behaves) — normally maintainer-review territory; flagging for the record.