### PR TITLE
chore: repoint repo URLs from Kb2uka to OpenHPSDR-Zeus-org

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Zeus wiki
-    url: https://github.com/Kb2uka/openhpsdr-zeus/wiki
+    url: https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus/wiki
     about: Setup, supported radios, and usage notes live on the wiki — please skim before filing.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1287,7 +1287,7 @@ jobs:
 
           ## License
 
-          GNU GPL v2 or later. See [LICENSE](https://github.com/Kb2uka/openhpsdr-zeus/blob/main/LICENSE) for details.
+          GNU GPL v2 or later. See [LICENSE](https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus/blob/main/LICENSE) for details.
           EOF
 
       - name: Create or Update Release

--- a/.github/workflows/sync-develop-to-experimental.yml
+++ b/.github/workflows/sync-develop-to-experimental.yml
@@ -1,6 +1,6 @@
 name: Sync develop → experimental
 
-# Architectural context: Kb2uka/openhpsdr-zeus uses three long-lived
+# Architectural context: OpenHPSDR-Zeus-org/openhpsdr-zeus uses three long-lived
 # branches with distinct trust levels:
 #
 #   main         — tagged releases only. Code-owner approval required.

--- a/Zeus.Plugins.Contracts/Zeus.Plugins.Contracts.csproj
+++ b/Zeus.Plugins.Contracts/Zeus.Plugins.Contracts.csproj
@@ -8,7 +8,7 @@
     <Description>Public surface for Openhpsdr-Zeus plugins. Reference from plugin projects.</Description>
     <Authors>Brian Keating (EI6LF), Christian Suarez (N9WAR), and contributors</Authors>
     <PackageLicenseExpression>GPL-2.0-or-later</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/Kb2uka/openhpsdr-zeus</RepositoryUrl>
+    <RepositoryUrl>https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Zeus.Server.Hosting/ActivationSpotsService.cs
+++ b/Zeus.Server.Hosting/ActivationSpotsService.cs
@@ -79,7 +79,7 @@ public sealed class ActivationSpotsService : BackgroundService
     {
         var c = new HttpClient { Timeout = TimeSpan.FromSeconds(20) };
         // POTA/SOTA APIs reject requests without a User-Agent.
-        c.DefaultRequestHeaders.UserAgent.ParseAdd("Zeus-HPSDR/1.0 (+https://github.com/Kb2uka/openhpsdr-zeus)");
+        c.DefaultRequestHeaders.UserAgent.ParseAdd("Zeus-HPSDR/1.0 (+https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus)");
         c.DefaultRequestHeaders.Accept.ParseAdd("application/json");
         return c;
     }

--- a/installers/create-linux-desktop-appimage.sh
+++ b/installers/create-linux-desktop-appimage.sh
@@ -169,7 +169,7 @@ WHAT YOU GET
   server process. For a browser-based / remote-friendly install, see the
   service-mode tarball (openhpsdr-zeus-${VERSION}-linux-x64.tar.gz).
 
-More info: https://github.com/Kb2uka/openhpsdr-zeus
+More info: https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus
 License:   GNU GPL v2 or later
 EOF
 

--- a/installers/create-linux-package.sh
+++ b/installers/create-linux-package.sh
@@ -313,7 +313,7 @@ Requirements:
   browser UI so Zeus still starts.
 
 For more information:
-https://github.com/Kb2uka/openhpsdr-zeus
+https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus
 
 License: GNU GPL v2 or later
 Copyright (C) 2025-2026 Brian Keating (EI6LF), Douglas J. Cerrato (KB2UKA), Christian Suarez (N9WAR), and contributors

--- a/installers/create-macos-app.sh
+++ b/installers/create-macos-app.sh
@@ -534,7 +534,7 @@ FIRST RUN — WDSP WISDOM
   minutes. The window will load, but do NOT click Discover/Connect
   until the wisdom build settles. Subsequent launches are instant.
 
-More info: https://github.com/Kb2uka/openhpsdr-zeus
+More info: https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus
 EOF
 else
     cat > "${DMG_TEMP}/README.txt" << 'EOF'
@@ -598,7 +598,7 @@ FIRST RUN — WDSP WISDOM
   minutes. The window will load, but do NOT click Discover/Connect
   until the wisdom build settles. Subsequent launches are instant.
 
-More info: https://github.com/Kb2uka/openhpsdr-zeus
+More info: https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus
 EOF
 fi
 

--- a/installers/zeus-windows.iss
+++ b/installers/zeus-windows.iss
@@ -9,7 +9,7 @@
 #define MyAppName "OpenHPSDR-Zeus"
 #define MyAppShortName "OpenHPSDR-Zeus"
 #define MyAppPublisher "Brian Keating (EI6LF), Douglas J. Cerrato (KB2UKA), Christian Suarez (N9WAR), and contributors"
-#define MyAppURL "https://github.com/Kb2uka/openhpsdr-zeus"
+#define MyAppURL "https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus"
 #define MyAppExeName "OpenhpsdrZeus.exe"
 
 ; Version will be passed via /DMyAppVersion="x.y.z" command line parameter

--- a/zeus-web/src/components/AboutPanel.tsx
+++ b/zeus-web/src/components/AboutPanel.tsx
@@ -69,7 +69,7 @@ export function AboutPanel() {
     setChecking(true);
     try {
       const response = await fetch(
-        'https://api.github.com/repos/Kb2uka/openhpsdr-zeus/releases/latest'
+        'https://api.github.com/repos/OpenHPSDR-Zeus-org/openhpsdr-zeus/releases/latest'
       );
       if (!response.ok) {
         throw new Error(`GitHub API returned ${response.status}`);
@@ -156,7 +156,7 @@ export function AboutPanel() {
           >
             🎉 A new version is available!{' '}
             <a
-              href="https://github.com/Kb2uka/openhpsdr-zeus/releases/latest"
+              href="https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus/releases/latest"
               target="_blank"
               rel="noopener noreferrer"
               style={{ color: 'var(--accent)', textDecoration: 'underline' }}
@@ -226,12 +226,12 @@ export function AboutPanel() {
         <p style={{ margin: 0, lineHeight: 1.6, color: 'var(--fg-2)', fontSize: 11 }}>
           Licensed under GNU GPL v2 or later. See{' '}
           <a
-            href="https://github.com/Kb2uka/openhpsdr-zeus"
+            href="https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus"
             target="_blank"
             rel="noopener noreferrer"
             style={{ color: 'var(--accent)', textDecoration: 'underline' }}
           >
-            github.com/Kb2uka/openhpsdr-zeus
+            github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus
           </a>{' '}
           for source code and documentation.
         </p>


### PR DESCRIPTION
## What

After the org migration, hardcoded `github.com/Kb2uka/openhpsdr-zeus` URLs were still baked into user-facing and build surfaces. They kept working via GitHub's transfer redirect, but that's why the old repo name still showed up — most visibly in the **nightly release notes** and the in-app **About panel**.

This repoints them to the canonical org path. **Same destination, zero behavior change** — we're just no longer leaning on the redirect.

## Changed (functional / user-facing only)

- **`zeus-web/AboutPanel.tsx`** — update-check API call (`api.github.com/repos/...`) + the two repo links
- **`.github/workflows/release.yml`** — LICENSE link in the nightly release body
- **`installers/`** — "More info" links in Linux AppImage, Linux package, macOS app (×2), Windows `.iss`
- **`Zeus.Plugins.Contracts.csproj`** RepositoryUrl, **`ActivationSpotsService.cs`** user-agent, **ISSUE_TEMPLATE** wiki link, sync-workflow comment

## Left as-is (intentional)

Historical references — beads data, RCA/lesson docs, PR #119 / issue-number comments — keep accurate history and the redirect keeps them valid.

## Why develop (not main)

The nightly builds develop's source with `release.yml@develop`, so landing here removes the old URL from the **next nightly**. main's tagged-release LICENSE link comes along at the next develop→main merge — no main change needed now.

## Verification

- `npm --prefix zeus-web run build` ✅
- `dotnet build Zeus.slnx` ✅ (0 warnings, 0 errors)
- Nightly publish target is `${{ github.repository }}` (dynamic → org), so nothing functional was wired to the old name.