### PR TITLE
feat(multi-rx): RX1–RX6 labels, ganged multi-select, unified per-receiver write path

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -1377,7 +1377,12 @@ public sealed record ReceiverSetRequest(
     RxMode? Mode = null,
     int? FilterLowHz = null,
     int? FilterHighHz = null,
-    double? AfGainDb = null);
+    double? AfGainDb = null,
+    // Named filter preset (e.g. "VAR1", "F5") this receiver's low/high cuts came
+    // from. Optimistic-only round-trip so the RX3+ passband shows the preset
+    // label the operator picked, exactly as RX2 carries FilterPresetNameB. The
+    // cuts in FilterLowHz/FilterHighHz remain authoritative for the DSP.
+    string? FilterPresetName = null);
 
 /// <summary>Operator settings for the POTA/SOTA Spots feature. Persisted in
 /// zeus-prefs.db (<c>SpotsSettingsStore</c>) and shared with the frontend.

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -756,7 +756,7 @@ public sealed class RadioService : IDisposable
         get { lock (_sync) return _activeClient is not null || _p2Active; }
     }
 
-    public StateDto Snapshot() { lock (_sync) return _state with { Receivers = ProjectReceivers(_state) }; }
+    public StateDto Snapshot() { lock (_sync) return _state with { Receivers = ProjectReceivers(_state), MaxReceivers = EffectiveMaxReceivers }; }
 
     /// <summary>Current operator preamp toggle. PreampOn isn't on the
     /// StateDto wire format, so DspPipelineService reads it directly when
@@ -1061,7 +1061,8 @@ public sealed class RadioService : IDisposable
         RxMode? mode = null,
         int? filterLowHz = null,
         int? filterHighHz = null,
-        double? afGainDb = null)
+        double? afGainDb = null,
+        string? filterPresetName = null)
     {
         if (index == 0)
             return vfoHz is long v0 ? SetVfo(v0) : Snapshot();
@@ -1080,6 +1081,7 @@ public sealed class RadioService : IDisposable
             if (mode is RxMode m) e.Mode = m;
             if (filterLowHz is int fl) e.FilterLowHz = fl;
             if (filterHighHz is int fh) e.FilterHighHz = fh;
+            if (filterPresetName is string fp) e.FilterPresetName = fp;
             if (afGainDb is double af) e.AfGainDb = Math.Clamp(af, -50.0, 20.0);
             if (enabled is bool en)
             {
@@ -3580,7 +3582,7 @@ public sealed class RadioService : IDisposable
             // fields on every mutation so StateChanged subscribers and the
             // SignalR broadcast always carry an up-to-date Receivers[] (wire
             // v2). Pure function of the flat fields — cheap (1–2 elements).
-            next = next with { Receivers = ProjectReceivers(next) };
+            next = next with { Receivers = ProjectReceivers(next), MaxReceivers = EffectiveMaxReceivers };
             _state = next;
         }
         _stateDirty = true;
@@ -3860,6 +3862,29 @@ public sealed class RadioService : IDisposable
             var connected = ConnectedBoardKind;
             if (connected != HpsdrBoardKind.Unknown) return connected;
             return _preferredRadioStore?.Get() ?? HpsdrBoardKind.Unknown;
+        }
+    }
+
+    // Board-aware count of user-visible receivers the connected radio can
+    // actually expose, advertised to the frontend via StateDto.MaxReceivers so
+    // the Receivers menu renders exactly the reachable slots. On Protocol-2 the
+    // standard DDC enable byte addresses DDC0..DDC7 (MaxRxDdc = 8), but
+    // Orion-family boards reserve the first RxBaseDdc slots (DDC0/1) for the
+    // PureSignal feedback pair, leaving user RX = MaxRxDdc - RxBaseDdc(board):
+    // 8 on Hermes-class, 6 on G2/Orion. Off P2 (Protocol-1 or disconnected) we
+    // keep the flat wire ceiling — P1 multi-RX board-awareness is a separate
+    // concern and changing it here would be an untested regression on HL2 etc.
+    public int EffectiveMaxReceivers
+    {
+        get
+        {
+            lock (_sync)
+            {
+                if (_p2Active)
+                    return Zeus.Protocol2.Protocol2Client.MaxRxDdc
+                         - Zeus.Protocol2.Protocol2Client.RxBaseDdc(ConnectedBoardKind);
+                return Zeus.Contracts.WireContract.MaxReceivers;
+            }
         }
     }
 

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -1064,10 +1064,36 @@ public sealed class RadioService : IDisposable
         double? afGainDb = null,
         string? filterPresetName = null)
     {
-        if (index == 0)
-            return vfoHz is long v0 ? SetVfo(v0) : Snapshot();
-        if (index == 1)
-            return SetRx2(new Rx2SetRequest(Enabled: enabled, VfoBHz: vfoHz, AfGainDb: afGainDb));
+        // RX1 (0) and RX2 (1) live on the flat StateDto fields, but the uniform
+        // numeric model means /api/receivers/{index} must drive every receiver.
+        // Route each supplied field to its canonical RX1/RX2 setter so all their
+        // side effects (TX recompute, band-mode memory, filter preset memory)
+        // still fire. The legacy A/B endpoints (/api/mode, /api/filter, /api/rx2)
+        // remain as thin aliases onto the same setters.
+        if (index == 0 || index == 1)
+        {
+            var receiver = index == 1 ? TxVfo.B : TxVfo.A;
+            if (index == 1 && enabled is bool en1)
+                SetRx2(new Rx2SetRequest(Enabled: en1));
+            if (vfoHz is long v)
+            {
+                if (index == 1) SetVfoB(v); else SetVfo(v);
+            }
+            if (mode is RxMode m) SetMode(m, receiver);
+            if (filterLowHz is not null || filterHighHz is not null || filterPresetName is not null)
+            {
+                var cur = Snapshot();
+                int lo = filterLowHz ?? (index == 1 ? cur.FilterLowHzB : cur.FilterLowHz);
+                int hi = filterHighHz ?? (index == 1 ? cur.FilterHighHzB : cur.FilterHighHz);
+                SetFilter(lo, hi, filterPresetName, receiver);
+            }
+            if (afGainDb is double af)
+            {
+                if (index == 1) SetRx2(new Rx2SetRequest(AfGainDb: af));
+                else SetRxAfGain(af);
+            }
+            return Snapshot();
+        }
         if (index < 2 || index >= _extraReceivers.Length)
             throw new ArgumentOutOfRangeException(
                 nameof(index), index, $"receiver index out of range (0..{_extraReceivers.Length - 1})");

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -1152,7 +1152,8 @@ public static class ZeusEndpoints
                 mode: req.Mode,
                 filterLowHz: req.FilterLowHz,
                 filterHighHz: req.FilterHighHz,
-                afGainDb: req.AfGainDb));
+                afGainDb: req.AfGainDb,
+                filterPresetName: req.FilterPresetName));
         });
 
         // Per-RX audio mute (RX1=0, RX2=1, RX3+=2..). Mirrors Thetis chkMUT /

--- a/tests/Zeus.Server.Tests/RadioServiceUnifiedReceiverWriteTests.cs
+++ b/tests/Zeus.Server.Tests/RadioServiceUnifiedReceiverWriteTests.cs
@@ -1,0 +1,119 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+// Uniform numeric-receiver write path: /api/receivers/{index} (RadioService
+// .SetReceiver) must drive EVERY receiver, including RX1 (0) and RX2 (1) which
+// live on the flat StateDto fields. Each supplied field routes to the canonical
+// RX1/RX2 setter so the legacy A/B endpoints and the unified endpoint stay in
+// lock-step. Part of the A/B -> numeric receiver migration.
+public sealed class RadioServiceUnifiedReceiverWriteTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-unifiedrx-{Guid.NewGuid():N}.db");
+    private readonly PaSettingsStore _paStore;
+    private readonly DspSettingsStore _dspStore;
+
+    public RadioServiceUnifiedReceiverWriteTests()
+    {
+        _paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance, _dbPath + ".pa");
+        _dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance, _dbPath + ".dsp");
+    }
+
+    public void Dispose()
+    {
+        _paStore.Dispose();
+        _dspStore.Dispose();
+        foreach (var suffix in new[] { "", ".pa", ".dsp" })
+        {
+            try { if (File.Exists(_dbPath + suffix)) File.Delete(_dbPath + suffix); } catch { }
+        }
+    }
+
+    private RadioService BuildRadio() => new(NullLoggerFactory.Instance, _dspStore, _paStore);
+
+    private static ReceiverDto Rx(StateDto s, int index) =>
+        s.Receivers!.Single(r => r.Index == index);
+
+    [Fact]
+    public void SetReceiver_Rx1_RoutesVfoModeFilterAndAf()
+    {
+        using var radio = BuildRadio();
+
+        radio.SetReceiver(0, vfoHz: 14_074_000);
+        radio.SetReceiver(0, mode: RxMode.DIGU);
+        radio.SetReceiver(0, filterLowHz: 200, filterHighHz: 2900, filterPresetName: "VAR2");
+        var s = radio.SetReceiver(0, afGainDb: -6.0);
+
+        // Flat RX1 fields and the projected receivers[0] entry agree.
+        Assert.Equal(14_074_000, s.VfoHz);
+        Assert.Equal(RxMode.DIGU, s.Mode);
+        Assert.Equal(200, s.FilterLowHz);
+        Assert.Equal(2900, s.FilterHighHz);
+        Assert.Equal("VAR2", s.FilterPresetName);
+        Assert.Equal(-6.0, s.RxAfGainDb);
+
+        var rx1 = Rx(s, 0);
+        Assert.Equal(14_074_000, rx1.VfoHz);
+        Assert.Equal(RxMode.DIGU, rx1.Mode);
+        Assert.Equal(200, rx1.FilterLowHz);
+        Assert.Equal(2900, rx1.FilterHighHz);
+        Assert.Equal("VAR2", rx1.FilterPresetName);
+    }
+
+    [Fact]
+    public void SetReceiver_Rx2_RoutesEnableVfoModeFilterAndAf()
+    {
+        using var radio = BuildRadio();
+
+        radio.SetReceiver(1, enabled: true, vfoHz: 7_074_000);
+        radio.SetReceiver(1, mode: RxMode.LSB);
+        radio.SetReceiver(1, filterLowHz: -2850, filterHighHz: -100, filterPresetName: "VAR1");
+        var s = radio.SetReceiver(1, afGainDb: -3.0);
+
+        // Flat RX2 (*B) fields and the projected receivers[1] entry agree.
+        Assert.True(s.Rx2Enabled);
+        Assert.Equal(7_074_000, s.VfoBHz);
+        Assert.Equal(RxMode.LSB, s.ModeB);
+        Assert.Equal(-2850, s.FilterLowHzB);
+        Assert.Equal(-100, s.FilterHighHzB);
+        Assert.Equal("VAR1", s.FilterPresetNameB);
+        Assert.Equal(-3.0, s.Rx2AfGainDb);
+
+        var rx2 = Rx(s, 1);
+        Assert.True(rx2.Enabled);
+        Assert.Equal(7_074_000, rx2.VfoHz);
+        Assert.Equal(RxMode.LSB, rx2.Mode);
+        Assert.Equal(-2850, rx2.FilterLowHz);
+        Assert.Equal(-100, rx2.FilterHighHz);
+    }
+
+    [Fact]
+    public void SetReceiver_Rx1Mode_MatchesLegacySetMode()
+    {
+        using var viaUnified = BuildRadio();
+        using var viaLegacy = BuildRadio();
+
+        var a = viaUnified.SetReceiver(0, mode: RxMode.CWU);
+        var b = viaLegacy.SetMode(RxMode.CWU, TxVfo.A);
+
+        Assert.Equal(b.Mode, a.Mode);
+        Assert.Equal(b.FilterLowHz, a.FilterLowHz);
+        Assert.Equal(b.FilterHighHz, a.FilterHighHz);
+    }
+
+    [Fact]
+    public void SetReceiver_PartialFilter_FillsMissingEdgeFromCurrent()
+    {
+        using var radio = BuildRadio();
+        radio.SetReceiver(0, filterLowHz: 100, filterHighHz: 2800, filterPresetName: "VAR1");
+
+        // Supply only the high edge — the low edge must persist.
+        var s = radio.SetReceiver(0, filterHighHz: 3200);
+
+        Assert.Equal(100, s.FilterLowHz);
+        Assert.Equal(3200, s.FilterHighHz);
+    }
+}

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -5630,6 +5630,7 @@ export function setReceiver(
     filterLowHz?: number;
     filterHighHz?: number;
     afGainDb?: number;
+    filterPresetName?: string | null;
   },
   signal?: AbortSignal,
 ): Promise<RadioStateDto> {
@@ -5642,10 +5643,13 @@ export function setReceiver(
         enabled: req.enabled,
         vfoHz: req.vfoHz,
         adcSource: req.adcSource,
-        mode: req.mode,
+        // RxMode serialises as its numeric ordinal on the write path (the
+        // server has no JsonStringEnumConverter) — same encoding setMode uses.
+        mode: req.mode !== undefined ? MODE_ORDER.indexOf(req.mode) : undefined,
         filterLowHz: req.filterLowHz,
         filterHighHz: req.filterHighHz,
         afGainDb: req.afGainDb,
+        filterPresetName: req.filterPresetName,
       }),
       signal,
     },

--- a/zeus-web/src/components/AfGainSlider.tsx
+++ b/zeus-web/src/components/AfGainSlider.tsx
@@ -44,8 +44,8 @@
 // License for details.
 
 import { useCallback, useState } from 'react';
-import { setRx2, setRxAfGain, type TxVfo } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import { getReceiverAfGainDb, postReceiverAfGain } from '../state/receiver-state';
 import { useLiveSlider } from '../hooks/useLiveSlider';
 
 // Master RX AF gain in dB. Drives WDSP's SetRXAPanelGain1(linear) server-side
@@ -58,14 +58,13 @@ const MIN = -50;
 const MAX = 20;
 
 export function AfGainSlider() {
-  const serverAf = useConnectionStore((s) => s.rxAfGainDb);
-  const serverAfB = useConnectionStore((s) => s.rx2AfGainDb);
-  const rx2Enabled = useConnectionStore((s) => s.rx2Enabled);
-  const rxFocus = useConnectionStore((s) => s.rxFocus);
+  // Follow the focused receiver (0=RX1, 1=RX2, >=2=RX3+) so the AF slider is the
+  // volume of whichever receiver the operator is working in — the A/B model
+  // generalised to any DDC.
+  const focusedRxIndex = useConnectionStore((s) => s.focusedRxIndex);
+  const activeAf = useConnectionStore((s) => getReceiverAfGainDb(s, focusedRxIndex));
   const connected = useConnectionStore((s) => s.status === 'Connected');
   const applyState = useConnectionStore((s) => s.applyState);
-  const activeReceiver: TxVfo = rxFocus === 'B' && rx2Enabled ? 'B' : 'A';
-  const activeAf = activeReceiver === 'B' ? serverAfB : serverAf;
 
   const [dragValue, setDragValue] = useState<number | null>(null);
   const value = dragValue ?? activeAf;
@@ -77,16 +76,14 @@ export function AfGainSlider() {
   const liveSlider = useLiveSlider<number>({
     send: useCallback(
       (v: number, signal: AbortSignal) =>
-        (activeReceiver === 'B'
-          ? setRx2({ afGainDb: v }, signal)
-          : setRxAfGain(v, signal))
+        postReceiverAfGain(focusedRxIndex, v, signal)
           .then((next) => {
             if (!signal.aborted) applyState(next);
           })
           .catch(() => {
             /* next poll will reconcile; don't noisily log on abort */
           }),
-      [activeReceiver, applyState],
+      [focusedRxIndex, applyState],
     ),
   });
 

--- a/zeus-web/src/components/AfGainSlider.tsx
+++ b/zeus-web/src/components/AfGainSlider.tsx
@@ -75,15 +75,22 @@ export function AfGainSlider() {
   // capping the wire rate to one POST per paint.
   const liveSlider = useLiveSlider<number>({
     send: useCallback(
-      (v: number, signal: AbortSignal) =>
-        postReceiverAfGain(focusedRxIndex, v, signal)
-          .then((next) => {
-            if (!signal.aborted) applyState(next);
-          })
+      (v: number, signal: AbortSignal) => {
+        // Ganged: stream AF to every selected receiver; reconcile from focused.
+        const { selectedRxIndices, focusedRxIndex: focused } = useConnectionStore.getState();
+        return Promise.all(
+          selectedRxIndices.map((idx) =>
+            postReceiverAfGain(idx, v, signal).then((next) => {
+              if (idx === focused && !signal.aborted) applyState(next);
+            }),
+          ),
+        )
+          .then(() => {})
           .catch(() => {
             /* next poll will reconcile; don't noisily log on abort */
-          }),
-      [focusedRxIndex, applyState],
+          });
+      },
+      [applyState],
     ),
   });
 

--- a/zeus-web/src/components/ModeBandwidth.tsx
+++ b/zeus-web/src/components/ModeBandwidth.tsx
@@ -47,6 +47,7 @@ import { useCallback } from 'react';
 import { type RxMode } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
 import {
+  gangedReceiverAction,
   getReceiverMode,
   optimisticSetReceiverMode,
   postReceiverMode,
@@ -75,29 +76,23 @@ export function ModeBandwidth() {
   // same model VFO B used via rxFocus — generalised to any numeric receiver so
   // the mode row drives whichever receiver the operator is working in.
   const focusedRxIndex = useConnectionStore((s) => s.focusedRxIndex);
-  const applyState = useConnectionStore((s) => s.applyState);
   const activeMode = useConnectionStore((s) => getReceiverMode(s, focusedRxIndex));
 
   const selectMode = useCallback(
     (m: RxMode) => {
       if (m === activeMode) return;
-      optimisticSetReceiverMode(focusedRxIndex, m);
-      // Per-band last-mode memory is an RX1/RX2 (A/B) concept; skip for RX3+.
+      // Ganged: apply to every selected receiver; the focused one reconciles.
+      gangedReceiverAction({
+        optimistic: (k) => optimisticSetReceiverMode(k, m),
+        post: (k) => postReceiverMode(k, m),
+      });
+      // Per-band last-mode memory is an RX1/RX2 (A/B) concept; record the
+      // focused receiver's band only.
       if (focusedRxIndex <= 1) {
         saveReceiverBandModeMemory(focusedRxIndex === 1 ? 'B' : 'A', m);
       }
-      postReceiverMode(focusedRxIndex, m)
-        .then((state) => {
-          applyState(state);
-          if (focusedRxIndex <= 1) {
-            saveReceiverBandModeMemory(focusedRxIndex === 1 ? 'B' : 'A', undefined, state);
-          }
-        })
-        .catch(() => {
-          /* next state poll will reconcile */
-        });
     },
-    [focusedRxIndex, activeMode, applyState],
+    [focusedRxIndex, activeMode],
   );
 
   return (

--- a/zeus-web/src/components/ModeBandwidth.tsx
+++ b/zeus-web/src/components/ModeBandwidth.tsx
@@ -44,8 +44,13 @@
 // License for details.
 
 import { useCallback } from 'react';
-import { setMode, type RxMode, type TxVfo } from '../api/client';
+import { type RxMode } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import {
+  getReceiverMode,
+  optimisticSetReceiverMode,
+  postReceiverMode,
+} from '../state/receiver-state';
 import { saveReceiverBandModeMemory } from '../util/band-memory';
 import { toolbarFavDragMime } from './toolbar/toolbarFavoriteDrag';
 
@@ -66,29 +71,33 @@ const MODES: readonly ModeEntry[] = [
 ];
 
 export function ModeBandwidth() {
-  const mode = useConnectionStore((s) => s.mode);
-  const modeB = useConnectionStore((s) => s.modeB);
-  const rx2Enabled = useConnectionStore((s) => s.rx2Enabled);
-  const rxFocus = useConnectionStore((s) => s.rxFocus);
+  // Follow the focused receiver across all DDCs (0=RX1, 1=RX2, >=2=RX3+), the
+  // same model VFO B used via rxFocus — generalised to any numeric receiver so
+  // the mode row drives whichever receiver the operator is working in.
+  const focusedRxIndex = useConnectionStore((s) => s.focusedRxIndex);
   const applyState = useConnectionStore((s) => s.applyState);
-  const activeReceiver: TxVfo = rxFocus === 'B' && rx2Enabled ? 'B' : 'A';
-  const activeMode = activeReceiver === 'B' ? modeB : mode;
+  const activeMode = useConnectionStore((s) => getReceiverMode(s, focusedRxIndex));
 
   const selectMode = useCallback(
     (m: RxMode) => {
       if (m === activeMode) return;
-      useConnectionStore.setState(activeReceiver === 'B' ? { modeB: m } : { mode: m });
-      saveReceiverBandModeMemory(activeReceiver, m);
-      setMode(m, undefined, activeReceiver)
+      optimisticSetReceiverMode(focusedRxIndex, m);
+      // Per-band last-mode memory is an RX1/RX2 (A/B) concept; skip for RX3+.
+      if (focusedRxIndex <= 1) {
+        saveReceiverBandModeMemory(focusedRxIndex === 1 ? 'B' : 'A', m);
+      }
+      postReceiverMode(focusedRxIndex, m)
         .then((state) => {
           applyState(state);
-          saveReceiverBandModeMemory(activeReceiver, undefined, state);
+          if (focusedRxIndex <= 1) {
+            saveReceiverBandModeMemory(focusedRxIndex === 1 ? 'B' : 'A', undefined, state);
+          }
         })
         .catch(() => {
           /* next state poll will reconcile */
         });
     },
-    [activeReceiver, activeMode, applyState],
+    [focusedRxIndex, activeMode, applyState],
   );
 
   return (

--- a/zeus-web/src/components/VfoDisplay.tsx
+++ b/zeus-web/src/components/VfoDisplay.tsx
@@ -146,8 +146,7 @@ export function VfoDisplay({
   compact = false,
 }: VfoDisplayProps = {}) {
   const targetIndex = resolveTargetIndex(receiver, rxIndex);
-  const resolvedLabel =
-    label ?? (targetIndex === 1 ? 'VFO B' : targetIndex >= 2 ? `RX${targetIndex + 1}` : 'VFO A');
+  const resolvedLabel = label ?? `RX${targetIndex + 1}`;
   const vfoHz = useConnectionStore((s) =>
     targetIndex === 0
       ? s.vfoHz

--- a/zeus-web/src/components/filter/FilterMiniPan.tsx
+++ b/zeus-web/src/components/filter/FilterMiniPan.tsx
@@ -1934,7 +1934,7 @@ function FilterMiniPanSurface({
     <div className={`filter-minipan-wrap ${split ? 'filter-minipan-wrap--split' : ''}`}>
       {showReceiverLabel && (
         <div className={`filter-minipan-vfo-tag mono ${receiver === 'B' ? 'is-rx2' : 'is-rx1'}`}>
-          {receiver === 'B' ? 'RX2 · VFO B' : 'RX1 · VFO A'}
+          {receiver === 'B' ? 'RX2' : 'RX1'}
         </div>
       )}
       <canvas

--- a/zeus-web/src/components/filter/FilterPanel.tsx
+++ b/zeus-web/src/components/filter/FilterPanel.tsx
@@ -14,34 +14,35 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import { createPortal } from 'react-dom';
 import { useConnectionStore } from '../../state/connection-store';
 import {
-  setFilter,
   getFilterPresets,
   type FilterPresetDto,
-  type TxVfo,
 } from '../../api/client';
+import {
+  getReceiverFilterHighHz,
+  getReceiverFilterLowHz,
+  getReceiverFilterPresetName,
+  getReceiverMode,
+  optimisticSetReceiverFilter,
+  optimisticSetReceiverPreset,
+  postReceiverFilter,
+} from '../../state/receiver-state';
 import { useFilterFavoritesStore, useFavoritesForMode } from '../../state/filter-favorites-store';
 import { FILTER_DRAG_MIME } from './filterRibbonShared';
 import { getPresetsForMode } from './filterPresets';
 
 export function FilterPanel() {
-  const mode = useConnectionStore((s) => s.mode);
-  const modeB = useConnectionStore((s) => s.modeB);
-  const filterPresetName = useConnectionStore((s) => s.filterPresetName);
-  const filterPresetNameB = useConnectionStore((s) => s.filterPresetNameB);
-  const filterLow = useConnectionStore((s) => s.filterLowHz);
-  const filterHigh = useConnectionStore((s) => s.filterHighHz);
-  const filterLowB = useConnectionStore((s) => s.filterLowHzB);
-  const filterHighB = useConnectionStore((s) => s.filterHighHzB);
-  const rx2Enabled = useConnectionStore((s) => s.rx2Enabled);
-  const rxFocus = useConnectionStore((s) => s.rxFocus);
+  // Follow the focused receiver (0=RX1, 1=RX2, >=2=RX3+) so the filter strip
+  // edits whichever receiver the operator is working in.
+  const focusedRxIndex = useConnectionStore((s) => s.focusedRxIndex);
+  const activeMode = useConnectionStore((s) => getReceiverMode(s, focusedRxIndex));
+  const activeFilterPresetName = useConnectionStore((s) =>
+    getReceiverFilterPresetName(s, focusedRxIndex),
+  );
+  const activeFilterLow = useConnectionStore((s) => getReceiverFilterLowHz(s, focusedRxIndex));
+  const activeFilterHigh = useConnectionStore((s) => getReceiverFilterHighHz(s, focusedRxIndex));
   const applyState = useConnectionStore((s) => s.applyState);
   const loadFavorites = useFilterFavoritesStore((s) => s.load);
   const updateFavorites = useFilterFavoritesStore((s) => s.update);
-  const activeReceiver: TxVfo = rxFocus === 'B' && rx2Enabled ? 'B' : 'A';
-  const activeMode = activeReceiver === 'B' ? modeB : mode;
-  const activeFilterPresetName = activeReceiver === 'B' ? filterPresetNameB : filterPresetName;
-  const activeFilterLow = activeReceiver === 'B' ? filterLowB : filterLow;
-  const activeFilterHigh = activeReceiver === 'B' ? filterHighB : filterHigh;
   const favoriteSlotNames = useFavoritesForMode(activeMode);
 
   // Seed from the local Thetis preset table so labels render correctly on
@@ -92,24 +93,13 @@ export function FilterPanel() {
 
   const selectPreset = useCallback(
     (slot: FilterPresetDto) => {
-      useConnectionStore.setState({
-        ...(activeReceiver === 'B'
-          ? {
-              filterLowHzB: slot.lowHz,
-              filterHighHzB: slot.highHz,
-              filterPresetNameB: slot.slotName,
-            }
-          : {
-              filterLowHz: slot.lowHz,
-              filterHighHz: slot.highHz,
-              filterPresetName: slot.slotName,
-            }),
-      });
-      setFilter(slot.lowHz, slot.highHz, slot.slotName, undefined, activeReceiver)
+      optimisticSetReceiverFilter(focusedRxIndex, slot.lowHz, slot.highHz);
+      optimisticSetReceiverPreset(focusedRxIndex, slot.slotName);
+      postReceiverFilter(focusedRxIndex, slot.lowHz, slot.highHz, slot.slotName)
         .then(applyState)
         .catch(() => { /* next state poll reconciles */ });
     },
-    [activeReceiver, applyState],
+    [focusedRxIndex, applyState],
   );
 
   // Close popover on outside click or Escape. Treats clicks inside either

--- a/zeus-web/src/components/filter/FilterPanel.tsx
+++ b/zeus-web/src/components/filter/FilterPanel.tsx
@@ -18,6 +18,7 @@ import {
   type FilterPresetDto,
 } from '../../api/client';
 import {
+  gangedReceiverAction,
   getReceiverFilterHighHz,
   getReceiverFilterLowHz,
   getReceiverFilterPresetName,
@@ -40,7 +41,6 @@ export function FilterPanel() {
   );
   const activeFilterLow = useConnectionStore((s) => getReceiverFilterLowHz(s, focusedRxIndex));
   const activeFilterHigh = useConnectionStore((s) => getReceiverFilterHighHz(s, focusedRxIndex));
-  const applyState = useConnectionStore((s) => s.applyState);
   const loadFavorites = useFilterFavoritesStore((s) => s.load);
   const updateFavorites = useFilterFavoritesStore((s) => s.update);
   const favoriteSlotNames = useFavoritesForMode(activeMode);
@@ -93,13 +93,15 @@ export function FilterPanel() {
 
   const selectPreset = useCallback(
     (slot: FilterPresetDto) => {
-      optimisticSetReceiverFilter(focusedRxIndex, slot.lowHz, slot.highHz);
-      optimisticSetReceiverPreset(focusedRxIndex, slot.slotName);
-      postReceiverFilter(focusedRxIndex, slot.lowHz, slot.highHz, slot.slotName)
-        .then(applyState)
-        .catch(() => { /* next state poll reconciles */ });
+      gangedReceiverAction({
+        optimistic: (k) => {
+          optimisticSetReceiverFilter(k, slot.lowHz, slot.highHz);
+          optimisticSetReceiverPreset(k, slot.slotName);
+        },
+        post: (k) => postReceiverFilter(k, slot.lowHz, slot.highHz, slot.slotName),
+      });
     },
-    [focusedRxIndex, applyState],
+    [],
   );
 
   // Close popover on outside click or Escape. Treats clicks inside either

--- a/zeus-web/src/components/filter/FilterRibbon.tsx
+++ b/zeus-web/src/components/filter/FilterRibbon.tsx
@@ -33,6 +33,7 @@ import {
   type RxMode,
 } from '../../api/client';
 import {
+  gangedReceiverAction,
   getReceiverFilterHighHz,
   getReceiverFilterLowHz,
   getReceiverFilterPresetName,
@@ -114,7 +115,6 @@ export function FilterRibbon({
     getReceiverFilterPresetName(s, focusedRxIndex),
   );
   const open = useConnectionStore((s) => s.filterAdvancedPaneOpen);
-  const applyState = useConnectionStore((s) => s.applyState);
   const favoriteSlotNames = useFavoritesForMode(activeMode);
   const [serverPresets, setServerPresets] = useState<FilterPresetDto[] | null>(null);
   const [dragSlot, setDragSlot] = useState<string | null>(null);
@@ -142,12 +142,14 @@ export function FilterRibbon({
   }, [presets]);
 
   const selectPreset = useCallback((slot: FilterPresetSlot) => {
-    optimisticSetReceiverFilter(focusedRxIndex, slot.lowHz, slot.highHz);
-    optimisticSetReceiverPreset(focusedRxIndex, slot.slotName);
-    postReceiverFilter(focusedRxIndex, slot.lowHz, slot.highHz, slot.slotName)
-      .then(applyState)
-      .catch(() => {});
-  }, [focusedRxIndex, applyState]);
+    gangedReceiverAction({
+      optimistic: (k) => {
+        optimisticSetReceiverFilter(k, slot.lowHz, slot.highHz);
+        optimisticSetReceiverPreset(k, slot.slotName);
+      },
+      post: (k) => postReceiverFilter(k, slot.lowHz, slot.highHz, slot.slotName),
+    });
+  }, []);
 
   const closeRibbon = useCallback(() => {
     useConnectionStore.setState({ filterAdvancedPaneOpen: false });
@@ -185,16 +187,21 @@ export function FilterRibbon({
     // defaults and never get overwritten — when one is active the edit falls
     // back to VAR1 (set by activeVarSlot above).
     const target = activeVarSlot;
-    optimisticSetReceiverFilter(focusedRxIndex, low, high);
-    optimisticSetReceiverPreset(focusedRxIndex, target);
+    gangedReceiverAction({
+      optimistic: (k) => {
+        optimisticSetReceiverFilter(k, low, high);
+        optimisticSetReceiverPreset(k, target);
+      },
+      post: (k) => postReceiverFilter(k, low, high, target),
+    });
     try {
-      await postReceiverFilter(focusedRxIndex, low, high, target).then(applyState);
+      // The VAR-slot override is a per-mode preset table edit (global), not a
+      // per-receiver write — record it once for the focused receiver's mode.
       await setFilterPresetOverride(activeMode, target, low, high);
-      // Refresh preset list so the VAR chip shows the new values.
       const fresh = await getFilterPresets(activeMode);
       setServerPresets(fresh);
     } catch { /* next state poll reconciles */ }
-  }, [loDraft, hiDraft, activeMode, focusedRxIndex, applyState, activeVarSlot]);
+  }, [loDraft, hiDraft, activeMode, activeVarSlot]);
 
   const onCustomKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') e.currentTarget.blur();
@@ -220,13 +227,17 @@ export function FilterRibbon({
       const newHi = currentHigh + dir * step;
       if (newHi <= currentLow + 50) return;
       const slot = currentPreset && /^VAR[12]$/.test(currentPreset) ? currentPreset : 'VAR1';
-      optimisticSetReceiverFilter(focusedRxIndex, currentLow, newHi);
-      optimisticSetReceiverPreset(focusedRxIndex, slot);
-      postReceiverFilter(focusedRxIndex, currentLow, newHi, slot).then(applyState).catch(() => {});
+      gangedReceiverAction({
+        optimistic: (k) => {
+          optimisticSetReceiverFilter(k, currentLow, newHi);
+          optimisticSetReceiverPreset(k, slot);
+        },
+        post: (k) => postReceiverFilter(k, currentLow, newHi, slot),
+      });
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [embedded, open, activeMode, focusedRxIndex, applyState, closeRibbon, section]);
+  }, [embedded, open, activeMode, focusedRxIndex, closeRibbon, section]);
 
   if (!embedded && !open) return null;
   // The mini-pan section can render before the preset table resolves; only

--- a/zeus-web/src/components/filter/FilterRibbon.tsx
+++ b/zeus-web/src/components/filter/FilterRibbon.tsx
@@ -26,14 +26,21 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useConnectionStore } from '../../state/connection-store';
 import {
-  setFilter,
   setFilterAdvancedPaneOpen,
   setFilterPresetOverride,
   getFilterPresets,
   type FilterPresetDto,
   type RxMode,
-  type TxVfo,
 } from '../../api/client';
+import {
+  getReceiverFilterHighHz,
+  getReceiverFilterLowHz,
+  getReceiverFilterPresetName,
+  getReceiverMode,
+  optimisticSetReceiverFilter,
+  optimisticSetReceiverPreset,
+  postReceiverFilter,
+} from '../../state/receiver-state';
 import {
   getPresetsForMode,
   nudgeStepHz,
@@ -97,23 +104,17 @@ export function FilterRibbon({
   embedded = false,
   section = 'all',
 }: { embedded?: boolean; section?: FilterRibbonSection } = {}) {
-  const mode = useConnectionStore((s) => s.mode);
-  const modeB = useConnectionStore((s) => s.modeB);
-  const filterLow = useConnectionStore((s) => s.filterLowHz);
-  const filterHigh = useConnectionStore((s) => s.filterHighHz);
-  const filterLowB = useConnectionStore((s) => s.filterLowHzB);
-  const filterHighB = useConnectionStore((s) => s.filterHighHzB);
-  const filterPresetName = useConnectionStore((s) => s.filterPresetName);
-  const filterPresetNameB = useConnectionStore((s) => s.filterPresetNameB);
-  const rx2Enabled = useConnectionStore((s) => s.rx2Enabled);
-  const rxFocus = useConnectionStore((s) => s.rxFocus);
+  // Follow the focused receiver (0=RX1, 1=RX2, >=2=RX3+) so the advanced filter
+  // ribbon edits whichever receiver the operator is working in.
+  const focusedRxIndex = useConnectionStore((s) => s.focusedRxIndex);
+  const activeMode = useConnectionStore((s) => getReceiverMode(s, focusedRxIndex));
+  const activeFilterLow = useConnectionStore((s) => getReceiverFilterLowHz(s, focusedRxIndex));
+  const activeFilterHigh = useConnectionStore((s) => getReceiverFilterHighHz(s, focusedRxIndex));
+  const activeFilterPresetName = useConnectionStore((s) =>
+    getReceiverFilterPresetName(s, focusedRxIndex),
+  );
   const open = useConnectionStore((s) => s.filterAdvancedPaneOpen);
   const applyState = useConnectionStore((s) => s.applyState);
-  const activeReceiver: TxVfo = rxFocus === 'B' && rx2Enabled ? 'B' : 'A';
-  const activeMode = activeReceiver === 'B' ? modeB : mode;
-  const activeFilterLow = activeReceiver === 'B' ? filterLowB : filterLow;
-  const activeFilterHigh = activeReceiver === 'B' ? filterHighB : filterHigh;
-  const activeFilterPresetName = activeReceiver === 'B' ? filterPresetNameB : filterPresetName;
   const favoriteSlotNames = useFavoritesForMode(activeMode);
   const [serverPresets, setServerPresets] = useState<FilterPresetDto[] | null>(null);
   const [dragSlot, setDragSlot] = useState<string | null>(null);
@@ -141,23 +142,12 @@ export function FilterRibbon({
   }, [presets]);
 
   const selectPreset = useCallback((slot: FilterPresetSlot) => {
-    useConnectionStore.setState({
-      ...(activeReceiver === 'B'
-        ? {
-            filterLowHzB: slot.lowHz,
-            filterHighHzB: slot.highHz,
-            filterPresetNameB: slot.slotName,
-          }
-        : {
-            filterLowHz: slot.lowHz,
-            filterHighHz: slot.highHz,
-            filterPresetName: slot.slotName,
-          }),
-    });
-    setFilter(slot.lowHz, slot.highHz, slot.slotName, undefined, activeReceiver)
+    optimisticSetReceiverFilter(focusedRxIndex, slot.lowHz, slot.highHz);
+    optimisticSetReceiverPreset(focusedRxIndex, slot.slotName);
+    postReceiverFilter(focusedRxIndex, slot.lowHz, slot.highHz, slot.slotName)
       .then(applyState)
       .catch(() => {});
-  }, [activeReceiver, applyState]);
+  }, [focusedRxIndex, applyState]);
 
   const closeRibbon = useCallback(() => {
     useConnectionStore.setState({ filterAdvancedPaneOpen: false });
@@ -195,27 +185,16 @@ export function FilterRibbon({
     // defaults and never get overwritten — when one is active the edit falls
     // back to VAR1 (set by activeVarSlot above).
     const target = activeVarSlot;
-    useConnectionStore.setState({
-      ...(activeReceiver === 'B'
-        ? {
-            filterLowHzB: low,
-            filterHighHzB: high,
-            filterPresetNameB: target,
-          }
-        : {
-            filterLowHz: low,
-            filterHighHz: high,
-            filterPresetName: target,
-          }),
-    });
+    optimisticSetReceiverFilter(focusedRxIndex, low, high);
+    optimisticSetReceiverPreset(focusedRxIndex, target);
     try {
-      await setFilter(low, high, target, undefined, activeReceiver).then(applyState);
+      await postReceiverFilter(focusedRxIndex, low, high, target).then(applyState);
       await setFilterPresetOverride(activeMode, target, low, high);
       // Refresh preset list so the VAR chip shows the new values.
       const fresh = await getFilterPresets(activeMode);
       setServerPresets(fresh);
     } catch { /* next state poll reconciles */ }
-  }, [loDraft, hiDraft, activeMode, activeReceiver, applyState, activeVarSlot]);
+  }, [loDraft, hiDraft, activeMode, focusedRxIndex, applyState, activeVarSlot]);
 
   const onCustomKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') e.currentTarget.blur();
@@ -235,22 +214,19 @@ export function FilterRibbon({
       const step = nudgeStepHz(activeMode) * (e.shiftKey ? 10 : 1);
       const dir = e.key === 'ArrowRight' ? 1 : -1;
       const s = useConnectionStore.getState();
-      const currentLow = activeReceiver === 'B' ? s.filterLowHzB : s.filterLowHz;
-      const currentHigh = activeReceiver === 'B' ? s.filterHighHzB : s.filterHighHz;
-      const currentPreset = activeReceiver === 'B' ? s.filterPresetNameB : s.filterPresetName;
+      const currentLow = getReceiverFilterLowHz(s, focusedRxIndex);
+      const currentHigh = getReceiverFilterHighHz(s, focusedRxIndex);
+      const currentPreset = getReceiverFilterPresetName(s, focusedRxIndex);
       const newHi = currentHigh + dir * step;
       if (newHi <= currentLow + 50) return;
       const slot = currentPreset && /^VAR[12]$/.test(currentPreset) ? currentPreset : 'VAR1';
-      useConnectionStore.setState(
-        activeReceiver === 'B'
-          ? { filterHighHzB: newHi, filterPresetNameB: slot }
-          : { filterHighHz: newHi, filterPresetName: slot },
-      );
-      setFilter(currentLow, newHi, slot, undefined, activeReceiver).then(applyState).catch(() => {});
+      optimisticSetReceiverFilter(focusedRxIndex, currentLow, newHi);
+      optimisticSetReceiverPreset(focusedRxIndex, slot);
+      postReceiverFilter(focusedRxIndex, currentLow, newHi, slot).then(applyState).catch(() => {});
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [embedded, open, activeMode, activeReceiver, applyState, closeRibbon, section]);
+  }, [embedded, open, activeMode, focusedRxIndex, applyState, closeRibbon, section]);
 
   if (!embedded && !open) return null;
   // The mini-pan section can render before the preset table resolves; only

--- a/zeus-web/src/components/toolbar/BandFavorites.test.tsx
+++ b/zeus-web/src/components/toolbar/BandFavorites.test.tsx
@@ -233,4 +233,37 @@ describe('BandFavorites', () => {
 
     unmount();
   });
+
+  it('gangs a band selection across every selected receiver', async () => {
+    // RX1 + RX2 both selected, RX1 focused. A band click must retune BOTH.
+    useConnectionStore.setState({
+      vfoHz: 14_200_000,
+      vfoBHz: 14_200_000,
+      mode: 'USB',
+      modeB: 'USB',
+      rx2Enabled: true,
+      focusedRxIndex: 0,
+      rxFocus: 'A',
+      selectedRxIndices: [0, 1],
+    });
+
+    const { container, unmount } = render(createElement(BandFavorites));
+    const fortyMeters = Array.from(container.querySelectorAll<HTMLButtonElement>('button'))
+      .find((button) => button.textContent === '40m');
+
+    await act(async () => {
+      fortyMeters?.click();
+      await Promise.resolve();
+    });
+
+    // Both receivers were commanded to the 40m centre (the ganged contract).
+    // The focused receiver (RX1) reconciles the store from its own response;
+    // RX2's committed value lands on the next state poll, so we assert the
+    // posts rather than the transiently-reconciled sibling field.
+    expect(setVfo).toHaveBeenCalledWith(7_074_000, undefined);
+    expect(setVfoB).toHaveBeenCalledWith(7_074_000, undefined);
+    expect(useConnectionStore.getState().vfoHz).toBe(7_074_000);
+
+    unmount();
+  });
 });

--- a/zeus-web/src/components/toolbar/BandFavorites.test.tsx
+++ b/zeus-web/src/components/toolbar/BandFavorites.test.tsx
@@ -42,6 +42,7 @@ function resetStores() {
     rx2Enabled: true,
     rxFocus: 'B',
     focusedRxIndex: 1,
+    selectedRxIndices: [1],
     mode: 'USB',
     modeB: 'LSB',
     filterLowHzB: -2850,
@@ -86,7 +87,7 @@ describe('BandFavorites', () => {
     });
 
     expect(fortyMeters).toBeTruthy();
-    expect(setVfoB).toHaveBeenCalledWith(7_074_000);
+    expect(setVfoB).toHaveBeenCalledWith(7_074_000, undefined);
     expect(setVfo).not.toHaveBeenCalled();
     expect(setMode).not.toHaveBeenCalled();
     expect(useConnectionStore.getState().vfoBHz).toBe(7_074_000);
@@ -145,7 +146,7 @@ describe('BandFavorites', () => {
 
     expect(twentyMeters).toBeTruthy();
     expect(setMode).toHaveBeenCalledWith('DIGU', undefined, 'B');
-    expect(setVfoB).toHaveBeenCalledWith(14_074_000);
+    expect(setVfoB).toHaveBeenCalledWith(14_074_000, undefined);
     expect(setVfo).not.toHaveBeenCalled();
     expect(useConnectionStore.getState().mode).toBe('USB');
     expect(useConnectionStore.getState().modeB).toBe('DIGU');

--- a/zeus-web/src/components/toolbar/BandFavorites.test.tsx
+++ b/zeus-web/src/components/toolbar/BandFavorites.test.tsx
@@ -41,6 +41,7 @@ function resetStores() {
     vfoBHz: 7_200_000,
     rx2Enabled: true,
     rxFocus: 'B',
+    focusedRxIndex: 1,
     mode: 'USB',
     modeB: 'LSB',
     filterLowHzB: -2850,

--- a/zeus-web/src/components/toolbar/BandFavorites.tsx
+++ b/zeus-web/src/components/toolbar/BandFavorites.tsx
@@ -9,15 +9,21 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   fetchBandMemory,
   saveBandMemory,
-  setMode,
-  setVfo,
-  setVfoB,
   type BandMemoryEntry,
   type RadioStateDto,
   type RxMode,
-  type TxVfo,
 } from '../../api/client';
 import { useConnectionStore } from '../../state/connection-store';
+import {
+  getReceiverMode,
+  getReceiverVfoHz,
+  optimisticSetReceiverMode,
+  optimisticSetReceiverVfo,
+  postReceiverMode,
+  postReceiverVfo,
+  rxIndexOf,
+  type ReceiverKey,
+} from '../../state/receiver-state';
 import { viewCenterFor } from '../../state/view-center';
 import {
   BAND_MEMORY_UPDATED_EVENT,
@@ -48,21 +54,23 @@ const BAND_OPTIONS: readonly ToolbarOption[] = HF_BANDS.map((b) => ({
 
 const SAVE_DEBOUNCE_MS = 500;
 
-function withRestoredMode(state: RadioStateDto, receiver: TxVfo, mode: RxMode): RadioStateDto {
-  return receiver === 'B' ? { ...state, modeB: mode } : { ...state, mode };
+function withRestoredMode(state: RadioStateDto, receiver: ReceiverKey, mode: RxMode): RadioStateDto {
+  const idx = rxIndexOf(receiver);
+  if (idx === 0) return { ...state, mode };
+  if (idx === 1) return { ...state, modeB: mode };
+  return {
+    ...state,
+    receivers: state.receivers?.map((r) => (r.index === idx ? { ...r, mode } : r)) ?? state.receivers,
+  };
 }
 
 export function BandFavorites() {
-  const vfoHz = useConnectionStore((s) => s.vfoHz);
-  const vfoBHz = useConnectionStore((s) => s.vfoBHz);
-  const rx2Enabled = useConnectionStore((s) => s.rx2Enabled);
-  const rxFocus = useConnectionStore((s) => s.rxFocus);
-  const mode = useConnectionStore((s) => s.mode);
-  const modeB = useConnectionStore((s) => s.modeB);
+  // Follow the focused receiver (0=RX1, 1=RX2, >=2=RX3+) so band selection tunes
+  // whichever receiver the operator is working in.
+  const focusedRxIndex = useConnectionStore((s) => s.focusedRxIndex);
+  const activeVfoHz = useConnectionStore((s) => getReceiverVfoHz(s, focusedRxIndex));
+  const activeMode = useConnectionStore((s) => getReceiverMode(s, focusedRxIndex));
   const applyState = useConnectionStore((s) => s.applyState);
-  const activeReceiver: TxVfo = rxFocus === 'B' && rx2Enabled ? 'B' : 'A';
-  const activeVfoHz = activeReceiver === 'B' ? vfoBHz : vfoHz;
-  const activeMode = activeReceiver === 'B' ? modeB : mode;
 
   const [currentBand, setCurrentBand] = useState<string>(() => bandOf(activeVfoHz));
   const memoryRef = useRef<Map<string, BandMemoryEntry>>(new Map());
@@ -148,25 +156,19 @@ export function BandFavorites() {
       const targetHz = stored?.hz ?? band.centerHz;
       const targetMode: RxMode | null = stored?.mode ?? null;
 
-      viewCenterFor(activeReceiver).markOptimisticTune();
-      useConnectionStore.setState(
-        activeReceiver === 'B'
-          ? targetMode && targetMode !== activeMode
-            ? { vfoBHz: targetHz, modeB: targetMode }
-            : { vfoBHz: targetHz }
-          : targetMode && targetMode !== activeMode
-          ? { vfoHz: targetHz, mode: targetMode }
-          : { vfoHz: targetHz },
-      );
-      const postVfo = activeReceiver === 'B' ? setVfoB : setVfo;
+      viewCenterFor(focusedRxIndex).markOptimisticTune();
+      optimisticSetReceiverVfo(focusedRxIndex, targetHz);
+      if (targetMode && targetMode !== activeMode) {
+        optimisticSetReceiverMode(focusedRxIndex, targetMode);
+      }
 
       void (async () => {
         let modeRestored = !targetMode || targetMode === activeMode;
         if (targetMode && targetMode !== activeMode) {
           try {
             applyState(withRestoredMode(
-              await setMode(targetMode, undefined, activeReceiver),
-              activeReceiver,
+              await postReceiverMode(focusedRxIndex, targetMode),
+              focusedRxIndex,
               targetMode,
             ));
             modeRestored = true;
@@ -175,10 +177,10 @@ export function BandFavorites() {
           }
         }
         try {
-          const next = await postVfo(targetHz);
+          const next = await postReceiverVfo(focusedRxIndex, targetHz);
           applyState(
             targetMode && modeRestored
-              ? withRestoredMode(next, activeReceiver, targetMode)
+              ? withRestoredMode(next, focusedRxIndex, targetMode)
               : next,
           );
         } catch {
@@ -186,7 +188,7 @@ export function BandFavorites() {
         }
       })();
     },
-    [activeReceiver, activeMode, applyState, currentBand, flushPendingSave],
+    [focusedRxIndex, activeMode, applyState, currentBand, flushPendingSave],
   );
 
   return (

--- a/zeus-web/src/components/toolbar/BandFavorites.tsx
+++ b/zeus-web/src/components/toolbar/BandFavorites.tsx
@@ -69,7 +69,6 @@ export function BandFavorites() {
   // whichever receiver the operator is working in.
   const focusedRxIndex = useConnectionStore((s) => s.focusedRxIndex);
   const activeVfoHz = useConnectionStore((s) => getReceiverVfoHz(s, focusedRxIndex));
-  const activeMode = useConnectionStore((s) => getReceiverMode(s, focusedRxIndex));
   const applyState = useConnectionStore((s) => s.applyState);
 
   const [currentBand, setCurrentBand] = useState<string>(() => bandOf(activeVfoHz));
@@ -156,39 +155,54 @@ export function BandFavorites() {
       const targetHz = stored?.hz ?? band.centerHz;
       const targetMode: RxMode | null = stored?.mode ?? null;
 
-      viewCenterFor(focusedRxIndex).markOptimisticTune();
-      optimisticSetReceiverVfo(focusedRxIndex, targetHz);
-      if (targetMode && targetMode !== activeMode) {
-        optimisticSetReceiverMode(focusedRxIndex, targetMode);
-      }
+      // Ganged: a band selection retunes EVERY selected receiver to the
+      // remembered (hz, mode) for that band; the store is reconciled only from
+      // the focused receiver's responses (the others' are ignored so they can't
+      // clobber the focused view — the next state poll reconciles them). With a
+      // single-receiver selection this is identical to the focused-only path.
+      const { selectedRxIndices, focusedRxIndex: focused } = useConnectionStore.getState();
 
-      void (async () => {
-        let modeRestored = !targetMode || targetMode === activeMode;
-        if (targetMode && targetMode !== activeMode) {
+      for (const idx of selectedRxIndices) {
+        const curMode = getReceiverMode(useConnectionStore.getState(), idx);
+        const isFocused = idx === focused;
+
+        viewCenterFor(idx).markOptimisticTune();
+        optimisticSetReceiverVfo(idx, targetHz);
+        if (targetMode && targetMode !== curMode) {
+          optimisticSetReceiverMode(idx, targetMode);
+        }
+
+        void (async () => {
+          let modeRestored = !targetMode || targetMode === curMode;
+          if (targetMode && targetMode !== curMode) {
+            try {
+              const res = withRestoredMode(
+                await postReceiverMode(idx, targetMode),
+                idx,
+                targetMode,
+              );
+              if (isFocused) applyState(res);
+              modeRestored = true;
+            } catch {
+              /* next state poll reconciles */
+            }
+          }
           try {
-            applyState(withRestoredMode(
-              await postReceiverMode(focusedRxIndex, targetMode),
-              focusedRxIndex,
-              targetMode,
-            ));
-            modeRestored = true;
+            const next = await postReceiverVfo(idx, targetHz);
+            if (isFocused) {
+              applyState(
+                targetMode && modeRestored
+                  ? withRestoredMode(next, idx, targetMode)
+                  : next,
+              );
+            }
           } catch {
             /* next state poll reconciles */
           }
-        }
-        try {
-          const next = await postReceiverVfo(focusedRxIndex, targetHz);
-          applyState(
-            targetMode && modeRestored
-              ? withRestoredMode(next, focusedRxIndex, targetMode)
-              : next,
-          );
-        } catch {
-          /* next state poll reconciles */
-        }
-      })();
+        })();
+      }
     },
-    [focusedRxIndex, activeMode, applyState, currentBand, flushPendingSave],
+    [applyState, currentBand, flushPendingSave],
   );
 
   return (

--- a/zeus-web/src/components/toolbar/ModeFavorites.test.tsx
+++ b/zeus-web/src/components/toolbar/ModeFavorites.test.tsx
@@ -30,6 +30,7 @@ function resetStores() {
     rx2Enabled: true,
     rxFocus: 'B',
     focusedRxIndex: 1,
+    selectedRxIndices: [1],
     mode: 'AM',
     modeB: 'USB',
   });

--- a/zeus-web/src/components/toolbar/ModeFavorites.test.tsx
+++ b/zeus-web/src/components/toolbar/ModeFavorites.test.tsx
@@ -29,6 +29,7 @@ function resetStores() {
     vfoBHz: 7_200_000,
     rx2Enabled: true,
     rxFocus: 'B',
+    focusedRxIndex: 1,
     mode: 'AM',
     modeB: 'USB',
   });

--- a/zeus-web/src/components/toolbar/ModeFavorites.tsx
+++ b/zeus-web/src/components/toolbar/ModeFavorites.tsx
@@ -8,6 +8,7 @@ import { useCallback } from 'react';
 import { type RxMode } from '../../api/client';
 import { useConnectionStore } from '../../state/connection-store';
 import {
+  gangedReceiverAction,
   getReceiverMode,
   optimisticSetReceiverMode,
   postReceiverMode,
@@ -33,29 +34,21 @@ export function ModeFavorites() {
   // Follow the focused receiver (0=RX1, 1=RX2, >=2=RX3+) so the favorite mode
   // buttons drive whichever receiver the operator is working in.
   const focusedRxIndex = useConnectionStore((s) => s.focusedRxIndex);
-  const applyState = useConnectionStore((s) => s.applyState);
   const activeMode = useConnectionStore((s) => getReceiverMode(s, focusedRxIndex));
 
   const onSelect = useCallback(
     (key: string) => {
       const m = key as RxMode;
       if (m === activeMode) return;
-      optimisticSetReceiverMode(focusedRxIndex, m);
+      gangedReceiverAction({
+        optimistic: (k) => optimisticSetReceiverMode(k, m),
+        post: (k) => postReceiverMode(k, m),
+      });
       if (focusedRxIndex <= 1) {
         saveReceiverBandModeMemory(focusedRxIndex === 1 ? 'B' : 'A', m);
       }
-      postReceiverMode(focusedRxIndex, m)
-        .then((state) => {
-          applyState(state);
-          if (focusedRxIndex <= 1) {
-            saveReceiverBandModeMemory(focusedRxIndex === 1 ? 'B' : 'A', undefined, state);
-          }
-        })
-        .catch(() => {
-          /* next state poll reconciles */
-        });
     },
-    [focusedRxIndex, activeMode, applyState],
+    [focusedRxIndex, activeMode],
   );
 
   return (

--- a/zeus-web/src/components/toolbar/ModeFavorites.tsx
+++ b/zeus-web/src/components/toolbar/ModeFavorites.tsx
@@ -5,8 +5,13 @@
 // favorite slot to pin it.
 
 import { useCallback } from 'react';
-import { setMode, type RxMode, type TxVfo } from '../../api/client';
+import { type RxMode } from '../../api/client';
 import { useConnectionStore } from '../../state/connection-store';
+import {
+  getReceiverMode,
+  optimisticSetReceiverMode,
+  postReceiverMode,
+} from '../../state/receiver-state';
 import { saveReceiverBandModeMemory } from '../../util/band-memory';
 import { ToolbarFavorites, type ToolbarOption } from './ToolbarFavorites';
 
@@ -25,30 +30,32 @@ const MODE_OPTIONS: readonly ToolbarOption[] = [
 ];
 
 export function ModeFavorites() {
-  const mode = useConnectionStore((s) => s.mode);
-  const modeB = useConnectionStore((s) => s.modeB);
-  const rx2Enabled = useConnectionStore((s) => s.rx2Enabled);
-  const rxFocus = useConnectionStore((s) => s.rxFocus);
+  // Follow the focused receiver (0=RX1, 1=RX2, >=2=RX3+) so the favorite mode
+  // buttons drive whichever receiver the operator is working in.
+  const focusedRxIndex = useConnectionStore((s) => s.focusedRxIndex);
   const applyState = useConnectionStore((s) => s.applyState);
-  const activeReceiver: TxVfo = rxFocus === 'B' && rx2Enabled ? 'B' : 'A';
-  const activeMode = activeReceiver === 'B' ? modeB : mode;
+  const activeMode = useConnectionStore((s) => getReceiverMode(s, focusedRxIndex));
 
   const onSelect = useCallback(
     (key: string) => {
       const m = key as RxMode;
       if (m === activeMode) return;
-      useConnectionStore.setState(activeReceiver === 'B' ? { modeB: m } : { mode: m });
-      saveReceiverBandModeMemory(activeReceiver, m);
-      setMode(m, undefined, activeReceiver)
+      optimisticSetReceiverMode(focusedRxIndex, m);
+      if (focusedRxIndex <= 1) {
+        saveReceiverBandModeMemory(focusedRxIndex === 1 ? 'B' : 'A', m);
+      }
+      postReceiverMode(focusedRxIndex, m)
         .then((state) => {
           applyState(state);
-          saveReceiverBandModeMemory(activeReceiver, undefined, state);
+          if (focusedRxIndex <= 1) {
+            saveReceiverBandModeMemory(focusedRxIndex === 1 ? 'B' : 'A', undefined, state);
+          }
         })
         .catch(() => {
           /* next state poll reconciles */
         });
     },
-    [activeReceiver, activeMode, applyState],
+    [focusedRxIndex, activeMode, applyState],
   );
 
   return (

--- a/zeus-web/src/layout/panels/HeroPanel.tsx
+++ b/zeus-web/src/layout/panels/HeroPanel.tsx
@@ -126,6 +126,8 @@ export function HeroPanel({
   const receivers = useConnectionStore((s) => s.receivers);
   const focusedRxIndex = useConnectionStore((s) => s.focusedRxIndex);
   const setFocusedRxIndex = useConnectionStore((s) => s.setFocusedRxIndex);
+  const selectedRxIndices = useConnectionStore((s) => s.selectedRxIndices);
+  const toggleRxSelection = useConnectionStore((s) => s.toggleRxSelection);
   // During TX the waterfall region shows the live transmitted spectrum
   // (WDSP TX analyzer pixels, streamed by the server while keyed).
   const keyed = useTxStore((s) => s.moxOn || s.tunOn);
@@ -485,10 +487,21 @@ export function HeroPanel({
                   type="button"
                   className={`hero-rx-audio-switch__key hero-rx-audio-switch__key--vfo ${
                     focusedRxIndex === r.index ? 'is-active' : ''
+                  } ${
+                    selectedRxIndices.includes(r.index) && focusedRxIndex !== r.index
+                      ? 'is-selected'
+                      : ''
                   }`}
-                  onClick={() => setFocusedRxIndex(r.index)}
-                  aria-pressed={focusedRxIndex === r.index}
-                  title={`Focus RX${r.index + 1} for mode, filter, band, keyboard tuning, and meters.`}
+                  // Plain click focuses (and collapses the selection to) this
+                  // receiver; Ctrl/Cmd-click toggles it in the multi-selection so
+                  // mode/filter/band/AF act on every selected receiver at once.
+                  onClick={(e) =>
+                    e.ctrlKey || e.metaKey
+                      ? toggleRxSelection(r.index)
+                      : setFocusedRxIndex(r.index)
+                  }
+                  aria-pressed={selectedRxIndices.includes(r.index)}
+                  title={`RX${r.index + 1}: click to focus, Ctrl/⌘-click to add to the multi-selection (ganged mode/filter/band/AF).`}
                 >
                   <span>{`RX${r.index + 1}`}</span>
                 </button>

--- a/zeus-web/src/layout/panels/VfoPanel.tsx
+++ b/zeus-web/src/layout/panels/VfoPanel.tsx
@@ -148,10 +148,8 @@ export function VfoPanel() {
   const active =
     lanes.find((l) => l.index === focusedRxIndex) ??
     lanes[0] ?? { index: 0, vfoHz, abId: 'A' as const };
-  const activeTitle =
-    active.index === 0 ? 'RX1 · VFO A' : active.index === 1 ? 'RX2 · VFO B' : `RX${active.index + 1}`;
-  const activeLabel =
-    active.index === 0 ? 'VFO A' : active.index === 1 ? 'VFO B' : `RX${active.index + 1}`;
+  const activeTitle = `RX${active.index + 1}`;
+  const activeLabel = `RX${active.index + 1}`;
   const activeAudible = audibleOf(active.index);
   const activeTx = txReceiverIndex === active.index;
 
@@ -182,7 +180,7 @@ export function VfoPanel() {
               }${muted ? ' · muted' : ''}`}
             >
               <span className="vfo-chip__id">
-                {l.index === 0 ? 'A' : l.index === 1 ? 'B' : l.index + 1}
+                {l.index + 1}
                 {isTx && <span className="vfo-chip__tx">TX</span>}
                 {muted && <VolumeX size={9} />}
               </span>
@@ -255,33 +253,33 @@ export function VfoPanel() {
             </label>
           )}
         </div>
-        {/* Dual-VFO tools — copy/swap A↔B. */}
-        <div className="vfo-md__tools" role="group" aria-label="VFO copy and swap">
+        {/* Dual-VFO tools — copy/swap RX1↔RX2. */}
+        <div className="vfo-md__tools" role="group" aria-label="RX1/RX2 copy and swap">
           <button
             type="button"
             className="vfo-tool-key"
             onClick={() => patchRx2({ vfoBHz: vfoHz })}
-            title="Copy VFO A to VFO B"
+            title="Copy RX1 to RX2"
           >
             <Copy size={12} />
-            <span>A&gt;B</span>
+            <span>1&gt;2</span>
           </button>
           <button
             type="button"
             className="vfo-tool-key"
             onClick={copyBToA}
             disabled={!rx2Enabled}
-            title="Copy VFO B to VFO A"
+            title="Copy RX2 to RX1"
           >
             <Copy size={12} />
-            <span>B&gt;A</span>
+            <span>2&gt;1</span>
           </button>
           <button
             type="button"
             className="vfo-tool-key"
             onClick={() => swapVfos().then(applyState).catch(() => {})}
             disabled={!rx2Enabled}
-            title="Swap VFO A and VFO B"
+            title="Swap RX1 and RX2"
           >
             <Repeat2 size={13} />
             <span>Swap</span>

--- a/zeus-web/src/layout/panels/VfoPanel.tsx
+++ b/zeus-web/src/layout/panels/VfoPanel.tsx
@@ -68,6 +68,8 @@ export function VfoPanel() {
   const txReceiverIndex = useConnectionStore((s) => s.txReceiverIndex);
   const focusedRxIndex = useConnectionStore((s) => s.focusedRxIndex);
   const setFocusedRxIndex = useConnectionStore((s) => s.setFocusedRxIndex);
+  const selectedRxIndices = useConnectionStore((s) => s.selectedRxIndices);
+  const toggleRxSelection = useConnectionStore((s) => s.toggleRxSelection);
 
   const patchRx2 = (req: {
     enabled?: boolean;
@@ -161,18 +163,21 @@ export function VfoPanel() {
           const muted = !audibleOf(l.index);
           const isTx = txReceiverIndex === l.index;
           const isActive = l.index === active.index;
+          const isSelected = selectedRxIndices.includes(l.index);
           return (
             <button
               key={l.index}
               type="button"
               role="tab"
               aria-selected={isActive}
-              className={`vfo-chip ${isActive ? 'is-active' : ''} ${isTx ? 'is-tx' : ''} ${
-                muted ? 'is-muted' : ''
-              }`}
+              className={`vfo-chip ${isActive ? 'is-active' : ''} ${
+                isSelected && !isActive ? 'is-selected' : ''
+              } ${isTx ? 'is-tx' : ''} ${muted ? 'is-muted' : ''}`}
               style={{ '--vfo-filter-color': receiverColorByIndex(l.index) } as CSSProperties}
-              onClick={() => setFocusedRxIndex(l.index)}
-              title={`${l.index === 0 ? 'RX1 / VFO A' : l.index === 1 ? 'RX2 / VFO B' : `RX${l.index + 1}`}${
+              onClick={(e) =>
+                e.ctrlKey || e.metaKey ? toggleRxSelection(l.index) : setFocusedRxIndex(l.index)
+              }
+              title={`RX${l.index + 1}: click to focus, Ctrl/⌘-click to multi-select${
                 isTx ? ' · transmitting here' : ''
               }${muted ? ' · muted' : ''}`}
             >

--- a/zeus-web/src/mobile/MobileApp.tsx
+++ b/zeus-web/src/mobile/MobileApp.tsx
@@ -274,7 +274,7 @@ export function MobileApp() {
         <MobileInstallPrompt />
         {activeTab === 'radio' ? (
           <>
-            <Section label="Frequency" meta="VFO A">
+            <Section label="Frequency" meta="RX1">
               <div className="m-vfo-grid">
                 <div className="m-vfo-wrap">
                   <VfoDisplay />
@@ -762,7 +762,7 @@ const TOOL_META: Record<MobileToolId, { name: string; desc: string; sub: string;
   tx: {
     name: 'TX Controls',
     desc: 'Step, AGC-T, drive, tune, mic gain',
-    sub: 'VFO A',
+    sub: 'RX1',
     icon: (
       <svg viewBox="0 0 24 24" aria-hidden>
         <circle cx="12" cy="12" r="3" />

--- a/zeus-web/src/state/connection-store.multiselect.test.ts
+++ b/zeus-web/src/state/connection-store.multiselect.test.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Multi-select / focus invariants for the uniform RX1-RX6 receiver model.
+// The selection drives ganged toolbar controls; the focused receiver is the
+// primary (always a member) whose values the controls display.
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useConnectionStore } from './connection-store';
+
+function reset() {
+  useConnectionStore.setState({ focusedRxIndex: 0, selectedRxIndices: [0], rxFocus: 'A' });
+}
+
+describe('connection-store multi-select', () => {
+  beforeEach(reset);
+
+  it('defaults to RX1 focused and solely selected', () => {
+    const s = useConnectionStore.getState();
+    expect(s.focusedRxIndex).toBe(0);
+    expect(s.selectedRxIndices).toEqual([0]);
+  });
+
+  it('plain focus collapses the selection to that receiver', () => {
+    useConnectionStore.getState().setFocusedRxIndex(3);
+    const s = useConnectionStore.getState();
+    expect(s.focusedRxIndex).toBe(3);
+    expect(s.selectedRxIndices).toEqual([3]);
+  });
+
+  it('toggle adds (and focuses) a receiver, kept sorted', () => {
+    useConnectionStore.getState().setFocusedRxIndex(2);
+    useConnectionStore.getState().toggleRxSelection(5);
+    useConnectionStore.getState().toggleRxSelection(3);
+    const s = useConnectionStore.getState();
+    expect(s.selectedRxIndices).toEqual([2, 3, 5]);
+    expect(s.focusedRxIndex).toBe(3); // last toggled-on receiver takes focus
+  });
+
+  it('toggling off a non-focused receiver leaves focus put', () => {
+    useConnectionStore.getState().setSelectedRxIndices([1, 2, 4]);
+    useConnectionStore.setState({ focusedRxIndex: 2 });
+    useConnectionStore.getState().toggleRxSelection(4);
+    const s = useConnectionStore.getState();
+    expect(s.selectedRxIndices).toEqual([1, 2]);
+    expect(s.focusedRxIndex).toBe(2);
+  });
+
+  it('toggling off the focused receiver moves focus to the lowest remaining', () => {
+    useConnectionStore.getState().setSelectedRxIndices([1, 2, 4]);
+    useConnectionStore.setState({ focusedRxIndex: 2 });
+    useConnectionStore.getState().toggleRxSelection(2);
+    const s = useConnectionStore.getState();
+    expect(s.selectedRxIndices).toEqual([1, 4]);
+    expect(s.focusedRxIndex).toBe(1);
+  });
+
+  it('never empties the selection — removing the last one is a no-op', () => {
+    useConnectionStore.getState().setFocusedRxIndex(3); // [3]
+    useConnectionStore.getState().toggleRxSelection(3);
+    const s = useConnectionStore.getState();
+    expect(s.selectedRxIndices).toEqual([3]);
+    expect(s.focusedRxIndex).toBe(3);
+  });
+
+  it('setSelectedRxIndices keeps focus if it survives, else picks the lowest', () => {
+    useConnectionStore.setState({ focusedRxIndex: 4, selectedRxIndices: [4] });
+    useConnectionStore.getState().setSelectedRxIndices([3, 1]);
+    let s = useConnectionStore.getState();
+    expect(s.selectedRxIndices).toEqual([1, 3]); // sorted
+    expect(s.focusedRxIndex).toBe(1); // 4 didn't survive → lowest
+
+    useConnectionStore.getState().setSelectedRxIndices([1, 5]);
+    s = useConnectionStore.getState();
+    expect(s.focusedRxIndex).toBe(1); // 1 survived → kept
+  });
+
+  it('mirrors rxFocus for the RX1/RX2 stitched view', () => {
+    useConnectionStore.getState().setFocusedRxIndex(1);
+    expect(useConnectionStore.getState().rxFocus).toBe('B');
+    useConnectionStore.getState().setFocusedRxIndex(0);
+    expect(useConnectionStore.getState().rxFocus).toBe('A');
+  });
+});

--- a/zeus-web/src/state/connection-store.ts
+++ b/zeus-web/src/state/connection-store.ts
@@ -88,6 +88,11 @@ export type ConnectionState = {
   // (0=RX1..). Drives the VFO-lane / hero highlight across all DDCs; rxFocus
   // stays the A/B stitched-view focus and mirrors this for indices 0/1.
   focusedRxIndex: number;
+  // Receivers the operator has multi-selected for ganged control. Toolbar
+  // actions (mode/filter/band/AF) apply to EVERY index here; focusedRxIndex is
+  // the primary whose values the controls display, and is always a member.
+  // Plain focus selects a single receiver; Ctrl/Cmd-click toggles membership.
+  selectedRxIndices: number[];
   mode: RxMode;
   modeB: RxMode;
   filterLowHz: number;
@@ -176,6 +181,8 @@ export type ConnectionState = {
   setTxLeveling: (txLeveling: TxLevelingConfigDto) => void;
   setRxFocus: (rxFocus: TxVfo) => void;
   setFocusedRxIndex: (index: number) => void;
+  setSelectedRxIndices: (indices: number[]) => void;
+  toggleRxSelection: (index: number) => void;
   setZoomLevel: (level: ZoomLevel) => void;
   setLastConnectedEndpoint: (ep: string | null) => void;
   setWisdomPhase: (phase: WisdomPhase) => void;
@@ -215,6 +222,7 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
   txReceiverIndex: 0,
   rxFocus: 'A',
   focusedRxIndex: 0,
+  selectedRxIndices: [0],
   mode: 'USB',
   modeB: 'USB',
   filterLowHz: 150,
@@ -283,8 +291,9 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
         txVfo: s.txVfo,
         txReceiverIndex: s.txReceiverIndex ?? prev.txReceiverIndex,
         rxFocus: s.rx2Enabled ? prev.rxFocus : 'A',
-        // UI-only focus — preserved across server state reconciles.
+        // UI-only focus + selection — preserved across server state reconciles.
         focusedRxIndex: prev.focusedRxIndex,
+        selectedRxIndices: prev.selectedRxIndices,
         mode: s.mode,
         modeB: s.modeB,
         filterLowHz: s.filterLowHz,
@@ -329,14 +338,45 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
   setSquelch: (squelch) => set({ squelch }),
   setTxLeveling: (txLeveling) => set({ txLeveling }),
   setRxFocus: (rxFocus) => set({ rxFocus }),
-  // Focus a receiver in the multi-DDC panels. Mirror into rxFocus for the
-  // RX1/RX2 stitched view so the existing A/B focus stays consistent.
+  // Focus a receiver in the multi-DDC panels. Plain focus collapses the
+  // selection to just this receiver. Mirror into rxFocus for the RX1/RX2
+  // stitched view so the existing A/B focus stays consistent (rxFocus is
+  // retired in a later phase of the numeric-receiver migration).
   setFocusedRxIndex: (focusedRxIndex) =>
     set(
       focusedRxIndex <= 1
-        ? { focusedRxIndex, rxFocus: focusedRxIndex === 1 ? 'B' : 'A' }
-        : { focusedRxIndex },
+        ? { focusedRxIndex, selectedRxIndices: [focusedRxIndex], rxFocus: focusedRxIndex === 1 ? 'B' : 'A' }
+        : { focusedRxIndex, selectedRxIndices: [focusedRxIndex] },
     ),
+  // Replace the multi-selection wholesale. Keeps focus on the same receiver if
+  // it survives, else focuses the lowest selected; never leaves it empty.
+  setSelectedRxIndices: (indices) =>
+    set((s) => {
+      const selectedRxIndices = indices.length ? [...indices].sort((a, b) => a - b) : [0];
+      const focusedRxIndex = selectedRxIndices.includes(s.focusedRxIndex)
+        ? s.focusedRxIndex
+        : selectedRxIndices[0] ?? 0;
+      return focusedRxIndex <= 1
+        ? { selectedRxIndices, focusedRxIndex, rxFocus: focusedRxIndex === 1 ? 'B' : 'A' }
+        : { selectedRxIndices, focusedRxIndex };
+    }),
+  // Ctrl/Cmd-click toggle: add (and focus) or remove a receiver from the
+  // selection. Removing the last one is a no-op — the control target is never
+  // empty. Removing the focused one moves focus to the lowest remaining.
+  toggleRxSelection: (index) =>
+    set((s) => {
+      const has = s.selectedRxIndices.includes(index);
+      if (has && s.selectedRxIndices.length === 1) return s;
+      const selectedRxIndices = has
+        ? s.selectedRxIndices.filter((i) => i !== index)
+        : [...s.selectedRxIndices, index].sort((a, b) => a - b);
+      const focusedRxIndex = has
+        ? (index === s.focusedRxIndex ? selectedRxIndices[0] ?? 0 : s.focusedRxIndex)
+        : index;
+      return focusedRxIndex <= 1
+        ? { selectedRxIndices, focusedRxIndex, rxFocus: focusedRxIndex === 1 ? 'B' : 'A' }
+        : { selectedRxIndices, focusedRxIndex };
+    }),
   setZoomLevel: (zoomLevel) => set({ zoomLevel }),
   setLastConnectedEndpoint: (lastConnectedEndpoint) =>
     set({ lastConnectedEndpoint }),

--- a/zeus-web/src/state/receiver-state.ts
+++ b/zeus-web/src/state/receiver-state.ts
@@ -36,8 +36,16 @@
 // sites — this module just routes field reads/writes.
 
 import { useConnectionStore } from './connection-store';
-import type { RadioStateDto, ReceiverDto } from '../api/client';
-import { setFilter, setReceiver, setVfo, setVfoB } from '../api/client';
+import type { RadioStateDto, ReceiverDto, RxMode } from '../api/client';
+import {
+  setFilter,
+  setMode,
+  setReceiver,
+  setRx2,
+  setRxAfGain,
+  setVfo,
+  setVfoB,
+} from '../api/client';
 
 /** Receiver discriminator. Numbers are canonical (0 = RX1, 1 = RX2, >= 2 =
  *  RX3+); `'A'`/`'B'` are legacy aliases for 0/1. */
@@ -109,6 +117,13 @@ export function getReceiverVfoFromState(
   return state.receivers?.find((r) => r.index === idx)?.vfoHz ?? state.vfoHz;
 }
 
+export function getReceiverAfGainDb(state: ConnState, key: ReceiverKey): number {
+  const idx = rxIndexOf(key);
+  if (idx === 0) return state.rxAfGainDb;
+  if (idx === 1) return state.rx2AfGainDb;
+  return receiverEntry(state, idx)?.afGainDb ?? state.rxAfGainDb;
+}
+
 export function getReceiverFilterPresetName(
   state: ConnState,
   key: ReceiverKey,
@@ -156,6 +171,19 @@ export function optimisticSetReceiverFilter(
   }
 }
 
+export function optimisticSetReceiverMode(key: ReceiverKey, mode: RxMode): void {
+  const idx = rxIndexOf(key);
+  if (idx === 0) {
+    useConnectionStore.setState({ mode });
+  } else if (idx === 1) {
+    useConnectionStore.setState({ modeB: mode });
+  } else {
+    useConnectionStore.setState((s) => ({
+      receivers: s.receivers.map((r) => (r.index === idx ? { ...r, mode } : r)),
+    }));
+  }
+}
+
 export function optimisticSetReceiverPreset(key: ReceiverKey, slot: string): void {
   const idx = rxIndexOf(key);
   if (idx === 0) {
@@ -198,5 +226,34 @@ export function postReceiverFilter(
   if (idx <= 1) {
     return setFilter(lo, hi, slot, signal, idx === 1 ? 'B' : 'A');
   }
-  return setReceiver(idx, { filterLowHz: lo, filterHighHz: hi }, signal);
+  // Carry the preset label so RX3+ rounds-trips the slot name (e.g. VAR1),
+  // exactly as RX1/RX2 do via setFilter's presetName argument.
+  return setReceiver(idx, { filterLowHz: lo, filterHighHz: hi, filterPresetName: slot }, signal);
+}
+
+/** Post an AF-gain (dB) change to any receiver. RX1 → master AF, RX2 → the
+ *  rx2 setter, RX3+ → their own DDC channel. Mirrors the VFO/filter routing. */
+export function postReceiverAfGain(
+  key: ReceiverKey,
+  db: number,
+  signal?: AbortSignal,
+) {
+  const idx = rxIndexOf(key);
+  if (idx === 0) return setRxAfGain(db, signal);
+  if (idx === 1) return setRx2({ afGainDb: db }, signal);
+  return setReceiver(idx, { afGainDb: db }, signal);
+}
+
+/** Post a mode change to any receiver. RX1/RX2 funnel through the legacy
+ *  /api/mode A/B path the server special-cases; RX3+ drive their own DDC
+ *  channel via setReceiver. Mirrors postReceiverFilter's routing. */
+export function postReceiverMode(
+  key: ReceiverKey,
+  mode: RxMode,
+  signal?: AbortSignal,
+) {
+  const idx = rxIndexOf(key);
+  if (idx === 0) return setMode(mode, signal, 'A');
+  if (idx === 1) return setMode(mode, signal, 'B');
+  return setReceiver(idx, { mode }, signal);
 }

--- a/zeus-web/src/state/receiver-state.ts
+++ b/zeus-web/src/state/receiver-state.ts
@@ -257,3 +257,36 @@ export function postReceiverMode(
   if (idx === 1) return setMode(mode, signal, 'B');
   return setReceiver(idx, { mode }, signal);
 }
+
+// ---------------------------------------------------------------------------
+// Ganged multi-select. A toolbar control (mode/filter/band/AF) acts on EVERY
+// selected receiver at once; the focused receiver is the primary whose
+// response reconciles the store. Direct per-pane manipulation (dragging a
+// passband on one receiver's panadapter) is NOT ganged — it stays on that pane.
+
+/** The receivers a ganged toolbar action targets (the live selection). */
+export function selectedReceiverKeys(): number[] {
+  return useConnectionStore.getState().selectedRxIndices;
+}
+
+/** Run a control action across every selected receiver: an optimistic store
+ *  update plus a REST post for each, reconciling the store from the focused
+ *  receiver's response (the others' responses are ignored to avoid clobbering
+ *  the focused view; the next state poll reconciles them). */
+export function gangedReceiverAction(opts: {
+  optimistic?: (key: number) => void;
+  post: (key: number) => Promise<RadioStateDto>;
+}): void {
+  const { selectedRxIndices, focusedRxIndex, applyState } = useConnectionStore.getState();
+  for (const idx of selectedRxIndices) opts.optimistic?.(idx);
+  for (const idx of selectedRxIndices) {
+    opts
+      .post(idx)
+      .then((res) => {
+        if (idx === focusedRxIndex) applyState(res);
+      })
+      .catch(() => {
+        /* next state poll reconciles */
+      });
+  }
+}

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -1464,6 +1464,13 @@
   background: linear-gradient(180deg, var(--accent-bright), var(--accent));
   box-shadow: 0 0 12px rgba(78,166,255,0.26);
 }
+/* Multi-selected but not focused: a receiver that ganged controls also act on.
+ * Subtler than .is-active (the focused/primary) — accent tint + inset outline. */
+.hero-rx-audio-switch__key.is-selected {
+  color: var(--fg-0);
+  background: rgba(78,166,255,0.12);
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
 
 /* RX audio mixer — small header trigger + movable popout (replaces the inline
  * switch so any number of DDC receivers fit without crowding the header). */
@@ -2245,6 +2252,12 @@
 .vfo-chip.is-active::before {
   background: var(--vfo-filter-color, var(--accent));
   box-shadow: 0 0 10px color-mix(in srgb, var(--vfo-filter-color, var(--accent)) 70%, transparent);
+}
+/* Multi-selected but not focused: a ganged-control target. Subtler than
+ * .is-active (the focused primary) — a dim receiver-colour outline. */
+.vfo-chip.is-selected {
+  border-color: color-mix(in srgb, var(--vfo-filter-color, var(--accent)) 38%, transparent);
+  background: color-mix(in srgb, var(--vfo-filter-color, var(--accent)) 7%, transparent);
 }
 .vfo-chip.is-muted { opacity: 0.55; }
 .vfo-chip.is-tx { border-color: color-mix(in srgb, var(--tx) 55%, transparent); }


### PR DESCRIPTION
@
Multi-DDC RX parity for the web client.

- Focus-following toolbar + board-aware receiver max.
- Ganged multi-select across RX1–RX6.
- Server: unify the per-receiver write path on `/api/receivers/{index}`.
- User-facing labels go **RX1–RX6** (no more VFO A/B).
- Gang band selection across all selected receivers.
@