### PR TITLE
feat(web): proximity strike alert for the lightning map

### DIFF
--- a/zeus-web/src/layout/panels/LightningMapPanel.css
+++ b/zeus-web/src/layout/panels/LightningMapPanel.css
@@ -146,3 +146,161 @@
   font-size: 9px;
 }
 .lightning-map .leaflet-control-attribution a { color: var(--fg-1); }
+
+/* Proximity-alert in-radius count flashes red while the alert is tripped. */
+.lightning-map .lm-hud-value.alert {
+  color: var(--tx, #ff4a59);
+  animation: lm-alert-blink 0.9s steps(1) infinite;
+}
+
+/* Alert banner — top-center, unmissable while a cell is closing in. */
+.lightning-map .lm-alert-banner {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 600;
+  padding: 7px 14px;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: #fff;
+  background: rgba(214, 40, 30, 0.92);
+  border: 1px solid var(--tx, #ff4a59);
+  border-radius: 4px;
+  box-shadow: 0 0 18px rgba(255, 74, 89, 0.5);
+  pointer-events: none;
+  white-space: nowrap;
+  animation: lm-alert-blink 1.1s steps(1) infinite;
+}
+
+@keyframes lm-alert-blink {
+  0%, 60% { opacity: 1; }
+  61%, 100% { opacity: 0.55; }
+}
+
+/* Alert settings — gear button bottom-right, above the recenter control. */
+.lightning-map .lm-settings-btn {
+  position: absolute;
+  right: 8px;
+  bottom: 50px;
+  z-index: 500;
+  padding: 4px 9px;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--fg-1);
+  background: rgba(6, 9, 16, 0.78);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 3px;
+  cursor: pointer;
+}
+.lightning-map .lm-settings-btn:hover {
+  border-color: var(--power, #ffb13c);
+  color: var(--power, #ffb13c);
+}
+.lightning-map .lm-settings-btn.on {
+  border-color: var(--power, #ffb13c);
+  color: var(--power, #ffb13c);
+}
+
+/* Settings popover. */
+.lightning-map .lm-settings {
+  position: absolute;
+  right: 8px;
+  bottom: 78px;
+  z-index: 600;
+  width: 230px;
+  padding: 10px 11px 11px;
+  background: rgba(6, 9, 16, 0.92);
+  border: 1px solid rgba(255, 177, 60, 0.3);
+  border-radius: 5px;
+  backdrop-filter: blur(6px);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  color: var(--fg-1);
+}
+
+.lightning-map .lm-settings-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 9px;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--power, #ffb13c);
+}
+.lightning-map .lm-settings-close {
+  background: none;
+  border: none;
+  color: var(--fg-2);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 2px;
+}
+.lightning-map .lm-settings-close:hover { color: var(--fg-1); }
+
+.lightning-map .lm-set-row {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-bottom: 8px;
+  font-size: 11px;
+  color: var(--fg-1);
+}
+.lightning-map .lm-set-row > span:first-child { flex: 0 0 auto; }
+
+.lightning-map .lm-set-row input[type='number'] {
+  width: 52px;
+  margin-left: auto;
+  padding: 3px 5px;
+  font-family: inherit;
+  font-size: 11px;
+  text-align: right;
+  color: var(--fg-0, #fff);
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 3px;
+  font-variant-numeric: tabular-nums;
+}
+.lightning-map .lm-set-row input[type='number']:focus {
+  outline: none;
+  border-color: var(--accent, #4a9eff);
+}
+
+.lightning-map .lm-set-unit {
+  flex: 0 0 auto;
+  width: 38px;
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--fg-2);
+}
+
+.lightning-map .lm-set-unit-sel {
+  flex: 0 0 auto;
+  width: 44px;
+  padding: 3px 4px;
+  font-family: inherit;
+  font-size: 10px;
+  color: var(--fg-0, #fff);
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 3px;
+}
+
+.lightning-map .lm-set-toggle {
+  cursor: pointer;
+}
+.lightning-map .lm-set-toggle input { cursor: pointer; }
+.lightning-map .lm-set-toggle span { margin-right: auto; }
+
+.lightning-map .lm-set-hint {
+  margin-top: 4px;
+  font-size: 10px;
+  line-height: 1.35;
+  color: var(--tx, #ff4a59);
+}

--- a/zeus-web/src/layout/panels/LightningMapPanel.tsx
+++ b/zeus-web/src/layout/panels/LightningMapPanel.tsx
@@ -33,6 +33,7 @@ import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import './LightningMapPanel.css';
 import { useWorkspace } from '../WorkspaceContext';
+import { distanceKm } from '../../components/design/geo';
 
 // CARTO dark basemap — free, no key, near-black land/ocean that lets the
 // amber strikes pop. Same family of tiles the public lightning viewers use.
@@ -58,6 +59,110 @@ interface Strike {
   lon: number;
   /** Wall-clock ms when we received it — drives the fade animation. */
   t: number;
+}
+
+// ── Proximity alert ─────────────────────────────────────────────────────────
+// The operator can ask to be warned when a storm cell is closing in: if at
+// least `threshold` strikes land within `radiusKm` of the home QTH inside a
+// rolling `windowMin`-minute window, the panel raises a visible (and optionally
+// audible) alert and pulses the radius ring red. Config is panel-local and
+// persisted to localStorage — same lightweight pattern the other panels use.
+const ALERT_STORAGE_KEY = 'zeus.lightning.alert';
+const KM_PER_MI = 1.609_344;
+// Panel-local strike-ramp colours (see CSS header) reused for the ring.
+const RING_AMBER = '#ffb13c';
+const RING_RED = '#ff4a59';
+
+interface AlertConfig {
+  enabled: boolean;
+  /** Strikes needed inside the window+radius to trip the alert. */
+  threshold: number;
+  /** Alert radius around home, stored canonically in km. */
+  radiusKm: number;
+  /** Rolling window (minutes) the strike count is measured over. */
+  windowMin: number;
+  /** Display/entry unit for the radius; storage stays km. */
+  unit: 'km' | 'mi';
+  /** Play a short chirp when the alert first trips. */
+  sound: boolean;
+}
+
+const DEFAULT_ALERT: AlertConfig = {
+  enabled: false,
+  threshold: 5,
+  radiusKm: 100,
+  windowMin: 10,
+  unit: 'km',
+  sound: true,
+};
+
+function readAlertConfig(): AlertConfig {
+  try {
+    if (typeof localStorage === 'undefined') return { ...DEFAULT_ALERT };
+    const raw = localStorage.getItem(ALERT_STORAGE_KEY);
+    if (!raw) return { ...DEFAULT_ALERT };
+    const p = JSON.parse(raw) as Partial<AlertConfig>;
+    return {
+      enabled: typeof p.enabled === 'boolean' ? p.enabled : DEFAULT_ALERT.enabled,
+      threshold:
+        typeof p.threshold === 'number' && Number.isFinite(p.threshold)
+          ? Math.max(1, Math.round(p.threshold))
+          : DEFAULT_ALERT.threshold,
+      radiusKm:
+        typeof p.radiusKm === 'number' && Number.isFinite(p.radiusKm) && p.radiusKm > 0
+          ? p.radiusKm
+          : DEFAULT_ALERT.radiusKm,
+      windowMin:
+        typeof p.windowMin === 'number' && Number.isFinite(p.windowMin) && p.windowMin > 0
+          ? p.windowMin
+          : DEFAULT_ALERT.windowMin,
+      unit: p.unit === 'mi' ? 'mi' : 'km',
+      sound: typeof p.sound === 'boolean' ? p.sound : DEFAULT_ALERT.sound,
+    };
+  } catch {
+    return { ...DEFAULT_ALERT };
+  }
+}
+
+function writeAlertConfig(c: AlertConfig): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.setItem(ALERT_STORAGE_KEY, JSON.stringify(c));
+  } catch {
+    // quota exceeded / private mode — accept silently.
+  }
+}
+
+// Lazily-created shared AudioContext for the alert chirp. Created on first use
+// (inside a user-gesture-driven render path) so browsers don't warn about an
+// autoplay context at module load.
+let alertAudioCtx: AudioContext | null = null;
+function playAlertChirp(): void {
+  try {
+    const Ctx =
+      window.AudioContext ||
+      (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!Ctx) return;
+    if (!alertAudioCtx) alertAudioCtx = new Ctx();
+    const ctx = alertAudioCtx;
+    if (ctx.state === 'suspended') void ctx.resume().catch(() => {});
+    const t0 = ctx.currentTime;
+    // Two short rising chirps — distinct from normal radio/UI tones.
+    for (const [offset, freq] of [[0, 740], [0.18, 988]] as const) {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = 'square';
+      osc.frequency.value = freq;
+      gain.gain.setValueAtTime(0.0001, t0 + offset);
+      gain.gain.exponentialRampToValueAtTime(0.16, t0 + offset + 0.012);
+      gain.gain.exponentialRampToValueAtTime(0.0001, t0 + offset + 0.14);
+      osc.connect(gain).connect(ctx.destination);
+      osc.start(t0 + offset);
+      osc.stop(t0 + offset + 0.16);
+    }
+  } catch {
+    // No audio output / blocked — the visible alert still fires.
+  }
 }
 
 // Blitzortung obfuscates each WebSocket frame with an LZW-style dictionary
@@ -132,10 +237,27 @@ export function LightningMapPanel() {
   // the plotted ring (which is capped + expires).
   const rateRef = useRef<number[]>([]);
   const homeLayerRef = useRef<L.LayerGroup | null>(null);
+  const alertLayerRef = useRef<L.LayerGroup | null>(null);
+  // Receipt timestamps for in-radius strikes — drives the proximity alert,
+  // pruned to the configured window each stats tick.
+  const nearRef = useRef<number[]>([]);
+  const prevAlertingRef = useRef(false);
 
   const [conn, setConn] = useState<ConnState>('connecting');
   const [rate, setRate] = useState(0); // strikes/min over the last 60 s
   const [shown, setShown] = useState(0); // strikes currently on the map
+  const [alertCfg, setAlertCfg] = useState<AlertConfig>(readAlertConfig);
+  const [alerting, setAlerting] = useState(false); // threshold currently tripped
+  const [nearCount, setNearCount] = useState(0); // in-radius strikes in window
+  const [showSettings, setShowSettings] = useState(false);
+
+  // Live config for the mount-once WebSocket/render effects, which capture refs
+  // (not state) to avoid stale closures. Also mirrors config to localStorage.
+  const alertCfgRef = useRef(alertCfg);
+  useEffect(() => {
+    alertCfgRef.current = alertCfg;
+    writeAlertConfig(alertCfg);
+  }, [alertCfg]);
 
   // Home QTH for the initial view + a marker dot. Captured in a ref so the WS /
   // map init effect stays mount-once and doesn't tear down when home resolves.
@@ -175,6 +297,8 @@ export function LightningMapPanel() {
 
     L.control.zoom({ position: 'bottomleft' }).addTo(map);
 
+    // Alert radius ring sits below the home marker so the QTH dot stays on top.
+    alertLayerRef.current = L.layerGroup().addTo(map);
     homeLayerRef.current = L.layerGroup().addTo(map);
     mapRef.current = map;
 
@@ -186,6 +310,7 @@ export function LightningMapPanel() {
       map.remove();
       mapRef.current = null;
       homeLayerRef.current = null;
+      alertLayerRef.current = null;
     };
   }, []);
 
@@ -209,6 +334,33 @@ export function LightningMapPanel() {
       .addTo(layer);
   }, [effectiveHome]);
 
+  // ── Alert radius ring — amber dashed normally, solid red while tripped ─────
+  useEffect(() => {
+    const layer = alertLayerRef.current;
+    if (!layer) return;
+    layer.clearLayers();
+    if (!alertCfg.enabled || !effectiveHome) return;
+    const color = alerting ? RING_RED : RING_AMBER;
+    L.circle([effectiveHome.lat, effectiveHome.lon], {
+      radius: alertCfg.radiusKm * 1000, // Leaflet circle radius is in metres
+      color,
+      weight: alerting ? 2.5 : 1.5,
+      opacity: alerting ? 0.95 : 0.6,
+      fillColor: color,
+      fillOpacity: alerting ? 0.12 : 0.05,
+      dashArray: alerting ? undefined : '6 6',
+      interactive: false,
+    }).addTo(layer);
+  }, [effectiveHome, alertCfg.enabled, alertCfg.radiusKm, alerting]);
+
+  // ── Audible chirp on the rising edge of an alert ───────────────────────────
+  useEffect(() => {
+    if (alerting && !prevAlertingRef.current && alertCfgRef.current.sound) {
+      playAlertChirp();
+    }
+    prevAlertingRef.current = alerting;
+  }, [alerting]);
+
   // ── Blitzortung WebSocket — multi-server failover + reconnect ──────────────
   useEffect(() => {
     let ws: WebSocket | null = null;
@@ -223,6 +375,15 @@ export function LightningMapPanel() {
       ring.push({ lat, lon, t: now });
       if (ring.length > MAX_STRIKES) ring.splice(0, ring.length - MAX_STRIKES);
       rateRef.current.push(now);
+
+      // Proximity-alert bookkeeping: stamp strikes inside the alert radius so
+      // the render loop can count them over the rolling window. Reading config
+      // and home from refs keeps this mount-once effect free of stale closures.
+      const cfg = alertCfgRef.current;
+      const home = homeRef.current;
+      if (cfg.enabled && home && distanceKm(home.lat, home.lon, lat, lon) <= cfg.radiusKm) {
+        nearRef.current.push(now);
+      }
     };
 
     const handleFrame = (raw: string) => {
@@ -388,6 +549,20 @@ export function LightningMapPanel() {
         if (drop > 0) stamps.splice(0, drop);
         setRate(stamps.length);
         setShown(ring.length);
+
+        // Proximity alert: prune in-radius stamps to the window, then compare
+        // the count to the threshold. Latches on/off purely from the live count
+        // so it clears on its own once the cell moves off or quiets down.
+        const cfg = alertCfgRef.current;
+        const near = nearRef.current;
+        const winMs = cfg.windowMin * 60_000;
+        const winCutoff = now - winMs;
+        let nDrop = 0;
+        while (nDrop < near.length && near[nDrop]! < winCutoff) nDrop += 1;
+        if (nDrop > 0) near.splice(0, nDrop);
+        const active = cfg.enabled && !!homeRef.current;
+        setNearCount(active ? near.length : 0);
+        setAlerting(active && near.length >= cfg.threshold);
       }
     };
     raf = window.requestAnimationFrame(frame);
@@ -408,6 +583,21 @@ export function LightningMapPanel() {
 
   const statusText = conn === 'live' ? 'Live feed' : conn === 'connecting' ? 'Connecting…' : 'Reconnecting…';
 
+  // Radius in the operator's chosen display unit (storage stays km).
+  const radiusDisplay =
+    alertCfg.unit === 'mi' ? alertCfg.radiusKm / KM_PER_MI : alertCfg.radiusKm;
+  const radiusLabel = `${Math.round(radiusDisplay)} ${alertCfg.unit}`;
+
+  const patchAlert = (patch: Partial<AlertConfig>) => setAlertCfg((c) => ({ ...c, ...patch }));
+
+  const onRadiusInput = (raw: string) => {
+    const v = Number(raw);
+    if (!Number.isFinite(v) || v <= 0) return;
+    patchAlert({ radiusKm: alertCfg.unit === 'mi' ? v * KM_PER_MI : v });
+  };
+
+  const onUnitChange = (unit: 'km' | 'mi') => patchAlert({ unit });
+
   return (
     <div className="lightning-map">
       <div ref={hostRef} className="lm-host" />
@@ -422,11 +612,120 @@ export function LightningMapPanel() {
           <span className="lm-hud-label">On map</span>
           <span className="lm-hud-value sub">{shown}</span>
         </div>
+        {alertCfg.enabled && (
+          <div className="lm-hud-row">
+            <span className="lm-hud-label">Near ≤{radiusLabel}</span>
+            <span className={`lm-hud-value sub${alerting ? ' alert' : ''}`}>{nearCount}</span>
+          </div>
+        )}
         <div className="lm-status">
           <span className={`lm-dot ${conn}`} />
           <span className="lm-status-text">{statusText}</span>
         </div>
       </div>
+
+      {alerting && (
+        <div className="lm-alert-banner" role="status" aria-live="assertive">
+          ⚡ Lightning alert — {nearCount} strikes within {radiusLabel} of your QTH
+        </div>
+      )}
+
+      <button
+        type="button"
+        className={`lm-settings-btn${alertCfg.enabled ? ' on' : ''}`}
+        onClick={() => setShowSettings((v) => !v)}
+        title="Proximity alert settings"
+        aria-expanded={showSettings}
+      >
+        ⚙ Alert
+      </button>
+
+      {showSettings && (
+        <div className="lm-settings" role="dialog" aria-label="Lightning proximity alert">
+          <div className="lm-settings-head">
+            <span>Proximity Alert</span>
+            <button
+              type="button"
+              className="lm-settings-close"
+              onClick={() => setShowSettings(false)}
+              title="Close"
+            >
+              ×
+            </button>
+          </div>
+
+          <label className="lm-set-row lm-set-toggle">
+            <input
+              type="checkbox"
+              checked={alertCfg.enabled}
+              onChange={(e) => patchAlert({ enabled: e.target.checked })}
+            />
+            <span>Enable alert</span>
+          </label>
+
+          <label className="lm-set-row">
+            <span>Alert when</span>
+            <input
+              type="number"
+              min={1}
+              max={999}
+              value={alertCfg.threshold}
+              onChange={(e) => {
+                const v = Math.round(Number(e.target.value));
+                if (Number.isFinite(v) && v >= 1) patchAlert({ threshold: v });
+              }}
+            />
+            <span className="lm-set-unit">strikes</span>
+          </label>
+
+          <label className="lm-set-row">
+            <span>Within</span>
+            <input
+              type="number"
+              min={1}
+              max={9999}
+              value={Math.round(radiusDisplay)}
+              onChange={(e) => onRadiusInput(e.target.value)}
+            />
+            <select
+              className="lm-set-unit-sel"
+              value={alertCfg.unit}
+              onChange={(e) => onUnitChange(e.target.value === 'mi' ? 'mi' : 'km')}
+            >
+              <option value="km">km</option>
+              <option value="mi">mi</option>
+            </select>
+          </label>
+
+          <label className="lm-set-row">
+            <span>Over the last</span>
+            <input
+              type="number"
+              min={1}
+              max={1440}
+              value={alertCfg.windowMin}
+              onChange={(e) => {
+                const v = Math.round(Number(e.target.value));
+                if (Number.isFinite(v) && v >= 1) patchAlert({ windowMin: v });
+              }}
+            />
+            <span className="lm-set-unit">min</span>
+          </label>
+
+          <label className="lm-set-row lm-set-toggle">
+            <input
+              type="checkbox"
+              checked={alertCfg.sound}
+              onChange={(e) => patchAlert({ sound: e.target.checked })}
+            />
+            <span>Play sound</span>
+          </label>
+
+          {alertCfg.enabled && !effectiveHome && (
+            <div className="lm-set-hint">Set your home QTH to enable proximity alerts.</div>
+          )}
+        </div>
+      )}
 
       <button type="button" className="lm-recenter" onClick={recenter} title="Re-center on your QTH">
         ⌖ Recenter


### PR DESCRIPTION
## What

Adds a configurable **proximity alert** to the Lightning Map panel: warn the operator when a storm cell is closing in on their QTH.

A new **"⚙ Alert"** settings popover (bottom-right) lets the operator set:
- **Strike-count threshold** (default **5**)
- **Radius** around home, with a **km/mi** unit selector (stored canonically in km)
- **Rolling time window** in minutes (default 10) so the count is time-bounded
- **Sound** on/off

When at least the threshold number of strikes land inside the radius of the home QTH within the window, the panel:
- shows a red **"⚡ Lightning alert"** banner (top-center, `aria-live`)
- flips the **alert radius ring** from amber-dashed to solid pulsing red
- surfaces a live **"Near ≤X"** count in the HUD (red while tripped)
- plays a short two-tone **chirp** on the rising edge (WebAudio, in-app — no browser dialogs)

The alert is computed live each stats tick (~4 Hz) and **self-clears** once the cell moves off or quiets below threshold. Config is panel-local and persisted to `localStorage` (same pattern other panels use). No-ops with an in-popover hint when no home QTH is set.

## Implementation notes
- Reuses `distanceKm` from `components/design/geo.ts` (haversine) for the radius test.
- In-radius strike timestamps are tracked in a ref and pruned to the window in the existing rAF loop — no new timers/threads.
- Strike-ramp/ring colors reuse this panel's existing local hexes (amber `#ffb13c` / red `#ff4a59`), consistent with the panel's documented local palette.

## Verification
- `tsc -b` and ESLint pass clean.
- Not browser-verified end-to-end: the headless preview can'\''t drive this panel'\''s Leaflet/canvas/rAF pipeline, and tripping the alert needs real in-radius strikes from the live Blitzortung feed. The detection logic is straightforward and type-checked; a live test would lower the threshold to 1 with a small radius/window to confirm banner/ring/chirp.

## Review note
New UX surface on the lightning panel (settings popover, banner, audible chirp) — flagging for a UX glance even though it'\''s additive and off by default.