### PR TITLE
fix(multi-rx): MULTI RX off collapses to RX1 only

### DIFF
--- a/zeus-web/src/state/receiver-state.ts
+++ b/zeus-web/src/state/receiver-state.ts
@@ -356,6 +356,11 @@ export async function setExposedReceiverCount(target: number): Promise<void> {
   if (n >= 2) setDesiredReceiverCount(n);
   try {
     if (n <= 1) {
+      // Collapse to RX1 only. Disabling RX2 (index 1) routes server-side to
+      // SetRx2, which does NOT cascade the RX3+ extras off — so clear the extra
+      // run first (index 2's disable cascades RX3.. off), then RX2. Without this
+      // the extras linger as a contiguity gap (RX2 off but RX3+ still streaming).
+      await setReceiver(2, { enabled: false }).catch(() => {});
       applyState(await setReceiver(1, { enabled: false }));
       return;
     }


### PR DESCRIPTION
## Problem
Turning **MULTI RX off** (and the RECEIVERS menu's "1" button) left RX3+ receivers running.

Root cause: collapsing called `setReceiver(1, {enabled:false})`, which routes server-side to `SetRx2` and returns **without** the RX3+ extras cascade (that cascade only runs for `index >= 2`, `RadioService.cs:1138-1142`). So RX2 went off but RX3-6 stayed enabled — a contiguity gap (RX2 off, RX3+ still streaming), and the UI kept showing the extra panes.

## Fix
In `setExposedReceiverCount`, the collapse path now disables index 2 first (its cascade clears RX3..) and then RX2 — leaving **RX1 only**. Fixes both the MULTI RX toggle and the RECEIVERS menu "1" button.

**MULTI RX on** already restores the operator's configured total: the desired count is recorded for `n >= 2`, and both the RECEIVERS menu and the toggle go through the same `setExposedReceiverCount` path.

## Testing
- `tsc -b && vite build` green.
- Needs a quick on-air sanity check on the G2 (enable 6, toggle MULTI RX off → only RX1; on → back to 6).