### PR TITLE
fix(web): move Lightning Map zoom control to bottom-left

### DIFF
--- a/zeus-web/src/layout/panels/LightningMapPanel.tsx
+++ b/zeus-web/src/layout/panels/LightningMapPanel.tsx
@@ -155,7 +155,9 @@ export function LightningMapPanel() {
       zoom: home ? 5 : 3,
       minZoom: 2,
       maxZoom: 11,
-      zoomControl: true,
+      // Zoom control lives bottom-left so it clears the strikes/min HUD card
+      // pinned top-left.
+      zoomControl: false,
       attributionControl: true,
       worldCopyJump: true,
       maxBounds: L.latLngBounds([-85, -200], [85, 200]),
@@ -170,6 +172,8 @@ export function LightningMapPanel() {
     })
       .on('tileerror', (e) => console.warn('Lightning map tile error:', e))
       .addTo(map);
+
+    L.control.zoom({ position: 'bottomleft' }).addTo(map);
 
     homeLayerRef.current = L.layerGroup().addTo(map);
     mapRef.current = map;


### PR DESCRIPTION
## What

Follow-up to #954. The Leaflet `+`/`−` zoom control on the Lightning Map panel defaulted to **top-left**, where it overlapped the strikes/min HUD card (see report below). This moves it to the **bottom-left** so it clears the card.

Change: disable Leaflet`s default `zoomControl`, then add `L.control.zoom({ position: "bottomleft" })`.

## Why a separate PR

The fix commit landed on the feature branch just after #954 was squash-merged, so it was not captured in that merge.

## Verification

- `tsc -b` clean.
- In the running dev preview (DOM check): the zoom control is now in the `.leaflet-bottom.leaflet-left` container with both buttons; top-left is clear; the HUD stays pinned top-left — no overlap.