### PR TITLE
fix(desktop): keep restored window on the visible work area (flash-and-no-window)

### DIFF
--- a/.github/workflows/dev-windows-build.yml
+++ b/.github/workflows/dev-windows-build.yml
@@ -1,0 +1,101 @@
+name: Dev Windows Build
+
+# Manually-dispatched, lightweight Windows desktop build for handing a test
+# build to an operator — e.g. to confirm a fix on their machine before it ships
+# in a release.
+#
+# How it differs from release.yml (deliberately minimal):
+#   - Does NOT rebuild native WDSP / miniaudio — it uses the committed win-x64
+#     natives under Zeus.Dsp/runtimes, so the job is a few minutes, not ~30.
+#   - Does NOT build an installer. It publishes one self-contained, PORTABLE
+#     folder, zipped as a workflow artifact: download it, unzip anywhere, and
+#     run the bundled "Launch Zeus Desktop.cmd".
+#   - Does NOT bundle the Edge WebView2 runtime. The portable build assumes the
+#     test machine already has it (stock Windows 11 does). If the window never
+#     appears AND %LOCALAPPDATA%\Zeus\zeus-startup.log shows a missing-WebView2
+#     error, install it from
+#     https://developer.microsoft.com/microsoft-edge/webview2/ and relaunch.
+#
+# Run it from the Actions tab -> "Dev Windows Build" -> Run workflow, choosing
+# the branch you want to test. The artifact is "zeus-dev-win-<arch>-<shortsha>".
+
+on:
+  workflow_dispatch:
+    inputs:
+      arch:
+        description: 'Target architecture'
+        type: choice
+        options:
+          - x64
+          - arm64
+        default: x64
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build portable desktop (win-${{ github.event.inputs.arch }})
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # The DeepCW ONNX model is a git submodule statically imported by the web
+      # bundle; without it `npm run build` (run by the csproj BuildSpa target
+      # during publish) fails to resolve the import. Mirrors release.yml.
+      - name: Init DeepCW model submodule (frontend build dependency)
+        run: git submodule update --init zeus-web/external/deepcw-engine
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      # npm is needed on PATH because OpenhpsdrZeus.csproj's BuildSpa target
+      # shells out to `npm ci` + `npm run build` before publish. The cache keys
+      # off zeus-web/package-lock.json.
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: zeus-web/package-lock.json
+
+      - name: Short SHA
+        id: sha
+        shell: bash
+        run: echo "short=${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      # Single self-contained publish. The csproj BuildSpa target (BeforeTargets
+      # ="Publish") rebuilds the React frontend into wwwroot first, so the
+      # published payload always carries a fresh SPA. The committed win-<arch>
+      # natives flow into publish/runtimes/win-<arch>/native automatically.
+      - name: Publish self-contained desktop
+        shell: bash
+        run: |
+          dotnet publish OpenhpsdrZeus/OpenhpsdrZeus.csproj \
+            -c Release \
+            -r win-${{ github.event.inputs.arch }} \
+            --self-contained true \
+            -p:VersionPrefix=0.0.0 \
+            -p:VersionSuffix=dev.${{ steps.sha.outputs.short }} \
+            -p:DebugType=embedded \
+            -p:DebugSymbols=false
+
+      # Double-clickable launchers so the operator doesn't have to know about
+      # the --desktop / --server flags. CRLF line endings + start so no console
+      # window lingers (the exe self-detaches its console in --desktop mode).
+      - name: Add desktop + server launchers
+        shell: bash
+        run: |
+          dest="OpenhpsdrZeus/bin/Release/net10.0/win-${{ github.event.inputs.arch }}/publish"
+          printf '@echo off\r\nstart "Zeus" "%%~dp0OpenhpsdrZeus.exe" --desktop\r\n' > "$dest/Launch Zeus Desktop.cmd"
+          printf '@echo off\r\nstart "Zeus Server" "%%~dp0OpenhpsdrZeus.exe" --server\r\n' > "$dest/Launch Zeus Server.cmd"
+          ls -la "$dest"
+
+      - name: Upload portable build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zeus-dev-win-${{ github.event.inputs.arch }}-${{ steps.sha.outputs.short }}
+          path: OpenhpsdrZeus/bin/Release/net10.0/win-${{ github.event.inputs.arch }}/publish/
+          if-no-files-found: error

--- a/OpenhpsdrZeus/Program.cs
+++ b/OpenhpsdrZeus/Program.cs
@@ -452,18 +452,38 @@ public partial class Program
         {
             try
             {
+                // Record the full display topology + the geometry we're about to
+                // restore. This is the smoking gun for "window flashes and never
+                // appears" reports where the startup log otherwise reaches
+                // "entering message loop" cleanly (the window IS created — it just
+                // lands off the visible desktop or comes up minimized).
+                try
+                {
+                    foreach (var mon in window.Monitors)
+                        StartupDiagnostics.Log(
+                            $"[geometry] monitor area=({mon.MonitorArea.X},{mon.MonitorArea.Y} {mon.MonitorArea.Width}x{mon.MonitorArea.Height}) " +
+                            $"work=({mon.WorkArea.X},{mon.WorkArea.Y} {mon.WorkArea.Width}x{mon.WorkArea.Height}) scale={mon.Scale}");
+                    StartupDiagnostics.Log(
+                        $"[geometry] saved width={savedGeometry.Width} height={savedGeometry.Height} maximized={savedGeometry.Maximized}");
+                }
+                catch (Exception ex) { StartupDiagnostics.Log($"[geometry] monitor enumerate failed: {ex.Message}"); }
+
+                // Always seat a sane on-screen normal size + position first — even
+                // when restoring maximized — so un-maximizing later lands on the
+                // visible desktop rather than wherever the saved bytes pointed.
+                PlaceWindowOnVisibleWorkArea(window, initialWidth, initialHeight);
                 if (savedGeometry.Maximized)
-                {
                     window.Maximized = true;
-                }
-                else
-                {
-                    window.Size = new System.Drawing.Size(initialWidth, initialHeight);
-                    window.Center();
-                }
+
+                // A frame that comes up minimized is indistinguishable from "no
+                // window" to the operator; some Windows builds have been observed
+                // to open this way after a restore. Force it back to normal.
+                if (window.Minimized)
+                    window.Minimized = false;
             }
             catch (Exception ex)
             {
+                StartupDiagnostics.Log($"[geometry] restore failed: {ex.Message}");
                 Console.Error.WriteLine($"window.geometry.restore failed: {ex.Message}");
             }
             finally
@@ -569,6 +589,63 @@ public partial class Program
         Console.WriteLine("Window closed; stopping backend.");
         app.StopAsync().GetAwaiter().GetResult();
         return 0;
+    }
+
+    // Photino occasionally opens the frame off the visible desktop on
+    // multi-monitor / fractional-DPI setups: the window IS created and the
+    // message loop runs (the startup log reaches "entering message loop"), but
+    // the operator sees only a brief flash because the frame landed beyond the
+    // work area, or larger than the monitor, or centred using a different
+    // monitor's metrics. Clamp the desired size to the monitor work area and
+    // force the position back inside it so a visible frame is guaranteed.
+    //
+    // Best-effort and self-contained: any failure falls back to Photino's own
+    // SetSize + Center so a quirky monitor query can never strand the window.
+    private static void PlaceWindowOnVisibleWorkArea(PhotinoWindow window, int desiredWidth, int desiredHeight)
+    {
+        try
+        {
+            var work = window.MainMonitor.WorkArea; // System.Drawing.Rectangle, OS pixels
+            // No usable monitor reported — let Photino place it and bail.
+            if (work.Width <= 0 || work.Height <= 0)
+            {
+                window.Size = new System.Drawing.Size(desiredWidth, desiredHeight);
+                window.Center();
+                return;
+            }
+
+            // Never open larger than the visible work area: a size saved on a
+            // bigger monitor would otherwise hang the frame off the edges.
+            var w = Math.Min(desiredWidth, work.Width);
+            var h = Math.Min(desiredHeight, work.Height);
+            window.Size = new System.Drawing.Size(w, h);
+
+            // Centre within the work area, then clamp so the title bar is always
+            // reachable even when the monitor origin is negative (a display to
+            // the left of / above the primary).
+            var left = work.X + (work.Width - w) / 2;
+            var top = work.Y + (work.Height - h) / 2;
+            left = Math.Max(work.X, Math.Min(left, work.X + work.Width - w));
+            top = Math.Max(work.Y, Math.Min(top, work.Y + work.Height - h));
+            window.Location = new System.Drawing.Point(left, top);
+
+            StartupDiagnostics.Log(
+                $"[geometry] placed at ({left},{top}) size {w}x{h} within work " +
+                $"({work.X},{work.Y} {work.Width}x{work.Height})");
+        }
+        catch (Exception ex)
+        {
+            StartupDiagnostics.Log($"[geometry] place-on-work-area failed, using Center(): {ex.Message}");
+            try
+            {
+                window.Size = new System.Drawing.Size(desiredWidth, desiredHeight);
+                window.Center();
+            }
+            catch (Exception inner)
+            {
+                Console.Error.WriteLine($"window.geometry.center fallback failed: {inner.Message}");
+            }
+        }
     }
 
     private static bool TryReadWorkspaceWindowRequest(string message, out WorkspaceWindowRequest request)


### PR DESCRIPTION
## Symptom

Operator report: after install, launching the desktop app "opens a flash window then closes — the main window never comes up." (Windows build 10.0.26200.)

## Root cause (from the operator's `zeus-startup.log`)

This is **not** a crash and **not** a missing dependency — the earlier WebView2 theory is disproven by the log:

- `webview2.runtime OK version=149.0.4022.80`, all natives load, Kestrel starts.
- **Every** launch reaches the final marker: `[phase] desktop: window created, entering message loop`.
- The process stays alive for many minutes (the `SocketException (995)` lines are discovery `TcpClient` probes cancelled at shutdown — harmless).

So the Photino frame **is** created and the message loop runs — the window just never becomes **visible**. The geometry-restore path in `RunDesktop` (`RegisterWindowCreatedHandler`) sets size/`Center()`/`Maximized` with no validation against the actual visible work area, so a saved size/position from a different monitor layout, a fractional-DPI `Center()` miscalc, or a maximized-restore quirk on a newer Windows build drops the frame off-screen. The operator's box differs from the working dev box only in Windows build (26200 vs 26100) and in having saved prefs (so the restore path is active).

## Fix

`PlaceWindowOnVisibleWorkArea(...)` clamps the restored frame to `window.MainMonitor.WorkArea` before show:

- cap size to the work area (a size saved on a bigger monitor can't hang off the edges),
- centre **within** the work area, then clamp the origin so the title bar is always reachable (handles monitors with a negative origin),
- guard against a minimized-on-open frame,
- fall back to Photino's own `Center()` if the monitor query fails — it can never strand the window.

It also logs the full display topology (monitor rects + scale) and the geometry being restored to `zeus-startup.log`, so any *remaining* off-screen report carries the smoking gun.

Pure desktop window-placement robustness — no defaults, UX behavior, DSP, or wire-format touched.

## Verification

- C# compiles (validated locally; CI build-test is the clean-room gate).
- Cannot reproduce on the dev box (window already comes up correctly there), so this is a defensive fix plus diagnostics. The new **Dev Windows Build** workflow (second commit) produces a portable build to hand the reporting operator (N0BUZ) to confirm on the failing 26200 machine. The next `zeus-startup.log` `[geometry]` lines will confirm the monitor/placement decision either way.

## Dev Windows Build workflow

Manually-dispatched (`Actions -> Dev Windows Build -> Run workflow`), uses committed win-x64 natives (no ~30-min native rebuild), publishes a portable self-contained folder with double-clickable launchers, zipped as `zeus-dev-win-<arch>-<sha>`. Hand it to a tester; unzip and run "Launch Zeus Desktop.cmd".