### PR TITLE
chore(plugins): repoint registry + download URLs to OpenHPSDR-Zeus-org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -285,7 +285,7 @@ We're also keeping an eye on operator reports for any remaining Windows-only qui
 - **Plugin-settings persistence fix** (#387). LiteDB upsert-by-`_id` bug was silently inserting new rows on every `SetAsync` instead of updating — operator dial-in could revert to defaults across desktop restarts. Now: atomic delete-by-key + insert, with descending-ID read so any pre-fix duplicates resolve to the latest value.
 - **Restart-required modal on every plugin install.** The "Please shut down Zeus and restart" dialog that previously fired only after the Download Audio Suite bundle install now also fires after a single-plugin install from the Plugins panel (Settings → Plugins → Browse / Install). New endpoints + AssemblyLoadContexts only register at backend startup, so the operator always gets the same explicit reminder.
 
-### Added — plugins shipping with this release (Kb2uka/openhpsdr-zeus-plugins)
+### Added — plugins shipping with this release (OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins)
 
 - **EQ v0.2.0** — Input + Output gain stages plus a live FFT spectrum behind the curve.
 - **NoiseGate v0.1.0** — new plugin. Peak-envelope detector with built-in 3 dB hysteresis, hold timer, asymmetric attack/release gain slew, range knob, output trim. Threshold rail UI with **OPEN / HOLD / CLOSED** state pill.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ long-running project a lot of the DSP heritage traces back to.
   — to interact with the map (pan / zoom), **press and hold the `M` key**.
   The experience isn't ideal yet and will improve over time.
 - **Radio discovery** on the LAN (Protocol-1 + Protocol-2 broadcast, in parallel)
-- **Plugin system** — operators install backend / UI / audio plugins from a curated registry or by URL. See [`docs/plugins/author-guide.md`](docs/plugins/author-guide.md); registry repo at [`Kb2uka/openhpsdr-zeus-plugins`](https://github.com/Kb2uka/openhpsdr-zeus-plugins).
+- **Plugin system** — operators install backend / UI / audio plugins from a curated registry or by URL. See [`docs/plugins/author-guide.md`](docs/plugins/author-guide.md); registry repo at [`OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins`](https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins).
 
 ## At a glance
 

--- a/Zeus.Plugins.Contracts/Registry/RegistryCatalog.cs
+++ b/Zeus.Plugins.Contracts/Registry/RegistryCatalog.cs
@@ -4,7 +4,7 @@ namespace Zeus.Plugins.Contracts.Registry;
 
 /// <summary>
 /// Top-level <c>registry.json</c> served by the plugin registry repo
-/// (default <c>Kb2uka/openhpsdr-zeus-plugins</c>).
+/// (default <c>OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins</c>).
 /// </summary>
 public sealed record RegistryCatalog
 {

--- a/Zeus.Plugins.Host/Registry/HttpRegistryClient.cs
+++ b/Zeus.Plugins.Host/Registry/HttpRegistryClient.cs
@@ -7,14 +7,14 @@ namespace Zeus.Plugins.Host.Registry;
 
 /// <summary>
 /// HTTPS-fetched registry client. Default source is the
-/// Kb2uka/openhpsdr-zeus-plugins repo's <c>registry.json</c>;
+/// OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins repo's <c>registry.json</c>;
 /// operators can override via <c>RegistryClientOptions.SourceUrl</c>
 /// (e.g. point at a private fork or a self-hosted file).
 /// </summary>
 public sealed class HttpRegistryClient : IRegistryClient
 {
     public const string DefaultUrl =
-        "https://raw.githubusercontent.com/Kb2uka/openhpsdr-zeus-plugins/main/registry.json";
+        "https://raw.githubusercontent.com/OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins/main/registry.json";
 
     private readonly HttpClient _http;
     private readonly ILogger<HttpRegistryClient>? _log;

--- a/docs/lessons/rf2k-extracted-to-plugin.md
+++ b/docs/lessons/rf2k-extracted-to-plugin.md
@@ -4,7 +4,7 @@
 **Branch:** `feature/extract-rf2k-plugin`
 **Removal commit:** `acd1a97` — *refactor(rf2k): remove RF2K-S amplifier integration from Zeus core*
 **Plugin id (replacement):** `com.openhpsdr.zeus.plugins.rf2k`
-**Plugin source:** [`openhpsdr-zeus-plugins`](https://github.com/Kb2uka/openhpsdr-zeus-plugins) repo, `samples/Rf2k/` (branch `feature/rf2k-plugin` at the time of writing).
+**Plugin source:** [`openhpsdr-zeus-plugins`](https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins) repo, `samples/Rf2k/` (branch `feature/rf2k-plugin` at the time of writing).
 
 ## What changed
 

--- a/docs/plugins/author-guide.md
+++ b/docs/plugins/author-guide.md
@@ -184,7 +184,7 @@ If you need custom DSP instead, implement `IAudioPlugin` — see `docs/plugins/a
 
 ## 7. Publishing to the registry
 
-PR your plugin entry to `github.com/Kb2uka/openhpsdr-zeus-plugins`:
+PR your plugin entry to `github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins`:
 
 ```json
 {
@@ -231,4 +231,4 @@ Authors who want to skip the registry can ship a direct URL and instruct operato
 - `docs/plugins/capabilities.md` — what each capability gates
 - `docs/plugins/audio-plugins.md` — `IAudioPlugin` deep dive
 - `docs/plugins/registry.md` — registry contract and PR flow
-- [`Kb2uka/openhpsdr-zeus-plugins/samples/`](https://github.com/Kb2uka/openhpsdr-zeus-plugins/tree/main/samples) — `HelloWorld` and `Amplifier` reference implementations in the plugin registry repo
+- [`OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins/samples/`](https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins/tree/main/samples) — `HelloWorld` and `Amplifier` reference implementations in the plugin registry repo

--- a/docs/plugins/registry.md
+++ b/docs/plugins/registry.md
@@ -1,7 +1,7 @@
 # Plugin registry
 
 Openhpsdr-Zeus pulls its plugin catalog from a separate repository at
-**[Kb2uka/openhpsdr-zeus-plugins](https://github.com/Kb2uka/openhpsdr-zeus-plugins)**.
+**[OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins](https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins)**.
 
 The curator (Brian Keating, EI6LF) will transfer the repo to KB2UKA at
 a later date.
@@ -11,7 +11,7 @@ a later date.
 Default catalog URL:
 
 ```
-https://raw.githubusercontent.com/Kb2uka/openhpsdr-zeus-plugins/main/registry.json
+https://raw.githubusercontent.com/OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins/main/registry.json
 ```
 
 This is hard-coded as `HttpRegistryClient.DefaultUrl` in

--- a/docs/plugins/registry.schema.json
+++ b/docs/plugins/registry.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/Kb2uka/openhpsdr-zeus/main/docs/plugins/registry.schema.json",
   "title": "Openhpsdr-Zeus plugin registry",
-  "description": "Schema for registry.json hosted by the Kb2uka/openhpsdr-zeus-plugins repo.",
+  "description": "Schema for registry.json hosted by the OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins repo.",
   "type": "object",
   "required": ["schemaVersion", "generated", "plugins"],
   "properties": {

--- a/docs/proposals/audio-chain-phase0.md
+++ b/docs/proposals/audio-chain-phase0.md
@@ -28,7 +28,7 @@ Explicit non-v1 (worth surfacing to KB2UKA as "want to add these?" rather than p
 
 ### Deployment model — each block is a registry plugin
 
-Per Brian's plugin system rebuild ([PR #368](https://github.com/Kb2uka/openhpsdr-zeus/pull/368), merged to `develop` at `a5f5df4` 2026-05-17), each of the five blocks ships as a **separate Zeus-native registry plugin**, NOT as code baked into Zeus core. The blocks are managed .NET assemblies authored by Zeus contributors and distributed through `Kb2uka/openhpsdr-zeus-plugins`. They are **not VST3 plugins** and have no relationship to the Steinberg ecosystem; the operational "MaxxBass" / "Aphex 204" / "Aural Exciter" naming refers to the well-known *processing techniques* we reimplement, not to any third-party plugin product.
+Per Brian's plugin system rebuild ([PR #368](https://github.com/Kb2uka/openhpsdr-zeus/pull/368), merged to `develop` at `a5f5df4` 2026-05-17), each of the five blocks ships as a **separate Zeus-native registry plugin**, NOT as code baked into Zeus core. The blocks are managed .NET assemblies authored by Zeus contributors and distributed through `OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins`. They are **not VST3 plugins** and have no relationship to the Steinberg ecosystem; the operational "MaxxBass" / "Aphex 204" / "Aural Exciter" naming refers to the well-known *processing techniques* we reimplement, not to any third-party plugin product.
 
 Each block implements:
 

--- a/docs/proposals/plugin-system-v2.md
+++ b/docs/proposals/plugin-system-v2.md
@@ -3,7 +3,7 @@
 **Status:** Accepted 2026-05-17 (maintainer: Brian, EI6LF)
 **Supersedes:** `docs/prds/plugins-system-architecture.md`, `docs/proposals/vst-host.md`, `docs/proposals/vst-host-phase2-wire.md`
 **Worktree:** `OPENHPSDR-Zeus.Worktrees/feature_plugin_system` on branch `feature/plugin-system`
-**Registry repo:** `github.com/Kb2uka/openhpsdr-zeus-plugins`
+**Registry repo:** `github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins`
 
 ---
 
@@ -23,7 +23,7 @@ Neither workstream produced a "plugin" the Zeus client could browse and install.
 | Plugin runtime | **In-process** .NET via `AssemblyLoadContext` (collectible) | Native to Zeus stack, low latency, cross-platform. Unload support for hot-reload. |
 | Audio (VST) hosting | **In-process** via small C++ bridge library (P/Invoke from .NET) | Maintainer accepted 64-bit-only constraint and dropping VST2. Removes sidecar IPC complexity. VST3 SDK (MIT) + CLAP SDK (MIT) only. |
 | Plugin packaging | Single zip with `plugin.json` + assembly + optional `ui/*.es.js` + optional `vst3/*.vst3` | One artifact, one drag-and-drop install. |
-| Registry | **Separate repo, HTTPS-fetched**: `Kb2uka/openhpsdr-zeus-plugins` | Lightweight; community contributions via PR to that repo, not Zeus core. |
+| Registry | **Separate repo, HTTPS-fetched**: `OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins` | Lightweight; community contributions via PR to that repo, not Zeus core. |
 | Bring-your-own-plugin | First-class: install by URL or local zip with optional SHA256 pinning | No registry round-trip required. |
 | Versioning | Plugin declares `sdk.abi` (exact match) + `sdk.minVersion` (SemVer) | ABI version for breaking changes; SemVer for additive. |
 | Settings storage | Scoped LiteDB collection per plugin id | One LiteDB seam, isolation between plugins. |
@@ -300,7 +300,7 @@ Tracked in the team's task list. Each iteration ⇒ one or more commits on `feat
 | **5** | Frontend Plugin Browser UI + Playwright integration tests. |
 | **6** | `IAudioPlugin` contract + `zeus-vst-bridge` C skeleton + stub P/Invoke. |
 | **7** | Native bridge implements VST3 load + process; integration test passes. |
-| **8** | Bootstrap `Kb2uka/openhpsdr-zeus-plugins` repo with schema, CI, seed entries. |
+| **8** | Bootstrap `OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins` repo with schema, CI, seed entries. |
 | **9** | Docs (`docs/plugins/`), final polish, all tests green. |
 
 ## 5. Risks + open questions

--- a/tests/Zeus.Plugins.Host.Tests/EndToEndPluginTests.cs
+++ b/tests/Zeus.Plugins.Host.Tests/EndToEndPluginTests.cs
@@ -16,7 +16,7 @@ namespace Zeus.Plugins.Host.Tests;
 /// and have it appear under <c>/api/plugins</c> with a working backend.
 ///
 /// Reference implementations live in the separate registry repo at
-/// <c>Kb2uka/openhpsdr-zeus-plugins/samples/</c>. These tests build
+/// <c>OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins/samples/</c>. These tests build
 /// shape-equivalent fixtures via Roslyn so the integration is
 /// exercised without pulling the registry repo into Zeus's reference
 /// graph.

--- a/tests/Zeus.Plugins.Host.Tests/HttpRegistryClientTests.cs
+++ b/tests/Zeus.Plugins.Host.Tests/HttpRegistryClientTests.cs
@@ -112,7 +112,7 @@ public class HttpRegistryClientTests
     [Fact]
     public void DefaultSourceUrl_PointsAtBrianbruffRegistryRepo()
     {
-        Assert.Contains("Kb2uka/openhpsdr-zeus-plugins", HttpRegistryClient.DefaultUrl);
+        Assert.Contains("OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins", HttpRegistryClient.DefaultUrl);
         Assert.StartsWith("https://", HttpRegistryClient.DefaultUrl);
     }
 

--- a/zeus-web/src/components/DownloadAudioSuiteButton.tsx
+++ b/zeus-web/src/components/DownloadAudioSuiteButton.tsx
@@ -7,7 +7,7 @@
 //
 // "Download Audio Suite" — one-click install of the six audio chain
 // plugins (Noise Gate → EQ → Compressor → Exciter → Bass → Reverb) from
-// the Kb2uka/openhpsdr-zeus-plugins GitHub releases. The plugin host can't
+// the OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins GitHub releases. The plugin host can't
 // register new endpoints / load new assemblies into the live process, so
 // after install finishes we show a modal telling the operator to restart
 // Zeus. No auto-restart — operator decides.
@@ -23,7 +23,7 @@ interface SuitePlugin {
   id: string;
   /** Human-readable display name shown in progress + result rows. */
   label: string;
-  /** Release zip URL on Kb2uka/openhpsdr-zeus-plugins. */
+  /** Release zip URL on OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins. */
   url: string;
 }
 
@@ -31,32 +31,32 @@ const AUDIO_SUITE: ReadonlyArray<SuitePlugin> = [
   {
     id: 'com.openhpsdr.zeus.samples.noisegate',
     label: 'Noise Gate',
-    url: 'https://github.com/Kb2uka/openhpsdr-zeus-plugins/releases/download/noisegate-v0.1.0/noisegate-0.1.0.zip',
+    url: 'https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins/releases/download/noisegate-v0.1.0/noisegate-0.1.0.zip',
   },
   {
     id: 'com.openhpsdr.zeus.samples.eq',
     label: 'EQ (10-band parametric)',
-    url: 'https://github.com/Kb2uka/openhpsdr-zeus-plugins/releases/download/eq-v0.2.0/eq-0.2.0.zip',
+    url: 'https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins/releases/download/eq-v0.2.0/eq-0.2.0.zip',
   },
   {
     id: 'com.openhpsdr.zeus.samples.compressor',
     label: 'Compressor',
-    url: 'https://github.com/Kb2uka/openhpsdr-zeus-plugins/releases/download/compressor-v0.1.2/compressor-0.1.2.zip',
+    url: 'https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins/releases/download/compressor-v0.1.2/compressor-0.1.2.zip',
   },
   {
     id: 'com.openhpsdr.zeus.samples.exciter',
     label: 'Aural-Exciter',
-    url: 'https://github.com/Kb2uka/openhpsdr-zeus-plugins/releases/download/exciter-v0.2.0/exciter-0.2.0.zip',
+    url: 'https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins/releases/download/exciter-v0.2.0/exciter-0.2.0.zip',
   },
   {
     id: 'com.openhpsdr.zeus.samples.bass',
     label: 'Bass Enhancer',
-    url: 'https://github.com/Kb2uka/openhpsdr-zeus-plugins/releases/download/bass-v0.2.0/bass-0.2.0.zip',
+    url: 'https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins/releases/download/bass-v0.2.0/bass-0.2.0.zip',
   },
   {
     id: 'com.openhpsdr.zeus.samples.reverb',
     label: 'Reverb',
-    url: 'https://github.com/Kb2uka/openhpsdr-zeus-plugins/releases/download/reverb-v0.2.0/reverb-0.2.0.zip',
+    url: 'https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins/releases/download/reverb-v0.2.0/reverb-0.2.0.zip',
   },
 ];
 


### PR DESCRIPTION
The plugin registry repo was transferred from `Kb2uka/openhpsdr-zeus-plugins` → **`OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins`**. This repoints every reference in Zeus to the org path so we fetch from the canonical owner instead of relying on GitHub's transfer redirect.

**Owner-only change** — branches (`/main/`), release tags and asset paths are preserved exactly.

## Safety: verified the org path is live *before* changing anything
- `raw.githubusercontent.com/OpenHPSDR-Zeus-org/openhpsdr-zeus-plugins/main/registry.json` → **200**
- All releases transferred with the repo (audio plugins, RF2K, TGXL, Voyeur).
- All six audio-suite release assets download at the org path → **200**.

## Functional references (the ones that matter at runtime)
- `Zeus.Plugins.Host/Registry/HttpRegistryClient.cs` — `DefaultUrl`, the single source of the registry fetch URL (`SourceUrl` defaults to it; the frontend just echoes the backend's resolved value).
- `zeus-web/src/components/DownloadAudioSuiteButton.tsx` — the six audio-plugin release-download URLs.
- `tests/Zeus.Plugins.Host.Tests/HttpRegistryClientTests.cs` — `DefaultUrl` assertion kept in lockstep.

## Docs / comments
README, CHANGELOG, `RegistryCatalog`, `EndToEndPluginTests`, `docs/plugins/*`, `docs/proposals/*`, `docs/lessons/rf2k-extracted-to-plugin.md`.

## Not affected
Already-installed plugins (e.g. RF2K-S) run from local files and don't re-fetch the registry to operate, so they're untouched. Even un-repointed, existing builds keep working via GitHub's redirect — this just makes the URLs canonical for future builds/installs.

## Verification
- `dotnet build Zeus.slnx` — 0 warnings, 0 errors.
- `Zeus.Plugins.Host.Tests` — 113 passed, 0 failed (incl. the registry-URL assertion).
- `npm --prefix zeus-web run build` — clean.
- `rg "Kb2uka/openhpsdr-zeus-plugins"` → 0 residual.