### PR TITLE
feat(web): even out multi-RX waterfall noise floors with one master dB scale

### DIFF
--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -58,7 +58,7 @@ import {
 } from '../dsp/signal-estimator';
 import { normalizeStitchedBins, stitchFloorShiftDb } from '../dsp/stitch-normalizer';
 import { getReceiverVfoHz, rxIndexOf, type ReceiverKey } from '../state/receiver-state';
-import { estimateRowFloorDb, reportReceiverFloorDb } from '../dsp/floor-normalization';
+import { estimateRowFloorDb, forgetReceiverFloor, reportReceiverFloorDb } from '../dsp/floor-normalization';
 import { effectiveRxWfWindow, useRxDbWindowStore } from '../state/rx-db-window-store';
 import * as viewCenter from '../state/view-center';
 import * as viewZoom from '../state/view-zoom';
@@ -569,6 +569,9 @@ export function Waterfall({
       cancelDrawBusFrame(redraw);
       releaseFrameConsumer();
       releaseEstimatorConsumer();
+      // Drop this pane's floor from the median anchor — a removed band shouldn't
+      // keep skewing the cross-RX normalization with its last reading.
+      forgetReceiverFloor(rxIndex);
       renderer?.dispose();
       // Free the ANGLE context slot on real unmounts, but give React
       // StrictMode's development-only effect remount a chance to cancel it.

--- a/zeus-web/src/components/WfDbScale.tsx
+++ b/zeus-web/src/components/WfDbScale.tsx
@@ -5,22 +5,38 @@
 //                         Douglas J. Cerrato (KB2UKA),
 //                         Christian Suarez (N9WAR), and contributors.
 
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
 import { useTxStore } from '../state/tx-store';
 import { useVfoLockStore } from '../state/vfo-lock-store';
 import { useConnectionStore } from '../state/connection-store';
-import { floorNormalizationOffsetDb } from '../dsp/floor-normalization';
+import { floorNormalizationOffsetDb, referenceFloorDb } from '../dsp/floor-normalization';
 import { useRxDbWindowStore, type RxWfWindow } from '../state/rx-db-window-store';
 
 const TICK_STRIDE_DB = 10;
+
+// How often the master scale re-reads the median floor for its readout. The
+// floor registry is plain module state (read per-frame by the renderer, not a
+// reactive store), and the floors are EMA-smoothed so they drift slowly — a
+// low-rate poll keeps the dB-above-floor labels current without re-rendering
+// the slider on every spectrum tick.
+const REF_FLOOR_POLL_MS = 500;
+
+type WfDbScaleProps = {
+  // Master mode: this single scale spans the whole multi-RX waterfall grid and
+  // drives the GLOBAL window. Every pane derives its own window as
+  // global + its measured floor offset (floor-normalization), so one drag moves
+  // all bands together and their noise floors stay aligned — instead of editing
+  // only the focused receiver's per-RX override (which leaves the rest behind).
+  master?: boolean;
+};
 
 // Draggable dB scale on the waterfall, mirroring DbScale's look and feel
 // but bound to the waterfall's independent dB window so panadapter and
 // waterfall noise floors can be set separately. Mirrors DbScale's RX/TX
 // swap so the operator can drag the waterfall scale during MOX/TUN without
 // disturbing their RX waterfall view.
-export function WfDbScale() {
+export function WfDbScale({ master = false }: WfDbScaleProps = {}) {
   // The RX waterfall scale follows the FOCUSED receiver: RX1 (index 0) edits
   // the global window; RX2+ each edit their own per-receiver window (persisted).
   // Select the reactive deps so the slider re-renders on focus / global-window /
@@ -31,6 +47,7 @@ export function WfDbScale() {
   const rxOverride = useRxDbWindowStore((s) => s.overrides[focusedRxIndex]);
   const shiftGlobalRx = useDisplaySettingsStore((s) => s.shiftWfDbRange);
   const shiftRxWindow = useRxDbWindowStore((s) => s.shiftRxWfWindow);
+  const clearAllRxWindows = useRxDbWindowStore((s) => s.clearAllRxWfWindows);
   const txDbMin = useDisplaySettingsStore((s) => s.wfTxDbMin);
   const txDbMax = useDisplaySettingsStore((s) => s.wfTxDbMax);
   const shiftTx = useDisplaySettingsStore((s) => s.shiftWfTxDbRange);
@@ -38,26 +55,39 @@ export function WfDbScale() {
   const tunOn = useTxStore((s) => s.tunOn);
   const keyed = moxOn || tunOn;
 
-  // Effective RX window for the focused receiver. Index 0 = global; an explicit
-  // override wins; otherwise the global window floor-normalized to RX1.
+  // Effective RX window shown on the scale.
+  // - Master mode: always the global window — it's the common reference every
+  //   pane floor-normalizes against, so the ticks read the band-agnostic scale
+  //   that all RX waterfalls share.
+  // - Otherwise (in-tile, focus-bound): index 0 = global; an explicit override
+  //   wins; else the global window floor-normalized to RX1.
   let rxWin: RxWfWindow;
-  if (focusedRxIndex <= 0) {
+  if (master || focusedRxIndex <= 0) {
     rxWin = { wfDbMin: globalRxMin, wfDbMax: globalRxMax };
   } else if (rxOverride) {
     rxWin = rxOverride;
   } else {
-    const off = floorNormalizationOffsetDb(focusedRxIndex, 0);
+    const off = floorNormalizationOffsetDb(focusedRxIndex);
     rxWin = { wfDbMin: globalRxMin + off, wfDbMax: globalRxMax + off };
   }
 
-  // RX-side shift routes to the global window for RX1, else the focused RX's
-  // per-receiver window.
+  // RX-side shift. Master mode drives the GLOBAL window — every pane follows it
+  // via its own measured floor offset, so all bands move together and stay
+  // evened-out. It also drops any stale per-RX overrides (they'd opt a pane out
+  // of normalization and leave it behind). Non-master routes to the global
+  // window for RX1, else the focused RX's per-receiver override.
   const shiftRx = useCallback(
     (delta: number) => {
-      if (focusedRxIndex <= 0) shiftGlobalRx(delta);
-      else shiftRxWindow(focusedRxIndex, delta);
+      if (master) {
+        clearAllRxWindows();
+        shiftGlobalRx(delta);
+      } else if (focusedRxIndex <= 0) {
+        shiftGlobalRx(delta);
+      } else {
+        shiftRxWindow(focusedRxIndex, delta);
+      }
     },
-    [focusedRxIndex, shiftGlobalRx, shiftRxWindow],
+    [master, focusedRxIndex, shiftGlobalRx, shiftRxWindow, clearAllRxWindows],
   );
 
   // Pick the active range + shifter based on whether we're keyed. Mirrors
@@ -66,6 +96,25 @@ export function WfDbScale() {
   const dbMin = keyed ? txDbMin : rxWin.wfDbMin;
   const dbMax = keyed ? txDbMax : rxWin.wfDbMax;
   const shift = keyed ? shiftTx : shiftRx;
+
+  // Master RX scale reads out as dB ABOVE the shared noise floor (floor = 0).
+  // That's the only frame true for every pane at once — normalization pins each
+  // band's floor to the same colour, so "+10 dB above floor" means the same
+  // everywhere, whereas an absolute dBm number only matches one band. Poll the
+  // median floor at a low rate (it's non-reactive module state). Null while
+  // keyed/non-master or before any floor is known → fall back to absolute dB.
+  const [refFloorDb, setRefFloorDb] = useState<number | null>(null);
+  const relativeToFloor = master && !keyed && refFloorDb != null;
+  useEffect(() => {
+    if (!master || keyed) {
+      setRefFloorDb(null);
+      return;
+    }
+    const tick = () => setRefFloorDb(referenceFloorDb());
+    tick();
+    const id = window.setInterval(tick, REF_FLOOR_POLL_MS);
+    return () => window.clearInterval(id);
+  }, [master, keyed]);
 
   const dragState = useRef<{
     startY: number;
@@ -122,21 +171,32 @@ export function WfDbScale() {
     [],
   );
 
-  const firstTick = Math.ceil(dbMin / TICK_STRIDE_DB) * TICK_STRIDE_DB;
-  const lastTick = Math.floor(dbMax / TICK_STRIDE_DB) * TICK_STRIDE_DB;
-  const ticks: { db: number; topPct: number }[] = [];
-  for (let db = firstTick; db <= lastTick; db += TICK_STRIDE_DB) {
-    const topPct = ((dbMax - db) / (dbMax - dbMin)) * 100;
-    ticks.push({ db, topPct });
+  // `label` is what the tick reads; `topPct` is its vertical position (always
+  // from the absolute window). In relative mode we step from the floor so a tick
+  // sits exactly on it (label 0) with clean +/-10 dB marks above and below;
+  // otherwise we step on absolute multiples of 10 as before.
+  const anchor = relativeToFloor ? refFloorDb! : 0;
+  const firstK = Math.ceil((dbMin - anchor) / TICK_STRIDE_DB);
+  const lastK = Math.floor((dbMax - anchor) / TICK_STRIDE_DB);
+  const ticks: { label: number; topPct: number }[] = [];
+  for (let k = firstK; k <= lastK; k++) {
+    const absDb = anchor + k * TICK_STRIDE_DB;
+    const topPct = ((dbMax - absDb) / (dbMax - dbMin)) * 100;
+    ticks.push({ label: relativeToFloor ? k * TICK_STRIDE_DB : absDb, topPct });
   }
 
   return (
     <div
       role="slider"
-      aria-label="Waterfall dB scale"
-      aria-valuemin={Math.round(dbMin)}
-      aria-valuemax={Math.round(dbMax)}
-      aria-valuenow={Math.round((dbMin + dbMax) / 2)}
+      aria-label={relativeToFloor ? 'Waterfall dB scale (dB above noise floor)' : 'Waterfall dB scale'}
+      aria-valuemin={Math.round(relativeToFloor ? dbMin - refFloorDb! : dbMin)}
+      aria-valuemax={Math.round(relativeToFloor ? dbMax - refFloorDb! : dbMax)}
+      aria-valuenow={Math.round((dbMin + dbMax) / 2 - (relativeToFloor ? refFloorDb! : 0))}
+      title={
+        relativeToFloor
+          ? `Waterfall brightness — dB above the shared noise floor (≈${Math.round(refFloorDb!)} dBm). One drag evens out every RX band.`
+          : undefined
+      }
       onPointerDown={onPointerDown}
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}
@@ -145,16 +205,29 @@ export function WfDbScale() {
     >
       {ticks.map((t) => (
         <div
-          key={t.db}
+          key={t.label}
           className="absolute left-0 right-0 flex items-center gap-1"
           style={{ top: `${t.topPct}%`, transform: 'translateY(-50%)' }}
         >
           <div className="h-px w-1.5 bg-neutral-500" />
           <div className="font-mono text-[9px] leading-none text-neutral-400">
-            {t.db}
+            {relativeToFloor && t.label > 0 ? `+${t.label}` : t.label}
           </div>
         </div>
       ))}
+      {/* Master mode: anchor caption — the absolute level the "0" tick (the
+          shared noise floor) sits at, so the relative scale still has dBm
+          context. */}
+      {relativeToFloor && (
+        <div
+          className="absolute bottom-1 left-0 right-0 text-center font-mono text-[8px] leading-tight text-neutral-500"
+          title="Median noise floor across all RX (the 0 dB reference)"
+        >
+          flr
+          <br />
+          {Math.round(refFloorDb!)}
+        </div>
+      )}
     </div>
   );
 }

--- a/zeus-web/src/dsp/floor-normalization.test.ts
+++ b/zeus-web/src/dsp/floor-normalization.test.ts
@@ -3,7 +3,9 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   estimateRowFloorDb,
   floorNormalizationOffsetDb,
+  forgetReceiverFloor,
   getReceiverFloorDb,
+  referenceFloorDb,
   reportReceiverFloorDb,
   resetReceiverFloors,
 } from './floor-normalization';
@@ -31,32 +33,68 @@ describe('estimateRowFloorDb', () => {
   });
 });
 
+describe('referenceFloorDb', () => {
+  it('is null before any floor is reported', () => {
+    expect(referenceFloorDb()).toBeNull();
+  });
+
+  it('is the receiver floor itself with one pane', () => {
+    reportReceiverFloorDb(0, -123);
+    expect(referenceFloorDb()).toBe(-123);
+  });
+
+  it('is the median (odd count), robust to an outlier band', () => {
+    reportReceiverFloorDb(0, -135);
+    reportReceiverFloorDb(1, -120);
+    reportReceiverFloorDb(2, -160); // dead-band outlier
+    expect(referenceFloorDb()).toBe(-135); // middle value, not dragged by -160
+  });
+
+  it('averages the two middle values (even count)', () => {
+    reportReceiverFloorDb(0, -135);
+    reportReceiverFloorDb(1, -120);
+    expect(referenceFloorDb()).toBeCloseTo(-127.5, 5);
+  });
+});
+
 describe('floorNormalizationOffsetDb', () => {
-  it('is 0 for the focused pane itself', () => {
+  it('is 0 before any floor is reported', () => {
+    expect(floorNormalizationOffsetDb(0)).toBe(0);
+  });
+
+  it('is 0 for a lone pane (median is its own floor)', () => {
     reportReceiverFloorDb(0, -120);
-    expect(floorNormalizationOffsetDb(0, 0)).toBe(0);
+    expect(floorNormalizationOffsetDb(0)).toBe(0);
   });
 
-  it('is 0 when either floor is unknown', () => {
+  it('is 0 when this pane has not reported yet', () => {
     reportReceiverFloorDb(0, -120);
-    expect(floorNormalizationOffsetDb(1, 0)).toBe(0); // pane 1 unknown
-    expect(floorNormalizationOffsetDb(0, 2)).toBe(0); // focus 2 unknown
+    expect(floorNormalizationOffsetDb(1)).toBe(0); // pane 1 unknown
   });
 
-  it('shifts a noisier pane up by (here - focused)', () => {
-    reportReceiverFloorDb(0, -135); // focused RX1 floor (20m, quiet)
-    reportReceiverFloorDb(1, -120); // RX2 floor (40m, noisier)
-    // RX2 is 15 dB hotter, so its window shifts +15 so its floor still maps low.
-    expect(floorNormalizationOffsetDb(1, 0)).toBeCloseTo(15, 1);
-    // And the reciprocal: a quieter pane shifts down.
-    expect(floorNormalizationOffsetDb(0, 1)).toBeCloseTo(-15, 1);
+  it('offsets each pane from the median floor', () => {
+    reportReceiverFloorDb(0, -135); // quiet
+    reportReceiverFloorDb(1, -120); // noisier → median is -127.5
+    // Noisier pane shifts its window up so its floor still maps low; the quiet
+    // pane shifts down. Both are symmetric about the shared median.
+    expect(floorNormalizationOffsetDb(1)).toBeCloseTo(7.5, 1);
+    expect(floorNormalizationOffsetDb(0)).toBeCloseTo(-7.5, 1);
   });
 
-  it('clamps the offset to +/-40 dB', () => {
+  it('clamps the offset to +/-80 dB', () => {
     reportReceiverFloorDb(0, -200);
-    reportReceiverFloorDb(1, 0);
-    expect(floorNormalizationOffsetDb(1, 0)).toBe(40);
-    expect(floorNormalizationOffsetDb(0, 1)).toBe(-40);
+    reportReceiverFloorDb(1, 0); // median -100 → raw offsets +/-100
+    expect(floorNormalizationOffsetDb(1)).toBe(80);
+    expect(floorNormalizationOffsetDb(0)).toBe(-80);
+  });
+
+  it('drops a forgotten pane from the anchor', () => {
+    reportReceiverFloorDb(0, -135);
+    reportReceiverFloorDb(1, -120);
+    forgetReceiverFloor(1);
+    // Only RX1 left → median is its own floor → offset 0.
+    expect(referenceFloorDb()).toBe(-135);
+    expect(floorNormalizationOffsetDb(0)).toBe(0);
   });
 });
 

--- a/zeus-web/src/dsp/floor-normalization.ts
+++ b/zeus-web/src/dsp/floor-normalization.ts
@@ -22,11 +22,14 @@
 // and the others washed-out or empty.
 //
 // Fix: every pane reports a smoothed estimate of its OWN noise floor here, and
-// at draw time shifts its dB window so its floor lands at the same colour as
-// the FOCUSED receiver's floor. The operator drags the slider while looking at
-// whatever RX they've focused; that same window then applies, anchored to each
-// pane's measured floor, across every band. The focused pane itself is never
-// shifted (offset 0), so single-RX behaviour is unchanged.
+// at draw time shifts its dB window so its floor lands at the same colour in
+// every band. The common anchor is the MEDIAN of all reported floors — no pane
+// is privileged, so adding/removing a band doesn't yank a reference pane around,
+// and one outlier band (dead, or stuffed with a contest signal) can't drag the
+// anchor the way a mean would. The single master dB slider then sets that shared
+// window relative to the median floor; each pane offsets from it by its own
+// measured floor, so they all stay evened-out. With one receiver the median IS
+// that receiver's floor (offset 0), so single-RX behaviour is unchanged.
 //
 // Indexed by 0-based rxIndex (RX1 = 0, RX2 = 1, RX3+ = 2..), matching
 // connection-store `focusedRxIndex` and `receiver-state` `rxIndexOf`.
@@ -40,11 +43,21 @@ const FLOOR_EMA_ALPHA = 0.1;
 
 // Clamp on the normalization shift so a transient bad estimate (e.g. a pane
 // momentarily full of a strong carrier) can never throw the window wildly.
-const MAX_OFFSET_DB = 40;
+// Real inter-band noise-floor spread is large — a busy 40m evening floors tens
+// of dB above a dead 10m/15m band — so this has to be wide enough to fully
+// align those extremes, while the robust 25th-percentile estimate (below) keeps
+// a carrier-stuffed pane from abusing the headroom.
+const MAX_OFFSET_DB = 80;
 
 // Reused scratch for the downsampled percentile sort — keeps the per-frame
 // estimate allocation-free. 256 samples is plenty for a robust low percentile.
 const scratch = new Float32Array(256);
+
+// Reused scratch for the median over reported floors. Sized well past any
+// realistic DDC count; floors beyond it are ignored (the median of the first
+// N is still representative). Keeps referenceFloorDb() allocation-free on the
+// per-frame redraw path.
+const refScratch = new Float64Array(32);
 
 /** Feed a fresh floor estimate (dB) for a receiver; smoothed via EMA. */
 export function reportReceiverFloorDb(rxIndex: number, floorDb: number): void {
@@ -61,23 +74,44 @@ export function getReceiverFloorDb(rxIndex: number): number | null {
   return floorByRx.get(rxIndex) ?? null;
 }
 
+/** Forget one receiver's floor (pane removed) so it leaves the median anchor. */
+export function forgetReceiverFloor(rxIndex: number): void {
+  floorByRx.delete(rxIndex);
+}
+
 /** Forget all receiver floors (receiver teardown / test reset). */
 export function resetReceiverFloors(): void {
   floorByRx.clear();
 }
 
 /**
- * dB-window offset to add to THIS pane's [dbMin, dbMax] so its noise floor
- * aligns to the focused receiver's floor. Returns 0 when this IS the focused
- * pane or when either floor is not yet known.
+ * Median of all reported receiver floors (dB) — the common normalization
+ * anchor and the "0 dB" reference the master scale reads against. Median, not
+ * mean, so one dead or carrier-stuffed band can't drag the anchor. Returns null
+ * until at least one floor has been reported. Allocation-free.
  */
-export function floorNormalizationOffsetDb(
-  thisRxIndex: number,
-  focusedRxIndex: number,
-): number {
-  if (thisRxIndex === focusedRxIndex) return 0;
+export function referenceFloorDb(): number | null {
+  let n = 0;
+  for (const v of floorByRx.values()) {
+    if (n >= refScratch.length) break;
+    refScratch[n++] = v;
+  }
+  if (n === 0) return null;
+  const view = refScratch.subarray(0, n);
+  view.sort();
+  const mid = n >> 1;
+  return n % 2 ? view[mid]! : (view[mid - 1]! + view[mid]!) / 2;
+}
+
+/**
+ * dB-window offset to add to THIS pane's [dbMin, dbMax] so its noise floor
+ * aligns to the shared median floor. Returns 0 when this pane's floor or the
+ * reference is not yet known, so an un-reported pane simply shows the raw
+ * window. Clamped to +/-MAX_OFFSET_DB against a transient bad estimate.
+ */
+export function floorNormalizationOffsetDb(thisRxIndex: number): number {
   const here = floorByRx.get(thisRxIndex);
-  const ref = floorByRx.get(focusedRxIndex);
+  const ref = referenceFloorDb();
   if (here == null || ref == null) return 0;
   const off = here - ref;
   return off < -MAX_OFFSET_DB ? -MAX_OFFSET_DB : off > MAX_OFFSET_DB ? MAX_OFFSET_DB : off;

--- a/zeus-web/src/layout/panels/HeroPanel.tsx
+++ b/zeus-web/src/layout/panels/HeroPanel.tsx
@@ -630,9 +630,12 @@ export function HeroPanel({
                   </div>
                 ))}
                 {/* One dB scale spanning the whole waterfall grid (left edge of
-                    all rows), rather than only the RX1 tile's row. Bound to the
-                    focused receiver's window, same as the in-tile scale. */}
-                <WfDbScale />
+                    all rows), rather than only the RX1 tile's row. Master mode
+                    (multi-RX only): it drives the global window — which every
+                    pane follows via its own measured floor offset — and reads
+                    out as dB above the shared noise floor, so one drag evens out
+                    every band. Single-RX keeps the plain absolute-dBm scale. */}
+                <WfDbScale master={multiRxSpectrum} />
               </div>
             )
           )}

--- a/zeus-web/src/state/rx-db-window-store.test.ts
+++ b/zeus-web/src/state/rx-db-window-store.test.ts
@@ -22,19 +22,23 @@ afterEach(() => {
 });
 
 describe('rx-db-window-store', () => {
-  it('RX1 (index 0) always resolves to the global window', () => {
+  it('RX1 resolves to the raw global window when no floors are reported', () => {
     useDisplaySettingsStore.setState({ wfDbMin: -130, wfDbMax: -40 });
     expect(effectiveRxWfWindow(0)).toEqual({ wfDbMin: -130, wfDbMax: -40 });
   });
 
-  it('an RXn without override floor-normalizes the global window to RX1', () => {
+  it('every pane (incl. RX1) floor-normalizes toward the median floor', () => {
     useDisplaySettingsStore.setState({ wfDbMin: -130, wfDbMax: -40 });
-    // RX1 floor -135, RX2 floor -120 → RX2 is 15 dB hotter → window shifts +15.
+    // Floors -135 (RX1) and -120 (RX2) → median -127.5. RX2 is +7.5 above it,
+    // RX1 is -7.5 below it; both windows shift by that, symmetric about median.
     reportReceiverFloorDb(0, -135);
     reportReceiverFloorDb(1, -120);
-    const win = effectiveRxWfWindow(1);
-    expect(win.wfDbMin).toBeCloseTo(-115, 1);
-    expect(win.wfDbMax).toBeCloseTo(-25, 1);
+    const rx2 = effectiveRxWfWindow(1);
+    expect(rx2.wfDbMin).toBeCloseTo(-122.5, 1);
+    expect(rx2.wfDbMax).toBeCloseTo(-32.5, 1);
+    const rx1 = effectiveRxWfWindow(0);
+    expect(rx1.wfDbMin).toBeCloseTo(-137.5, 1);
+    expect(rx1.wfDbMax).toBeCloseTo(-47.5, 1);
   });
 
   it('an explicit override wins over the normalized default', () => {
@@ -61,6 +65,17 @@ describe('rx-db-window-store', () => {
     useRxDbWindowStore.getState().clearRxWfWindow(2);
     expect(useRxDbWindowStore.getState().overrides[2]).toBeUndefined();
     expect(effectiveRxWfWindow(2)).toEqual({ wfDbMin: -130, wfDbMax: -40 });
+  });
+
+  it('clearAll drops every override so all receivers re-normalize', () => {
+    useDisplaySettingsStore.setState({ wfDbMin: -130, wfDbMax: -40 });
+    useRxDbWindowStore.getState().setRxWfWindow(1, -100, -20);
+    useRxDbWindowStore.getState().setRxWfWindow(2, -90, -10);
+    useRxDbWindowStore.getState().clearAllRxWfWindows();
+    expect(useRxDbWindowStore.getState().overrides).toEqual({});
+    expect(effectiveRxWfWindow(1)).toEqual({ wfDbMin: -130, wfDbMax: -40 });
+    expect(effectiveRxWfWindow(2)).toEqual({ wfDbMin: -130, wfDbMax: -40 });
+    expect(JSON.parse(localStorage.getItem('zeus.rxWfDbWindows')!)).toEqual({});
   });
 
   it('ignores index 0 and inverted windows', () => {

--- a/zeus-web/src/state/rx-db-window-store.ts
+++ b/zeus-web/src/state/rx-db-window-store.ts
@@ -24,9 +24,9 @@
 // window (which already round-trips to server prefs).
 //
 // Until a receiver has an explicit override, its effective window is the global
-// window shifted by its floor-normalization offset (anchored to RX1), so floors
-// line up out of the box. Once the operator drags a receiver's scale, that
-// absolute window sticks and persists across restarts (localStorage).
+// window shifted by its floor-normalization offset (anchored to the median floor
+// across all panes), so floors line up out of the box. Once the operator drags a
+// receiver's scale, that absolute window sticks and persists (localStorage).
 
 import { create } from 'zustand';
 import { useDisplaySettingsStore } from './display-settings-store';
@@ -100,6 +100,8 @@ type RxDbWindowState = {
   shiftRxWfWindow: (rxIndex: number, deltaDb: number) => void;
   /** Drop a receiver's override so it falls back to the normalized default. */
   clearRxWfWindow: (rxIndex: number) => void;
+  /** Drop EVERY override so all receivers fall back to floor normalization. */
+  clearAllRxWfWindows: () => void;
 };
 
 export const useRxDbWindowStore = create<RxDbWindowState>((set, get) => ({
@@ -128,20 +130,25 @@ export const useRxDbWindowStore = create<RxDbWindowState>((set, get) => ({
     writeSaved(overrides);
     set({ overrides });
   },
+
+  clearAllRxWfWindows: () => {
+    if (Object.keys(get().overrides).length === 0) return;
+    writeSaved({});
+    set({ overrides: {} });
+  },
 }));
 
 /**
  * The effective waterfall dB window for a receiver index.
- * - RX1 (0): the global window (display-settings-store).
- * - RXn with an explicit override: that absolute window.
- * - RXn without one: the global window shifted by its floor-normalization
- *   offset (anchored to RX1), so its noise floor lines up with RX1's.
+ * - RXn (>=1) with an explicit override: that absolute window.
+ * - Otherwise (incl. RX1): the global window shifted by the receiver's
+ *   floor-normalization offset, so every pane's noise floor lands at the shared
+ *   median level. With one receiver the offset is 0 → the raw global window.
  */
 export function effectiveRxWfWindow(rxIndex: number): RxWfWindow {
   const ds = useDisplaySettingsStore.getState();
-  if (rxIndex <= 0) return { wfDbMin: ds.wfDbMin, wfDbMax: ds.wfDbMax };
-  const ov = useRxDbWindowStore.getState().overrides[rxIndex];
+  const ov = rxIndex >= 1 ? useRxDbWindowStore.getState().overrides[rxIndex] : undefined;
   if (ov) return ov;
-  const off = floorNormalizationOffsetDb(rxIndex, 0);
+  const off = floorNormalizationOffsetDb(rxIndex);
   return { wfDbMin: ds.wfDbMin + off, wfDbMax: ds.wfDbMax + off };
 }


### PR DESCRIPTION
## Problem

In multi-RX, each band's waterfall sits on a different absolute noise floor (a busy 40m floors tens of dB above a dead 10m/15m band). With one dB-scale slider, only one pane looked right and the rest were washed-out or black — and after #963 collapsed the per-tile scales into a single grid-spanning scale, dragging it only moved the **focused** receiver (silently creating a per-RX override), so the bands never evened out.

## What changed

- **Median anchor.** Floor normalization now anchors to the **median** floor across all panes (was RX1), so no receiver is privileged and one outlier band can't drag the reference. Panes leave the median when their tile unmounts.
- **Master scale.** The grid-spanning `WfDbScale` runs in `master` mode (multi-RX only): it drives the **global** window — every pane follows via its own measured floor offset — and clears stale per-RX overrides that would otherwise opt a pane out of normalization. One drag now evens out every band.
- **dB-above-floor readout.** In master mode the scale reads out relative to the shared noise floor (floor = `0`, `+10/+20…` above), the only frame that's true for every band at once, with the absolute median floor shown as a small caption for context. **Single-RX keeps the familiar absolute-dBm scale.**
- **Wider clamp.** Normalization offset clamp 40 → 80 dB to cover real inter-band spread.

## Files

- `dsp/floor-normalization.ts` — `referenceFloorDb()` (median), single-arg `floorNormalizationOffsetDb`, `forgetReceiverFloor`, clamp 40→80.
- `state/rx-db-window-store.ts` — `clearAllRxWfWindows`, every pane (incl. RX1) offsets from the median.
- `components/WfDbScale.tsx` — `master` mode: drives global window, clears overrides, dB-above-floor ticks + floor caption.
- `components/Waterfall.tsx` — drop floor on pane unmount.
- `layout/panels/HeroPanel.tsx` — `master` gated to multi-RX.

## Testing

- `tsc -b --noEmit` clean, ESLint clean, **990/990** frontend tests pass (floor-normalization + rx-db-window suites updated for the median anchor + master readout; added coverage for median/even-odd/outlier/forget/clearAll).
- ⚠️ **Not yet verified on hardware** — WebGL can't be rendered headlessly. Needs an eyeball on a live multi-RX radio with several bands open.

## Notes / follow-ups

- **AUTO dB mode + multi-RX:** AUTO still fits the global window to RX1's spectrum only, so with the average anchor RX1's displayed window can sit slightly off the AUTO fit. FIXED is the sane multi-RX mode; AUTO+multi-RX is a separate follow-up.
- Scope is the **waterfall** only; the panadapter trace/DbScale still uses absolute dB.
