### PR TITLE
feat(web): manage saved layouts from a dropdown with full CRUD

### DIFF
--- a/zeus-web/src/components/LeftLayoutBar.tsx
+++ b/zeus-web/src/components/LeftLayoutBar.tsx
@@ -107,7 +107,13 @@ export function LeftLayoutBar() {
     setModal({ kind: 'delete', id, name });
   };
 
-  const openEdit = (id: string) => setModal({ kind: 'edit', id });
+  // Opening the manager switches the workspace to that layout so the editor's
+  // "current arrangement" (used by Save / Save as new) always matches the
+  // layout being edited.
+  const openManage = (id: string) => {
+    setActiveLayout(id);
+    setModal({ kind: 'edit', id });
+  };
 
   const handleModalSave = (value: LayoutSettingsValue) => {
     if (modal.kind === 'create') {
@@ -127,6 +133,26 @@ export function LeftLayoutBar() {
       setWorkspaceLockedInLayout(modal.id, value.locked);
     }
     setModal({ kind: 'closed' });
+  };
+
+  // Save as new — copy the CURRENT panel arrangement into a fresh saved layout
+  // and re-target the manager to it. addLayout makes the new layout active.
+  const handleSaveAsNew = (value: LayoutSettingsValue) => {
+    const ws = useLayoutStore.getState().workspace;
+    const newId = addLayout(value.name, {
+      icon: value.icon || undefined,
+      description: value.description || undefined,
+      workspace: value.locked ? { ...ws, locked: true } : ws,
+    });
+    setModal({ kind: 'edit', id: newId });
+  };
+
+  // Delete from the manager — removeLayout promotes the next layout to active;
+  // follow it so the still-open manager keeps editing a valid layout.
+  const handleManagerDelete = (id: string) => {
+    removeLayout(id);
+    const nextActive = useLayoutStore.getState().activeLayoutId;
+    setModal({ kind: 'edit', id: nextActive });
   };
 
   const editingLayout =
@@ -209,7 +235,7 @@ export function LeftLayoutBar() {
                   <button
                     type="button"
                     className="lb-gear"
-                    onClick={() => openEdit(l.id)}
+                    onClick={() => openManage(l.id)}
                     title={`Edit ${l.name}`}
                     aria-label={`Edit ${l.name}`}
                   >
@@ -285,6 +311,19 @@ export function LeftLayoutBar() {
             icon: editingLayout.icon ?? '',
             description: editingLayout.description ?? '',
             locked: parseLayoutOrDefault(editingLayout.layoutJson).locked === true,
+          }}
+          manager={{
+            layouts: layouts.map((l) => ({
+              id: l.id,
+              name: l.name,
+              ...(l.icon ? { icon: l.icon } : {}),
+              locked: lockedLayoutIds.has(l.id),
+            })),
+            selectedId: modal.id,
+            onSelect: openManage,
+            onSaveAsNew: handleSaveAsNew,
+            onDelete: handleManagerDelete,
+            canDelete: layouts.length > 1,
           }}
           onSave={handleModalSave}
           onClose={() => setModal({ kind: 'closed' })}

--- a/zeus-web/src/layout/LayoutSettingsModal.tsx
+++ b/zeus-web/src/layout/LayoutSettingsModal.tsx
@@ -3,16 +3,25 @@
 // Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
 // Copyright (C) 2025-2026 Brian Keating (EI6LF), Christian Suarez (N9WAR), and contributors.
 //
-// LayoutSettingsModal — edit the presentation metadata of a NamedLayout.
-// Replaces the double-click-to-rename interaction in the LeftLayoutBar with
-// a small modal that captures: short label (what shows under the icon), the
-// icon itself (an emoji selected from a quick palette or freely typed), and
-// a longer description used as the hover tooltip.
+// LayoutSettingsModal — create or manage saved layouts.
 //
-// The same modal is reused for "create new layout" — when no layout id is
-// supplied the parent treats Save as addLayout(name, {icon, description}).
+// Two shapes:
+//   • Create mode (no `manager` prop): a simple form that captures a label,
+//     icon, description, and lock state for a brand-new blank layout. Used by
+//     the LeftLayoutBar "+" slot.
+//   • Manager mode (`manager` prop supplied): the form is fronted by a "Saved
+//     layouts" dropdown listing every layout for the radio. Picking one
+//     switches the workspace to it and re-targets the editor. From here the
+//     operator gets the full CRUD set:
+//       - Save        → write the edited label/icon/description/lock to the
+//                        selected layout (its panel arrangement is already the
+//                        live one, so Save also commits the current layout).
+//       - Save as new → copy the CURRENT panel arrangement into a brand-new
+//                        saved layout under a new name.
+//       - Delete      → remove the selected layout (two-click confirm).
+//     Renaming is just editing the label and pressing Save.
 
-import { useId, useRef, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 import { X } from 'lucide-react';
 import { useDialogFocusTrap } from './useDialogFocusTrap';
 
@@ -31,12 +40,39 @@ export interface LayoutSettingsValue {
   locked: boolean;
 }
 
+/** One entry in the manager dropdown. */
+export interface LayoutManagerEntry {
+  id: string;
+  name: string;
+  icon?: string;
+  locked: boolean;
+}
+
+/** Manager-mode controls. When supplied the modal renders the saved-layouts
+ *  dropdown plus the Delete / Save-as-new affordances. */
+export interface LayoutManagerControls {
+  /** All saved layouts for the current radio, in display order. */
+  layouts: LayoutManagerEntry[];
+  /** The layout currently being edited (also the active workspace). */
+  selectedId: string;
+  /** Switch to / edit another saved layout. */
+  onSelect: (id: string) => void;
+  /** Copy the current panel arrangement into a new saved layout. */
+  onSaveAsNew: (value: LayoutSettingsValue) => void;
+  /** Delete the selected layout. */
+  onDelete: (id: string) => void;
+  /** False when only one layout remains (the last can't be deleted). */
+  canDelete: boolean;
+}
+
 interface LayoutSettingsModalProps {
-  /** Modal title. "Layout settings" for edit, "New layout" for create. */
+  /** Modal title. "Layout settings" for manage, "New layout" for create. */
   title: string;
   initial: LayoutSettingsValue;
   onSave: (value: LayoutSettingsValue) => void;
   onClose: () => void;
+  /** When supplied, the modal is a saved-layouts manager (dropdown + CRUD). */
+  manager?: LayoutManagerControls;
 }
 
 export function LayoutSettingsModal({
@@ -44,12 +80,16 @@ export function LayoutSettingsModal({
   initial,
   onSave,
   onClose,
+  manager,
 }: LayoutSettingsModalProps) {
   const titleId = useId();
   const [name, setName] = useState(initial.name);
   const [icon, setIcon] = useState(initial.icon);
   const [description, setDescription] = useState(initial.description);
   const [locked, setLocked] = useState(initial.locked);
+  // Manager-only transient state.
+  const [newName, setNewName] = useState('');
+  const [confirmDelete, setConfirmDelete] = useState(false);
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const nameRef = useRef<HTMLInputElement | null>(null);
 
@@ -58,6 +98,20 @@ export function LayoutSettingsModal({
     initialFocusRef: nameRef,
     onClose,
   });
+
+  // When the operator picks a different layout from the dropdown, the parent
+  // re-derives `initial` from the newly-selected layout — resync the editable
+  // fields to it. Keyed on the selection id so it never clobbers in-progress
+  // typing (the stored values only change on Save).
+  useEffect(() => {
+    setName(initial.name);
+    setIcon(initial.icon);
+    setDescription(initial.description);
+    setLocked(initial.locked);
+    setNewName('');
+    setConfirmDelete(false);
+    // Resync only when the managed selection changes, not on every keystroke.
+  }, [manager?.selectedId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleSave = () => {
     const trimmedName = name.trim();
@@ -68,6 +122,18 @@ export function LayoutSettingsModal({
       description: description.trim(),
       locked,
     });
+  };
+
+  const commitSaveAsNew = () => {
+    const trimmed = newName.trim();
+    if (!trimmed || !manager) return;
+    manager.onSaveAsNew({
+      name: trimmed,
+      icon: icon.trim(),
+      description: description.trim(),
+      locked,
+    });
+    setNewName('');
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -113,6 +179,28 @@ export function LayoutSettingsModal({
         </div>
 
         <div className="layout-settings-body">
+          {manager && (
+            <label className="layout-settings-field">
+              <span className="layout-settings-field-label">Saved layouts</span>
+              <select
+                className="layout-settings-input layout-settings-select"
+                value={manager.selectedId}
+                onChange={(e) => manager.onSelect(e.target.value)}
+                aria-label="Saved layouts"
+              >
+                {manager.layouts.map((l) => (
+                  <option key={l.id} value={l.id}>
+                    {(l.icon ? `${l.icon}  ` : '') + l.name}
+                    {l.locked ? '  🔒' : ''}
+                  </option>
+                ))}
+              </select>
+              <span className="layout-settings-field-hint">
+                Pick a layout to switch the workspace to it and edit it below.
+              </span>
+            </label>
+          )}
+
           <div className="layout-settings-preview" aria-hidden>
             <div className="layout-settings-preview-tile">
               <span className="layout-settings-preview-icon">
@@ -137,7 +225,7 @@ export function LayoutSettingsModal({
               aria-label="Layout label"
             />
             <span className="layout-settings-field-hint">
-              Short — appears below the icon.
+              Short — appears below the icon. Edit it and Save to rename.
             </span>
           </label>
 
@@ -224,14 +312,70 @@ export function LayoutSettingsModal({
               </span>
             </span>
           </label>
+
+          {manager && (
+            <div className="layout-settings-field layout-settings-saveas">
+              <span className="layout-settings-field-label">
+                Save as new layout
+              </span>
+              <div className="layout-settings-icon-row">
+                <input
+                  type="text"
+                  className="layout-settings-input"
+                  value={newName}
+                  maxLength={24}
+                  onChange={(e) => setNewName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      commitSaveAsNew();
+                    }
+                  }}
+                  placeholder="New layout name"
+                  aria-label="New layout name"
+                />
+                <button
+                  type="button"
+                  className="btn ghost sm"
+                  disabled={!newName.trim()}
+                  onClick={commitSaveAsNew}
+                  title="Copy the current panel arrangement into a new saved layout"
+                >
+                  Create
+                </button>
+              </div>
+              <span className="layout-settings-field-hint">
+                Copies the current panel arrangement into a new saved layout.
+              </span>
+            </div>
+          )}
         </div>
 
         <div className="layout-settings-actions">
-          <button
-            type="button"
-            className="btn ghost"
-            onClick={onClose}
-          >
+          {manager && (
+            <button
+              type="button"
+              className="btn ghost layout-settings-delete"
+              disabled={!manager.canDelete}
+              onClick={() => {
+                if (!confirmDelete) {
+                  setConfirmDelete(true);
+                  return;
+                }
+                manager.onDelete(manager.selectedId);
+              }}
+              onBlur={() => setConfirmDelete(false)}
+              title={
+                manager.canDelete
+                  ? 'Delete this saved layout'
+                  : 'The last layout can’t be deleted'
+              }
+            >
+              {confirmDelete ? 'Confirm delete?' : 'Delete'}
+            </button>
+          )}
+          <span className="layout-settings-actions-spacer" />
+          <button type="button" className="btn ghost" onClick={onClose}>
             Cancel
           </button>
           <button

--- a/zeus-web/src/styles/all-panels.css
+++ b/zeus-web/src/styles/all-panels.css
@@ -1363,9 +1363,33 @@
 }
 .layout-settings-actions {
   display: flex;
+  align-items: center;
   justify-content: flex-end;
   gap: 8px;
   padding: 10px 16px;
   border-top: 1px solid var(--panel-border);
   background: var(--bg-0);
+}
+/* Pushes the trailing Cancel/Save cluster to the right while Delete stays
+   pinned left in the manager footer. */
+.layout-settings-actions-spacer {
+  flex: 1 1 auto;
+}
+/* Native select styled to match the text inputs. */
+.layout-settings-select {
+  cursor: pointer;
+  appearance: auto;
+}
+/* "Save as new" group, set off from the metadata fields by a hairline rule. */
+.layout-settings-saveas {
+  margin-top: 4px;
+  padding-top: 12px;
+  border-top: 1px solid var(--panel-border);
+}
+/* Delete reads as a destructive action — TX red on hover/focus, no palette
+   change to chrome at rest. */
+.layout-settings-delete:not(:disabled):hover,
+.layout-settings-delete:not(:disabled):focus-visible {
+  border-color: var(--tx);
+  color: var(--tx);
 }


### PR DESCRIPTION
## What & why

Saved layouts already exist per radio, but they were only surfaced as the vertical icon **tab rail** on the left, and the active layout auto-saves as you drag panels around — so there was no easy way to manage them or pick one back. This turns the **Layout settings** dialog (gear ⚙ on any layout in the rail) into a proper saved-layouts manager.

## What it does

A **Saved layouts** dropdown lists every layout for the radio. Picking one switches the workspace to it and re-targets the editor. From there:

- **Save** — write the edited label/icon/description/lock to the selected layout (its arrangement is the live one, so Save also commits the current layout).
- **Save as new** — copy the **current** panel arrangement into a brand-new saved layout under a new name.
- **Rename** — edit the label and Save.
- **Delete** — remove the selected layout (two-click `Delete` → `Confirm delete?`; the last layout can't be deleted).

Opening the gear now also switches the workspace to that layout, so Save / Save as new always act on what the operator sees.

## Implementation

- Purely frontend — reuses the existing per-radio named-layout store API (`addLayout` / `updateLayoutMeta` / `setWorkspaceLockedInLayout` / `removeLayout` / `setActiveLayout`). **No backend / wire-format changes.**
- The dropdown and the left rail tab strip read the same store, so they stay in sync automatically.
- Styling uses existing `tokens.css` variables only (destructive Delete hover uses `--tx`); no palette changes.

### Files
- `zeus-web/src/layout/LayoutSettingsModal.tsx` — manager mode (dropdown + CRUD); create mode unchanged.
- `zeus-web/src/components/LeftLayoutBar.tsx` — wires the gear to the manager.
- `zeus-web/src/styles/all-panels.css` — select / save-as / footer styling.

## Verification

- `tsc -b --noEmit` clean; ESLint clean on changed files; zero browser console errors.
- Drove the dialog live (Vite dev): **Save as new** "Contest" appeared in both the dropdown and the rail and auto-selected; **Rename** to "Contest A" reflected everywhere and closed on Save; **Delete** armed the two-click confirm, removed the layout, retargeted to the promoted layout, and correctly disabled Delete with one layout remaining.

## Notes for reviewers

- Minor UX change worth a look: opening the gear now switches the active workspace to that layout (previously it edited metadata without switching). Happy to gate that behind selection-only if preferred.