### PR TITLE
fix(desktop): stop 0xc0000005 crash by not navigating the webview from WindowCreated

### DIFF
--- a/OpenhpsdrZeus/Program.cs
+++ b/OpenhpsdrZeus/Program.cs
@@ -387,6 +387,35 @@ public partial class Program
         var iconPath = Path.Combine(AppContext.BaseDirectory, iconFileName);
         var detachedWorkspaceWindows = new List<PhotinoWindow>();
 
+        // The dark placeholder loaded as StartString carries a tiny script that,
+        // once the page is live (i.e. WebView2 has finished initialising), posts a
+        // `zeus.placeholderReady` message back to the host. The host then navigates
+        // to the SPA from the WebMessageReceived handler below — a point where the
+        // native WebView2 control is provably ready to accept a navigation.
+        //
+        // This replaces the old approach of calling window.Load(startUrl) directly
+        // from the WindowCreated handler. WindowCreated fires *during* native window
+        // construction, before WebView2's CoreWebView2 is initialised; calling
+        // Photino_NavigateToUrl there dereferences a not-yet-created control and
+        // hard-crashes the process with a native access violation (0xc0000005 —
+        // an uncatchable corrupted-state exception, so no try/catch and no managed
+        // diagnostics handler can intercept it). Driving the SPA navigation off the
+        // placeholder-ready message keeps it on the live WebView2 while still
+        // happening AFTER the WindowCreated resize, so the no-reflow guarantee from
+        // #930 holds. If the host bridge is somehow absent the placeholder navigates
+        // itself as a fallback.
+        const string placeholderHtml =
+            "<!doctype html><meta name=\"color-scheme\" content=\"dark\">" +
+            "<body style=\"margin:0;height:100vh;background:#0a0a0c\">" +
+            "<script>(function(){function spa(){location.replace('__START_URL__');}" +
+            "try{var e=window.external;" +
+            "if(e&&typeof e.sendMessage==='function')" +
+            "e.sendMessage(JSON.stringify({type:'zeus.placeholderReady'}));" +
+            "else spa();}catch(_){spa();}})();</script>";
+        // Navigate to the SPA exactly once, even if the ready message arrives more
+        // than once (e.g. a placeholder reload).
+        var spaLoaded = false;
+
         // Window construction is where a missing WebView2 runtime throws — the
         // last phase marker in the log will be this one if that's the cause.
         StartupDiagnostics.Phase("desktop: creating Photino window (needs WebView2)");
@@ -401,6 +430,18 @@ public partial class Program
             .RegisterWebMessageReceivedHandler((sender, msg) =>
             {
                 if (sender is not PhotinoWindow owner) return;
+                // The dark placeholder reports it is live once WebView2 is ready.
+                // Navigate to the SPA here, not from WindowCreated — see the long
+                // note above placeholderHtml for why the WindowCreated path AVs.
+                if (IsPlaceholderReady(msg))
+                {
+                    if (spaLoaded) return;
+                    spaLoaded = true;
+                    StartupDiagnostics.Phase("desktop: placeholder ready, loading SPA");
+                    try { owner.Load(new Uri(startUrl)); }
+                    catch (Exception ex) { Console.Error.WriteLine($"window.spa.load failed: {ex.Message}"); }
+                    return;
+                }
                 if (TryReadWorkspaceWindowRequest(msg, out var request))
                 {
                     OpenWorkspaceWindow(owner, detachedWorkspaceWindows, request, iconPath);
@@ -414,12 +455,13 @@ public partial class Program
                     OpenExternalUrl(externalUrl);
             })
             // Deliberately load a dark placeholder, NOT the SPA, as the startup
-            // content. The real SPA navigation is deferred to the WindowCreated
-            // handler below so it happens AFTER the frame is resized to the saved
-            // geometry — see the comment there. The placeholder matches --bg-app
+            // content. The placeholder posts `zeus.placeholderReady` once WebView2
+            // is live; the WebMessageReceived handler above then navigates to the
+            // SPA — after the WindowCreated resize, so React's first layout measures
+            // the final viewport (no panel reflow). The placeholder matches --bg-app
             // (#0a0a0c) so the brief pre-size frame is invisible against the dark
             // chrome instead of flashing white.
-            .LoadRawString("<!doctype html><meta name=\"color-scheme\" content=\"dark\"><body style=\"margin:0;height:100vh;background:#0a0a0c\">");
+            .LoadRawString(placeholderHtml.Replace("__START_URL__", startUrl));
 
         // Remember the last NORMAL (non-maximized) frame size as resize events
         // arrive. This is only needed for the maximized-at-close case: when the
@@ -486,20 +528,14 @@ public partial class Program
                 StartupDiagnostics.Log($"[geometry] restore failed: {ex.Message}");
                 Console.Error.WriteLine($"window.geometry.restore failed: {ex.Message}");
             }
-            finally
-            {
-                // Navigate to the SPA only NOW — after the frame has been resized
-                // to the saved geometry. Loading it in the builder chain made
-                // WebView2 paint the SPA at the min-size opening frame (Photino
-                // frequently opens at SetMinWidth/Height and the resize lands a
-                // frame later), so React's first layout measured the small
-                // viewport and the panels visibly reflowed when the window grew.
-                // Deferring the load means React's first measurement is the final
-                // size and the panels don't jump. In a finally so a failed resize
-                // above can never strand the window on the dark placeholder.
-                try { window.Load(new Uri(startUrl)); }
-                catch (Exception ex) { Console.Error.WriteLine($"window.spa.load failed: {ex.Message}"); }
-            }
+            // NOTE: the SPA is NOT loaded here. Calling window.Load(startUrl) from
+            // this WindowCreated callback runs Photino_NavigateToUrl re-entrantly
+            // during native window construction — before CoreWebView2 exists — which
+            // crashes the process with a native access violation (0xc0000005). The
+            // navigation is driven instead by the `zeus.placeholderReady` web
+            // message (see placeholderHtml and the WebMessageReceived handler),
+            // which fires once WebView2 is live and still after this resize, so the
+            // no-reflow guarantee is preserved without the crash.
         });
 
         // Maximized and minimized are tracked separately: both must suppress
@@ -645,6 +681,22 @@ public partial class Program
             {
                 Console.Error.WriteLine($"window.geometry.center fallback failed: {inner.Message}");
             }
+        }
+    }
+
+    // The dark startup placeholder posts this once WebView2 is live, signalling
+    // that it is safe to navigate the window to the SPA. Kept deliberately narrow
+    // so it can never be confused with the SPA's own messages.
+    private static bool IsPlaceholderReady(string message)
+    {
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<WorkspaceWindowRequest>(message, WebMessageJsonOptions);
+            return parsed?.Type == "zeus.placeholderReady";
+        }
+        catch (JsonException)
+        {
+            return false;
         }
     }
 

--- a/docs/lessons/photino-navigate-from-windowcreated-av.md
+++ b/docs/lessons/photino-navigate-from-windowcreated-av.md
@@ -1,0 +1,81 @@
+# Never navigate the Photino webview from `WindowCreated`
+
+## Symptom
+
+Desktop launch (`OpenhpsdrZeus --desktop`) flashes and dies with a raw Windows
+dialog:
+
+> **OpenhpsdrZeus.exe - System Error**
+> Exception Processing Message 0xc0000005 - Unexpected parameters
+
+`%LOCALAPPDATA%\Zeus\zeus-startup.log` shows a **completely clean** startup —
+WebView2 OK, native libs loadable, prefs usable — reaching
+`[phase] desktop: window created, entering message loop` and the geometry
+`[geometry] placed at ...` line, then nothing. No `[error]`, no
+`AppDomain.UnhandledException`.
+
+The Windows Application event log (provider `.NET Runtime`, Event ID **1026**)
+holds the real stack:
+
+```
+Description: The process was terminated due to an unhandled exception.
+Stack:
+   at Photino.NET.PhotinoWindow.Photino_NavigateToUrl(IntPtr, System.String)
+   at Photino.NET.PhotinoWindow.Load(System.Uri)
+   at Program...<RunDesktop>b__2            ← the RegisterWindowCreatedHandler body
+   at Photino.NET.PhotinoWindow.OnWindowCreated()
+   at Photino.NET.PhotinoWindow.WaitForClose()
+```
+
+## Root cause
+
+`0xc0000005` is a native **access violation**, not a managed exception. It is
+also a *corrupted-state exception*: by default .NET will not deliver it to a
+managed `try/catch`, `AppDomain.UnhandledException`, or
+`TaskScheduler.UnobservedTaskException` — which is why `StartupDiagnostics`'
+last-resort handlers never fire and the OS shows its own hard-error dialog
+instead of our `ReportStartupFatal` MessageBox.
+
+The fault is `Photino_NavigateToUrl` dereferencing a WebView2 control that does
+not exist yet. Photino's `WindowCreated` callback runs **during native window
+construction**, *before* `CoreWebView2` is initialised. Calling
+`window.Load(url)` from there invokes `Photino_NavigateToUrl` re-entrantly on a
+null/garbage control pointer → AV.
+
+It is deterministic, not a corrupt profile: clearing / recreating the Photino
+WebView2 user-data folder (`%LOCALAPPDATA%\Photino\EBWebView`) reproduces the
+crash identically.
+
+## Fix
+
+Navigate the SPA only once WebView2 is **provably live** — never from
+`WindowCreated`. The robust pattern:
+
+1. Load a dark placeholder string as the window's `StartString`. Photino
+   navigates this itself once the control is ready (this is *not* re-entrant and
+   does not crash).
+2. The placeholder posts `zeus.placeholderReady` via
+   `window.external.sendMessage(...)` as soon as it loads.
+3. The host's `RegisterWebMessageReceivedHandler` navigates to the SPA on that
+   message. The webview is alive there (it just ran JS), so `Load` is safe — and
+   it still happens *after* the `WindowCreated` resize, preserving the
+   no-panel-reflow guarantee from #930.
+
+A pure-JS `location.replace(startUrl)` fallback in the placeholder covers the
+(desktop-impossible) case where the host bridge is absent.
+
+See `OpenhpsdrZeus/Program.cs` → `RunDesktop` (the `placeholderHtml` template and
+the `zeus.placeholderReady` branch in the WebMessageReceived handler).
+
+## Rules of thumb
+
+- **Photino 4.x exposes no "WebView2 ready" event.** `WindowCreating` and
+  `WindowCreated` both fire too early to navigate. The earliest safe signal is a
+  web message (or `LocationChanged`) from already-loaded content.
+- An `0xc0000005` with a clean `zeus-startup.log` is a native crash **after** the
+  last phase marker — read the **Windows Event Log (Event 1026)** for the managed
+  stack; the diagnostics handlers cannot catch corrupted-state exceptions.
+- To reproduce/verify headlessly, launch `--desktop`, then check that the process
+  survives and that **no new Event 1026** appears (a crash leaves the process hung
+  on the modal error dialog, so "still running" alone is not proof — check the
+  event log).


### PR DESCRIPTION
## Problem

Desktop launch (`OpenhpsdrZeus --desktop`) crashes on **every** start with a native access violation:

> **OpenhpsdrZeus.exe - System Error** — Exception Processing Message `0xc0000005` - Unexpected parameters

`%LOCALAPPDATA%\Zeus\zeus-startup.log` is completely clean (WebView2 OK, native libs loadable, prefs usable) right up to `entering message loop` and `[geometry] placed at ...`, then nothing — no `[error]`, no `AppDomain.UnhandledException`. The Windows Application event log (provider `.NET Runtime`, **Event ID 1026**) holds the real stack:

```
Description: The process was terminated due to an unhandled exception.
Stack:
   at Photino.NET.PhotinoWindow.Photino_NavigateToUrl(IntPtr, System.String)
   at Photino.NET.PhotinoWindow.Load(System.Uri)
   at Program...<RunDesktop>b__2            ← RegisterWindowCreatedHandler body
   at Photino.NET.PhotinoWindow.OnWindowCreated()
   at Photino.NET.PhotinoWindow.WaitForClose()
```

## Root cause

`window.Load(new Uri(startUrl))` was called from inside the `RegisterWindowCreatedHandler` (deferred-load pattern from #930/#951). Photino's `WindowCreated` callback runs **during native window construction, before `CoreWebView2` is initialised**, so `Photino_NavigateToUrl` dereferences a not-yet-created WebView2 control → access violation.

`0xc0000005` is a *corrupted-state exception*, which .NET does not deliver to managed `try/catch` or to the `StartupDiagnostics` last-resort handlers — hence the silent flash + raw OS dialog instead of our `ReportStartupFatal` message box.

It is deterministic and **not** environmental: moving `%LOCALAPPDATA%\Photino\EBWebView` aside and launching with a fresh WebView2 profile reproduces the crash identically. This breaks desktop launch on the current WebView2 runtime for everyone, not just one machine.

## Fix

Navigate the SPA only once WebView2 is provably live, never from `WindowCreated`:

1. The dark placeholder (still the first paint — no white flash) is loaded as `StartString`; Photino navigates it safely when the control is ready.
2. The placeholder posts `zeus.placeholderReady` via `window.external.sendMessage(...)` once it loads.
3. The existing `RegisterWebMessageReceivedHandler` loads the SPA on that message — where `CoreWebView2` is alive, and still **after** the `WindowCreated` resize, so #930's no-panel-reflow behaviour is preserved.

A pure-JS `location.replace(startUrl)` fallback in the placeholder covers the (desktop-impossible) case where the host bridge is absent. Adds a `docs/lessons/` note documenting the gotcha.

## Verification

- `dotnet build OpenhpsdrZeus` — clean.
- Launched `--desktop`: process stays up with **zero new Event 1026 crashes** (previously crashed within ~12s every launch); `zeus-startup.log` reaches the new `[phase] desktop: placeholder ready, loading SPA` marker; backend serves the SPA (`HTTP 200`).
- Before/after compared by moving the WebView2 profile aside to rule out a corrupt-cache cause.

Scope: `OpenhpsdrZeus/Program.cs` (`RunDesktop`) + one lesson doc. No contract/wire/default changes.