### PR TITLE
fix(web): waterfall dB scale spans the full multi-row waterfall grid

### DIFF
--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -79,6 +79,9 @@ type WaterfallProps = {
   tuneReceiver?: PanTuneGestureOptions['tuneReceiver'];
   stitched?: boolean;
   foreground?: boolean;
+  /** Render the in-tile dB scale on RX1. Off when the parent draws one scale
+   *  spanning the whole (possibly multi-row) waterfall grid instead. */
+  dbScale?: boolean;
 };
 
 type WaterfallValueDomain = 'rx-db' | 'pop' | 'tx-db';
@@ -93,6 +96,7 @@ export function Waterfall({
   tuneReceiver,
   stitched = false,
   foreground = true,
+  dbScale = true,
 }: WaterfallProps = {}) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -706,8 +710,9 @@ export function Waterfall({
           Waterfall renderer unavailable
         </div>
       )}
-      {/* One global waterfall dB scale — only RX1 (leftmost) renders it. */}
-      {rxIndex === 0 && <WfDbScale />}
+      {/* One global waterfall dB scale — only RX1 (leftmost) renders it, and
+          only when the parent isn't drawing a grid-spanning scale itself. */}
+      {dbScale && rxIndex === 0 && <WfDbScale />}
       {/* Dial-position cursor on BOTH halves (RX2) — each tracks its own VFO. */}
       <div
         ref={cursorRef}

--- a/zeus-web/src/components/WaterfallHeightfield.tsx
+++ b/zeus-web/src/components/WaterfallHeightfield.tsx
@@ -57,6 +57,9 @@ type Props = {
   foreground?: boolean;
   touchMode?: PanTuneGestureOptions['touchMode'];
   tuneReceiver?: PanTuneGestureOptions['tuneReceiver'];
+  /** Render the in-tile dB scale on RX1. Off when the parent draws one scale
+   *  spanning the whole (possibly multi-row) waterfall grid instead. */
+  dbScale?: boolean;
   /** Called once if WebGPU is unavailable, the renderer fails to init, or the
    *  device is lost, so the parent (WaterfallSurface) falls back to the WebGL
    *  waterfall. */
@@ -72,6 +75,7 @@ export function WaterfallHeightfield({
   foreground = true,
   touchMode = 'normal',
   tuneReceiver,
+  dbScale = true,
   onUnavailable,
 }: Props = {}) {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -432,7 +436,7 @@ export function WaterfallHeightfield({
     >
       <canvas ref={canvasRef} style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }} />
       {/* One global waterfall dB scale — only RX1 (leftmost) renders it. */}
-      {status === 'ready' && rxIndex === 0 && <WfDbScale />}
+      {status === 'ready' && dbScale && rxIndex === 0 && <WfDbScale />}
       {/* Dial-position cursor on BOTH halves (RX2) — each tracks its own VFO so
           the stitched pair behaves like one waterfall with two live dials. */}
       {status === 'ready' && (

--- a/zeus-web/src/components/WaterfallSurface.tsx
+++ b/zeus-web/src/components/WaterfallSurface.tsx
@@ -47,6 +47,7 @@ export function WaterfallSurface(props: WaterfallProps) {
         foreground={props.foreground}
         touchMode={props.touchMode}
         tuneReceiver={props.tuneReceiver}
+        dbScale={props.dbScale}
         onUnavailable={() => setHeightfieldUnavailable(true)}
       />
     );

--- a/zeus-web/src/layout/panels/HeroPanel.tsx
+++ b/zeus-web/src/layout/panels/HeroPanel.tsx
@@ -48,6 +48,7 @@ import type { MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent }
 import { GripVertical, Sliders, Volume2, VolumeX, X } from 'lucide-react';
 import { Panadapter } from '../../components/Panadapter';
 import { WaterfallSurface } from '../../components/WaterfallSurface';
+import { WfDbScale } from '../../components/WfDbScale';
 import { ZoomControl } from '../../components/ZoomControl';
 import { WaterfallSpeedControl } from '../../components/WaterfallSpeedControl';
 import { SpectrumControls } from '../../components/SpectrumControls';
@@ -623,9 +624,14 @@ export function HeroPanel({
                       stitched={multiRxSpectrum && p.index <= 1}
                       foreground={focusedRxIndex === p.index}
                       tuneReceiver={p.index}
+                      dbScale={false}
                     />
                   </div>
                 ))}
+                {/* One dB scale spanning the whole waterfall grid (left edge of
+                    all rows), rather than only the RX1 tile's row. Bound to the
+                    focused receiver's window, same as the in-tile scale. */}
+                <WfDbScale />
               </div>
             )
           )}


### PR DESCRIPTION
## Problem

The waterfall dB-scale slider only ran down the left of the **first row** in a multi-row receiver layout instead of the full left edge.

The slider (`WfDbScale`) was rendered inside the RX1 tile (gated `rxIndex === 0`). With 1–3 receivers the waterfall grid is a single row, so RX1's tile fills the whole region and the scale spans full height. At 4+ receivers the grid wraps (`gridAutoRows: 1fr`, 3 columns), making RX1 just the top-left cell — so the scale, positioned `top-0 bottom-0` within that cell, stopped at the first row.

(Reported from a 6-RX layout — the scale ticks ran only down the top row.)

## Fix

Lift the dB scale up to the **waterfall grid container** so one scale spans all rows on the left edge, while keeping the in-tile scale for the standalone surfaces.

- **`Waterfall.tsx` / `WaterfallHeightfield.tsx`** — add a `dbScale` prop (default `true`); the in-tile `WfDbScale` renders only when `dbScale && rxIndex === 0`.
- **`WaterfallSurface.tsx`** — forward `dbScale` to the heightfield path (the WebGL path already spreads props).
- **`HeroPanel.tsx`** — the non-keyed waterfall grid passes `dbScale={false}` to its panes and renders a single grid-spanning `<WfDbScale />` overlay (`spectrumGridStyle` is `position: relative`, so the overlay covers the full multi-row height).

Standalone cases keep the in-tile scale (default `true`): the keyed TX panafall and the mobile layout — both single full-height waterfalls already. The scale stays bound to the focused receiver's dB window, so behaviour is unchanged apart from height.

## Verification

- `tsc -b --noEmit` — clean
- `Waterfall` tests — 4 passed

Not browser-verified: the multi-row grid only appears when connected to a radio with 4+ DDC receivers, and the waterfall is a WebGL/WebGPU canvas that does not render in the headless preview harness. The change is a structural relocation of an existing DOM overlay.