### PR TITLE
feat(multi-rx): per-receiver waterfall dB scale + floor normalization, MULTI RX UX

### DIFF
--- a/zeus-web/src/components/ReceiversPanel.tsx
+++ b/zeus-web/src/components/ReceiversPanel.tsx
@@ -18,6 +18,10 @@
 
 import { setReceiver } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import {
+  PRACTICAL_MAX_RECEIVERS,
+  setExposedReceiverCount,
+} from '../state/receiver-state';
 
 function formatMhz(hz: number): string {
   return `${(hz / 1_000_000).toFixed(6)} MHz`;
@@ -33,35 +37,26 @@ export function ReceiversPanel() {
   const connected = status === 'Connected';
   const isP2 = connectedProtocol === 'P2';
 
+  // Effective ceiling = whatever the build/wire allows, clamped to the count
+  // that actually streams on hardware (see PRACTICAL_MAX_RECEIVERS).
+  const effectiveMax = Math.min(maxReceivers, PRACTICAL_MAX_RECEIVERS);
+
   // Number of contiguous active receivers (RX1 always counts).
   const exposedCount = Math.max(1, receivers.filter((r) => r.enabled).length);
 
-  // Set the exposed receiver count by composing the per-index endpoint. Server
-  // contiguity does the cascade: enabling index target-1 turns on RX2..target-1;
-  // disabling index target turns off everything above it.
+  // Set the exposed receiver count via the shared action (composes the per-index
+  // endpoint; the server contiguity cascade does the rest).
   function setExposedCount(target: number): void {
-    const n = Math.min(Math.max(target, 1), maxReceivers);
+    const n = Math.min(Math.max(target, 1), effectiveMax);
     if (n === exposedCount) return;
-    if (n <= 1) {
-      setReceiver(1, { enabled: false }).then(applyState).catch(() => {});
-      return;
-    }
-    setReceiver(n - 1, { enabled: true })
-      .then((s) => {
-        applyState(s);
-        if (n < maxReceivers) {
-          return setReceiver(n, { enabled: false }).then(applyState);
-        }
-        return undefined;
-      })
-      .catch(() => {});
+    setExposedReceiverCount(n);
   }
 
   function setAdc(index: number, adcSource: number): void {
     setReceiver(index, { adcSource }).then(applyState).catch(() => {});
   }
 
-  const countOptions = Array.from({ length: maxReceivers }, (_, i) => i + 1);
+  const countOptions = Array.from({ length: effectiveMax }, (_, i) => i + 1);
 
   return (
     <div className="ps-shell">
@@ -99,7 +94,7 @@ export function ReceiversPanel() {
                 <em>
                   How many hardware DDC receivers to run concurrently. RX1..RXN
                   are activated together (contiguous DDC run); each tunes to its
-                  own VFO. Up to {maxReceivers}.
+                  own VFO. Up to {effectiveMax}.
                 </em>
               </div>
               <div className="btn-row wrap" role="group" aria-label="Exposed receiver count">
@@ -113,6 +108,23 @@ export function ReceiversPanel() {
                     {n}
                   </button>
                 ))}
+              </div>
+            </div>
+
+            <div className="ps-field">
+              <div className="ps-name">
+                ADC source
+                <em>
+                  Each receiver reads from one of the radio's two ADCs.{' '}
+                  <strong>ADC 0</strong> is your main receive antenna (the same
+                  one RX1 uses) — leave receivers here unless you have a reason
+                  not to. <strong>ADC 1</strong> is the separate RX2/EXT antenna
+                  jack on the back of the radio; only move a receiver to ADC 1 if
+                  you actually have a second antenna wired to that jack, otherwise
+                  that receiver will be silent (it'll be listening to a dead
+                  input). There's no performance gain from spreading receivers
+                  across ADCs — many DDCs share one ADC with no penalty.
+                </em>
               </div>
             </div>
 

--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -58,6 +58,8 @@ import {
 } from '../dsp/signal-estimator';
 import { normalizeStitchedBins, stitchFloorShiftDb } from '../dsp/stitch-normalizer';
 import { getReceiverVfoHz, rxIndexOf, type ReceiverKey } from '../state/receiver-state';
+import { estimateRowFloorDb, reportReceiverFloorDb } from '../dsp/floor-normalization';
+import { effectiveRxWfWindow, useRxDbWindowStore } from '../state/rx-db-window-store';
 import * as viewCenter from '../state/view-center';
 import * as viewZoom from '../state/view-zoom';
 import { useTxStore } from '../state/tx-store';
@@ -247,7 +249,7 @@ export function Waterfall({
 
     const redraw = () => {
       if (contextLost || !renderer) return;
-      const { wfDbMin, wfDbMax, wfTxDbMin, wfTxDbMax, waterfallScrollSpeed } =
+      const { wfTxDbMin, wfTxDbMax, waterfallScrollSpeed } =
         useDisplaySettingsStore.getState();
       const { moxOn, tunOn } = useTxStore.getState();
       const keyed = moxOn || tunOn;
@@ -264,10 +266,15 @@ export function Waterfall({
         renderer.setScrollSpeed(waterfallScrollSpeed);
         lastScrollSpeed = waterfallScrollSpeed;
       }
-      // Mirror DbScale.tsx — keyed (MOX/TUN) renders the TX waterfall
-      // window so the operator's RX noise-floor view stays put.
-      const dbMin = popOn ? 0 : keyed ? wfTxDbMin : wfDbMin;
-      const dbMax = popOn ? 1 : keyed ? wfTxDbMax : wfDbMax;
+      // Mirror DbScale.tsx — keyed (MOX/TUN) renders the TX waterfall window so
+      // the operator's RX noise-floor view stays put.
+      // Per-receiver RX window: RX1 uses the global window; every other receiver
+      // uses its own — an operator override (set by focusing it and dragging the
+      // WfDbScale), or the global window floor-normalized to RX1 so noise floors
+      // line up out of the box. Keyed/POP domains are absolute, never per-RX.
+      const rxWin = popOn || keyed ? null : effectiveRxWfWindow(rxIndex);
+      const dbMin = popOn ? 0 : keyed ? wfTxDbMin : rxWin!.wfDbMin;
+      const dbMax = popOn ? 1 : keyed ? wfTxDbMax : rxWin!.wfDbMax;
       renderer.setPopMode(popOn, popIntensity, reliefDepth, smoothness);
       renderer.draw(
         dbMin,
@@ -408,6 +415,14 @@ export function Waterfall({
         if (rxIndex === 0 && !useTxStore.getState().moxOn && !useTxStore.getState().tunOn) {
           useDisplaySettingsStore.getState().updateAutoRange(wfDb);
         }
+        // Report this pane's noise floor for cross-band normalization (every
+        // receiver, RX domain only). Cheap downsampled percentile, EMA-smoothed
+        // in the registry; consumed by redraw() to align floors to RX1 so one
+        // dB-scale slider fits every band.
+        if (!useTxStore.getState().moxOn && !useTxStore.getState().tunOn) {
+          const floorDb = estimateRowFloorDb(wfDb);
+          if (floorDb != null) reportReceiverFloorDb(rxIndex, floorDb);
+        }
       }
       // RX only: substitute the per-bin floor-subtracted texture row so weak
       // coherent carriers get shape before the colormap. Gated off while keyed
@@ -450,6 +465,12 @@ export function Waterfall({
       // Every secondary lives in the receivers[] array (RX2 = index 1).
       if (rxIndex === 0) return;
       if (state.receivers !== prev.receivers) requestRedraw();
+    });
+
+    // Repaint when this receiver's per-RX dB window override changes (operator
+    // dragged the WfDbScale while this RX was focused).
+    const unsubRxWin = useRxDbWindowStore.subscribe((state, prev) => {
+      if (state.overrides[rxIndex] !== prev.overrides[rxIndex]) requestRedraw();
     });
 
     // Repaint on dB-range or colormap changes so the WfDbScale drag and the
@@ -528,6 +549,7 @@ export function Waterfall({
       unsubViewCenter();
       unsubViewZoom();
       unsubConn();
+      unsubRxWin();
       unsubSettings();
       unsubTx();
       unsubEnhance();

--- a/zeus-web/src/components/WfDbScale.tsx
+++ b/zeus-web/src/components/WfDbScale.tsx
@@ -9,6 +9,9 @@ import { useCallback, useRef } from 'react';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
 import { useTxStore } from '../state/tx-store';
 import { useVfoLockStore } from '../state/vfo-lock-store';
+import { useConnectionStore } from '../state/connection-store';
+import { floorNormalizationOffsetDb } from '../dsp/floor-normalization';
+import { useRxDbWindowStore, type RxWfWindow } from '../state/rx-db-window-store';
 
 const TICK_STRIDE_DB = 10;
 
@@ -18,22 +21,50 @@ const TICK_STRIDE_DB = 10;
 // swap so the operator can drag the waterfall scale during MOX/TUN without
 // disturbing their RX waterfall view.
 export function WfDbScale() {
-  const rxDbMin = useDisplaySettingsStore((s) => s.wfDbMin);
-  const rxDbMax = useDisplaySettingsStore((s) => s.wfDbMax);
+  // The RX waterfall scale follows the FOCUSED receiver: RX1 (index 0) edits
+  // the global window; RX2+ each edit their own per-receiver window (persisted).
+  // Select the reactive deps so the slider re-renders on focus / global-window /
+  // override changes, then resolve this receiver's effective window.
+  const focusedRxIndex = useConnectionStore((s) => s.focusedRxIndex);
+  const globalRxMin = useDisplaySettingsStore((s) => s.wfDbMin);
+  const globalRxMax = useDisplaySettingsStore((s) => s.wfDbMax);
+  const rxOverride = useRxDbWindowStore((s) => s.overrides[focusedRxIndex]);
+  const shiftGlobalRx = useDisplaySettingsStore((s) => s.shiftWfDbRange);
+  const shiftRxWindow = useRxDbWindowStore((s) => s.shiftRxWfWindow);
   const txDbMin = useDisplaySettingsStore((s) => s.wfTxDbMin);
   const txDbMax = useDisplaySettingsStore((s) => s.wfTxDbMax);
-  const shiftRx = useDisplaySettingsStore((s) => s.shiftWfDbRange);
   const shiftTx = useDisplaySettingsStore((s) => s.shiftWfTxDbRange);
   const moxOn = useTxStore((s) => s.moxOn);
   const tunOn = useTxStore((s) => s.tunOn);
   const keyed = moxOn || tunOn;
 
+  // Effective RX window for the focused receiver. Index 0 = global; an explicit
+  // override wins; otherwise the global window floor-normalized to RX1.
+  let rxWin: RxWfWindow;
+  if (focusedRxIndex <= 0) {
+    rxWin = { wfDbMin: globalRxMin, wfDbMax: globalRxMax };
+  } else if (rxOverride) {
+    rxWin = rxOverride;
+  } else {
+    const off = floorNormalizationOffsetDb(focusedRxIndex, 0);
+    rxWin = { wfDbMin: globalRxMin + off, wfDbMax: globalRxMax + off };
+  }
+
+  // RX-side shift routes to the global window for RX1, else the focused RX's
+  // per-receiver window.
+  const shiftRx = useCallback(
+    (delta: number) => {
+      if (focusedRxIndex <= 0) shiftGlobalRx(delta);
+      else shiftRxWindow(focusedRxIndex, delta);
+    },
+    [focusedRxIndex, shiftGlobalRx, shiftRxWindow],
+  );
+
   // Pick the active range + shifter based on whether we're keyed. Mirrors
-  // DbScale.tsx — each side has its own waterfall Grid Min/Max so the
-  // operator can hide the silence-time TX floor without moving the RX
-  // noise-floor view.
-  const dbMin = keyed ? txDbMin : rxDbMin;
-  const dbMax = keyed ? txDbMax : rxDbMax;
+  // DbScale.tsx — keyed uses the global TX waterfall window so the operator can
+  // hide the silence-time TX floor without moving the RX noise-floor view.
+  const dbMin = keyed ? txDbMin : rxWin.wfDbMin;
+  const dbMax = keyed ? txDbMax : rxWin.wfDbMax;
   const shift = keyed ? shiftTx : shiftRx;
 
   const dragState = useRef<{

--- a/zeus-web/src/dsp/floor-normalization.test.ts
+++ b/zeus-web/src/dsp/floor-normalization.test.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  estimateRowFloorDb,
+  floorNormalizationOffsetDb,
+  getReceiverFloorDb,
+  reportReceiverFloorDb,
+  resetReceiverFloors,
+} from './floor-normalization';
+
+afterEach(() => resetReceiverFloors());
+
+describe('estimateRowFloorDb', () => {
+  it('returns null for an empty row', () => {
+    expect(estimateRowFloorDb(new Float32Array(0))).toBeNull();
+  });
+
+  it('estimates the low-percentile floor, ignoring strong carriers', () => {
+    // A flat -130 dB floor with a handful of -40 dB carriers poking through.
+    const row = new Float32Array(1000).fill(-130);
+    for (let i = 0; i < 1000; i += 100) row[i] = -40;
+    const floor = estimateRowFloorDb(row)!;
+    expect(floor).toBeCloseTo(-130, 0); // 25th pct sits firmly in the floor
+  });
+
+  it('ignores non-finite bins', () => {
+    const row = new Float32Array(512).fill(-120);
+    row[0] = Number.NaN;
+    row[1] = Number.POSITIVE_INFINITY;
+    expect(estimateRowFloorDb(row)).toBeCloseTo(-120, 0);
+  });
+});
+
+describe('floorNormalizationOffsetDb', () => {
+  it('is 0 for the focused pane itself', () => {
+    reportReceiverFloorDb(0, -120);
+    expect(floorNormalizationOffsetDb(0, 0)).toBe(0);
+  });
+
+  it('is 0 when either floor is unknown', () => {
+    reportReceiverFloorDb(0, -120);
+    expect(floorNormalizationOffsetDb(1, 0)).toBe(0); // pane 1 unknown
+    expect(floorNormalizationOffsetDb(0, 2)).toBe(0); // focus 2 unknown
+  });
+
+  it('shifts a noisier pane up by (here - focused)', () => {
+    reportReceiverFloorDb(0, -135); // focused RX1 floor (20m, quiet)
+    reportReceiverFloorDb(1, -120); // RX2 floor (40m, noisier)
+    // RX2 is 15 dB hotter, so its window shifts +15 so its floor still maps low.
+    expect(floorNormalizationOffsetDb(1, 0)).toBeCloseTo(15, 1);
+    // And the reciprocal: a quieter pane shifts down.
+    expect(floorNormalizationOffsetDb(0, 1)).toBeCloseTo(-15, 1);
+  });
+
+  it('clamps the offset to +/-40 dB', () => {
+    reportReceiverFloorDb(0, -200);
+    reportReceiverFloorDb(1, 0);
+    expect(floorNormalizationOffsetDb(1, 0)).toBe(40);
+    expect(floorNormalizationOffsetDb(0, 1)).toBe(-40);
+  });
+});
+
+describe('reportReceiverFloorDb EMA', () => {
+  it('seeds on first report then smooths', () => {
+    reportReceiverFloorDb(3, -100);
+    expect(getReceiverFloorDb(3)).toBe(-100);
+    // Second report eases toward the new value (alpha 0.1), not a jump.
+    reportReceiverFloorDb(3, -120);
+    const v = getReceiverFloorDb(3)!;
+    expect(v).toBeGreaterThan(-120);
+    expect(v).toBeLessThan(-100);
+    expect(v).toBeCloseTo(-102, 0); // -100 + (-20 * 0.1)
+  });
+
+  it('ignores non-finite reports', () => {
+    reportReceiverFloorDb(4, -110);
+    reportReceiverFloorDb(4, Number.NaN);
+    expect(getReceiverFloorDb(4)).toBe(-110);
+  });
+});

--- a/zeus-web/src/dsp/floor-normalization.ts
+++ b/zeus-web/src/dsp/floor-normalization.ts
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+// Per-receiver waterfall noise-floor registry for cross-band normalization.
+//
+// Each waterfall pane (RX1..RXn) sits on a different band, so each has a
+// different absolute noise floor — 40m might floor at -120 dB while 20m floors
+// at -135 dB. With a single dB-scale slider that makes one pane look correct
+// and the others washed-out or empty.
+//
+// Fix: every pane reports a smoothed estimate of its OWN noise floor here, and
+// at draw time shifts its dB window so its floor lands at the same colour as
+// the FOCUSED receiver's floor. The operator drags the slider while looking at
+// whatever RX they've focused; that same window then applies, anchored to each
+// pane's measured floor, across every band. The focused pane itself is never
+// shifted (offset 0), so single-RX behaviour is unchanged.
+//
+// Indexed by 0-based rxIndex (RX1 = 0, RX2 = 1, RX3+ = 2..), matching
+// connection-store `focusedRxIndex` and `receiver-state` `rxIndexOf`.
+
+const floorByRx = new Map<number, number>();
+
+// EMA smoothing for the per-receiver floor — fast enough to settle on a band
+// change within a couple of seconds, slow enough that the colours don't jitter
+// frame to frame as the instantaneous floor estimate wobbles.
+const FLOOR_EMA_ALPHA = 0.1;
+
+// Clamp on the normalization shift so a transient bad estimate (e.g. a pane
+// momentarily full of a strong carrier) can never throw the window wildly.
+const MAX_OFFSET_DB = 40;
+
+// Reused scratch for the downsampled percentile sort — keeps the per-frame
+// estimate allocation-free. 256 samples is plenty for a robust low percentile.
+const scratch = new Float32Array(256);
+
+/** Feed a fresh floor estimate (dB) for a receiver; smoothed via EMA. */
+export function reportReceiverFloorDb(rxIndex: number, floorDb: number): void {
+  if (!Number.isFinite(floorDb)) return;
+  const prev = floorByRx.get(rxIndex);
+  floorByRx.set(
+    rxIndex,
+    prev == null ? floorDb : prev + (floorDb - prev) * FLOOR_EMA_ALPHA,
+  );
+}
+
+/** Smoothed noise floor (dB) for a receiver, or null if none reported yet. */
+export function getReceiverFloorDb(rxIndex: number): number | null {
+  return floorByRx.get(rxIndex) ?? null;
+}
+
+/** Forget all receiver floors (receiver teardown / test reset). */
+export function resetReceiverFloors(): void {
+  floorByRx.clear();
+}
+
+/**
+ * dB-window offset to add to THIS pane's [dbMin, dbMax] so its noise floor
+ * aligns to the focused receiver's floor. Returns 0 when this IS the focused
+ * pane or when either floor is not yet known.
+ */
+export function floorNormalizationOffsetDb(
+  thisRxIndex: number,
+  focusedRxIndex: number,
+): number {
+  if (thisRxIndex === focusedRxIndex) return 0;
+  const here = floorByRx.get(thisRxIndex);
+  const ref = floorByRx.get(focusedRxIndex);
+  if (here == null || ref == null) return 0;
+  const off = here - ref;
+  return off < -MAX_OFFSET_DB ? -MAX_OFFSET_DB : off > MAX_OFFSET_DB ? MAX_OFFSET_DB : off;
+}
+
+/**
+ * Robust low-percentile (25th) floor estimate over a dB spectrum row,
+ * downsampled to <=256 samples for cheapness. The 25th percentile sits in the
+ * lower tail — robust against the deep nulls between carriers while ignoring
+ * the signal energy above the floor. Returns null if no finite samples.
+ * Allocation-free (reuses a module scratch buffer).
+ */
+export function estimateRowFloorDb(row: Float32Array): number | null {
+  const n = row.length;
+  if (n === 0) return null;
+  const target = Math.min(scratch.length, n);
+  const step = Math.max(1, Math.floor(n / target));
+  let count = 0;
+  for (let i = 0; i < n && count < scratch.length; i += step) {
+    const v = row[i];
+    if (v !== undefined && Number.isFinite(v)) scratch[count++] = v;
+  }
+  if (count === 0) return null;
+  const view = scratch.subarray(0, count);
+  view.sort();
+  return view[Math.floor(count * 0.25)] ?? null;
+}

--- a/zeus-web/src/layout/panels/HeroPanel.tsx
+++ b/zeus-web/src/layout/panels/HeroPanel.tsx
@@ -304,7 +304,7 @@ export function HeroPanel({
     minHeight: 0,
     height: '100%',
     display: 'grid',
-    gridTemplateColumns: `repeat(${Math.min(spectrumPanes.length, 4)}, minmax(0, 1fr))`,
+    gridTemplateColumns: `repeat(${Math.min(spectrumPanes.length, 3)}, minmax(0, 1fr))`,
     gridAutoRows: '1fr',
     gap: 0,
     overflow: 'hidden',
@@ -332,20 +332,35 @@ export function HeroPanel({
           {heroTitle}
         </span>
         {multiRx && (
-          <button
-            ref={mixerTriggerRef}
-            type="button"
-            className={`hero-rx-mixer-trigger ${mixerOpen ? 'is-open' : ''}`}
-            onClick={toggleMixer}
+          // Centered in the drag bar: absolutely positioned at the header's
+          // horizontal midpoint so it sits dead-center regardless of the title
+          // and right-side control widths.
+          <span
+            style={{
+              position: 'absolute',
+              left: '50%',
+              transform: 'translateX(-50%)',
+              display: 'inline-flex',
+              zIndex: 2,
+            }}
             onPointerDown={stopDrag}
             onMouseDown={stopDrag}
-            aria-pressed={mixerOpen}
-            aria-label="Receiver audio mixer"
-            title="Receiver audio mixer — hear/mute and focus each DDC"
           >
-            <Sliders size={11} />
-            <span>RX MIX</span>
-          </button>
+            <button
+              ref={mixerTriggerRef}
+              type="button"
+              className={`hero-rx-mixer-trigger ${mixerOpen ? 'is-open' : ''}`}
+              onClick={toggleMixer}
+              onPointerDown={stopDrag}
+              onMouseDown={stopDrag}
+              aria-pressed={mixerOpen}
+              aria-label="Receiver audio mixer"
+              title="Receiver audio mixer — hear/mute and focus each DDC"
+            >
+              <Sliders size={11} />
+              <span>RX MIX</span>
+            </button>
+          </span>
         )}
         <div
           className="hero-tile-controls"

--- a/zeus-web/src/layout/panels/VfoPanel.tsx
+++ b/zeus-web/src/layout/panels/VfoPanel.tsx
@@ -58,10 +58,12 @@ import { receiverColorByIndex } from '../../components/spectrumReceiverColor';
 import { VfoDisplay } from '../../components/VfoDisplay';
 import { useConnectionStore } from '../../state/connection-store';
 import {
+  getDesiredReceiverCount,
   getReceiverAfGainDb,
   getReceiverVfoHz,
   optimisticSetReceiverAfGain,
   optimisticSetReceiverVfo,
+  setExposedReceiverCount,
 } from '../../state/receiver-state';
 
 export function VfoPanel() {
@@ -115,10 +117,18 @@ export function VfoPanel() {
     setVfo(vfoBHz).then(applyState).catch(() => {});
   };
 
-  const toggleRx2 = () => {
-    const enabled = !rx2Enabled;
-    setFocusedRxIndex(enabled ? 1 : 0);
-    patchRx2({ enabled });
+  // MULTI RX master toggle: enable the whole multi-DDC set the operator
+  // configured in Settings → Receivers (remembered count, default 2), or
+  // collapse back to RX1 only. Replaces the old single "+ RX2" affordance.
+  const multiRxOn = rx2Enabled;
+  const toggleMultiRx = () => {
+    if (multiRxOn) {
+      setFocusedRxIndex(0);
+      setExposedReceiverCount(1);
+    } else {
+      setFocusedRxIndex(1);
+      setExposedReceiverCount(getDesiredReceiverCount());
+    }
   };
 
   // AF gain for the active receiver. RX1's level is the main RX volume (lives in
@@ -195,18 +205,21 @@ export function VfoPanel() {
             </button>
           );
         })}
-        {!rx2Enabled && (
-          <button
-            type="button"
-            className="vfo-chip vfo-chip--add"
-            onClick={toggleRx2}
-            title="Enable RX2 (second receiver)"
-            aria-label="Enable RX2"
-          >
-            <Headphones size={13} />
-            <span className="vfo-chip__band">+ RX2</span>
-          </button>
-        )}
+        <button
+          type="button"
+          className={`vfo-chip vfo-chip--add ${multiRxOn ? 'is-active' : ''}`}
+          onClick={toggleMultiRx}
+          title={
+            multiRxOn
+              ? 'Disable extra receivers (back to RX1 only)'
+              : 'Enable multiple receivers (set how many in Settings → Receivers)'
+          }
+          aria-label="Toggle multiple receivers"
+          aria-pressed={multiRxOn}
+        >
+          <Headphones size={13} />
+          <span className="vfo-chip__band">MULTI RX</span>
+        </button>
       </div>
 
       {/* Active receiver detail — the full-size tuning surface. */}
@@ -290,15 +303,15 @@ export function VfoPanel() {
             <Repeat2 size={13} />
             <span>Swap</span>
           </button>
-          {rx2Enabled && (
+          {multiRxOn && (
             <button
               type="button"
               className="vfo-tool-key"
-              onClick={toggleRx2}
-              title="Disable RX2"
+              onClick={toggleMultiRx}
+              title="Disable extra receivers (back to RX1 only)"
             >
               <Headphones size={12} />
-              <span>RX2 off</span>
+              <span>MULTI off</span>
             </button>
           )}
         </div>

--- a/zeus-web/src/state/receiver-state.ts
+++ b/zeus-web/src/state/receiver-state.ts
@@ -301,3 +301,67 @@ export function gangedReceiverAction(opts: {
       });
   }
 }
+
+// ---------------------------------------------------------------------------
+// Multi-RX exposed-count control. Shared by the Settings RECEIVERS panel and
+// the MULTI-RX toolbar toggle so both compose the same per-index endpoint calls
+// and honour the same practical ceiling.
+
+// Protocol ceiling is WireContract.MaxReceivers (8 DDCs), but the count that
+// actually streams on a G2/Saturn at the wide multi-DDC sample rates
+// (768/1536 kHz) is 6 — beyond that the radio's DDC throughput budget is
+// exceeded and the extra DDCs come up dead. Cap the operator-facing count here.
+export const PRACTICAL_MAX_RECEIVERS = 6;
+
+const DESIRED_COUNT_KEY = 'zeus.multiRx.desiredCount';
+
+function clampDesired(n: number): number {
+  return Math.min(Math.max(Math.round(n), 2), PRACTICAL_MAX_RECEIVERS);
+}
+
+/** The operator's chosen multi-RX count, remembered across an off toggle and
+ *  restarts so the MULTI-RX button can re-enable the same set. Default 2. */
+export function getDesiredReceiverCount(): number {
+  try {
+    const raw =
+      typeof localStorage !== 'undefined' ? localStorage.getItem(DESIRED_COUNT_KEY) : null;
+    const n = raw ? Number.parseInt(raw, 10) : Number.NaN;
+    if (Number.isFinite(n)) return clampDesired(n);
+  } catch {
+    /* ignore */
+  }
+  return 2;
+}
+
+export function setDesiredReceiverCount(n: number): void {
+  try {
+    if (typeof localStorage !== 'undefined')
+      localStorage.setItem(DESIRED_COUNT_KEY, String(clampDesired(n)));
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Expose N contiguous receivers (RX1..RXn). Composes the per-index enable
+ * endpoint; the server's contiguity cascade enables RX2..RXn-1 / disables the
+ * rest. n>=2 also records the desired count so a later MULTI-RX re-enable
+ * restores it. n<=1 collapses back to RX1 only.
+ */
+export async function setExposedReceiverCount(target: number): Promise<void> {
+  const st = useConnectionStore.getState();
+  const effectiveMax = Math.min(st.maxReceivers, PRACTICAL_MAX_RECEIVERS);
+  const n = Math.min(Math.max(Math.round(target), 1), effectiveMax);
+  const applyState = st.applyState;
+  if (n >= 2) setDesiredReceiverCount(n);
+  try {
+    if (n <= 1) {
+      applyState(await setReceiver(1, { enabled: false }));
+      return;
+    }
+    applyState(await setReceiver(n - 1, { enabled: true }));
+    if (n < effectiveMax) applyState(await setReceiver(n, { enabled: false }));
+  } catch {
+    /* next state poll reconciles */
+  }
+}

--- a/zeus-web/src/state/rx-db-window-store.test.ts
+++ b/zeus-web/src/state/rx-db-window-store.test.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  effectiveRxWfWindow,
+  useRxDbWindowStore,
+} from './rx-db-window-store';
+import { useDisplaySettingsStore } from './display-settings-store';
+import { resetReceiverFloors, reportReceiverFloorDb } from '../dsp/floor-normalization';
+
+beforeEach(() => {
+  useRxDbWindowStore.setState({ overrides: {} });
+  resetReceiverFloors();
+  try {
+    localStorage.removeItem('zeus.rxWfDbWindows');
+  } catch {
+    /* ignore */
+  }
+});
+afterEach(() => {
+  useRxDbWindowStore.setState({ overrides: {} });
+  resetReceiverFloors();
+});
+
+describe('rx-db-window-store', () => {
+  it('RX1 (index 0) always resolves to the global window', () => {
+    useDisplaySettingsStore.setState({ wfDbMin: -130, wfDbMax: -40 });
+    expect(effectiveRxWfWindow(0)).toEqual({ wfDbMin: -130, wfDbMax: -40 });
+  });
+
+  it('an RXn without override floor-normalizes the global window to RX1', () => {
+    useDisplaySettingsStore.setState({ wfDbMin: -130, wfDbMax: -40 });
+    // RX1 floor -135, RX2 floor -120 → RX2 is 15 dB hotter → window shifts +15.
+    reportReceiverFloorDb(0, -135);
+    reportReceiverFloorDb(1, -120);
+    const win = effectiveRxWfWindow(1);
+    expect(win.wfDbMin).toBeCloseTo(-115, 1);
+    expect(win.wfDbMax).toBeCloseTo(-25, 1);
+  });
+
+  it('an explicit override wins over the normalized default', () => {
+    useDisplaySettingsStore.setState({ wfDbMin: -130, wfDbMax: -40 });
+    reportReceiverFloorDb(0, -135);
+    reportReceiverFloorDb(1, -120);
+    useRxDbWindowStore.getState().setRxWfWindow(1, -100, -20);
+    expect(effectiveRxWfWindow(1)).toEqual({ wfDbMin: -100, wfDbMax: -20 });
+  });
+
+  it('shift creates an override from the current effective window, preserving span', () => {
+    useDisplaySettingsStore.setState({ wfDbMin: -130, wfDbMax: -40 });
+    useRxDbWindowStore.getState().shiftRxWfWindow(1, 10);
+    const win = useRxDbWindowStore.getState().overrides[1]!;
+    expect(win.wfDbMin).toBeCloseTo(-120, 1);
+    expect(win.wfDbMax).toBeCloseTo(-30, 1);
+    expect(win.wfDbMax - win.wfDbMin).toBeCloseTo(90, 1); // span preserved
+  });
+
+  it('clear drops the override back to the default', () => {
+    useDisplaySettingsStore.setState({ wfDbMin: -130, wfDbMax: -40 });
+    useRxDbWindowStore.getState().setRxWfWindow(2, -90, -10);
+    expect(useRxDbWindowStore.getState().overrides[2]).toBeDefined();
+    useRxDbWindowStore.getState().clearRxWfWindow(2);
+    expect(useRxDbWindowStore.getState().overrides[2]).toBeUndefined();
+    expect(effectiveRxWfWindow(2)).toEqual({ wfDbMin: -130, wfDbMax: -40 });
+  });
+
+  it('ignores index 0 and inverted windows', () => {
+    useRxDbWindowStore.getState().setRxWfWindow(0, -100, -20);
+    useRxDbWindowStore.getState().setRxWfWindow(1, -20, -100); // inverted
+    expect(useRxDbWindowStore.getState().overrides[0]).toBeUndefined();
+    expect(useRxDbWindowStore.getState().overrides[1]).toBeUndefined();
+  });
+
+  it('persists overrides to localStorage', () => {
+    useRxDbWindowStore.getState().setRxWfWindow(1, -110, -30);
+    const raw = localStorage.getItem('zeus.rxWfDbWindows');
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw!)).toMatchObject({ '1': { wfDbMin: -110, wfDbMax: -30 } });
+  });
+});

--- a/zeus-web/src/state/rx-db-window-store.ts
+++ b/zeus-web/src/state/rx-db-window-store.ts
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+// Per-receiver waterfall dB-window overrides for the multi-DDC display.
+//
+// The global waterfall window (display-settings-store wfDbMin/wfDbMax) is RX1's
+// window and the default for every other receiver. When the operator focuses a
+// receiver and drags the waterfall dB scale, the adjustment is stored HERE,
+// keyed by 0-based rxIndex (RX2 = 1, RX3+ = 2..), so each receiver keeps its
+// own scale. RX1 (index 0) is never stored here — it stays on the global
+// window (which already round-trips to server prefs).
+//
+// Until a receiver has an explicit override, its effective window is the global
+// window shifted by its floor-normalization offset (anchored to RX1), so floors
+// line up out of the box. Once the operator drags a receiver's scale, that
+// absolute window sticks and persists across restarts (localStorage).
+
+import { create } from 'zustand';
+import { useDisplaySettingsStore } from './display-settings-store';
+import { floorNormalizationOffsetDb } from '../dsp/floor-normalization';
+
+const STORAGE_KEY = 'zeus.rxWfDbWindows';
+
+// Absolute dB bounds + minimum span a window may occupy. Mirrors the spirit of
+// display-settings-store's clamp so a drag can't push the window off-scale.
+const ABS_MIN_DB = -200;
+const ABS_MAX_DB = 20;
+
+export type RxWfWindow = { wfDbMin: number; wfDbMax: number };
+
+/** Shift a window by deltaDb, preserving span and clamping into the abs range. */
+function shiftWindow(min: number, max: number, deltaDb: number): RxWfWindow {
+  let nmin = min + deltaDb;
+  let nmax = max + deltaDb;
+  if (nmin < ABS_MIN_DB) {
+    const c = ABS_MIN_DB - nmin;
+    nmin += c;
+    nmax += c;
+  }
+  if (nmax > ABS_MAX_DB) {
+    const c = nmax - ABS_MAX_DB;
+    nmin -= c;
+    nmax -= c;
+  }
+  return { wfDbMin: nmin, wfDbMax: nmax };
+}
+
+function readSaved(): Record<number, RxWfWindow> {
+  try {
+    if (typeof localStorage === 'undefined') return {};
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as Record<string, RxWfWindow>;
+    const out: Record<number, RxWfWindow> = {};
+    for (const [k, v] of Object.entries(parsed)) {
+      const idx = Number.parseInt(k, 10);
+      if (
+        Number.isFinite(idx) &&
+        idx >= 1 &&
+        typeof v?.wfDbMin === 'number' &&
+        typeof v?.wfDbMax === 'number' &&
+        v.wfDbMin < v.wfDbMax
+      ) {
+        out[idx] = { wfDbMin: v.wfDbMin, wfDbMax: v.wfDbMax };
+      }
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function writeSaved(overrides: Record<number, RxWfWindow>): void {
+  try {
+    if (typeof localStorage !== 'undefined')
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(overrides));
+  } catch {
+    /* ignore */
+  }
+}
+
+type RxDbWindowState = {
+  overrides: Record<number, RxWfWindow>;
+  /** Set an absolute window for a receiver (rxIndex >= 1). */
+  setRxWfWindow: (rxIndex: number, wfDbMin: number, wfDbMax: number) => void;
+  /** Shift a receiver's effective window by deltaDb (creates an override). */
+  shiftRxWfWindow: (rxIndex: number, deltaDb: number) => void;
+  /** Drop a receiver's override so it falls back to the normalized default. */
+  clearRxWfWindow: (rxIndex: number) => void;
+};
+
+export const useRxDbWindowStore = create<RxDbWindowState>((set, get) => ({
+  overrides: readSaved(),
+
+  setRxWfWindow: (rxIndex, wfDbMin, wfDbMax) => {
+    if (rxIndex < 1 || !(wfDbMin < wfDbMax)) return;
+    const overrides = { ...get().overrides, [rxIndex]: { wfDbMin, wfDbMax } };
+    writeSaved(overrides);
+    set({ overrides });
+  },
+
+  shiftRxWfWindow: (rxIndex, deltaDb) => {
+    if (rxIndex < 1) return;
+    const cur = effectiveRxWfWindow(rxIndex);
+    const next = shiftWindow(cur.wfDbMin, cur.wfDbMax, deltaDb);
+    const overrides = { ...get().overrides, [rxIndex]: next };
+    writeSaved(overrides);
+    set({ overrides });
+  },
+
+  clearRxWfWindow: (rxIndex) => {
+    if (!(rxIndex in get().overrides)) return;
+    const overrides = { ...get().overrides };
+    delete overrides[rxIndex];
+    writeSaved(overrides);
+    set({ overrides });
+  },
+}));
+
+/**
+ * The effective waterfall dB window for a receiver index.
+ * - RX1 (0): the global window (display-settings-store).
+ * - RXn with an explicit override: that absolute window.
+ * - RXn without one: the global window shifted by its floor-normalization
+ *   offset (anchored to RX1), so its noise floor lines up with RX1's.
+ */
+export function effectiveRxWfWindow(rxIndex: number): RxWfWindow {
+  const ds = useDisplaySettingsStore.getState();
+  if (rxIndex <= 0) return { wfDbMin: ds.wfDbMin, wfDbMax: ds.wfDbMax };
+  const ov = useRxDbWindowStore.getState().overrides[rxIndex];
+  if (ov) return ov;
+  const off = floorNormalizationOffsetDb(rxIndex, 0);
+  return { wfDbMin: ds.wfDbMin + off, wfDbMax: ds.wfDbMax + off };
+}


### PR DESCRIPTION
## Summary

Net-new multi-RX **display** features layered on develop's existing A/B-collapse infrastructure (`receiver-state`, `focusedRxIndex`, numeric panes). Nothing here re-touches the collapse — it builds on it.

### Waterfall dB scale — per-receiver, floor-normalized
Each receiver sits on a different band with a different absolute noise floor, so one global dB-scale slider looked correct on one pane and washed-out/empty on others. Now:

- **`dsp/floor-normalization.ts`** — each waterfall pane reports a rolling 25th-percentile estimate of its own noise floor (EMA-smoothed, allocation-free).
- **`state/rx-db-window-store.ts`** — per-receiver dB-window overrides, keyed by `rxIndex`, persisted to `localStorage`. `effectiveRxWfWindow`: RX1 = the global window; RXn = its own override, or the global window **floor-normalized to RX1** so the floors line up across bands under a single slider.
- **`WfDbScale`** follows the **focused** receiver — RX1 edits the global (server-backed) window, RX2+ each edit their own persisted window.
- **`Waterfall`** renders each pane with its effective window (RX1 unchanged → single-RX behaviour identical to today).

### Multi-RX UX
- **MULTI RX toggle** (`VfoPanel`) — the old `+ RX2` becomes a master toggle that enables/disables the whole configured receiver set (remembered count via `setExposedReceiverCount`/`getDesiredReceiverCount`, default 2), with a matching "MULTI off".
- **RECEIVERS panel** — practical **6-receiver cap** (`PRACTICAL_MAX_RECEIVERS`; the G2/Saturn DDC-throughput ceiling at 1536 kHz — 8 stays the protocol max), plus an **ADC 0 / ADC 1 explainer** (ADC1 = the separate RX2/EXT antenna jack; only use it with a second antenna wired, else the receiver is silent — no auto-spread).
- **Grid wraps after 3 panes per row** (was 4); **RX MIX centered** in the hero header drag bar.

## Persistence note
Per-RX dB windows persist via `localStorage` (per-origin; survives restarts). RX1's window continues to round-trip to server prefs as before. Moving the per-RX windows into the server prefs DB (radio-profile / cross-device) is a possible follow-up.

## Testing
- `floor-normalization` unit tests (9) + `rx-db-window-store` unit tests (7) — all green.
- Full production frontend build (`tsc -b && vite build`) green.
- Not yet bench-verified on live hardware — needs a multi-band G2 to eyeball floor alignment and the focus-bound slider (WebGL, can't verify headlessly).