### PR TITLE
fix(host): don't crash on shutdown from LiteDB shared-mutex dispose (0xc0000005)

### DIFF
--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -32,8 +32,49 @@ public static class ZeusHost
     {
         var app = Build(args, options);
         await InitializeAsync(app, cancellationToken);
-        await app.RunAsync(cancellationToken);
+        try
+        {
+            await app.RunAsync(cancellationToken);
+        }
+        catch (Exception ex) when (IsBenignShutdownDisposeError(ex))
+        {
+            // Headless/service mode reaches here on a clean Ctrl-C: app.RunAsync's
+            // finally runs Host.DisposeAsync(), which disposes the ~50 LiteDB
+            // settings stores. Each opens zeus-prefs.db with Connection=shared, so
+            // LiteDB wraps a named Mutex; SharedEngine.Dispose() calls
+            // Mutex.ReleaseMutex(), which throws when the disposing thread isn't the
+            // one that took the mutex (Windows mutex thread-affinity). That throw
+            // was escaping Main as an unhandled exception and crashing the process
+            // with a 0xc0000005 system-error dialog *after* a clean shutdown. By the
+            // time we get here data is already checkpointed and the OS releases the
+            // named mutex on process exit, so the throw is benign — swallow it and
+            // exit 0 instead of letting it abort the process. (Desktop/--server
+            // modes use StartAsync/StopAsync and never hit this path.)
+            Console.Error.WriteLine(
+                $"shutdown: ignored benign LiteDB shared-mutex dispose error: {ex.GetBaseException().Message}");
+        }
         return 0;
+    }
+
+    // True for the LiteDB shared-connection Mutex.ReleaseMutex() thread-affinity
+    // throw that surfaces only during host teardown. Matched narrowly (across the
+    // whole inner-exception chain) so a genuine fault during shutdown still
+    // propagates. See the call site in RunAsync for why it is safe to ignore.
+    private static bool IsBenignShutdownDisposeError(Exception ex)
+    {
+        for (var cur = ex; cur is not null; cur = cur.InnerException)
+        {
+            if (cur is System.Threading.SynchronizationLockException or System.Threading.AbandonedMutexException)
+                return true;
+            // Mutex.ReleaseMutex() from a non-owning thread throws ApplicationException
+            // with this message ("Object synchronization method was called from an
+            // unsynchronized block of code.").
+            if (cur is ApplicationException &&
+                cur.Message.Contains("synchronization method was called from an unsynchronized block",
+                    StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
     }
 
     /// <summary>


### PR DESCRIPTION
## Symptom

Running Zeus in **headless/service mode** (bare `OpenhpsdrZeus` with no args — Docker, Raspberry Pi, or double-clicking the exe) crashes on a clean Ctrl-C / window-close with a Windows `0xc0000005` "Exception Processing Message … Unexpected parameters" system-error dialog **after** the app has already shut down.

Captured by the startup log's `AppDomain.UnhandledException` handler:

```
System.ApplicationException: Object synchronization method was called from an unsynchronized block of code.
   at System.Threading.Mutex.ReleaseMutex()
   at LiteDB.SharedEngine.Dispose(Boolean disposing)
   at LiteDB.LiteDatabase.Dispose()
   at Zeus.Plugins.Host.PluginSettingsStore.Dispose()
   at Zeus.Plugins.Host.PluginManager.DisposeAsync()
   at ...HostingAbstractionsHostExtensions.RunAsync(IHost host, ...)
   at Zeus.Server.ZeusHost.RunAsync(...)
   at Program.Main(...)
```

## Root cause

`app.RunAsync()`'s `finally` runs `Host.DisposeAsync()`, which disposes the ~50 LiteDB settings stores. Each opens `zeus-prefs.db` with `Connection=shared`, so LiteDB wraps a **named `Mutex`**. `SharedEngine.Dispose()` calls `Mutex.ReleaseMutex()`, which throws when the disposing thread isn't the one that acquired the mutex — Windows mutexes have **thread affinity**, and host teardown disposes on a different thread than the one that opened the DB. `PluginSettingsStore` was simply first in disposal order; any of the ~50 stores can trigger it. The throw escaped `Main` unhandled and aborted the process.

## Fix

Catch the throw **narrowly** at the host-run boundary in `ZeusHost.RunAsync` — the single chokepoint every store disposal unwinds through — and exit 0. By teardown the data is already checkpointed and the OS releases the named mutex on process exit, so the throw is benign. This avoids guarding 50 individual `Dispose()` methods.

`IsBenignShutdownDisposeError` matches only `SynchronizationLockException` / `AbandonedMutexException` / the specific `ApplicationException` message across the inner-exception chain, so a genuine shutdown fault still propagates.

## Scope / safety

- **Desktop** (`--desktop`) and **`--server`** modes use `StartAsync`/`StopAsync` and never run `Host.DisposeAsync()`, so they never hit this path — unchanged.
- No defaults, UX, DSP, PureSignal, or wire-format touched. Host-lifecycle robustness only.

## Verification

- `Zeus.Server.Hosting` compiles clean.
- Discovered from a real captured crash log on a Windows 10.0.26100 box running the bare exe in service mode; the same shutdown sequence in desktop mode (in the same log) shuts down cleanly.