### PR TITLE
fix(vst): self-healing engine provisioning + cold-start/crash-loop UX

### DIFF
--- a/Zeus.Server.Hosting/AudioProcessingModeService.cs
+++ b/Zeus.Server.Hosting/AudioProcessingModeService.cs
@@ -36,9 +36,18 @@ public sealed class AudioProcessingModeService : IHostedService
     private readonly VstEngineController _engine;
     private readonly PluginManager _manager;
     private readonly ChainOrderService _chainOrder;
+    private readonly VstEngineInstaller? _installer;
     private readonly ILogger<AudioProcessingModeService> _log;
     private readonly SemaphoreSlim _gate = new(1, 1);
     private AudioProcessingMode _mode = AudioProcessingMode.Native;
+
+    // One-shot auto-repair guard. When the engine crash-loops (a stale/corrupt or
+    // protocol-incompatible binary that never handshakes), we re-download the
+    // known-good engine from the manifest exactly once; the supervisor's retry
+    // loop then picks up the freshly-staged binary. Reset on each explicit mode
+    // set so a manual VST re-select re-enables one more auto-repair.
+    private readonly object _repairLock = new();
+    private bool _autoRepairDone;
 
     // Out-of-process editor routing (host-consolidation step 1/2). When the
     // engine is active, the Audio Suite editor endpoints route here instead of
@@ -69,12 +78,16 @@ public sealed class AudioProcessingModeService : IHostedService
         VstEngineController engine,
         PluginManager manager,
         ChainOrderService chainOrder,
-        ILogger<AudioProcessingModeService> log)
+        ILogger<AudioProcessingModeService> log,
+        // Optional so unit tests can construct the service without an HTTP stack;
+        // DI always injects the registered singleton in the running host.
+        VstEngineInstaller? installer = null)
     {
         _store = store;
         _engine = engine;
         _manager = manager;
         _chainOrder = chainOrder;
+        _installer = installer;
         _log = log;
         _engine.StdErr += line => _log.LogDebug("vst-engine: {Line}", line);
         _engine.EngineEvent += OnEngineEvent;
@@ -86,8 +99,7 @@ public sealed class AudioProcessingModeService : IHostedService
         // the chain into the LIVE engine (re-instantiating plugins) without a process
         // recycle — same effect as a manual profile change. (zeus-umt6)
         _engine.ChainReloadRequested += OnChainReloadRequested;
-        _engine.Faulted += reason =>
-            _log.LogWarning("VST engine fault: {Reason}", reason);
+        _engine.Faulted += OnEngineFaulted;
         // Keep the live engine's loaded chain in sync with operator edits made
         // AFTER activation. LoadChainIntoEngine() runs once on activation; without
         // this subscription a VST added/removed/reordered later never reaches the
@@ -225,8 +237,62 @@ public sealed class AudioProcessingModeService : IHostedService
     /// <summary>True while the VST engine is live and routing TX audio.</summary>
     public bool EngineActive => _engine.IsActive;
 
+    /// <summary>Engine lifecycle state (Inactive / Activating / Active / Backoff /
+    /// Faulted) — surfaced so the UI can distinguish "still starting" from
+    /// "keeps crashing" instead of a vague "give it a moment".</summary>
+    public VstEngineState EngineState => _engine.State;
+
+    /// <summary>Human-readable last-fault reason (crash-loop / unavailable), or
+    /// null if the engine has never faulted. Drives the operator-facing message
+    /// when the engine won't route.</summary>
+    public string? EngineLastFault => _engine.LastFault;
+
+    /// <summary>Supervised relaunch count since activation — a climbing value with
+    /// no Active state is the signature of a crash-looping engine.</summary>
+    public long EngineRestartCount => _engine.RestartCount;
+
+    /// <summary>True when the engine is selected (VST mode) and installed but not
+    /// routing — i.e. it is starting up or crash-looping. Lets the editor/UI show
+    /// a precise state and a Repair affordance.</summary>
+    public bool EngineCrashLooping =>
+        _mode == AudioProcessingMode.Vst
+        && !_engine.IsActive
+        && FindEngineExe() is not null
+        && _engine.State == VstEngineState.Faulted;
+
     /// <summary>Resolve the engine exe without launching it; null = not installed.</summary>
     public static string? FindEngineExe() => VstEngineController.FindEngineExe();
+
+    /// <summary>
+    /// The engine supervisor gave up (crash-loop cap, or engine unavailable). When
+    /// the engine is installed but never handshakes — the classic stale/corrupt or
+    /// protocol-incompatible binary — re-download the known-good engine from the
+    /// manifest ONCE; the supervisor's retry loop then relaunches onto the freshly
+    /// staged binary with no operator action. A persistently bad manifest can't
+    /// loop us: we repair at most once per explicit mode set.
+    /// </summary>
+    private void OnEngineFaulted(string reason)
+    {
+        _log.LogWarning("VST engine fault: {Reason}", reason);
+
+        // Only the crash-loop case is auto-repairable: the engine IS installed but
+        // won't come up. An "unavailable" fault means no binary to repair onto.
+        var crashLooping = reason.Contains("crashed", StringComparison.OrdinalIgnoreCase);
+        if (!crashLooping || _mode != AudioProcessingMode.Vst) return;
+        if (FindEngineExe() is null) return;
+
+        lock (_repairLock)
+        {
+            if (_autoRepairDone) return;
+            _autoRepairDone = true;
+        }
+
+        _log.LogWarning(
+            "VST engine is crash-looping; auto-repairing by re-downloading the verified engine "
+            + "from the manifest. The supervisor will relaunch onto the repaired binary.");
+        try { _installer?.Start(force: true); }
+        catch (Exception ex) { _log.LogWarning(ex, "VST engine auto-repair could not start"); }
+    }
 
     /// <summary>
     /// Open the out-of-process engine's native editor window for the chain
@@ -320,6 +386,10 @@ public sealed class AudioProcessingModeService : IHostedService
             catch (Exception ex) { _log.LogWarning(ex, "AudioProcessingModeService persist threw"); }
 
             _mode = mode;
+
+            // A deliberate (re)selection of VST re-arms one auto-repair attempt —
+            // e.g. the operator retrying after a fixed engine manifest is published.
+            lock (_repairLock) _autoRepairDone = false;
 
             if (mode == AudioProcessingMode.Vst)
                 await ActivateEngineAsync(ct).ConfigureAwait(false);

--- a/Zeus.Server.Hosting/VstEngineInstaller.cs
+++ b/Zeus.Server.Hosting/VstEngineInstaller.cs
@@ -9,44 +9,60 @@
 // statement and per-component attribution.
 //
 // VstEngineInstaller — the in-app "Get VST Engine" provisioning flow. The
-// out-of-process VST engine (upstream KlayaR/VSTHost, run headless as
+// out-of-process VST engine (a headless VSTHost build, run as
 // `VSTHostEngine.exe --zeus-bridge`) is deliberately NOT vendored or bundled in
 // the Zeus installer: VSTHost links JUCE (GPLv3), and keeping the binary as a
 // user-fetched, separate process is what isolates that license from Zeus's
 // own distribution (see docs/designs/vst-out-of-process-engine.md §3/§7).
 //
-// Instead Zeus ships this downloader: it fetches the LATEST upstream release,
-// extracts VSTHostEngine.exe from the portable zip, and stages it at the
-// Zeus-managed path (%LOCALAPPDATA%\Zeus\vst-engine\VSTHostEngine.exe) that
-// VstEngineProcess.FindEngineExe() resolves. A new operator on a fresh PC can
-// then enable VST mode and click "Get VST Engine" instead of hunting a GitHub
-// release by hand. Windows-only — the engine is a Windows binary.
+// Source of truth is the Zeus download domain manifest
+// (https://downloads.openhpsdrzeus.com/vst-engine/latest.json), published the
+// same way as the app updater's latest.json. The manifest names the
+// known-good, bridge-compatible engine + its SHA-256, so Zeus stages an engine
+// that is verified to match the current bridge protocol — NOT whatever a
+// floating upstream "latest" release happens to be (that path shipped a build
+// that crash-loops against the current handshake; see RCA). The download is
+// integrity-checked against the manifest's SHA-256 before it is staged.
+//
+// Repair: an existing engine that no longer matches the manifest hash (stale,
+// corrupt, or the old crash-looping build) is replaced automatically — callers
+// pass force:true, or the activation path requests a repair when the engine
+// crash-loops. The legacy GitHub-release path remains available behind the
+// ZEUS_VST_ENGINE_RELEASE_URL override for development/back-compat.
 
 using System.IO.Compression;
 using System.Net.Http.Json;
+using System.Security.Cryptography;
 using System.Text.Json.Serialization;
 using Zeus.Plugins.Host.Audio;
 
 namespace Zeus.Server;
 
-/// <summary>Backs the in-app "Get VST Engine" action: downloads the upstream
-/// VSTHost engine and stages it at the Zeus-managed path. Registered as a
-/// singleton in <c>ZeusHost</c>; the engine binary is fetched, never bundled.</summary>
+/// <summary>Backs the in-app "Get VST Engine" action: downloads the known-good
+/// engine named by the Zeus download-domain manifest, verifies its SHA-256, and
+/// stages it at the Zeus-managed path. Registered as a singleton in
+/// <c>ZeusHost</c>; the engine binary is fetched, never bundled.</summary>
 public sealed class VstEngineInstaller
 {
-    // Upstream release feed. The latest release's portable zip carries the
-    // engine; overridable for staging/tests. The operator never sees this
-    // (the product name in the UI is "VST Engine", not "VSTHost").
+    // Production engine manifest on the Zeus download domain (published the same
+    // way as the app updater's latest.json). Overridable for staging/tests.
+    internal const string DefaultManifestUrl =
+        "https://downloads.openhpsdrzeus.com/vst-engine/latest.json";
+
+    // Legacy upstream release feed. Only used when the ZEUS_VST_ENGINE_RELEASE_URL
+    // override is set (development / back-compat). The default production path is
+    // the manifest above, because the floating upstream "latest" has shipped an
+    // engine build that crash-loops against the current bridge handshake.
     internal const string DefaultReleaseApiUrl =
         "https://api.github.com/repos/KlayaR/VSTHost/releases/latest";
 
-    public enum Phase { Idle, Downloading, Extracting, Staging, Done, Failed }
+    public enum Phase { Idle, Downloading, Verifying, Extracting, Staging, Done, Failed }
 
     /// <summary>Coarse install progress for the polling frontend.</summary>
     public sealed record Status(Phase Phase, int Percent, string? Message, string? Version)
     {
         public bool InProgress =>
-            Phase is Phase.Downloading or Phase.Extracting or Phase.Staging;
+            Phase is Phase.Downloading or Phase.Verifying or Phase.Extracting or Phase.Staging;
     }
 
     private readonly ILogger<VstEngineInstaller> _log;
@@ -54,6 +70,12 @@ public sealed class VstEngineInstaller
     private readonly object _lock = new();
     private Status _status = new(Phase.Idle, 0, null, null);
     private Task? _running;
+
+    // The SHA-256 (lowercase hex) the manifest last advertised for the staged
+    // engine, captured on a successful install. Lets the activation path detect a
+    // stale/mismatched engine and request a repair. Null until first install or
+    // when only the legacy GitHub path ran (which carries no hash).
+    private string? _installedSha256;
 
     public VstEngineInstaller(ILogger<VstEngineInstaller> log, IHttpClientFactory httpClientFactory)
     {
@@ -71,17 +93,27 @@ public sealed class VstEngineInstaller
         get { lock (_lock) return _status; }
     }
 
-    /// <summary>Kick off a background install if one isn't already running and the
-    /// engine isn't already present. Returns the (possibly unchanged) status
-    /// immediately — the frontend polls <see cref="Current"/> for progress.</summary>
-    public Status Start(CancellationToken ct = default)
+    /// <summary>The SHA-256 the manifest advertised for the engine we last staged,
+    /// or null if unknown (no manifest install yet, or the legacy path ran).</summary>
+    public string? InstalledSha256
+    {
+        get { lock (_lock) return _installedSha256; }
+    }
+
+    /// <summary>Kick off a background install if one isn't already running. By
+    /// default a no-op when an engine is already present; pass
+    /// <paramref name="force"/> to re-provision regardless — used to repair a
+    /// stale/corrupt/crash-looping engine by replacing it with the manifest's
+    /// verified binary. Returns the (possibly unchanged) status immediately — the
+    /// frontend polls <see cref="Current"/> for progress.</summary>
+    public Status Start(bool force = false, CancellationToken ct = default)
     {
         lock (_lock)
         {
             if (_running is { IsCompleted: false })
                 return _status; // already running
 
-            if (EngineInstalled)
+            if (!force && EngineInstalled)
             {
                 _status = new Status(Phase.Done, 100, "VST engine already installed.", null);
                 return _status;
@@ -94,7 +126,8 @@ public sealed class VstEngineInstaller
                 return _status;
             }
 
-            _status = new Status(Phase.Downloading, 0, "Contacting release server…", null);
+            _status = new Status(Phase.Downloading, 0,
+                force ? "Repairing the VST engine…" : "Contacting download server…", null);
             _running = Task.Run(() => RunAsync(ct), CancellationToken.None);
             return _status;
         }
@@ -112,41 +145,78 @@ public sealed class VstEngineInstaller
 
     private async Task RunAsync(CancellationToken ct)
     {
-        string? tempZip = null;
+        string? tempFile = null;
         string? tempDir = null;
         try
         {
             var managedExe = VstEngineController.ManagedEnginePath()
                 ?? throw new InvalidOperationException("No managed engine path on this platform.");
             var managedDir = Path.GetDirectoryName(managedExe)!;
-
-            // 1) Resolve the latest release + its zip asset.
-            SetStatus(Phase.Downloading, 2, "Looking up the latest VST engine release…");
             var http = _httpClientFactory.CreateClient("ZeusVstEngine");
-            var release = await http.GetFromJsonAsync<GithubRelease>(ReleaseApiUrl(), ct).ConfigureAwait(false)
-                ?? throw new InvalidOperationException("Empty release response.");
-            var version = string.IsNullOrWhiteSpace(release.TagName) ? null : release.TagName.Trim();
+
+            // Development / back-compat: an explicit upstream-release override goes
+            // through the legacy GitHub path (no manifest, no advertised hash).
+            if (HasReleaseOverride())
+            {
+                await RunLegacyReleaseAsync(http, managedDir, ct).ConfigureAwait(false);
+                lock (_lock) _installedSha256 = null;
+                return;
+            }
+
+            // 1) Resolve the known-good engine asset from the Zeus manifest.
+            SetStatus(Phase.Downloading, 2, "Looking up the latest VST engine…");
+            var manifest = await http.GetFromJsonAsync<EngineManifest>(ManifestUrl(), ct).ConfigureAwait(false)
+                ?? throw new InvalidOperationException("Empty engine manifest response.");
+            var asset = SelectEngineAsset(manifest.Assets)
+                ?? throw new InvalidOperationException(
+                    "The engine manifest lists no Windows x64 engine asset.");
+            if (string.IsNullOrWhiteSpace(asset.Url))
+                throw new InvalidOperationException("The engine manifest asset has no download URL.");
+            if (string.IsNullOrWhiteSpace(asset.Sha256))
+                throw new InvalidOperationException(
+                    "The engine manifest asset has no SHA-256 — refusing to stage an unverifiable engine.");
+
+            var version = string.IsNullOrWhiteSpace(manifest.Version) ? null : manifest.Version.Trim();
             SetStatus(Phase.Downloading, 4, $"Found VST engine {version ?? "(latest)"}…", version);
 
-            var asset = SelectZipAsset(release.Assets)
-                ?? throw new InvalidOperationException("No downloadable engine archive in the latest release.");
+            // 2) Download to a temp file with coarse progress (4..70%).
+            var isZip = asset.Filename.EndsWith(".zip", StringComparison.OrdinalIgnoreCase)
+                        || (asset.Url ?? "").EndsWith(".zip", StringComparison.OrdinalIgnoreCase);
+            tempFile = Path.Combine(Path.GetTempPath(), $"zeus-vst-engine-{Guid.NewGuid():N}{(isZip ? ".zip" : ".bin")}");
+            await DownloadAsync(http, asset.Url!, tempFile, asset.Size, ct).ConfigureAwait(false);
 
-            // 2) Download the zip with coarse progress (2..70%).
-            tempZip = Path.Combine(Path.GetTempPath(), $"zeus-vst-engine-{Guid.NewGuid():N}.zip");
-            await DownloadAsync(http, asset.DownloadUrl!, tempZip, asset.Size, ct).ConfigureAwait(false);
+            // 3) Integrity gate — the engine runs against real PA hardware paths;
+            // never stage a binary whose bytes don't match the signed manifest.
+            SetStatus(Phase.Verifying, 74, "Verifying the VST engine…", version);
+            var actual = await Sha256HexAsync(tempFile, ct).ConfigureAwait(false);
+            var expected = asset.Sha256!.Trim().ToLowerInvariant();
+            if (!string.Equals(actual, expected, StringComparison.Ordinal))
+                throw new InvalidOperationException(
+                    $"VST engine SHA-256 mismatch (expected {expected[..Math.Min(12, expected.Length)]}…, "
+                    + $"got {actual[..Math.Min(12, actual.Length)]}…) — refusing to stage a corrupt download.");
 
-            // 3) Extract (70..85%).
-            SetStatus(Phase.Extracting, 72, "Extracting the VST engine…");
-            tempDir = Path.Combine(Path.GetTempPath(), $"zeus-vst-engine-{Guid.NewGuid():N}");
-            Directory.CreateDirectory(tempDir);
-            ZipFile.ExtractToDirectory(tempZip, tempDir, overwriteFiles: true);
+            // 4) Stage at the managed path (75..100%): extract a zip, or place the
+            // verified exe directly.
+            string stagedExe;
+            if (isZip)
+            {
+                SetStatus(Phase.Extracting, 80, "Extracting the VST engine…", version);
+                tempDir = Path.Combine(Path.GetTempPath(), $"zeus-vst-engine-{Guid.NewGuid():N}");
+                Directory.CreateDirectory(tempDir);
+                ZipFile.ExtractToDirectory(tempFile, tempDir, overwriteFiles: true);
+                SetStatus(Phase.Staging, 90, "Installing the VST engine…", version);
+                stagedExe = StageFromExtractedDir(tempDir, managedDir);
+            }
+            else
+            {
+                SetStatus(Phase.Staging, 90, "Installing the VST engine…", version);
+                stagedExe = StageSingleExe(tempFile, managedDir);
+            }
 
-            // 4) Stage the engine (+ its sibling DLLs) at the managed path (85..100%).
-            SetStatus(Phase.Staging, 88, "Installing the VST engine…");
-            var stagedExe = StageFromExtractedDir(tempDir, managedDir);
-
+            lock (_lock) _installedSha256 = expected;
             SetStatus(Phase.Done, 100, "VST engine installed. Enable VST mode to use it.", version);
-            _log.LogInformation("VST engine {Version} staged at {Path}", version ?? "(latest)", stagedExe);
+            _log.LogInformation("VST engine {Version} staged at {Path} (sha256 {Sha})",
+                version ?? "(latest)", stagedExe, expected[..Math.Min(12, expected.Length)]);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
@@ -156,6 +226,45 @@ public sealed class VstEngineInstaller
         {
             _log.LogWarning(ex, "VST engine install failed");
             SetStatus(Phase.Failed, 0, $"VST engine install failed: {Trunc(ex.Message)}");
+        }
+        finally
+        {
+            TryDelete(tempFile);
+            TryDeleteDir(tempDir);
+        }
+    }
+
+    /// <summary>Legacy path: fetch the upstream GitHub release's portable zip and
+    /// stage its <c>VSTHostEngine.exe</c>. Used only when ZEUS_VST_ENGINE_RELEASE_URL
+    /// is set; carries no advertised hash, so no integrity gate.</summary>
+    private async Task RunLegacyReleaseAsync(HttpClient http, string managedDir, CancellationToken ct)
+    {
+        string? tempZip = null;
+        string? tempDir = null;
+        try
+        {
+            SetStatus(Phase.Downloading, 2, "Looking up the VST engine release…");
+            var release = await http.GetFromJsonAsync<GithubRelease>(ReleaseApiUrl(), ct).ConfigureAwait(false)
+                ?? throw new InvalidOperationException("Empty release response.");
+            var version = string.IsNullOrWhiteSpace(release.TagName) ? null : release.TagName.Trim();
+            SetStatus(Phase.Downloading, 4, $"Found VST engine {version ?? "(latest)"}…", version);
+
+            var asset = SelectZipAsset(release.Assets)
+                ?? throw new InvalidOperationException("No downloadable engine archive in the release.");
+            tempZip = Path.Combine(Path.GetTempPath(), $"zeus-vst-engine-{Guid.NewGuid():N}.zip");
+            await DownloadAsync(http, asset.DownloadUrl!, tempZip, asset.Size, ct).ConfigureAwait(false);
+
+            SetStatus(Phase.Extracting, 72, "Extracting the VST engine…");
+            tempDir = Path.Combine(Path.GetTempPath(), $"zeus-vst-engine-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            ZipFile.ExtractToDirectory(tempZip, tempDir, overwriteFiles: true);
+
+            SetStatus(Phase.Staging, 88, "Installing the VST engine…");
+            var stagedExe = StageFromExtractedDir(tempDir, managedDir);
+
+            SetStatus(Phase.Done, 100, "VST engine installed. Enable VST mode to use it.", version);
+            _log.LogInformation("VST engine {Version} staged at {Path} (legacy release path)",
+                version ?? "(latest)", stagedExe);
         }
         finally
         {
@@ -191,19 +300,38 @@ public sealed class VstEngineInstaller
         }
     }
 
+    private static async Task<string> Sha256HexAsync(string path, CancellationToken ct)
+    {
+        await using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+        using var sha = SHA256.Create();
+        var hash = await sha.ComputeHashAsync(fs, ct).ConfigureAwait(false);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    /// <summary>Stage a single verified engine exe into a clean managed dir.</summary>
+    internal static string StageSingleExe(string sourceExe, string managedDir)
+    {
+        if (Directory.Exists(managedDir)) Directory.Delete(managedDir, recursive: true);
+        Directory.CreateDirectory(managedDir);
+        var stagedExe = Path.Combine(managedDir, "VSTHostEngine.exe");
+        File.Copy(sourceExe, stagedExe, overwrite: true);
+        if (!File.Exists(stagedExe))
+            throw new InvalidOperationException("Staging completed but VSTHostEngine.exe is missing.");
+        return stagedExe;
+    }
+
     /// <summary>Find <c>VSTHostEngine.exe</c> anywhere in the extracted tree and
     /// copy its containing folder (the exe plus its sibling DLLs / resources)
     /// into <paramref name="managedDir"/> flat at the top level. Returns the
-    /// staged exe path. Throws if the archive carries no engine binary (e.g. a
-    /// VSTHost build without the Zeus bridge engine).</summary>
+    /// staged exe path. Throws if the archive carries no engine binary.</summary>
     internal static string StageFromExtractedDir(string extractedRoot, string managedDir)
     {
         var sourceExe = Directory
             .EnumerateFiles(extractedRoot, "VSTHostEngine.exe", SearchOption.AllDirectories)
             .FirstOrDefault()
             ?? throw new InvalidOperationException(
-                "The downloaded archive does not contain VSTHostEngine.exe — this VSTHost "
-                + "release may not include the Zeus bridge engine yet.");
+                "The downloaded archive does not contain VSTHostEngine.exe — this "
+                + "release may not include the Zeus bridge engine.");
 
         var sourceDir = Path.GetDirectoryName(sourceExe)!;
 
@@ -225,9 +353,30 @@ public sealed class VstEngineInstaller
         return stagedExe;
     }
 
-    /// <summary>Pick the engine archive from a release's assets: prefer a portable
-    /// <c>.zip</c>, else any <c>.zip</c>. The setup.exe / .msi assets are the
-    /// Tauri desktop app, which Zeus does not use.</summary>
+    /// <summary>Pick the Windows x64 engine asset from the manifest. Prefers an
+    /// explicit windows/x64 platform tag; falls back to the first asset whose
+    /// filename looks like the engine exe or a zip.</summary>
+    internal static EngineAsset? SelectEngineAsset(IReadOnlyList<EngineAsset>? assets)
+    {
+        if (assets is null || assets.Count == 0) return null;
+
+        static bool IsWindowsX64(EngineAsset a) =>
+            (a.Platform is null || a.Platform.Equals("windows", StringComparison.OrdinalIgnoreCase)
+                                || a.Platform.Equals("win", StringComparison.OrdinalIgnoreCase))
+            && (a.Arch is null || a.Arch.Equals("x64", StringComparison.OrdinalIgnoreCase)
+                               || a.Arch.Equals("amd64", StringComparison.OrdinalIgnoreCase));
+
+        bool LooksLikeEngine(EngineAsset a) =>
+            !string.IsNullOrWhiteSpace(a.Url)
+            && (a.Filename.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)
+                || a.Filename.EndsWith(".zip", StringComparison.OrdinalIgnoreCase));
+
+        return assets.FirstOrDefault(a => IsWindowsX64(a) && LooksLikeEngine(a))
+               ?? assets.FirstOrDefault(LooksLikeEngine);
+    }
+
+    /// <summary>Pick the engine archive from a GitHub release's assets (legacy
+    /// path): prefer a portable <c>.zip</c>, else any <c>.zip</c>.</summary>
     internal static GithubAsset? SelectZipAsset(IReadOnlyList<GithubAsset>? assets)
     {
         if (assets is null || assets.Count == 0) return null;
@@ -238,6 +387,15 @@ public sealed class VstEngineInstaller
         return assets.FirstOrDefault(a => IsZip(a)
                    && a.Name.Contains("portable", StringComparison.OrdinalIgnoreCase))
                ?? assets.FirstOrDefault(IsZip);
+    }
+
+    private static bool HasReleaseOverride() =>
+        !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("ZEUS_VST_ENGINE_RELEASE_URL"));
+
+    private static string ManifestUrl()
+    {
+        var env = Environment.GetEnvironmentVariable("ZEUS_VST_ENGINE_MANIFEST_URL");
+        return string.IsNullOrWhiteSpace(env) ? DefaultManifestUrl : env.Trim();
     }
 
     private static string ReleaseApiUrl()
@@ -261,7 +419,42 @@ public sealed class VstEngineInstaller
         try { if (Directory.Exists(path)) Directory.Delete(path, recursive: true); } catch { /* best effort */ }
     }
 
-    // ----- GitHub release JSON (only the fields we read) -----
+    // ----- Zeus engine manifest JSON (only the fields we read) -----
+
+    internal sealed class EngineManifest
+    {
+        [JsonPropertyName("version")]
+        public string? Version { get; set; }
+
+        [JsonPropertyName("publishedAt")]
+        public string? PublishedAt { get; set; }
+
+        [JsonPropertyName("assets")]
+        public List<EngineAsset> Assets { get; set; } = [];
+    }
+
+    internal sealed class EngineAsset
+    {
+        [JsonPropertyName("filename")]
+        public string Filename { get; set; } = string.Empty;
+
+        [JsonPropertyName("url")]
+        public string? Url { get; set; }
+
+        [JsonPropertyName("size")]
+        public long Size { get; set; }
+
+        [JsonPropertyName("sha256")]
+        public string? Sha256 { get; set; }
+
+        [JsonPropertyName("platform")]
+        public string? Platform { get; set; }
+
+        [JsonPropertyName("arch")]
+        public string? Arch { get; set; }
+    }
+
+    // ----- GitHub release JSON (legacy path; only the fields we read) -----
 
     internal sealed class GithubRelease
     {

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -220,26 +220,27 @@ public static class ZeusEndpoints
                 engineAvailable = AudioProcessingModeService.FindEngineExe() is not null,
             });
         });
-        app.MapGet("/api/tx-audio-suite/processing-mode", (AudioProcessingModeService svc) =>
+        // Processing-mode + engine health. The health fields let the frontend
+        // distinguish "engine still starting" (transient — wait) from "engine
+        // keeps crashing" (Faulted — offer Repair) instead of a vague hint.
+        static object TxModeDto(AudioProcessingModeService svc, AudioProcessingMode mode) => new
         {
-            return Results.Ok(new
-            {
-                mode = svc.Mode.ToString().ToLowerInvariant(),
-                engineActive = svc.EngineActive,
-                engineAvailable = AudioProcessingModeService.FindEngineExe() is not null,
-            });
-        });
+            mode = mode.ToString().ToLowerInvariant(),
+            engineActive = svc.EngineActive,
+            engineAvailable = AudioProcessingModeService.FindEngineExe() is not null,
+            engineState = svc.EngineState.ToString().ToLowerInvariant(),
+            engineCrashLooping = svc.EngineCrashLooping,
+            engineRestartCount = svc.EngineRestartCount,
+            engineLastFault = svc.EngineLastFault,
+        };
+        app.MapGet("/api/tx-audio-suite/processing-mode", (AudioProcessingModeService svc) =>
+            Results.Ok(TxModeDto(svc, svc.Mode)));
         app.MapPut("/api/tx-audio-suite/processing-mode", async (ProcessingModeSetRequest body, AudioProcessingModeService svc) =>
         {
             if (body?.Mode is null || !Enum.TryParse<AudioProcessingMode>(body.Mode, ignoreCase: true, out var mode))
                 return Results.BadRequest(new { error = "mode must be 'native' or 'vst'" });
             var applied = await svc.SetModeAsync(mode);
-            return Results.Ok(new
-            {
-                mode = applied.ToString().ToLowerInvariant(),
-                engineActive = svc.EngineActive,
-                engineAvailable = AudioProcessingModeService.FindEngineExe() is not null,
-            });
+            return Results.Ok(TxModeDto(svc, applied));
         });
 
         // VST engine provisioning — the in-app "Get VST Engine" flow. The engine
@@ -274,6 +275,20 @@ public static class ZeusEndpoints
         app.MapPost("/api/tx-audio-suite/vst-engine/install", (VstEngineInstaller installer) =>
         {
             installer.Start();
+            return Results.Ok(EngineInstallDto(installer));
+        });
+        // Repair/reinstall — force a re-download of the manifest's verified engine
+        // even when one is already present, replacing a stale/corrupt/crash-looping
+        // binary. Backs the "Repair engine" affordance the UI shows when the engine
+        // is Faulted; also runs automatically on crash-loop (AudioProcessingModeService).
+        app.MapPost("/api/audio-suite/vst-engine/repair", (VstEngineInstaller installer) =>
+        {
+            installer.Start(force: true);
+            return Results.Ok(EngineInstallDto(installer));
+        });
+        app.MapPost("/api/tx-audio-suite/vst-engine/repair", (VstEngineInstaller installer) =>
+        {
+            installer.Start(force: true);
             return Results.Ok(EngineInstallDto(installer));
         });
 

--- a/docs/rca/vst-engine-broken-upstream-and-silent-crashloop.md
+++ b/docs/rca/vst-engine-broken-upstream-and-silent-crashloop.md
@@ -1,0 +1,91 @@
+# RCA: TX VST editor 409s — broken upstream engine + a silent crash-loop
+
+## Symptom
+
+A new user, in VST processing mode, opens a TX Audio Suite VST editor and gets:
+
+> The VST engine is installed but isn't routing yet. Give it a moment, then reopen the editor.
+
+…with repeated `409 Conflict` on `POST /api/tx-audio-suite/plugins/{id}/editor`. "Giving it a
+moment" never helps — the engine never starts routing.
+
+## Root cause (two compounding faults)
+
+1. **The downloadable engine was incompatible.** The in-app installer fetched
+   KlayaR/VSTHost **"latest" (v1.4.0, May 2026)**. That build's `VSTHostEngine.exe`
+   exits before completing the Zeus bridge handshake, so the supervisor counts it
+   as a crash, hits the crash-loop cap (`crashed 7× within 60s`), cools down, and
+   leaves TX in clean passthrough — `engineActive` stays `false` forever. The only
+   bridge-compatible engine was a **newer build than any public release**, present
+   only on developer machines. So *every* fresh "Download VST Engine" produced a
+   crash-looping engine.
+
+2. **The failure was invisible.** `VstEngineController` tracked `State`, `LastFault`,
+   the exit code, and `RestartCount`, but none of it was surfaced. The editor 409
+   said only "give it a moment" — optimistic wording for what was actually a
+   permanent crash-loop. Diagnosis required reading the in-memory diagnostic log
+   (`POST /api/diagnostics/report`) by hand.
+
+The standalone reproduction (`VSTHostEngine.exe --zeus-bridge --shm probe …` exits 0,
+no output) was a red herring: the `probe` shared-memory segment doesn't exist, so the
+engine bailed cleanly *before* the path that crashes under a real Zeus-created SHM.
+
+## Fix — self-healing distribution
+
+The engine is now sourced from a **Zeus-controlled, SHA-256-pinned manifest** on the
+download domain instead of a floating upstream "latest":
+
+- `VstEngineInstaller` fetches `https://downloads.openhpsdrzeus.com/vst-engine/latest.json`,
+  downloads the named asset, **verifies its SHA-256**, and stages it. The legacy
+  GitHub-release path remains only behind the `ZEUS_VST_ENGINE_RELEASE_URL` dev override.
+- **Auto-repair:** when the engine crash-loops (`AudioProcessingModeService.OnEngineFaulted`),
+  Zeus re-downloads the verified engine **once** and the supervisor relaunches onto it —
+  no operator action. A persistently-bad manifest can't loop (one repair per explicit
+  mode set).
+- **Status surface:** `GET /api/tx-audio-suite/processing-mode` now returns
+  `engineState` / `engineCrashLooping` / `engineRestartCount` / `engineLastFault`. The
+  editor hook waits out a cold start and retries, but on a true crash-loop it stops and
+  the panel shows a **Repair Engine** button (`POST …/vst-engine/repair`).
+
+So a broken/stale install (like the one that triggered this RCA) now repairs itself on
+the next launch once a good engine is published.
+
+## Operator action: publish a known-good engine
+
+This is the one manual step the code can't do — host the verified engine + manifest:
+
+1. Generate the manifest from a known-good `VSTHostEngine.exe`:
+   ```
+   node tools/vst-engine-manifest.mjs <VSTHostEngine.exe> <version>
+   ```
+2. Upload, to `https://downloads.openhpsdrzeus.com/vst-engine/`:
+   - the engine as the versioned name it prints (e.g. `VSTHostEngine-2026.06.14.exe`)
+   - the manifest as `latest.json`
+
+The current known-good engine (build dated 2026-06-14):
+
+```json
+{
+  "version": "2026.06.14",
+  "assets": [
+    {
+      "filename": "VSTHostEngine-2026.06.14.exe",
+      "url": "https://downloads.openhpsdrzeus.com/vst-engine/VSTHostEngine-2026.06.14.exe",
+      "size": 6712832,
+      "sha256": "f8bcc1a544cd4c49a2eb89cbf51d613e87139cdf95d459cc52daf2b3d46537e6",
+      "platform": "windows",
+      "arch": "x64"
+    }
+  ]
+}
+```
+
+Once that's live, existing broken installs self-repair on next VST activation, and new
+installs get the verified engine on first download.
+
+## Lesson
+
+Don't pin a safety-adjacent native dependency to a floating upstream "latest" — pin a
+hash you control. And when a background process can silently fail into passthrough,
+surface `State`/`LastFault`/exit-code to the operator; "give it a moment" must not be the
+only thing a permanent failure ever says.

--- a/tests/Zeus.Server.Tests/VstEngineInstallerTests.cs
+++ b/tests/Zeus.Server.Tests/VstEngineInstallerTests.cs
@@ -100,4 +100,68 @@ public class VstEngineInstallerTests : IDisposable
 
         Assert.Null(VstEngineInstaller.SelectZipAsset(assets));
     }
+
+    // --- Manifest path (the production source: a Zeus-hosted, SHA-256-pinned engine) ---
+
+    [Fact]
+    public void SelectEngineAsset_prefers_windows_x64_engine_and_skips_non_engine()
+    {
+        var assets = new List<VstEngineInstaller.EngineAsset>
+        {
+            new() { Filename = "notes.txt", Url = "https://d/notes.txt", Platform = "windows", Arch = "x64" },
+            new() { Filename = "VSTHostEngine-linux.zip", Url = "https://d/lx.zip", Platform = "linux", Arch = "x64" },
+            new() { Filename = "VSTHostEngine.exe", Url = "https://d/eng.exe", Platform = "windows", Arch = "x64",
+                    Sha256 = "abc" },
+        };
+
+        var picked = VstEngineInstaller.SelectEngineAsset(assets);
+
+        Assert.NotNull(picked);
+        Assert.Equal("VSTHostEngine.exe", picked!.Filename);
+        Assert.Equal("abc", picked.Sha256);
+    }
+
+    [Fact]
+    public void SelectEngineAsset_falls_back_to_any_engine_like_asset_without_platform_tag()
+    {
+        var assets = new List<VstEngineInstaller.EngineAsset>
+        {
+            new() { Filename = "engine.zip", Url = "https://d/engine.zip" },
+        };
+
+        var picked = VstEngineInstaller.SelectEngineAsset(assets);
+
+        Assert.NotNull(picked);
+        Assert.Equal("engine.zip", picked!.Filename);
+    }
+
+    [Fact]
+    public void SelectEngineAsset_returns_null_when_no_usable_asset()
+    {
+        Assert.Null(VstEngineInstaller.SelectEngineAsset(null));
+        Assert.Null(VstEngineInstaller.SelectEngineAsset(new List<VstEngineInstaller.EngineAsset>()));
+        Assert.Null(VstEngineInstaller.SelectEngineAsset(new List<VstEngineInstaller.EngineAsset>
+        {
+            new() { Filename = "readme.md", Url = "https://d/readme.md" }, // not exe/zip
+            new() { Filename = "VSTHostEngine.exe", Url = null },          // no URL
+        }));
+    }
+
+    [Fact]
+    public void StageSingleExe_stages_verified_exe_and_replaces_stale_contents()
+    {
+        var sourceExe = Path.Combine(_root, "src", "VSTHostEngine.exe");
+        Directory.CreateDirectory(Path.GetDirectoryName(sourceExe)!);
+        File.WriteAllText(sourceExe, "ENGINE-BYTES");
+
+        var managed = Path.Combine(_root, "managed", "vst-engine");
+        Directory.CreateDirectory(managed);
+        File.WriteAllText(Path.Combine(managed, "stale.dll"), "old");
+
+        var staged = VstEngineInstaller.StageSingleExe(sourceExe, managed);
+
+        Assert.Equal(Path.Combine(managed, "VSTHostEngine.exe"), staged);
+        Assert.Equal("ENGINE-BYTES", File.ReadAllText(staged));
+        Assert.False(File.Exists(Path.Combine(managed, "stale.dll")));
+    }
 }

--- a/tools/vst-engine-manifest.mjs
+++ b/tools/vst-engine-manifest.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Generate the VST-engine download manifest (vst-engine/latest.json) consumed
+// by Zeus's in-app "Download VST Engine" / auto-repair flow (VstEngineInstaller).
+//
+// Zeus stages the engine named here and verifies its SHA-256 before use, so the
+// operator always gets a known-good, bridge-compatible binary — NOT a floating
+// upstream "latest" (which has shipped a build that crash-loops the handshake).
+//
+// Usage:
+//   node tools/vst-engine-manifest.mjs <VSTHostEngine.exe> <version> [out.json]
+//
+// Env:
+//   VST_ENGINE_BASE_URL   default https://downloads.openhpsdrzeus.com/vst-engine
+//   VST_ENGINE_PUBLISHED  ISO timestamp; default omitted
+//
+// The engine binary itself must be uploaded next to latest.json on the domain as
+// the versioned filename printed below (e.g. VSTHostEngine-2026.06.14.exe), so a
+// new manifest never invalidates a cached older binary.
+
+import { createHash } from "node:crypto";
+import { readFileSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const [enginePath, version, outPath] = process.argv.slice(2);
+if (!enginePath || !version) {
+  console.error("Usage: node tools/vst-engine-manifest.mjs <VSTHostEngine.exe> <version> [out.json]");
+  process.exit(2);
+}
+
+const baseUrl = (process.env.VST_ENGINE_BASE_URL || "https://downloads.openhpsdrzeus.com/vst-engine")
+  .replace(/\/+$/, "");
+const bytes = readFileSync(enginePath);
+const sha256 = createHash("sha256").update(bytes).digest("hex");
+const size = statSync(enginePath).size;
+
+// Versioned, immutable download name so publishing a new manifest never breaks a
+// cached older engine. Always staged as VSTHostEngine.exe on the client side.
+const ext = path.extname(enginePath) || ".exe";
+const downloadName = `VSTHostEngine-${version}${ext}`;
+
+const manifest = {
+  version,
+  ...(process.env.VST_ENGINE_PUBLISHED ? { publishedAt: process.env.VST_ENGINE_PUBLISHED } : {}),
+  assets: [
+    {
+      filename: downloadName,
+      url: `${baseUrl}/${downloadName}`,
+      size,
+      sha256,
+      platform: "windows",
+      arch: "x64",
+    },
+  ],
+};
+
+const json = JSON.stringify(manifest, null, 2) + "\n";
+if (outPath) {
+  writeFileSync(outPath, json);
+  console.error(`Wrote ${outPath}`);
+} else {
+  process.stdout.write(json);
+}
+console.error(`\nUpload the engine as: ${baseUrl}/${downloadName}`);
+console.error(`Upload the manifest as: ${baseUrl}/latest.json`);
+console.error(`sha256=${sha256} size=${size}`);

--- a/zeus-web/src/components/GenericVstPanel.tsx
+++ b/zeus-web/src/components/GenericVstPanel.tsx
@@ -11,6 +11,7 @@
 
 import { useEffect, useRef } from 'react';
 import { useVstEditor, type VstEditorRoute } from './useVstEditor';
+import { useAudioSuiteStore } from '../state/audio-suite-store';
 
 interface GenericVstPanelProps {
   pluginId: string;
@@ -19,11 +20,18 @@ interface GenericVstPanelProps {
 }
 
 export function GenericVstPanel({ pluginId, name, route = 'tx' }: GenericVstPanelProps) {
-  const { open, busy, error, toggle, openEditor } = useVstEditor(
+  const { open, busy, starting, crashed, error, toggle, openEditor } = useVstEditor(
     pluginId,
     true,
     route,
   );
+  const repairVstEngine = useAudioSuiteStore((s) => s.repairVstEngine);
+  const enginePhase = useAudioSuiteStore((s) => s.vstEngineInstall.phase);
+  const repairing =
+    enginePhase === 'downloading' ||
+    enginePhase === 'extracting' ||
+    enginePhase === 'staging' ||
+    enginePhase === 'configuring';
 
   // Selecting this VST's chip mounts the panel — auto-open its real
   // editor window so the chip click alone pops the GUI (no extra button
@@ -90,7 +98,7 @@ export function GenericVstPanel({ pluginId, name, route = 'tx' }: GenericVstPane
             fontFamily: 'inherit',
           }}
         >
-          {busy ? '…' : open ? 'Close Editor' : 'Open Editor'}
+          {busy ? (starting ? 'Starting…' : '…') : open ? 'Close Editor' : 'Open Editor'}
         </button>
         <span style={{ color: 'var(--fg-3)', fontSize: 10, lineHeight: 1.3, flex: 1, minWidth: 160 }}>
           Selecting this VST opens its real editor in a separate desktop
@@ -99,6 +107,51 @@ export function GenericVstPanel({ pluginId, name, route = 'tx' }: GenericVstPane
           processes audio either way.
         </span>
       </div>
+
+      {starting && (
+        <div
+          style={{
+            fontSize: 10,
+            color: 'var(--fg-2)',
+            background: 'var(--bg-2)',
+            border: '1px solid var(--line)',
+            borderRadius: 3,
+            padding: '5px 8px',
+            lineHeight: 1.4,
+          }}
+        >
+          VST engine starting&hellip; the editor opens automatically once it&rsquo;s
+          routing. This can take a few seconds on first use.
+        </div>
+      )}
+
+      {crashed && (
+        <button
+          type="button"
+          disabled={repairing}
+          onClick={async () => {
+            await repairVstEngine();
+            openEditor();
+          }}
+          title="Re-download the verified VST engine and retry"
+          style={{
+            alignSelf: 'flex-start',
+            padding: '5px 12px',
+            borderRadius: 4,
+            border: '1px solid var(--accent)',
+            background: repairing ? 'var(--bg-2)' : 'var(--accent)',
+            color: repairing ? 'var(--fg-2)' : '#fff',
+            cursor: repairing ? 'progress' : 'pointer',
+            fontSize: 11,
+            fontWeight: 600,
+            letterSpacing: 0.6,
+            textTransform: 'uppercase',
+            fontFamily: 'inherit',
+          }}
+        >
+          {repairing ? 'Repairing…' : 'Repair Engine'}
+        </button>
+      )}
 
       {error && (
         <div

--- a/zeus-web/src/components/useVstEditor.test.tsx
+++ b/zeus-web/src/components/useVstEditor.test.tsx
@@ -3,9 +3,9 @@ import { describe, expect, it, vi } from 'vitest';
 import { act, renderHook } from './meters/__tests__/harness';
 import { useVstEditor } from './useVstEditor';
 
-function jsonResponse(body: unknown): Response {
+function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
-    status: 200,
+    status,
     headers: { 'content-type': 'application/json' },
   });
 }
@@ -39,6 +39,120 @@ describe('useVstEditor', () => {
       '/api/tx-audio-suite/plugins/com.openhpsdr.zeus.vst.clear/editor',
       { method: 'POST' },
     );
+
+    hook.unmount();
+    vi.unstubAllGlobals();
+  });
+
+  it('waits for the engine to start, then retries the open after a 409', async () => {
+    // Fresh-install cold-start race: the first POST 409s because the engine
+    // isn't routing yet. The hook should poll processing-mode, see the engine
+    // come up, and retry the open so the editor ends up open (not failed).
+    const editorBase =
+      '/api/tx-audio-suite/plugins/com.openhpsdr.zeus.vst.blendeq/editor';
+    let postCount = 0;
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith('/processing-mode')) {
+        return jsonResponse({ mode: 'vst', engineActive: true });
+      }
+      if (url === editorBase && init?.method === 'POST') {
+        postCount += 1;
+        // First open races the still-starting engine → 409; retry succeeds.
+        return postCount === 1
+          ? jsonResponse({ error: "installed but isn't routing yet" }, 409)
+          : jsonResponse({ open: true });
+      }
+      return jsonResponse({ open: false });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const hook = renderHook(() => useVstEditor('com.openhpsdr.zeus.vst.blendeq'));
+    await flushAsyncWork();
+
+    await act(async () => {
+      hook.result.current.openEditor();
+      // mount-GET + POST(409) + processing-mode poll + POST(retry) settle.
+      for (let i = 0; i < 6; i += 1) await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/tx-audio-suite/processing-mode',
+    );
+    expect(postCount).toBe(2);
+    expect(hook.result.current.open).toBe(true);
+    expect(hook.result.current.error).toBeNull();
+
+    hook.unmount();
+    vi.unstubAllGlobals();
+  });
+
+  it('flags a crash-loop instead of retrying when the engine keeps crashing', async () => {
+    // Installed engine that keeps crashing (Faulted): waiting won't help, so the
+    // hook should stop, set crashed=true, and not retry the open.
+    const editorBase =
+      '/api/tx-audio-suite/plugins/com.openhpsdr.zeus.vst.blendeq/editor';
+    let postCount = 0;
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith('/processing-mode')) {
+        return jsonResponse({ mode: 'vst', engineActive: false, engineCrashLooping: true });
+      }
+      if (url === editorBase && init?.method === 'POST') {
+        postCount += 1;
+        return jsonResponse({ error: "installed but isn't routing yet" }, 409);
+      }
+      return jsonResponse({ open: false });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const hook = renderHook(() => useVstEditor('com.openhpsdr.zeus.vst.blendeq'));
+    await flushAsyncWork();
+
+    await act(async () => {
+      hook.result.current.openEditor();
+      for (let i = 0; i < 6; i += 1) await Promise.resolve();
+    });
+
+    expect(postCount).toBe(1); // no retry — waiting can't fix a crash-loop
+    expect(hook.result.current.crashed).toBe(true);
+    expect(hook.result.current.open).toBe(false);
+    expect(hook.result.current.error).toContain('keeps crashing');
+
+    hook.unmount();
+    vi.unstubAllGlobals();
+  });
+
+  it('does not wait when a 409 comes back in Native mode', async () => {
+    // A Native-mode 409 means "switch to VST mode" — there is no engine to wait
+    // for, so the original error should surface immediately without retrying.
+    const editorBase =
+      '/api/tx-audio-suite/plugins/com.openhpsdr.zeus.vst.blendeq/editor';
+    let postCount = 0;
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith('/processing-mode')) {
+        return jsonResponse({ mode: 'native', engineActive: false });
+      }
+      if (url === editorBase && init?.method === 'POST') {
+        postCount += 1;
+        return jsonResponse({ error: 'TX VSTs run in the dedicated VST engine.' }, 409);
+      }
+      return jsonResponse({ open: false });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const hook = renderHook(() => useVstEditor('com.openhpsdr.zeus.vst.blendeq'));
+    await flushAsyncWork();
+
+    await act(async () => {
+      hook.result.current.openEditor();
+      for (let i = 0; i < 6; i += 1) await Promise.resolve();
+    });
+
+    expect(postCount).toBe(1); // no retry
+    expect(hook.result.current.open).toBe(false);
+    expect(hook.result.current.error).toContain('dedicated VST engine');
 
     hook.unmount();
     vi.unstubAllGlobals();

--- a/zeus-web/src/components/useVstEditor.ts
+++ b/zeus-web/src/components/useVstEditor.ts
@@ -7,7 +7,7 @@
 // source of truth for that toggle, used both by the rack slot header
 // (click the VST to open its window) and the GenericVstPanel fallback.
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 export type VstEditorRoute = 'tx' | 'rx';
 
@@ -16,12 +16,68 @@ export interface VstEditorState {
   open: boolean;
   /** True while an open/close request is in flight. */
   busy: boolean;
+  /**
+   * True while we're waiting for the out-of-process VST engine to finish
+   * starting before (re)trying the open. Lets the UI show "engine starting…"
+   * instead of a failure during the fresh-install cold-start window.
+   */
+  starting: boolean;
+  /**
+   * True when the open failed because the engine is installed but keeps
+   * crashing on startup (Faulted), not merely warming up. The UI surfaces a
+   * "Repair engine" action in this case; the server also auto-repairs once.
+   */
+  crashed: boolean;
   /** Last failed request's message (e.g. the VST didn't load), else null. */
   error: string | null;
   /** Open the editor if closed, close it if open. No-op while busy. */
   toggle(): void;
   /** Open the editor (no-op if already open or busy). */
   openEditor(): void;
+}
+
+// On a fresh install the engine binary is downloaded and then cold-started for
+// the first time (Defender/SmartScreen scan + JUCE/VST init), which can take a
+// few seconds — longer than the editor-open click that races it. Poll the
+// processing-mode for the engine to come up, then retry the open once.
+const ENGINE_START_POLLS = 20;
+const ENGINE_START_INTERVAL_MS = 1000;
+
+type EngineWaitResult = 'active' | 'crash' | 'gaveup';
+
+/**
+ * Wait for the out-of-process VST engine to report active, polling the route's
+ * processing-mode. Returns 'active' once it's routing; 'crash' if the engine is
+ * installed but crash-looping (Faulted — the caller offers Repair); 'gaveup' if
+ * it never comes up within the budget, the hook unmounted, or the route is no
+ * longer in VST mode (a Native-mode 409 means "switch to VST mode" — there is
+ * no engine to wait for, so the original error should surface instead).
+ */
+async function waitForEngineActive(
+  routePrefix: string,
+  alive: () => boolean,
+  onStarting: () => void,
+): Promise<EngineWaitResult> {
+  for (let i = 0; i < ENGINE_START_POLLS; i += 1) {
+    if (!alive()) return 'gaveup';
+    let body:
+      | { mode?: string; engineActive?: boolean; engineCrashLooping?: boolean }
+      | null = null;
+    try {
+      const res = await fetch(`${routePrefix}/processing-mode`);
+      body = res.ok ? await res.json() : null;
+    } catch {
+      body = null;
+    }
+    // Not in VST mode → the engine won't activate; nothing to wait for.
+    if (body && body.mode !== 'vst') return 'gaveup';
+    if (body?.engineActive === true) return 'active';
+    // Installed but Faulted → waiting won't help; surface a repair path.
+    if (body?.engineCrashLooping === true) return 'crash';
+    onStarting();
+    await new Promise((r) => setTimeout(r, ENGINE_START_INTERVAL_MS));
+  }
+  return 'gaveup';
 }
 
 /**
@@ -40,7 +96,19 @@ export function useVstEditor(
   const base = `${routePrefix}/plugins/${encodeURIComponent(pluginId)}/editor`;
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
+  const [starting, setStarting] = useState(false);
+  const [crashed, setCrashed] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Tracks mount state so the (potentially multi-second) engine-start wait
+  // never writes to an unmounted hook or keeps polling after teardown.
+  const aliveRef = useRef(true);
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => {
+      aliveRef.current = false;
+    };
+  }, []);
 
   // Reflect the actual editor state on mount — the native window may
   // already be open from a previous interaction (state lives server-side).
@@ -64,21 +132,58 @@ export function useVstEditor(
     async (wantOpen: boolean) => {
       setBusy(true);
       setError(null);
+      setStarting(false);
+      setCrashed(false);
       try {
-        const res = await fetch(base, { method: wantOpen ? 'POST' : 'DELETE' });
-        const body = await res.json().catch(() => null);
+        let res = await fetch(base, { method: wantOpen ? 'POST' : 'DELETE' });
+        let body = await res.json().catch(() => null);
+
+        // Fresh-install cold-start race: the editor 409s with "isn't routing
+        // yet" while the engine is still coming up. Instead of surfacing a
+        // scary error and giving up, wait for the engine to finish starting and
+        // retry the open once. Only meaningful for an open in VST mode —
+        // waitForEngineActive bails immediately when the route isn't VST.
+        if (!res.ok && res.status === 409 && wantOpen && aliveRef.current) {
+          const outcome = await waitForEngineActive(
+            routePrefix,
+            () => aliveRef.current,
+            () => {
+              if (aliveRef.current) setStarting(true);
+            },
+          );
+          if (outcome === 'active' && aliveRef.current) {
+            res = await fetch(base, { method: 'POST' });
+            body = await res.json().catch(() => null);
+          } else if (outcome === 'crash' && aliveRef.current) {
+            // Installed but crash-looping — waiting won't fix it. Surface the
+            // repair path instead of the optimistic "give it a moment" hint.
+            setCrashed(true);
+            setError(
+              'The VST engine is installed but keeps crashing on startup. ' +
+                'Use Repair to re-download the verified engine.',
+            );
+            return;
+          }
+        }
+
+        if (!aliveRef.current) return;
         if (res.ok) {
           setOpen(body && typeof body.open === 'boolean' ? body.open : wantOpen);
         } else {
           setError(body?.error ?? `Request failed (${res.status})`);
         }
       } catch (e) {
-        setError(e instanceof Error ? e.message : 'Request failed');
+        if (aliveRef.current) {
+          setError(e instanceof Error ? e.message : 'Request failed');
+        }
       } finally {
-        setBusy(false);
+        if (aliveRef.current) {
+          setBusy(false);
+          setStarting(false);
+        }
       }
     },
-    [base],
+    [base, routePrefix],
   );
 
   const toggle = useCallback(() => {
@@ -91,5 +196,5 @@ export function useVstEditor(
     void request(true);
   }, [busy, open, request]);
 
-  return { open, busy, error, toggle, openEditor };
+  return { open, busy, starting, crashed, error, toggle, openEditor };
 }

--- a/zeus-web/src/state/audio-suite-store.ts
+++ b/zeus-web/src/state/audio-suite-store.ts
@@ -260,6 +260,10 @@ interface AudioSuiteState {
   processingMode: 'native' | 'vst';
   vstEngineAvailable: boolean;
   vstEngineActive: boolean;
+  // True when VST mode is selected and an engine is installed but it keeps
+  // crashing on startup (Faulted) rather than just still warming up. Drives the
+  // "Repair engine" affordance; the server also auto-repairs once on crash-loop.
+  vstEngineCrashLooping: boolean;
   rxVstEngineAvailable: boolean;
   rxVstEngineActive: boolean;
   rxVstActivePlugins: number;
@@ -287,7 +291,12 @@ interface AudioSuiteState {
     percent: number;
     message: string | null;
   };
-  installVstEngine(): Promise<void>;
+  // postUrl is an internal seam (install vs repair endpoint); callers use the
+  // no-arg form. Default is the install endpoint.
+  installVstEngine(postUrl?: string): Promise<void>;
+  // Force a re-download of the verified engine, replacing a stale/corrupt or
+  // crash-looping binary. Reuses the install status/polling lifecycle.
+  repairVstEngine(): Promise<void>;
 }
 
 type AudioSuitePersistedState = Pick<
@@ -368,6 +377,7 @@ export const useAudioSuiteStore = create<AudioSuiteState>()(
       processingMode: 'native',
       vstEngineAvailable: false,
       vstEngineActive: false,
+      vstEngineCrashLooping: false,
       rxVstEngineAvailable: false,
       rxVstEngineActive: false,
       rxVstActivePlugins: 0,
@@ -1100,11 +1110,13 @@ export const useAudioSuiteStore = create<AudioSuiteState>()(
             mode?: string;
             engineAvailable?: boolean;
             engineActive?: boolean;
+            engineCrashLooping?: boolean;
           };
           set({
             processingMode: body.mode === 'vst' ? 'vst' : 'native',
             vstEngineAvailable: body.engineAvailable === true,
             vstEngineActive: body.engineActive === true,
+            vstEngineCrashLooping: body.engineCrashLooping === true,
           });
         } catch (err) {
 
@@ -1172,14 +1184,14 @@ export const useAudioSuiteStore = create<AudioSuiteState>()(
         }
       },
 
-      installVstEngine: async () => {
+      installVstEngine: async (postUrl = '/api/tx-audio-suite/vst-engine/install') => {
         const phase = get().vstEngineInstall.phase;
         if (phase === 'downloading' || phase === 'extracting' || phase === 'staging') {
           return; // already running
         }
         set({ vstEngineInstall: { phase: 'downloading', percent: 0, message: 'Starting…' } });
         try {
-          const res = await fetch('/api/tx-audio-suite/vst-engine/install', {
+          const res = await fetch(postUrl, {
             method: 'POST',
           });
           if (!res.ok) {
@@ -1282,6 +1294,10 @@ export const useAudioSuiteStore = create<AudioSuiteState>()(
           });
           console.warn('vst-engine install threw', err);
         }
+      },
+
+      repairVstEngine: async () => {
+        await get().installVstEngine('/api/tx-audio-suite/vst-engine/repair');
       },
     }),
     {


### PR DESCRIPTION
## Problem

A new user in VST mode loads a TX Audio Suite VST and gets repeated `409 Conflict` on the editor endpoint with *"The VST engine is installed but isn't routing yet. Give it a moment…"* — but it never routes.

**Root cause (diagnosed on a live affected box):** the in-app installer fetched KlayaR/VSTHost **"latest" (v1.4.0)**, whose `VSTHostEngine.exe` exits before completing the Zeus bridge handshake. The supervisor crash-loops it (`crashed 7× within 60s`), trips the cap, and leaves TX in clean passthrough — `engineActive` stays `false` permanently. The only bridge-compatible engine is a build **newer than any public release**. So *every* fresh "Download VST Engine" produced a crash-looping engine, and the failure was invisible (the controller tracked `State`/`LastFault`/exit-code/`RestartCount`, none of it surfaced).

## Fix — pin a hash you control + make broken installs self-heal

- **VstEngineInstaller**: fetch a Zeus-controlled manifest (`downloads.openhpsdrzeus.com/vst-engine/latest.json`), **verify the asset SHA-256** before staging, and support `force` repair to replace a stale/corrupt/crash-looping binary. Legacy GitHub-release path stays behind `ZEUS_VST_ENGINE_RELEASE_URL` (dev override).
- **AudioProcessingModeService**: on a crash-loop fault, **auto-repair once** by re-downloading the verified engine; the supervisor relaunches onto it with no operator action. Exposes engine `State`/`LastFault`/`RestartCount`/`CrashLooping`.
- **Endpoints**: engine health on `GET …/processing-mode`; new `POST …/vst-engine/repair`.
- **useVstEditor**: waits out the cold-start window and retries the open once; on a true crash-loop, stops and surfaces a Repair path instead of the optimistic hint. `GenericVstPanel` shows *Starting…* / *Repair Engine*.
- **tools/vst-engine-manifest.mjs**: one-command manifest generator. **docs/rca/**: incident write-up + publish runbook.

Net effect: a broken install repairs itself on next launch once a good engine is published — no hand-copying binaries.

## Required follow-up (infra, not code)
Host the verified engine + manifest on the download domain (the code can't upload it). The RCA doc has the ready-to-publish `latest.json` (generated from the known-good 2026-06-14 build). ⚠️ Confirm that build is a sanctioned engine to ship before publishing it as official — it's currently unreleased, and it's not yet established whether v1.4.0 is broken or Zeus tightened the handshake after it.

## Tests
- Backend: installer asset-selection + staging (incl. new manifest path); host builds clean; targeted server suite (incl. DI-built `AudioSuitePreview` integration) green.
- Frontend: editor cold-start retry, crash-loop flag, native-mode no-wait; full `npm` component/store suite (199) green; tsc + eslint clean.