### PR TITLE
fix(web): show band-plan overlay only in single-RX mode

### DIFF
--- a/zeus-web/src/components/BandOverlay.tsx
+++ b/zeus-web/src/components/BandOverlay.tsx
@@ -47,8 +47,10 @@ import * as viewCenter from '../state/view-center';
 // the span so the bars glide in lock-step with the trace during a tuning
 // glide. This keeps React out of the per-frame path entirely.
 //
-// The overlay is RX-1 only (`receiver === 'A'`) — RX2 / stitched halves keep
-// their existing clean look so the operator can compare bands at a glance.
+// The overlay is single-RX only: it renders on RX-1 (`receiver === 'A'`) and
+// only when a single spectrum pane is exposed. In multi-RX mode (RX2 / stitched
+// halves / standalone RX3+) every pane keeps its clean look so the operator can
+// compare bands at a glance.
 
 const COLORS = {
   // `tint` fills the freq-number bar (kept low-alpha so ticks read through);

--- a/zeus-web/src/components/Panadapter.tsx
+++ b/zeus-web/src/components/Panadapter.tsx
@@ -79,6 +79,7 @@ type PanadapterProps = {
   tuneReceiver?: PanTuneGestureOptions['tuneReceiver'];
   stitched?: boolean;
   foreground?: boolean;
+  multiRx?: boolean;
 };
 
 export function Panadapter({
@@ -87,6 +88,7 @@ export function Panadapter({
   tuneReceiver,
   stitched = false,
   foreground = true,
+  multiRx = false,
 }: PanadapterProps = {}) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -477,7 +479,7 @@ export function Panadapter({
       } as CSSProperties}
     >
       <canvas ref={canvasRef} style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }} />
-      {rxIndex === 0 && (!stitched || foreground) && <BandOverlay receiver={receiver} />}
+      {rxIndex === 0 && !multiRx && <BandOverlay receiver={receiver} />}
       <div
         className="pointer-events-none absolute z-[25] rounded-sm px-2 py-0.5 font-mono text-[10px]"
         style={{

--- a/zeus-web/src/layout/panels/HeroPanel.tsx
+++ b/zeus-web/src/layout/panels/HeroPanel.tsx
@@ -592,6 +592,7 @@ export function HeroPanel({
                     receiver={p.index}
                     stitched={multiRxSpectrum && p.index <= 1}
                     foreground={focusedRxIndex === p.index}
+                    multiRx={multiRxSpectrum}
                     tuneReceiver={p.index}
                   />
                 </div>


### PR DESCRIPTION
## What

The licence-class **band-plan overlay** (the freq-scale header tint + `40M Phone` / `40M CW/Digital` chips) was still rendering on the focused RX1 half in multi-RX / stitched-dual views. It should only appear when a single panadapter is on screen.

## Change

- `Panadapter.tsx` — add a `multiRx` prop; the overlay now renders only when `rxIndex === 0 && !multiRx` (was `rxIndex === 0 && (!stitched || foreground)`).
- `HeroPanel.tsx` — pass `multiRx={multiRxSpectrum}` (true whenever more than one spectrum pane is exposed: RX2 enabled, or any standalone RX3+ pane).
- `BandOverlay.tsx` — update the header comment to document the single-RX-only behaviour.

Mobile (`MobileApp`) is single-RX and uses the default `multiRx = false`, so it is unaffected.

## Verification

`tsc -p tsconfig.app.json --noEmit` passes clean. The overlay's multi-RX path needs a connected radio with a second receiver, which the headless preview can't exercise, so this was verified by typecheck + code inspection rather than the browser.