### PR TITLE
fix(vst): don't fail rescan when stub DLL is locked by a loaded plugin

### DIFF
--- a/Zeus.Plugins.Host/VstDirectoryScanService.cs
+++ b/Zeus.Plugins.Host/VstDirectoryScanService.cs
@@ -502,6 +502,21 @@ public sealed class VstDirectoryScanService
             .GetManifestResourceStream(StubResourceName)
             ?? throw new InvalidOperationException(
                 $"embedded stub resource '{StubResourceName}' not found");
+
+        // Idempotent by design. The stub is a constant embedded resource, so
+        // every package's copy is byte-identical. Once a plugin is loaded its
+        // collectible ALC holds an OS file lock on this DLL (LoadFromAssemblyPath
+        // keeps the file open for the context's lifetime, and a just-unloaded ALC
+        // keeps it locked until GC reclaims it). Clobbering it on a re-scan throws
+        // "the process cannot access the file … because it is being used by
+        // another process" — the failure that made a rescan over an already-
+        // populated plugin root report every plugin as Failed. A present,
+        // correctly-sized stub is already correct: leave it untouched. Only an
+        // absent or truncated copy (an interrupted prior write — which is never
+        // loaded, so never locked) is (re)written.
+        if (File.Exists(destPath) && new FileInfo(destPath).Length == res.Length)
+            return;
+
         using var file = File.Create(destPath);
         res.CopyTo(file);
     }

--- a/tests/Zeus.Plugins.Host.Tests/VstDirectoryScanServiceTests.cs
+++ b/tests/Zeus.Plugins.Host.Tests/VstDirectoryScanServiceTests.cs
@@ -205,6 +205,39 @@ public class VstDirectoryScanServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task Scan_Does_Not_Fail_When_Stub_Dll_Is_Locked()
+    {
+        // Repro of the field failure: a rescan over an already-populated plugin
+        // root reported every plugin as Failed with "the process cannot access
+        // the file … because it is being used by another process". A loaded
+        // plugin's ALC holds an OS lock on its stub DLL, so re-writing it on a
+        // rescan throws. The stub is a constant embedded resource — a present,
+        // correctly-sized copy is already correct and must not be clobbered.
+        WriteFakeVst("Comp.vst3");
+        var first = await _scanner.ScanAsync(_srcDir, default);
+        var id = first.Registered[0].Id;
+        var stubPath = Path.Combine(_root, "plugins", id, StubAssemblyName);
+
+        // Drop it from the active set so the rescan takes the registration
+        // (write) path again instead of the skip-by-id shortcut...
+        await _manager.DeactivateAsync(id, default);
+
+        // ...and hold the exact OS lock a loaded ALC keeps on the stub
+        // (LoadFromAssemblyPath opens the DLL with read-share for the context's
+        // lifetime). File.Create against this throws — the bug under test.
+        using var heldLock = new FileStream(
+            stubPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+
+        var second = await _scanner.ScanAsync(_srcDir, default);
+
+        Assert.Empty(second.Errors);
+        Assert.Single(second.Registered);
+        Assert.Equal(id, second.Registered[0].Id);
+    }
+
+    private const string StubAssemblyName = "Zeus.Plugins.VstHostStub.dll";
+
+    [Fact]
     public async Task Scan_Registers_Multiple_With_Distinct_Ids()
     {
         WriteFakeVst("Reverb.vst3");


### PR DESCRIPTION
## Problem

A rescan over an already-populated plugin root reported **every** plugin as `Failed` with:

> the process cannot access the file … because it is being used by another process

A loaded plugin's collectible `AssemblyLoadContext` holds an OS file lock on its stub DLL — `LoadFromAssemblyPath` keeps the file open for the context's lifetime — so re-writing the stub on a rescan throws.

## Fix

The stub is a constant embedded resource, so every package's copy is byte-identical. A present, correctly-sized stub is already correct — leave it untouched. Only an absent or truncated copy (an interrupted prior write, which is never loaded and so never locked) is (re)written. The write becomes idempotent.

## Test

Adds `Scan_Does_Not_Fail_When_Stub_Dll_Is_Locked`, which holds the exact read-share `FileStream` lock a loaded ALC keeps on the stub, then asserts the rescan still registers cleanly with no errors. Full `VstDirectoryScanServiceTests` suite: **12 passed, 0 failed**.

## Context

Follow-up to the VST self-healing work merged in #955 — this guard was written on top of that and wasn't part of the original PR.