### PR TITLE
feat(cat): Kenwood TS-2000 CAT control over TCP + Network settings tab

### DIFF
--- a/Zeus.Contracts/CatDtos.cs
+++ b/Zeus.Contracts/CatDtos.cs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+namespace Zeus.Contracts;
+
+/// <summary>Persisted CAT (Kenwood TS-2000 over TCP) server config. Mirrors
+/// <see cref="TciRuntimeConfig"/>. Default port 19090 (operator-configurable —
+/// there is no universal TCP-CAT port; match it to your client).</summary>
+public sealed record CatRuntimeConfig(
+    bool Enabled = false,
+    string BindAddress = "127.0.0.1",
+    int Port = 19090);
+
+/// <summary>CAT server status response. Mirrors <see cref="TciStatus"/>.</summary>
+public sealed record CatStatus(
+    bool CurrentlyEnabled,
+    int CurrentPort,
+    string CurrentBindAddress,
+    bool PendingEnabled,
+    int PendingPort,
+    string PendingBindAddress,
+    int ClientCount,
+    bool PortAvailable,
+    bool RequiresRestart,
+    string? Error);
+
+/// <summary>CAT port test request. Mirrors <see cref="TciTestRequest"/>.</summary>
+public sealed record CatTestRequest(string BindAddress, int Port);
+
+/// <summary>CAT port test result. Mirrors <see cref="TciTestResult"/>.</summary>
+public sealed record CatTestResult(bool Ok, string? Error);

--- a/Zeus.Contracts/MoxSource.cs
+++ b/Zeus.Contracts/MoxSource.cs
@@ -44,4 +44,11 @@ public enum MoxSource : byte
     /// override. The plugin keys; on-air audio still flows through the normal
     /// TX chain and all interlocks.</summary>
     Plugin = 4,
+    /// <summary>A CAT (Kenwood TS-2000 over TCP) client keying TX via a
+    /// <c>TX;</c> command — a logger / digital-mode app (WSJT-X, N1MM+,
+    /// fldigi, Hamlib net rigctl). Same release rule as <see cref="Tci"/>:
+    /// only the CAT source releases what it itself claimed, and
+    /// <see cref="UI"/> remains the master override. CAT keying never arms
+    /// PureSignal and never auto-keys on connect.</summary>
+    Cat = 5,
 }

--- a/Zeus.Server.Hosting/Cat/CatCommandHandler.cs
+++ b/Zeus.Server.Hosting/Cat/CatCommandHandler.cs
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using Zeus.Contracts;
+
+namespace Zeus.Server.Cat;
+
+/// <summary>
+/// Stateless-per-connection Kenwood TS-2000 command dispatcher. Holds the
+/// per-session Auto-Information level and routes each parsed command to the
+/// verified Zeus seams. Deliberately decoupled from socket I/O (it takes a
+/// <c>send</c> callback and a <c>latestRxDbm</c> accessor) so the full Tier-1
+/// command surface — including the safety-critical "no auto-key" and per-source
+/// MOX-ownership behaviour — is unit-testable without a TCP connection.
+///
+/// All keying goes through <see cref="TxService.TrySetMox"/> with
+/// <see cref="MoxSource.Cat"/>; CAT never arms PureSignal and only keys on an
+/// explicit <c>TX;</c>.
+/// </summary>
+internal sealed class CatCommandHandler
+{
+    private readonly RadioService _radio;
+    private readonly TxService _tx;
+    private readonly CatOptions _options;
+    private readonly Func<double> _latestRxDbm;
+    private readonly Action<string> _send;
+
+    private int _autoInfo;
+
+    public CatCommandHandler(
+        RadioService radio,
+        TxService tx,
+        CatOptions options,
+        Func<double> latestRxDbm,
+        Action<string> send)
+    {
+        _radio = radio;
+        _tx = tx;
+        _options = options;
+        _latestRxDbm = latestRxDbm;
+        _send = send;
+    }
+
+    /// <summary>True once the client issued AI1/AI2 — gates unsolicited pushes.</summary>
+    public bool AutoInfoEnabled => Volatile.Read(ref _autoInfo) > 0;
+
+    public void Dispatch(string token)
+    {
+        string cmd = CatProtocol.CommandId(token);
+        string args = CatProtocol.Args(token);
+        switch (cmd)
+        {
+            case "ID": _send("ID019;"); break;                            // TS-2000 id (Hamlib requires first)
+            case "PS": _send("PS1;"); break;                              // power on
+            case "AI": HandleAi(args); break;
+            case "FA": HandleFreq(args, vfoB: false); break;
+            case "FB": HandleFreq(args, vfoB: true); break;
+            case "MD": HandleMode(args); break;
+            case "IF": HandleIf(); break;
+            case "TX": _tx.TrySetMox(true, MoxSource.Cat, out _); break;   // explicit key only
+            case "RX": _tx.TrySetMox(false, MoxSource.Cat, out _); break;
+            case "FR": HandleFrFt(args, "FR"); break;                     // RX VFO / split (report-only Tier-1)
+            case "FT": HandleFrFt(args, "FT"); break;
+            case "SM": HandleSmeter(); break;
+            case "PC": HandlePc(args); break;
+            default: _send(CatProtocol.Error); break;                     // "?;" — Kenwood unknown/unsupported
+        }
+    }
+
+    private void HandleAi(string args)
+    {
+        if (args.Length == 0)
+        {
+            _send(CatProtocol.Response("AI", Volatile.Read(ref _autoInfo).ToString()));
+            return;
+        }
+        if (int.TryParse(args.AsSpan(0, 1), out int level))
+        {
+            Volatile.Write(ref _autoInfo, level);
+            // On enabling, optionally seed current state so the client need not
+            // poll. RX/status only — never a TX frame, never a key.
+            if (level > 0 && _options.SendInitialStateOnConnect)
+                HandleIf();
+        }
+    }
+
+    private void HandleFreq(string args, bool vfoB)
+    {
+        string cmd = vfoB ? "FB" : "FA";
+        if (args.Length == 0)
+        {
+            var state = _radio.Snapshot();
+            // VFO B lives in the Receivers projection at index 1 (the flat
+            // VFO-B fields were retired in the A/B wire collapse); fall back to
+            // VFO A when there is no second receiver.
+            long f = state.VfoHz;
+            if (vfoB)
+            {
+                var rxs = state.Receivers;
+                f = rxs is not null && rxs.Count > 1 ? rxs[1].VfoHz : state.VfoHz;
+            }
+            _send(CatProtocol.Response(cmd, CatProtocol.FormatFreq(f)));
+            return;
+        }
+        if (CatProtocol.TryParseFreq(args, out long hz) && hz > 0)
+        {
+            // External source — bypass the frozen-NCO recenter heuristic so the
+            // hardware tracks the commanded frequency absolutely (issue #461,
+            // same as TCI). Kenwood set commands have no reply.
+            if (vfoB) _radio.SetVfoB(hz);
+            else _radio.SetVfo(hz, fromExternal: true);
+        }
+    }
+
+    private void HandleMode(string args)
+    {
+        if (args.Length == 0)
+        {
+            _send(CatProtocol.Response("MD", CatProtocol.ModeDigit(_radio.Snapshot().Mode)));
+            return;
+        }
+        var mode = CatProtocol.ParseMode(args[..1]);
+        if (mode is not null) _radio.SetMode(mode.Value);
+    }
+
+    private void HandleIf()
+    {
+        var state = _radio.Snapshot();
+        _send(CatProtocol.Response("IF",
+            CatProtocol.BuildIfBody(state.VfoHz, state.Mode, _tx.IsMoxOn, split: false)));
+    }
+
+    private void HandleFrFt(string args, string cmd)
+    {
+        // Zeus has no true split seam yet (RIT/XIT/split are Tier-2). Report RX
+        // and TX both on VFO A (no split); accept a set without error so clients
+        // that probe split don't choke. WSJT-X "Fake It" needs no split.
+        if (args.Length == 0) _send(CatProtocol.Response(cmd, "0"));
+    }
+
+    private void HandleSmeter()
+    {
+        // SM reply: "SM" + P1(meter 0=main) + 4-digit value (0000-0030).
+        _send(CatProtocol.Response("SM", "0" + CatProtocol.SMeterField(_latestRxDbm())));
+    }
+
+    private void HandlePc(string args)
+    {
+        if (args.Length == 0)
+        {
+            int cur = Math.Clamp(_radio.Snapshot().DrivePct, 0, 100);
+            _send(CatProtocol.Response("PC", cur.ToString().PadLeft(3, '0')));
+            return;
+        }
+        if (int.TryParse(args, out int set))
+        {
+            set = Math.Clamp(set, 0, 100);
+            if (_options.LimitPowerLevels) set = Math.Min(set, 50);
+            _radio.SetDrive(set);
+        }
+    }
+}

--- a/Zeus.Server.Hosting/Cat/CatOptions.cs
+++ b/Zeus.Server.Hosting/Cat/CatOptions.cs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+namespace Zeus.Server.Cat;
+
+/// <summary>
+/// Configuration for the CAT (Computer Aided Transceiver) server. CAT is a
+/// Kenwood TS-2000 ASCII command protocol carried over a raw TCP socket,
+/// spoken by loggers (N1MM+, Log4OM), digital-mode apps (WSJT-X, JTDX,
+/// fldigi), and the Hamlib <c>rigctl</c>/<c>net rigctl</c> bridge. It mirrors
+/// the TCI server (<see cref="Tci.TciOptions"/>); the only structural
+/// difference is transport (raw TCP vs. WebSocket-over-Kestrel).
+/// </summary>
+public sealed class CatOptions
+{
+    /// <summary>
+    /// Enable the CAT server. Defaults to false for security — CAT has no
+    /// authentication; localhost binding is the security boundary.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Bind address for the CAT TCP server. Defaults to 127.0.0.1
+    /// (localhost-only). Set to "0.0.0.0" to allow LAN clients, but only on
+    /// trusted networks — CAT grants full TX control with no authentication.
+    /// </summary>
+    public string BindAddress { get; set; } = "127.0.0.1";
+
+    /// <summary>
+    /// TCP port for the CAT server. Defaults to 19090 (the piHPSDR rigctl
+    /// default — recognizable to SDR operators; avoids 6060/5173/40001). There
+    /// is no universal TCP-CAT port standard, so this MUST be set to whatever
+    /// the client (WSJT-X/N1MM/fldigi/Hamlib) is pointed at.
+    /// </summary>
+    public int Port { get; set; } = 19090;
+
+    /// <summary>
+    /// Rate-limit interval in milliseconds for coalescing high-frequency
+    /// Auto-Information (AI) pushes (VFO changes during tuning). Defaults to
+    /// 50 ms (20 Hz). Without this, an AI2 client spinning the VFO floods the
+    /// link. Mirrors <see cref="Tci.TciOptions.RateLimitMs"/>.
+    /// </summary>
+    public int RateLimitMs { get; set; } = 50;
+
+    /// <summary>
+    /// Send the current radio state to a client immediately after it enables
+    /// Auto-Information (AI1/AI2). Defaults to true. Poll-only (AI0) clients
+    /// never receive unsolicited frames regardless.
+    /// </summary>
+    public bool SendInitialStateOnConnect { get; set; } = true;
+
+    /// <summary>
+    /// Limit TX drive (PC command) to a safe level for unattended automated
+    /// operation. When true, drive is clamped to 50%. Defaults to false.
+    /// Mirrors <see cref="Tci.TciOptions.LimitPowerLevels"/>.
+    /// </summary>
+    public bool LimitPowerLevels { get; set; } = false;
+}

--- a/Zeus.Server.Hosting/Cat/CatProtocol.cs
+++ b/Zeus.Server.Hosting/Cat/CatProtocol.cs
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using System.Text;
+using Zeus.Contracts;
+
+namespace Zeus.Server.Cat;
+
+/// <summary>
+/// Pure parse/format helpers for the Kenwood TS-2000 CAT protocol (the subset
+/// Thetis emulates and that WSJT-X / N1MM+ / fldigi / Hamlib require). All
+/// I/O lives in <see cref="CatSession"/>; everything here is a side-effect-free
+/// transform so it can be unit-tested in isolation. ASCII only.
+///
+/// Framing: commands are a 2-letter prefix + optional fixed-width args, each
+/// terminated by ';'. They may arrive batched ("FA;MD;") or split across TCP
+/// segments — <see cref="ExtractCommands"/> handles both.
+///
+/// The <see cref="BuildIfBody"/> field layout is taken byte-for-byte from
+/// Thetis <c>CATCommands.IF()</c> (the authoritative reference): freq(11) +
+/// step(4) + RIT/XIT-value(6) + RIT(1) + XIT(1) + membank(3) + TX/RX(1) +
+/// mode(1) + FR/FT(1) + scan(1) + split(1) + balance(4) = 35 bytes.
+/// </summary>
+public static class CatProtocol
+{
+    public const char Terminator = ';';
+
+    /// <summary>Wrap a payload into a full terminated response, e.g.
+    /// <c>Response("FA", "00007074000")</c> → <c>"FA00007074000;"</c>.</summary>
+    public static string Response(string cmd, string payload = "") => cmd + payload + Terminator;
+
+    /// <summary>The Kenwood "command not understood" reply.</summary>
+    public const string Error = "?;";
+
+    /// <summary>
+    /// Split an accumulator into complete commands (terminator stripped) and
+    /// the trailing remainder (an incomplete command still arriving). Pure: the
+    /// caller keeps the remainder for the next read. Returns whole tokens like
+    /// "FA00007074000" or "ID".
+    /// </summary>
+    public static (List<string> Commands, string Remainder) ExtractCommands(string accumulated)
+    {
+        var commands = new List<string>();
+        int start = 0;
+        for (int i = 0; i < accumulated.Length; i++)
+        {
+            if (accumulated[i] != Terminator) continue;
+            var token = accumulated.Substring(start, i - start).Trim();
+            if (token.Length > 0) commands.Add(token);
+            start = i + 1;
+        }
+        return (commands, accumulated[start..]);
+    }
+
+    /// <summary>The 2-letter command id (upper-cased), or "" if too short.</summary>
+    public static string CommandId(string token) =>
+        token.Length >= 2 ? token[..2].ToUpperInvariant() : token.ToUpperInvariant();
+
+    /// <summary>The argument portion after the 2-letter id ("" for a bare query).</summary>
+    public static string Args(string token) => token.Length > 2 ? token[2..] : "";
+
+    /// <summary>Format a frequency in Hz as the 11-digit Kenwood field. Values
+    /// wider than 11 digits keep the least-significant 11 (matches Thetis).</summary>
+    public static string FormatFreq(long hz)
+    {
+        if (hz < 0) hz = 0;
+        var s = hz.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        return s.Length > 11 ? s[^11..] : s.PadLeft(11, '0');
+    }
+
+    /// <summary>Parse an 11-digit (or shorter) Kenwood frequency field to Hz.</summary>
+    public static bool TryParseFreq(string field, out long hz) =>
+        long.TryParse(field, System.Globalization.NumberStyles.None,
+            System.Globalization.CultureInfo.InvariantCulture, out hz);
+
+    /// <summary>Zeus mode → Kenwood TS-2000 mode digit. Unknown/Zeus-only modes
+    /// fall back to "2" (USB), matching Thetis's Mode2KString fallback.</summary>
+    public static string ModeDigit(RxMode mode) => mode switch
+    {
+        RxMode.LSB => "1",
+        RxMode.USB => "2",
+        // Kenwood digit 3 = CW (normal, upper = CWU); 7 = CW-R (reverse = CWL).
+        // Matches Thetis Mode2KString and Hamlib (3=RIG_MODE_CW, 7=RIG_MODE_CWR).
+        RxMode.CWU => "3",
+        RxMode.FM => "4",
+        RxMode.AM => "5",
+        RxMode.DIGL => "6",
+        RxMode.CWL => "7",
+        RxMode.DIGU => "9",
+        RxMode.SAM => "5",   // no Kenwood equivalent — report as AM
+        RxMode.DSB => "2",   // no Kenwood equivalent — report as USB
+        RxMode.FreeDv => "2", // runs as USB at the WDSP layer
+        _ => "2",
+    };
+
+    /// <summary>Kenwood TS-2000 mode digit → Zeus mode, or null if unmapped.</summary>
+    public static RxMode? ParseMode(string field) => field switch
+    {
+        "1" => RxMode.LSB,
+        "2" => RxMode.USB,
+        "3" => RxMode.CWU,   // Kenwood 3 = CW (normal) → CWU
+        "4" => RxMode.FM,
+        "5" => RxMode.AM,
+        "6" => RxMode.DIGL,
+        "7" => RxMode.CWL,   // Kenwood 7 = CW-R (reverse) → CWL
+        "9" => RxMode.DIGU,
+        _ => null,
+    };
+
+    /// <summary>
+    /// Map a receive level in dBm to the Kenwood SM meter range (0000–0030).
+    /// Approximate, monotonic, Tier-1 (digital-mode/logging clients don't gate
+    /// on SM accuracy; precise S-unit calibration is a documented follow-up).
+    /// ~-121 dBm → 0, ~-1 dBm → 30 (≈4 dB per step).
+    /// </summary>
+    public static int SMeter(double dbm)
+    {
+        int v = (int)Math.Round((dbm + 121.0) / 4.0);
+        return Math.Clamp(v, 0, 30);
+    }
+
+    /// <summary>4-digit zero-padded SM field, e.g. 14 → "0014".</summary>
+    public static string SMeterField(double dbm) =>
+        SMeter(dbm).ToString(System.Globalization.CultureInfo.InvariantCulture).PadLeft(4, '0');
+
+    /// <summary>
+    /// Build the 35-byte IF response body (NOT including the "IF" prefix or the
+    /// ';' terminator). Field widths are exact per Thetis CATCommands.IF().
+    /// RIT/XIT are Tier-2; for Tier-1 pass ritOn=xitOn=false (→ "+00000").
+    /// </summary>
+    public static string BuildIfBody(
+        long freqHz, RxMode mode, bool mox, bool split,
+        int ritXitHz = 0, bool ritOn = false, bool xitOn = false)
+    {
+        int it = ritOn ? ritXitHz : (xitOn ? ritXitHz : 0);
+        string incr = (it < 0 ? "-" : "+")
+            + Math.Min(Math.Abs(it), 99999).ToString(System.Globalization.CultureInfo.InvariantCulture).PadLeft(5, '0');
+
+        var sb = new StringBuilder(35);
+        sb.Append(FormatFreq(freqHz)); // P1 freq            11
+        sb.Append("0000");             // P2 step size        4 (Zeus exposes no tune-step)
+        sb.Append(incr);               // P3 RIT/XIT value    6 (sign + 5)
+        sb.Append(ritOn ? '1' : '0');  // P4 RIT status       1
+        sb.Append(xitOn ? '1' : '0');  // P5 XIT status       1
+        sb.Append("000");              // P6 memory bank      3 (dummy)
+        sb.Append(mox ? '1' : '0');    // P7 TX/RX status     1
+        sb.Append(ModeDigit(mode));    // P8 mode             1
+        sb.Append('0');                // P9 FR/FT            1 (dummy)
+        sb.Append('0');                // P10 scan            1 (dummy)
+        sb.Append(split ? '1' : '0');  // P11 split           1
+        sb.Append("0000");             // P12 balance         4 (dummy)
+        return sb.ToString();          // total              35
+    }
+}

--- a/Zeus.Server.Hosting/Cat/CatServer.cs
+++ b/Zeus.Server.Hosting/Cat/CatServer.cs
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Sockets;
+using Microsoft.Extensions.Options;
+using Zeus.Contracts;
+
+namespace Zeus.Server.Cat;
+
+/// <summary>
+/// CAT (Computer Aided Transceiver) server. Accepts Kenwood TS-2000 ASCII
+/// clients on a dedicated raw-TCP listener (default :19090). Spoken by loggers
+/// (N1MM+, Log4OM), digital-mode apps (WSJT-X, JTDX, fldigi), and the Hamlib
+/// <c>rigctl</c> bridge. Mirrors <see cref="Tci.TciServer"/>; the one structural
+/// difference is that CAT owns its <see cref="TcpListener"/> accept loop (TCI's
+/// accept loop is provided by Kestrel, which cannot serve a raw line protocol).
+///
+/// Control-only: unlike TCI there is no IQ / RX-audio / TX-chrono streaming, so
+/// none of that machinery exists here. Unsolicited frames go only to clients
+/// that enabled Auto-Information (AI1/AI2); a fresh connection is silent until
+/// the client speaks, and CAT never auto-keys TX.
+/// </summary>
+public sealed class CatServer : IHostedService, IDisposable
+{
+    private readonly ILogger<CatServer> _log;
+    private readonly CatOptions _options;
+    private readonly RadioService _radio;
+    private readonly TxService _tx;
+    private readonly DspPipelineService _pipeline;
+    private readonly ILoggerFactory _loggerFactory;
+
+    private readonly ConcurrentDictionary<Guid, CatSession> _clients = new();
+    private TcpListener? _listener;
+    private CancellationTokenSource? _acceptCts;
+    private Task? _acceptTask;
+    private bool _subscribed;
+
+    // Latest RX signal level (dBm) for the SM (S-meter) poll. Stored as long
+    // bits + Interlocked so a 32-bit runtime (Pi) can't read a torn double.
+    private long _latestRxDbmBits = BitConverter.DoubleToInt64Bits(-130.0);
+
+    public CatServer(
+        IOptions<CatOptions> options,
+        RadioService radio,
+        TxService tx,
+        DspPipelineService pipeline,
+        ILoggerFactory loggerFactory)
+    {
+        _log = loggerFactory.CreateLogger<CatServer>();
+        _options = options.Value;
+        _radio = radio;
+        _tx = tx;
+        _pipeline = pipeline;
+        _loggerFactory = loggerFactory;
+    }
+
+    public int ClientCount => _clients.Count;
+
+    public double LatestRxDbm => BitConverter.Int64BitsToDouble(Interlocked.Read(ref _latestRxDbmBits));
+
+    public Task StartAsync(CancellationToken ct)
+    {
+        if (!_options.Enabled)
+        {
+            _log.LogInformation("cat.disabled (set Cat:Enabled=true to enable)");
+            return Task.CompletedTask;
+        }
+
+        IPAddress ip;
+        if (_options.BindAddress is "0.0.0.0" or "*" or "")
+            ip = IPAddress.Any;
+        else if (string.Equals(_options.BindAddress, "localhost", StringComparison.OrdinalIgnoreCase))
+            ip = IPAddress.Loopback;
+        else if (!IPAddress.TryParse(_options.BindAddress, out ip!))
+        {
+            _log.LogWarning("cat.bind.invalid bind={Bind} — CAT not started", _options.BindAddress);
+            return Task.CompletedTask;
+        }
+
+        try
+        {
+            _listener = new TcpListener(ip, _options.Port);
+            _listener.Start();
+        }
+        catch (SocketException ex)
+        {
+            _log.LogWarning(ex, "cat.listen.failed bind={Bind} port={Port} — CAT not started",
+                _options.BindAddress, _options.Port);
+            _listener = null;
+            return Task.CompletedTask;
+        }
+
+        _radio.StateChanged += OnRadioStateChanged;
+        _radio.MoxChanged += OnMoxChanged;
+        _pipeline.RxMeterUpdated += OnRxMeterUpdated;
+        _subscribed = true;
+
+        _acceptCts = new CancellationTokenSource();
+        _acceptTask = AcceptLoopAsync(_acceptCts.Token);
+
+        _log.LogInformation("cat.listening bind={Bind} port={Port}", _options.BindAddress, _options.Port);
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken ct)
+    {
+        if (_subscribed)
+        {
+            _radio.StateChanged -= OnRadioStateChanged;
+            _radio.MoxChanged -= OnMoxChanged;
+            _pipeline.RxMeterUpdated -= OnRxMeterUpdated;
+            _subscribed = false;
+        }
+
+        _acceptCts?.Cancel();
+        try { _listener?.Stop(); } catch { /* already torn down */ }
+
+        _log.LogInformation("cat.stopping active={Count}", _clients.Count);
+        foreach (var session in _clients.Values) session.Dispose();
+        _clients.Clear();
+
+        if (_acceptTask is not null)
+        {
+            try { await _acceptTask.WaitAsync(TimeSpan.FromSeconds(2), ct); }
+            catch { /* accept loop drained or timed out */ }
+        }
+        _acceptCts?.Dispose();
+        _acceptCts = null;
+    }
+
+    private async Task AcceptLoopAsync(CancellationToken ct)
+    {
+        var listener = _listener!;
+        while (!ct.IsCancellationRequested)
+        {
+            TcpClient client;
+            try
+            {
+                client = await listener.AcceptTcpClientAsync(ct);
+            }
+            catch (OperationCanceledException) { return; }
+            catch (ObjectDisposedException) { return; }
+            catch (SocketException) when (ct.IsCancellationRequested) { return; }
+            catch (SocketException ex)
+            {
+                _log.LogDebug(ex, "cat.accept transient error");
+                continue;
+            }
+
+            _ = HandleClientAsync(client, ct);
+        }
+    }
+
+    private async Task HandleClientAsync(TcpClient client, CancellationToken ct)
+    {
+        var id = Guid.NewGuid();
+        var sessionLog = _loggerFactory.CreateLogger<CatSession>();
+        var session = new CatSession(id, client, sessionLog, _radio, _tx, _options, () => LatestRxDbm);
+        _clients[id] = session;
+        _log.LogInformation("cat.client.connected id={Id} total={Count}", id, _clients.Count);
+        try
+        {
+            await session.RunAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            _log.LogDebug(ex, "cat.client ended with error id={Id}", id);
+        }
+        finally
+        {
+            _clients.TryRemove(id, out _);
+            session.Dispose();
+            _log.LogInformation("cat.client.disconnected id={Id} total={Count}", id, _clients.Count);
+        }
+    }
+
+    // --- Auto-Information pushes (AI1/AI2 sessions only) ---
+
+    private void OnRadioStateChanged(StateDto state)
+    {
+        if (_clients.IsEmpty) return;
+        // VFO can fire rapidly during tuning → rate-limit FA and IF.
+        BroadcastRateLimited("FA", CatProtocol.Response("FA", CatProtocol.FormatFreq(state.VfoHz)));
+        Broadcast(CatProtocol.Response("MD", CatProtocol.ModeDigit(state.Mode)));
+        BroadcastRateLimited("IF",
+            CatProtocol.Response("IF", CatProtocol.BuildIfBody(state.VfoHz, state.Mode, _tx.IsMoxOn, split: false)));
+    }
+
+    private void OnMoxChanged(bool moxOn)
+    {
+        if (_clients.IsEmpty) return;
+        var state = _radio.Snapshot();
+        // TX/RX transition is immediate (not rate-limited) so a logger sees the
+        // edge promptly. IF carries the TX/RX bit.
+        Broadcast(CatProtocol.Response("IF", CatProtocol.BuildIfBody(state.VfoHz, state.Mode, moxOn, split: false)));
+    }
+
+    private void OnRxMeterUpdated(int channelId, double dbm)
+    {
+        // RX1 only for the SM poll; just cache the latest level (no push — SM is
+        // a polled command in the Kenwood protocol).
+        if (channelId == 0)
+            Interlocked.Exchange(ref _latestRxDbmBits, BitConverter.DoubleToInt64Bits(dbm));
+    }
+
+    private void Broadcast(string line)
+    {
+        foreach (var session in _clients.Values)
+            if (session.AutoInfoEnabled) session.Send(line);
+    }
+
+    private void BroadcastRateLimited(string key, string line)
+    {
+        foreach (var session in _clients.Values)
+            if (session.AutoInfoEnabled) session.SendRateLimited(key, line);
+    }
+
+    public void Dispose()
+    {
+        foreach (var session in _clients.Values) session.Dispose();
+        _clients.Clear();
+        _acceptCts?.Dispose();
+    }
+}

--- a/Zeus.Server.Hosting/Cat/CatSession.cs
+++ b/Zeus.Server.Hosting/Cat/CatSession.cs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using System.Collections.Concurrent;
+using System.Net.Sockets;
+using System.Text;
+using Zeus.Server.Tci; // reuse TciRateLimiter (DRY — generic key/interval coalescer)
+
+namespace Zeus.Server.Cat;
+
+/// <summary>
+/// Per-client CAT session over a raw TCP socket. Mirrors <see cref="TciSession"/>:
+/// a send loop drains an outbound queue; a receive loop accumulates bytes until
+/// a ';' terminator and hands each complete Kenwood command to a
+/// <see cref="CatCommandHandler"/>. This class owns only the socket I/O and the
+/// framing; the command logic (and its safety properties — no auto-key,
+/// per-source MOX ownership) lives in the handler so it can be unit-tested
+/// without a TCP connection.
+/// </summary>
+public sealed class CatSession : IDisposable
+{
+    // The longest legal Kenwood command is well under this; a token that grows
+    // past it without a terminator is a misbehaving/abusive client → dropped.
+    private const int MaxPendingChars = 256;
+
+    private readonly Guid _id;
+    private readonly TcpClient _client;
+    private readonly NetworkStream _stream;
+    private readonly ILogger<CatSession> _log;
+    private readonly TciRateLimiter _rateLimiter;
+    private readonly CatCommandHandler _handler;
+
+    private readonly ConcurrentQueue<string> _outbound = new();
+    private readonly SemaphoreSlim _outboundSignal = new(0);
+    private int _disposed;
+
+    public CatSession(
+        Guid id,
+        TcpClient client,
+        ILogger<CatSession> log,
+        RadioService radio,
+        TxService tx,
+        CatOptions options,
+        Func<double> latestRxDbm)
+    {
+        _id = id;
+        _client = client;
+        _stream = client.GetStream();
+        _log = log;
+        _rateLimiter = new TciRateLimiter(options.RateLimitMs, Send);
+        _handler = new CatCommandHandler(radio, tx, options, latestRxDbm, Send);
+    }
+
+    /// <summary>True once the client has issued AI1/AI2 — gates unsolicited
+    /// state-change pushes the server broadcasts.</summary>
+    public bool AutoInfoEnabled => _handler.AutoInfoEnabled;
+
+    public async Task RunAsync(CancellationToken ct)
+    {
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        try
+        {
+            var sendTask = SendLoopAsync(linkedCts.Token);
+            var recvTask = ReceiveLoopAsync(linkedCts.Token);
+            await Task.WhenAny(sendTask, recvTask);
+            linkedCts.Cancel();
+            try { await Task.WhenAll(sendTask, recvTask); } catch { /* drained */ }
+        }
+        finally
+        {
+            _rateLimiter.Dispose();
+        }
+    }
+
+    /// <summary>Enqueue a terminated CAT response for sending.</summary>
+    public void Send(string line)
+    {
+        if (Volatile.Read(ref _disposed) != 0) return;
+        _outbound.Enqueue(line);
+        try { _outboundSignal.Release(); } catch (ObjectDisposedException) { }
+    }
+
+    /// <summary>Enqueue a rate-limited (coalesced-by-key) push, e.g. FA during a
+    /// VFO spin. Bursts collapse to one send per RateLimitMs.</summary>
+    public void SendRateLimited(string key, string line) => _rateLimiter.Enqueue(key, line);
+
+    private async Task SendLoopAsync(CancellationToken ct)
+    {
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                await _outboundSignal.WaitAsync(ct);
+                while (_outbound.TryDequeue(out var line))
+                {
+                    var bytes = Encoding.ASCII.GetBytes(line);
+                    await _stream.WriteAsync(bytes, ct);
+                    await _stream.FlushAsync(ct);
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (IOException ex) { _log.LogDebug(ex, "cat send loop ended id={Id}", _id); }
+        catch (ObjectDisposedException) { }
+        catch (Exception ex) { _log.LogDebug(ex, "cat send loop failed id={Id}", _id); }
+    }
+
+    private async Task ReceiveLoopAsync(CancellationToken ct)
+    {
+        var buf = new byte[2048];
+        var acc = new StringBuilder();
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                int n = await _stream.ReadAsync(buf, ct);
+                if (n == 0) return; // peer closed
+
+                acc.Append(Encoding.ASCII.GetString(buf, 0, n));
+                var (commands, remainder) = CatProtocol.ExtractCommands(acc.ToString());
+                acc.Clear();
+                // Bound an un-terminated command so a client that never sends ';'
+                // can't grow the buffer without limit.
+                acc.Append(remainder.Length > MaxPendingChars ? string.Empty : remainder);
+
+                foreach (var token in commands)
+                {
+                    try { _handler.Dispatch(token); }
+                    catch (Exception ex) { _log.LogDebug(ex, "cat dispatch error id={Id} token={Token}", _id, token); }
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (IOException ex) { _log.LogDebug(ex, "cat recv loop ended id={Id}", _id); }
+        catch (ObjectDisposedException) { }
+        catch (Exception ex) { _log.LogDebug(ex, "cat recv loop failed id={Id}", _id); }
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+        try { _outboundSignal.Release(); } catch { }
+        try { _stream.Dispose(); } catch { }
+        try { _client.Dispose(); } catch { }
+        _outboundSignal.Dispose();
+    }
+}

--- a/Zeus.Server.Hosting/CatConfigStore.cs
+++ b/Zeus.Server.Hosting/CatConfigStore.cs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using LiteDB;
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+// Single-row collection: there is one CAT server per Zeus instance, so a
+// profile key would just be ceremony. Mirrors TciConfigStore — same
+// Connection=shared pattern and Directory guard (no new exposure to the
+// Linux LiteDB shared-mode caveat, GH #682).
+public sealed class CatConfigStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<CatConfigEntry> _entries;
+    private readonly ILogger<CatConfigStore> _log;
+    private readonly object _sync = new();
+
+    public CatConfigStore(ILogger<CatConfigStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _entries = _db.GetCollection<CatConfigEntry>("cat_config");
+
+        _log.LogInformation("CatConfigStore initialized at {Path}", dbPath);
+    }
+
+    // null = nothing persisted yet — caller should fall back to appsettings.
+    public CatRuntimeConfig? Get()
+    {
+        lock (_sync)
+        {
+            var e = _entries.FindAll().FirstOrDefault();
+            if (e is null) return null;
+            return new CatRuntimeConfig(
+                Enabled: e.Enabled,
+                BindAddress: e.BindAddress,
+                Port: e.Port);
+        }
+    }
+
+    public void Set(CatRuntimeConfig config)
+    {
+        lock (_sync)
+        {
+            var existing = _entries.FindAll().FirstOrDefault();
+            if (existing is null)
+            {
+                _entries.Insert(new CatConfigEntry
+                {
+                    Enabled = config.Enabled,
+                    BindAddress = config.BindAddress,
+                    Port = config.Port,
+                    UpdatedUtc = DateTime.UtcNow,
+                });
+            }
+            else
+            {
+                existing.Enabled = config.Enabled;
+                existing.BindAddress = config.BindAddress;
+                existing.Port = config.Port;
+                existing.UpdatedUtc = DateTime.UtcNow;
+                _entries.Update(existing);
+            }
+        }
+    }
+
+    public void Dispose() => _db.Dispose();
+}
+
+public sealed class CatConfigEntry
+{
+    public int Id { get; set; }
+    public bool Enabled { get; set; }
+    public string BindAddress { get; set; } = "127.0.0.1";
+    public int Port { get; set; } = 19090;
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/CatManagementService.cs
+++ b/Zeus.Server.Hosting/CatManagementService.cs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using System.Net;
+using System.Net.Sockets;
+using Microsoft.Extensions.Options;
+using Zeus.Contracts;
+using Zeus.Server.Cat;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Management service for CAT server configuration and status. Mirrors
+/// <see cref="TciManagementService"/>. CAT owns its own TcpListener, so a live
+/// rebind is technically possible, but for parity (and to keep the surface
+/// minimal) port/bind changes are persisted and applied on the next restart —
+/// the UI reports RequiresRestart, exactly like TCI. Hot-rebind is a documented
+/// low-risk follow-up.
+/// </summary>
+public sealed class CatManagementService
+{
+    private readonly ILogger<CatManagementService> _log;
+    private readonly CatServer _catServer;
+    private readonly CatOptions _startupOptions;
+    private readonly CatConfigStore _store;
+
+    private CatRuntimeConfig _pendingConfig;
+
+    public CatManagementService(
+        ILogger<CatManagementService> log,
+        CatServer catServer,
+        IOptions<CatOptions> options,
+        CatConfigStore store)
+    {
+        _log = log;
+        _catServer = catServer;
+        _startupOptions = options.Value;
+        _store = store;
+
+        _pendingConfig = _store.Get() ?? new CatRuntimeConfig(
+            Enabled: _startupOptions.Enabled,
+            BindAddress: _startupOptions.BindAddress,
+            Port: _startupOptions.Port);
+    }
+
+    public CatStatus GetStatus()
+    {
+        var currentlyEnabled = _startupOptions.Enabled;
+        var currentPort = _startupOptions.Port;
+        var currentBindAddress = _startupOptions.BindAddress;
+        var clientCount = _catServer.ClientCount;
+
+        // The running CatServer is the listener for this port — probe-binding
+        // the same port here always fails with "address already in use" and
+        // surfaces a false-positive in the UI. Skip it; "is this port free to
+        // switch to?" is answered by TestPort, which the panel calls before a
+        // bind/port change. (Same lesson as TciManagementService.)
+        bool portAvailable = true;
+        string? error = null;
+
+        var requiresRestart = _pendingConfig.Enabled != currentlyEnabled
+                            || _pendingConfig.Port != currentPort
+                            || _pendingConfig.BindAddress != currentBindAddress;
+
+        return new CatStatus(
+            CurrentlyEnabled: currentlyEnabled,
+            CurrentPort: currentPort,
+            CurrentBindAddress: currentBindAddress,
+            PendingEnabled: _pendingConfig.Enabled,
+            PendingPort: _pendingConfig.Port,
+            PendingBindAddress: _pendingConfig.BindAddress,
+            ClientCount: clientCount,
+            PortAvailable: portAvailable,
+            RequiresRestart: requiresRestart,
+            Error: error);
+    }
+
+    public CatStatus SetConfig(CatRuntimeConfig config)
+    {
+        var normalized = new CatRuntimeConfig(
+            Enabled: config.Enabled,
+            BindAddress: string.IsNullOrWhiteSpace(config.BindAddress)
+                ? "127.0.0.1"
+                : config.BindAddress.Trim(),
+            Port: config.Port is > 0 and < 65536 ? config.Port : 19090);
+
+        _pendingConfig = normalized;
+        try
+        {
+            _store.Set(normalized);
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "cat.config.persist failed");
+        }
+
+        _log.LogInformation(
+            "cat.config.updated enabled={Enabled} bind={Bind} port={Port} (restart required)",
+            normalized.Enabled, normalized.BindAddress, normalized.Port);
+
+        return GetStatus();
+    }
+
+    public CatTestResult TestPort(string bindAddress, int port)
+    {
+        if (port is <= 0 or >= 65536)
+            return new CatTestResult(Ok: false, Error: "Port must be between 1 and 65535");
+
+        var addr = string.IsNullOrWhiteSpace(bindAddress) ? "127.0.0.1" : bindAddress.Trim();
+
+        if (!IsPortAvailable(addr, port))
+            return new CatTestResult(Ok: false, Error: $"Port {port} is already in use on {addr}");
+
+        return new CatTestResult(Ok: true, Error: null);
+    }
+
+    private static bool IsPortAvailable(string bindAddress, int port)
+    {
+        try
+        {
+            IPAddress ip;
+            if (bindAddress is "0.0.0.0" or "*" or "")
+                ip = IPAddress.Any;
+            else if (string.Equals(bindAddress, "localhost", StringComparison.OrdinalIgnoreCase))
+                ip = IPAddress.Loopback;
+            else if (!IPAddress.TryParse(bindAddress, out var parsed))
+                return false;
+            else
+                ip = parsed;
+
+            using var socket = new Socket(ip.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+            socket.Bind(new IPEndPoint(ip, port));
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -3280,6 +3280,23 @@ public static class ZeusEndpoints
             return Results.Ok(result);
         });
 
+        app.MapGet("/api/cat/status", (CatManagementService cat) => cat.GetStatus());
+
+        app.MapPost("/api/cat/config", (CatRuntimeConfig req, CatManagementService cat, HttpContext ctx) =>
+        {
+            log.LogInformation("api.cat.config enabled={En} bind={Bind} port={Port}", req.Enabled, req.BindAddress, req.Port);
+            var status = cat.SetConfig(req);
+            return Results.Ok(status);
+        });
+
+        app.MapPost("/api/cat/test", (CatTestRequest req, CatManagementService cat, HttpContext ctx) =>
+        {
+            if (string.IsNullOrWhiteSpace(req.BindAddress) || req.Port is <= 0 or >= 65536)
+                return Results.BadRequest(new { error = "bindAddress and port required" });
+            var result = cat.TestPort(req.BindAddress.Trim(), req.Port);
+            return Results.Ok(result);
+        });
+
         app.Map("/ws", async (HttpContext ctx, StreamingHub hub) =>
         {
             if (!ctx.WebSockets.IsWebSocketRequest)

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -214,6 +214,22 @@ public static class ZeusHost
             tciBindAddress = persistedTci.BindAddress;
             tciPort = persistedTci.Port;
         }
+
+        // CAT (Kenwood TS-2000 over TCP) persisted runtime override, mirroring
+        // the TCI bootstrap above. CatServer reads CatOptions directly (it owns
+        // its TcpListener — no Kestrel binding), so we only need the persisted
+        // value here to feed PostConfigure<CatOptions> below; there is no
+        // cat-enabled/bind/port local to thread into Kestrel.
+        CatRuntimeConfig? persistedCat = null;
+        try
+        {
+            using var bootstrapCatStore = new CatConfigStore(NullLogger<CatConfigStore>.Instance);
+            persistedCat = bootstrapCatStore.Get();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"cat.config.bootstrap-load failed: {ex.Message}");
+        }
         // PERF_PASS_3_DEBUG: force-disable TCI bind when running a second
         // instance on the same box (Brian's main session keeps :40001).
         // Uncommitted local edit.
@@ -821,6 +837,28 @@ public static class ZeusHost
         builder.Services.AddSingleton<SpotBroadcastService>();
         builder.Services.AddHostedService(sp => sp.GetRequiredService<SpotBroadcastService>());
         builder.Services.AddSingleton<TciManagementService>();
+
+        // CAT (Kenwood TS-2000 over TCP) server — control-only sibling of TCI for
+        // loggers / digital-mode apps (WSJT-X, N1MM+, fldigi, Hamlib net rigctl).
+        // Disabled by default; enable via appsettings.json Cat:Enabled=true or the
+        // Network settings tab. CatServer owns its own TcpListener (a raw line
+        // protocol Kestrel can't serve), so — unlike TCI — there is NO Kestrel
+        // port-branch entry below; it binds in its own StartAsync.
+        builder.Services.Configure<Cat.CatOptions>(builder.Configuration.GetSection("Cat"));
+        if (persistedCat is not null)
+        {
+            var pendingCat = persistedCat;
+            builder.Services.PostConfigure<Cat.CatOptions>(o =>
+            {
+                o.Enabled = pendingCat.Enabled;
+                o.BindAddress = pendingCat.BindAddress;
+                o.Port = pendingCat.Port;
+            });
+        }
+        builder.Services.AddSingleton<CatConfigStore>();
+        builder.Services.AddSingleton<Cat.CatServer>();
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<Cat.CatServer>());
+        builder.Services.AddSingleton<CatManagementService>();
 
         // ZeusChat — operator-to-operator chat over the Cloudflare relay.
         // Singleton (API surface) + hosted service (relay connection lifecycle),

--- a/Zeus.Server.Hosting/appsettings.json
+++ b/Zeus.Server.Hosting/appsettings.json
@@ -14,5 +14,13 @@
     "SendInitialStateOnConnect": true,
     "CwBecomesCwuAbove10MHz": false,
     "LimitPowerLevels": false
+  },
+  "Cat": {
+    "Enabled": false,
+    "BindAddress": "127.0.0.1",
+    "Port": 19090,
+    "RateLimitMs": 50,
+    "SendInitialStateOnConnect": true,
+    "LimitPowerLevels": false
   }
 }

--- a/docs/designs/cat-control-plan.md
+++ b/docs/designs/cat-control-plan.md
@@ -1,0 +1,72 @@
+# CAT control (Kenwood TS-2000 over TCP) — implementation plan
+
+Status: **in progress (draft PR build, loop)**. Goal: CAT control to parity with Thetis / MI0BOT
+Thetis for Hermes Lite, mirroring the existing TCI server. New **Network** settings tab absorbs the
+TCI tab and adds CAT beside it. No PureSignal changes; no new deps; cross-platform; TCP only.
+
+## Architecture (mirrors `Zeus.Server.Hosting/Tci/` seam-for-seam)
+
+One deliberate divergence: TCI rides Kestrel (WebSocket-over-HTTP via the ZeusHost `UseWhen`
+port-branch). CAT is a raw ASCII line protocol Kestrel can't serve, so **`CatServer` owns its own
+`TcpListener` accept loop** inside `StartAsync`. Everything else mirrors TCI.
+
+New backend files (each models the named TCI twin):
+- `Zeus.Server.Hosting/Cat/CatOptions.cs` ← TciOptions (Enabled=false, BindAddress=127.0.0.1, Port=19090, RateLimitMs, LimitPowerLevels, SendInitialStateOnConnect).
+- `Zeus.Server.Hosting/Cat/CatProtocol.cs` ← TciProtocol (static parse/format; Kenwood mode map; `FormatFreq` 11-digit; `BuildIf` 35-char TS-2000 IF frame).
+- `Zeus.Server.Hosting/Cat/CatSession.cs` ← TciSession (per-client SendLoop+ReceiveLoop; accumulate bytes until `;` with a capped buffer; dispatch switch; `AutoInfo` flag gates async pushes).
+- `Zeus.Server.Hosting/Cat/CatServer.cs` ← TciServer (IHostedService; owns TcpListener accept loop; subscribes RadioService.StateChanged/MoxChanged + RxMeter; ConcurrentDictionary clients; broadcast only to AI-enabled sessions).
+- `Zeus.Server.Hosting/CatConfigStore.cs` ← TciConfigStore (LiteDB single-row `cat_config`, Connection=shared, Directory guard — same pattern, no new #682 exposure).
+- `Zeus.Server.Hosting/CatManagementService.cs` ← TciManagementService (GetStatus/SetConfig/TestPort; RequiresRestart; self-port-probe skip).
+- `Zeus.Contracts/CatDtos.cs` ← TciDtos (CatRuntimeConfig/CatStatus/CatTestRequest/CatTestResult — additive Contracts, red-light).
+- `Zeus.Contracts/MoxSource.cs` EDIT: append `Cat = 5` (append-only; red-light, sign-off).
+
+Wiring: `ZeusHost.cs` DI + persisted `PostConfigure<CatOptions>` (mirror TCI block; **no** Kestrel/port-branch entry — CAT owns its socket). `ZeusEndpoints.cs`: `/api/cat/status|config|test`. `appsettings.json`: disabled-by-default `Cat` section.
+
+## Verified Zeus seams (CAT reuses, no new radio-path code)
+`_radio.Snapshot()`, `_radio.SetVfo(hz, fromExternal:true)`, `_radio.SetMode(mode)`, `_radio.SetFilter(lo,hi)`,
+`_radio.SetDrive(pct)`, `_tx.TrySetMox(on, MoxSource.Cat, out _)`, `_tx.TrySetTun(on, out _)`, `_tx.IsMoxOn/IsTunOn`.
+Echo post-call truth after MOX (MSHV lesson).
+
+## Command coverage (Kenwood TS-2000 subset)
+**Tier 1 (now):** `ID;`→`ID019;` · `PS;`→`PS1;` · `AI/AI<n>;` (async gate) · `FA/FA<11>;` (VFO A) · `FB/FB<11>;` (VFO B) ·
+`MD/MD<n>;` (mode map 1=LSB,2=USB,3=CWL,4=FM,5=AM,6=DIGL,7=CWU,9=DIGU) · `IF;` (35-char status) · `TX/TX<n>;`→MOX on (MoxSource.Cat) ·
+`RX;`→MOX off · `FR/FT;` (split) · `SM/SM<n>;` (S-meter 0000-0030 from cached RxMeter dBm) · `PC/PC<3>;` (drive, LimitPowerLevels clamp).
+**Tier 2 (next PR):** RT/XT/RU/RD/RC (RIT/XIT), AG (AF gain), GT (AGC), FW (filter), KS/KY (CW keyer), SQ/NB/NR.
+**Tier 3 (defer):** ZZ* extended set, memory MC/MR/MW, antenna AN, scan SC, band BD/BU.
+
+## Transport
+Raw `TcpListener`+`NetworkStream`, ASCII, `;`-terminated; handle split-across-segments AND batched commands;
+cap accumulator (~256 B). Default **port 19090** (operator-configurable; no universal TCP-CAT standard), Enabled=false,
+bind 127.0.0.1 (localhost = security boundary, no auth — same as TCI; UI warns on non-loopback). AI async updates push
+FA/MD/IF to AI-enabled sessions only, VFO rate-limited (reuse TciRateLimiter). **Never** send before a client command;
+**never** auto-key on connect. Port/bind change = RequiresRestart (mirror TCI; hot-rebind a documented follow-up).
+
+## UI — Network tab
+`SettingsMenu.tsx`: `SettingsTabId` `'tci'`→`'network'`; TABS `{id:'network',label:'NETWORK'}`; render `<NetworkSettingsPanel/>`;
+**grep & fix every stale `'tci'` tab ref** (initialTab/deep-links/persisted last-tab → else falls back to PA).
+`NetworkSettingsPanel.tsx`: stacks the unchanged `<TciSettingsPanel/>` + new `<CatSettingsPanel/>` as two titled sub-sections (token styling only).
+`CatSettingsPanel.tsx` (clone TciSettingsPanel), `api/cat.ts` (clone api/tci.ts), `state/cat-store.ts` (clone tci-store.ts; no localStorage seed / no auto-POST on load).
+
+## Safety (baked in)
+PureSignal: zero touches; CAT keys only via `TrySetMox(.., MoxSource.Cat)`. No auto-key/auto-arm on connect (test asserts no MOX after connect+AI).
+`MoxSource.Cat=5` → CAT-keyed MOX only releasable by CAT (UI master; trips bypass). No new deps (raw sockets + hand-written parser).
+Cross-platform (TcpListener/ASCII/Stopwatch only). Default loopback + UI warn on 0.0.0.0.
+
+## Task iterations
+1. **Backend core:** CatOptions, CatDtos, MoxSource.Cat, CatConfigStore, CatProtocol (+ build).
+2. **Server+session:** CatServer (TcpListener accept loop + subscriptions) + CatSession (framing + dispatch + AI) (+ build).
+3. **Tier-1 commands** wired to verified seams; MOX echo.
+4. **Async updates** (StateChanged/MoxChanged/RxMeter → AI sessions, rate-limited).
+5. **Management + endpoints + ZeusHost DI + appsettings.**
+6. **Frontend** Network tab + CAT panel/store/api + stale-tci-ref fixes (+ npm build).
+7. **Tests** (CatProtocol IF/mode round-trip; CatSession dispatch/AI/MOX-ownership/no-auto-key; CatManagementService persist/restart/test via IsolatedPrefsFactory).
+8. **Adversarial audit swarm + gates + parity doc + DRAFT PR** (flag Contracts/architecture for sign-off).
+
+## Top risks to verify (skeptical audit)
+1. `IF;` 35-char field offsets/widths must match Hamlib `kenwood.c` byte-for-byte or rig-detect silently fails.
+2. `MoxSource.Cat=5` append-safety where serialized (MoxStateFrame/persisted) + no exhaustive-switch-without-default.
+3. Owned TcpListener: graceful StopAsync, half-open detection, partial-read reassembly, bounded accumulator.
+4. AI flood rate-limit (reuse TciRateLimiter); poll clients use lock-free Snapshot + cached meter.
+5. Per-source (not per-session) MOX ownership edge — mirror TCI, document.
+6. Network-tab rename breaking deep-links/persisted tab — grep all `'tci'`.
+7. No-auth LAN TX exposure — keep loopback default, warn on 0.0.0.0.

--- a/docs/references/cat-ts2000-parity.md
+++ b/docs/references/cat-ts2000-parity.md
@@ -1,0 +1,87 @@
+# CAT (Kenwood TS-2000 over TCP) — command parity reference
+
+Zeus's CAT server speaks a subset of the Kenwood TS-2000 ASCII CAT protocol over a raw TCP
+socket, so loggers (N1MM+, Log4OM), digital-mode apps (WSJT-X, JTDX, fldigi), and the Hamlib
+`rigctl`/`net rigctl` bridge can control the radio. It mirrors the TCI server
+(`Zeus.Server.Hosting/Tci/`); the only structural difference is transport (raw TCP vs.
+WebSocket-over-Kestrel). Default port **19090**, disabled by default, loopback bind.
+
+**Board-agnostic by construction.** CAT contains zero board-specific code. Every command maps to
+the same `RadioService` / `TxService` seam the TCI server and the UI already use, so it behaves
+identically across every board Zeus supports (Metis / Hermes / HermesII / ANAN-10/10E/100-series /
+OrionMkII family incl. G2 / HermesC10 / Hermes-Lite 2) and both Protocol 1 and Protocol 2. The only
+hardware Zeus can currently bench-test on is the **ANAN-G2 (P2)**; correctness on all other boards
+rests on this board-agnostic design + the test suite + CI, not on a bench.
+
+## Wire framing
+
+ASCII; each command is a 2-letter id + optional fixed-width args, terminated by `;`. Commands may
+arrive batched (`FA;MD;`) or split across TCP segments; `CatProtocol.ExtractCommands` reassembles
+both, and a never-terminated token is bounded at 256 chars. Unknown/unsupported commands reply
+`?;` (Kenwood convention). Set commands have no reply; query commands reply.
+
+## Tier-1 command coverage (implemented)
+
+| Cmd | Form | Meaning | Zeus seam |
+|-----|------|---------|-----------|
+| `ID` | get | radio id → `ID019;` (TS-2000) | static — Hamlib requires this first for rig-detect |
+| `PS` | get | power status → `PS1;` | static |
+| `AI` | get/set | Auto-Information level; gates async pushes | per-session flag (mirrors TCI rx_sensors) |
+| `FA` | get/set | VFO A frequency (11-digit Hz) | `Snapshot().VfoHz` / `SetVfo(hz, fromExternal:true)` |
+| `FB` | get/set | VFO B frequency | `Snapshot().Receivers[1].VfoHz` / `SetVfoB(hz)` |
+| `MD` | get/set | mode (Kenwood digit) | `Snapshot().Mode` / `SetMode(mode)` |
+| `IF` | get | 35-byte transceiver status | synthesized from `Snapshot()` + `_tx.IsMoxOn` |
+| `TX` | set | key MOX | `TrySetMox(true, MoxSource.Cat)` |
+| `RX` | set | unkey MOX | `TrySetMox(false, MoxSource.Cat)` |
+| `FR`/`FT` | get/set | RX/TX VFO (split) | report-only (no-split); accept-noop set — Zeus has no split seam yet |
+| `SM` | get | S-meter (0000–0030) | cached `RxMeterUpdated` dBm → approximate Kenwood scale |
+| `PC` | get/set | drive/power (0–100%) | `Snapshot().DrivePct` / `SetDrive(pct)` (clamp 50% if LimitPowerLevels) |
+
+### Mode digit map (`MD`)
+`1`=LSB `2`=USB `3`=CWU(CW, normal) `4`=FM `5`=AM `6`=DIGL(FSK) `7`=CWL(CW-R, reverse) `9`=DIGU(FSK-R)
+— CW polarity per Thetis `Mode2KString` and Hamlib (3=`RIG_MODE_CW`, 7=`RIG_MODE_CWR`). Zeus-only
+modes fall back: SAM→5(AM), DSB→2(USB), FreeDv→2(USB, runs as USB at WDSP). Matches Thetis
+`Mode2KString` (`"2"` fallback).
+
+### IF response field layout (taken byte-for-byte from Thetis `CATCommands.IF()`)
+`IF` + 35-byte body + `;` (38 chars total):
+
+| Field | Width | Offset | Source |
+|-------|-------|--------|--------|
+| P1 frequency | 11 | 0 | VFO A Hz, zero-padded |
+| P2 step size | 4 | 11 | `0000` (Zeus exposes no tune-step) |
+| P3 RIT/XIT value | 6 | 15 | sign + 5 digits; `+00000` (Tier-1 has no RIT) |
+| P4 RIT status | 1 | 21 | `0` |
+| P5 XIT status | 1 | 22 | `0` |
+| P6 memory bank | 3 | 23 | `000` |
+| P7 TX/RX | 1 | 26 | `1` if MOX else `0` |
+| P8 mode | 1 | 27 | Kenwood mode digit |
+| P9 FR/FT | 1 | 28 | `0` |
+| P10 scan | 1 | 29 | `0` |
+| P11 split | 1 | 30 | `0` (no split) |
+| P12 balance | 4 | 31 | `0000` |
+
+## Auto-Information (async pushes)
+`AI1;`/`AI2;` sets the session's AI flag; the server then pushes `FA`/`MD`/`IF` on radio
+state-change events (`RadioService.StateChanged`/`MoxChanged`), VFO rate-limited (reuses
+`TciRateLimiter`). `AI0;` (default) = poll-only; such clients only get query responses. **No frame
+is ever sent before an explicit client command, and a CAT connection never auto-keys TX.**
+
+## Tier-2 (next PR)
+RIT/XIT (`RT`/`XT`/`RU`/`RD`/`RC` → `SetRit`/`SetXit`), AF gain (`AG`), AGC (`GT`), filter width
+(`FW`), CW keyer (`KS`/`KY`), DSP toggles (`SQ`/`NB`/`NR`), true split (needs a RadioService split seam).
+
+## Tier-3 (out of scope)
+ZZ* PowerSDR/Thetis extended set, memory channels (`MC`/`MR`/`MW`), antenna (`AN`), scan (`SC`),
+band up/down (`BD`/`BU`) — no logger/digital-mode dependency.
+
+## Client setup (example — WSJT-X)
+Settings → Radio → Rig = **Kenwood TS-2000**, CAT = **Network**, Network Server = `ZeusIP:19090`,
+PTT = **CAT**. Hamlib net rigctl: point `rigctld -m 2014` (TS-2000) at the same host:port.
+
+## Safety invariants
+- CAT keys ONLY via `TxService.TrySetMox(.., MoxSource.Cat)` — never arms PureSignal, never
+  auto-keys on connect. A CAT-keyed MOX is releasable only by CAT or the UI master override
+  (SWR/timeout trips still bypass).
+- No new dependencies (raw `TcpListener` + hand-written parser). Cross-platform (sockets/ASCII only).
+- Loopback default; the UI warns on a non-loopback bind (no authentication).

--- a/tests/Zeus.Server.Tests/Cat/CatCommandHandlerTests.cs
+++ b/tests/Zeus.Server.Tests/Cat/CatCommandHandlerTests.cs
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server;
+using Zeus.Server.Cat;
+
+namespace Zeus.Server.Tests.Cat;
+
+// Dispatch-level tests for the Tier-1 CAT command set, driving the real
+// RadioService / TxService through CatCommandHandler with a captured send
+// callback. Focus is on correctness AND the safety contract: CAT keys ONLY on
+// an explicit TX;, owns its MOX via MoxSource.Cat, and never auto-keys.
+public sealed class CatCommandHandlerTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-cat-handler-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+        try { if (File.Exists(_dbPath + ".pa")) File.Delete(_dbPath + ".pa"); } catch { }
+    }
+
+    private (CatCommandHandler H, RadioService Radio, TxService Tx, List<string> Out) Build(
+        CatOptions? options = null, double latestDbm = -73.0)
+    {
+        var lf = NullLoggerFactory.Instance;
+        var dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance, _dbPath);
+        var paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance, _dbPath + ".pa");
+        var radio = new RadioService(lf, dspStore, paStore);
+        radio.MarkProtocol2Connected("127.0.0.1:1024", 48_000);
+        var hub = new StreamingHub(new NullLogger<StreamingHub>());
+        var pipeline = new DspPipelineService(radio, hub, Array.Empty<IRxAudioSink>(), lf);
+        var tx = new TxService(radio, pipeline, hub, NullBandPlanService.Instance, new NullLogger<TxService>());
+        var output = new List<string>();
+        var handler = new CatCommandHandler(radio, tx, options ?? new CatOptions(), () => latestDbm, output.Add);
+        return (handler, radio, tx, output);
+    }
+
+    [Fact]
+    public void Id_RespondsTs2000()
+    {
+        var (h, _, _, o) = Build();
+        h.Dispatch("ID");
+        Assert.Equal(new[] { "ID019;" }, o);
+    }
+
+    [Fact]
+    public void Ps_RespondsPowerOn()
+    {
+        var (h, _, _, o) = Build();
+        h.Dispatch("PS");
+        Assert.Equal(new[] { "PS1;" }, o);
+    }
+
+    [Fact]
+    public void Fa_GetThenSet()
+    {
+        var (h, radio, _, o) = Build();
+        radio.SetVfo(7_074_000);
+        h.Dispatch("FA");
+        Assert.Equal(new[] { "FA00007074000;" }, o);
+
+        h.Dispatch("FA00014250000");
+        Assert.Equal(14_250_000, radio.Snapshot().VfoHz);
+    }
+
+    [Fact]
+    public void Md_GetThenSet()
+    {
+        var (h, radio, _, o) = Build();
+        radio.SetMode(RxMode.USB);
+        h.Dispatch("MD");
+        Assert.Equal(new[] { "MD2;" }, o);
+
+        h.Dispatch("MD3"); // Kenwood 3 = CW (normal) = CWU
+        Assert.Equal(RxMode.CWU, radio.Snapshot().Mode);
+    }
+
+    [Fact]
+    public void If_Is38CharFramedResponse()
+    {
+        var (h, radio, _, o) = Build();
+        radio.SetVfo(7_074_000);
+        h.Dispatch("IF");
+        Assert.Single(o);
+        Assert.StartsWith("IF", o[0]);
+        Assert.EndsWith(";", o[0]);
+        Assert.Equal(38, o[0].Length); // "IF" + 35 body + ";"
+    }
+
+    [Fact]
+    public void Tx_Keys_With_CatSource_Then_Rx_Unkeys()
+    {
+        var (h, _, tx, _) = Build();
+        h.Dispatch("TX");
+        Assert.True(tx.IsMoxOn);
+        Assert.Equal(MoxSource.Cat, tx.MoxOwner);
+
+        h.Dispatch("RX");
+        Assert.False(tx.IsMoxOn);
+    }
+
+    [Fact]
+    public void EnablingAutoInfo_DoesNotKey_NoAutoKeyContract()
+    {
+        var (h, _, tx, _) = Build();
+        Assert.False(h.AutoInfoEnabled);
+
+        h.Dispatch("AI2");
+        Assert.True(h.AutoInfoEnabled);
+        // Safety: enabling Auto-Information must never key the transmitter.
+        Assert.False(tx.IsMoxOn);
+        Assert.Null(tx.MoxOwner);
+    }
+
+    [Fact]
+    public void Ai_Query_ReportsLevel_And_SeedsStateOnEnable()
+    {
+        var (h, _, _, o) = Build();
+        h.Dispatch("AI");
+        Assert.Equal(new[] { "AI0;" }, o);
+
+        o.Clear();
+        h.Dispatch("AI1"); // enable → seeds an IF frame (SendInitialStateOnConnect default true)
+        Assert.Contains(o, s => s.StartsWith("IF"));
+
+        o.Clear();
+        h.Dispatch("AI");
+        Assert.Equal(new[] { "AI1;" }, o);
+    }
+
+    [Fact]
+    public void Pc_GetThenSet_AndPowerLimitClamp()
+    {
+        var (h, radio, _, o) = Build();
+        h.Dispatch("PC050");
+        Assert.Equal(50, radio.Snapshot().DrivePct);
+
+        o.Clear();
+        h.Dispatch("PC");
+        Assert.Equal(new[] { "PC050;" }, o);
+
+        // LimitPowerLevels clamps to 50%.
+        var (h2, radio2, _, _) = Build(new CatOptions { LimitPowerLevels = true });
+        h2.Dispatch("PC080");
+        Assert.Equal(50, radio2.Snapshot().DrivePct);
+    }
+
+    [Fact]
+    public void Sm_ReportsScaledMeter()
+    {
+        var (h, _, _, o) = Build(latestDbm: -73.0);
+        h.Dispatch("SM");
+        Assert.Equal(new[] { "SM00012;" }, o); // -73 dBm → 12
+    }
+
+    [Fact]
+    public void UnknownCommand_ReturnsKenwoodError()
+    {
+        var (h, _, _, o) = Build();
+        h.Dispatch("ZZXYZ");
+        Assert.Equal(new[] { "?;" }, o);
+    }
+}

--- a/tests/Zeus.Server.Tests/Cat/CatProtocolTests.cs
+++ b/tests/Zeus.Server.Tests/Cat/CatProtocolTests.cs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using Zeus.Contracts;
+using Zeus.Server.Cat;
+
+namespace Zeus.Server.Tests.Cat;
+
+// Pure-protocol tests for the Kenwood TS-2000 CAT layer. The IF body layout is
+// the highest parity risk (Hamlib/WSJT-X silently fail rig-detect on a wrong
+// field offset), so it is asserted byte-for-byte against the Thetis
+// CATCommands.IF() field widths.
+public sealed class CatProtocolTests
+{
+    [Theory]
+    [InlineData(7074000L, "00007074000")]
+    [InlineData(0L, "00000000000")]
+    [InlineData(146520000L, "00146520000")]
+    public void FormatFreq_Is11DigitsZeroPadded(long hz, string expected)
+        => Assert.Equal(expected, CatProtocol.FormatFreq(hz));
+
+    [Theory]
+    [InlineData(RxMode.LSB, "1")]
+    [InlineData(RxMode.USB, "2")]
+    [InlineData(RxMode.CWU, "3")]  // Kenwood 3 = CW (normal) = CWU — per Thetis/Hamlib
+    [InlineData(RxMode.FM, "4")]
+    [InlineData(RxMode.AM, "5")]
+    [InlineData(RxMode.DIGL, "6")]
+    [InlineData(RxMode.CWL, "7")]  // Kenwood 7 = CW-R (reverse) = CWL
+    [InlineData(RxMode.DIGU, "9")]
+    public void ModeDigit_ParseMode_RoundTrip(RxMode mode, string digit)
+    {
+        Assert.Equal(digit, CatProtocol.ModeDigit(mode));
+        Assert.Equal(mode, CatProtocol.ParseMode(digit));
+    }
+
+    [Theory]
+    [InlineData(RxMode.SAM, "5")]   // no Kenwood equivalent → AM
+    [InlineData(RxMode.DSB, "2")]   // → USB
+    [InlineData(RxMode.FreeDv, "2")] // runs as USB at WDSP
+    public void ModeDigit_ZeusOnlyModes_FallBack(RxMode mode, string digit)
+        => Assert.Equal(digit, CatProtocol.ModeDigit(mode));
+
+    [Theory]
+    [InlineData("8")]
+    [InlineData("0")]
+    [InlineData("x")]
+    public void ParseMode_Unmapped_IsNull(string digit)
+        => Assert.Null(CatProtocol.ParseMode(digit));
+
+    [Fact]
+    public void BuildIfBody_Is35Chars_WithExactFieldLayout()
+    {
+        // freq(11) step(4) incr(6) rit(1) xit(1) mem(3) tx(1) mode(1) frft(1) scan(1) split(1) bal(4)
+        string body = CatProtocol.BuildIfBody(7074000, RxMode.USB, mox: false, split: false);
+        Assert.Equal(35, body.Length);
+        Assert.Equal("00007074000", body[0..11]);   // P1 freq
+        Assert.Equal("0000", body[11..15]);          // P2 step
+        Assert.Equal("+00000", body[15..21]);        // P3 RIT/XIT value
+        Assert.Equal('0', body[21]);                 // P4 RIT
+        Assert.Equal('0', body[22]);                 // P5 XIT
+        Assert.Equal("000", body[23..26]);           // P6 memory bank
+        Assert.Equal('0', body[26]);                 // P7 TX/RX (RX)
+        Assert.Equal('2', body[27]);                 // P8 mode (USB)
+        Assert.Equal('0', body[28]);                 // P9 FR/FT
+        Assert.Equal('0', body[29]);                 // P10 scan
+        Assert.Equal('0', body[30]);                 // P11 split
+        Assert.Equal("0000", body[31..35]);          // P12 balance
+    }
+
+    [Fact]
+    public void BuildIfBody_MoxAndSplit_SetTheirBits()
+    {
+        string body = CatProtocol.BuildIfBody(14250000, RxMode.CWU, mox: true, split: true);
+        Assert.Equal(35, body.Length);
+        Assert.Equal('1', body[26]); // TX
+        Assert.Equal('3', body[27]); // CWU → Kenwood 3 (CW normal)
+        Assert.Equal('1', body[30]); // split
+    }
+
+    [Fact]
+    public void Response_WrapsWithTerminator()
+    {
+        Assert.Equal("FA00007074000;", CatProtocol.Response("FA", "00007074000"));
+        Assert.Equal("ID019;", CatProtocol.Response("ID", "019"));
+        Assert.Equal("?;", CatProtocol.Error);
+    }
+
+    [Fact]
+    public void ExtractCommands_BatchedAndSplit()
+    {
+        var (cmds, rem) = CatProtocol.ExtractCommands("FA;MD;");
+        Assert.Equal(new[] { "FA", "MD" }, cmds);
+        Assert.Equal("", rem);
+
+        (cmds, rem) = CatProtocol.ExtractCommands("FA00014250000");
+        Assert.Empty(cmds);
+        Assert.Equal("FA00014250000", rem); // incomplete — held for next read
+
+        (cmds, rem) = CatProtocol.ExtractCommands("ID;FA0001");
+        Assert.Equal(new[] { "ID" }, cmds);
+        Assert.Equal("FA0001", rem);
+    }
+
+    [Theory]
+    [InlineData("FA00007074000", "FA", "00007074000")]
+    [InlineData("ID", "ID", "")]
+    [InlineData("MD2", "MD", "2")]
+    public void CommandId_And_Args(string token, string id, string args)
+    {
+        Assert.Equal(id, CatProtocol.CommandId(token));
+        Assert.Equal(args, CatProtocol.Args(token));
+    }
+
+    [Theory]
+    [InlineData(-200.0, 0)]
+    [InlineData(-130.0, 0)]
+    [InlineData(-73.0, 12)]
+    [InlineData(0.0, 30)]
+    [InlineData(100.0, 30)]
+    public void SMeter_ClampsToKenwoodRange(double dbm, int expected)
+        => Assert.Equal(expected, CatProtocol.SMeter(dbm));
+
+    [Fact]
+    public void SMeterField_Is4Digits()
+        => Assert.Equal("0012", CatProtocol.SMeterField(-73.0));
+}

--- a/zeus-web/src/api/cat.ts
+++ b/zeus-web/src/api/cat.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+// REST client for the CAT (Kenwood TS-2000 over TCP) server. Mirrors api/tci.ts.
+
+import { ApiError } from './client';
+
+export type CatStatus = {
+  currentlyEnabled: boolean;
+  currentPort: number;
+  currentBindAddress: string;
+  pendingEnabled: boolean;
+  pendingPort: number;
+  pendingBindAddress: string;
+  clientCount: number;
+  portAvailable: boolean;
+  requiresRestart: boolean;
+  error: string | null;
+};
+
+export type CatConfig = {
+  enabled: boolean;
+  bindAddress: string;
+  port: number;
+};
+
+export type CatTestResult = { ok: boolean; error: string | null };
+
+const DEFAULT_PORT = 19090;
+
+function normalizeStatus(raw: unknown): CatStatus {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  return {
+    currentlyEnabled: Boolean(r.currentlyEnabled),
+    currentPort: typeof r.currentPort === 'number' ? r.currentPort : DEFAULT_PORT,
+    currentBindAddress: typeof r.currentBindAddress === 'string' ? r.currentBindAddress : '127.0.0.1',
+    pendingEnabled: Boolean(r.pendingEnabled),
+    pendingPort: typeof r.pendingPort === 'number' ? r.pendingPort : DEFAULT_PORT,
+    pendingBindAddress: typeof r.pendingBindAddress === 'string' ? r.pendingBindAddress : '127.0.0.1',
+    clientCount: typeof r.clientCount === 'number' ? r.clientCount : 0,
+    portAvailable: Boolean(r.portAvailable),
+    requiresRestart: Boolean(r.requiresRestart),
+    error: typeof r.error === 'string' && r.error.length > 0 ? r.error : null,
+  };
+}
+
+async function jsonFetch<T>(input: RequestInfo, init: RequestInit | undefined, parse: (raw: unknown) => T): Promise<T> {
+  const res = await fetch(input, init);
+  if (!res.ok) {
+    let message = `${res.status} ${res.statusText}`;
+    try {
+      const body = (await res.json()) as unknown;
+      if (body && typeof body === 'object' && 'error' in body && typeof (body as { error: unknown }).error === 'string') {
+        message = (body as { error: string }).error;
+      }
+    } catch {
+      /* non-JSON */
+    }
+    throw new ApiError(res.status, message);
+  }
+  return parse((await res.json()) as unknown);
+}
+
+export function getCatStatus(signal?: AbortSignal): Promise<CatStatus> {
+  return jsonFetch('/api/cat/status', { signal }, normalizeStatus);
+}
+
+export function postCatConfig(cfg: CatConfig, signal?: AbortSignal): Promise<CatStatus> {
+  return jsonFetch(
+    '/api/cat/config',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(cfg),
+      signal,
+    },
+    normalizeStatus,
+  );
+}
+
+export function testCatPort(bindAddress: string, port: number, signal?: AbortSignal): Promise<CatTestResult> {
+  return jsonFetch(
+    '/api/cat/test',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ bindAddress, port }),
+      signal,
+    },
+    (raw) => {
+      const r = (raw ?? {}) as Record<string, unknown>;
+      return { ok: Boolean(r.ok), error: typeof r.error === 'string' && r.error ? r.error : null };
+    },
+  );
+}

--- a/zeus-web/src/components/CatSettingsPanel.tsx
+++ b/zeus-web/src/components/CatSettingsPanel.tsx
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+import { useEffect, useState } from 'react';
+import { useCatStore } from '../state/cat-store';
+
+export function CatSettingsPanel() {
+  const config = useCatStore((s) => s.config);
+  const status = useCatStore((s) => s.status);
+  const testInFlight = useCatStore((s) => s.testInFlight);
+  const lastTestResult = useCatStore((s) => s.lastTestResult);
+  const saveConfig = useCatStore((s) => s.saveConfig);
+  const test = useCatStore((s) => s.test);
+
+  const [bindAddress, setBindAddress] = useState(config.bindAddress);
+  const [port, setPort] = useState(String(config.port));
+  const [enabled, setEnabled] = useState(config.enabled);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setBindAddress(config.bindAddress);
+    setPort(String(config.port));
+    setEnabled(config.enabled);
+  }, [config.bindAddress, config.port, config.enabled]);
+
+  const currentlyEnabled = status?.currentlyEnabled ?? false;
+  const clientCount = status?.clientCount ?? 0;
+  const requiresRestart = status?.requiresRestart ?? false;
+  const portAvailable = status?.portAvailable ?? true;
+
+  async function onSave(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      const portNum = Number(port);
+      if (!Number.isFinite(portNum) || portNum <= 0 || portNum >= 65536) return;
+      await saveConfig({
+        enabled,
+        bindAddress: bindAddress.trim() || '127.0.0.1',
+        port: portNum,
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function onTest() {
+    const portNum = Number(port);
+    if (!Number.isFinite(portNum) || portNum <= 0 || portNum >= 65536) return;
+    await test(bindAddress.trim() || '127.0.0.1', portNum);
+  }
+
+  return (
+    <div style={{ maxWidth: 700 }}>
+      <h3
+        style={{
+          margin: '0 0 14px',
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: '0.12em',
+          textTransform: 'uppercase',
+          color: 'var(--fg-2)',
+        }}
+      >
+        CAT (COMPUTER AIDED TRANSCEIVER)
+      </h3>
+
+      <div
+        style={{
+          padding: 12,
+          marginBottom: 16,
+          fontSize: 11,
+          lineHeight: 1.5,
+          color: 'var(--fg-2)',
+          background: 'var(--bg-0)',
+          border: '1px solid var(--panel-border)',
+          borderRadius: 'var(--r-sm)',
+        }}
+      >
+        CAT is a Kenwood TS-2000 command protocol over TCP for control by logging software
+        (N1MM+, Log4OM), digital-mode apps (WSJT-X, JTDX, fldigi), and the Hamlib net rigctl
+        bridge. In the client, choose rig <strong>Kenwood TS-2000</strong> (CAT over TCP/network),
+        host = Zeus IP, port = below. Port changes require restarting Zeus to take effect.
+      </div>
+
+      <form onSubmit={onSave} style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+        <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+            style={{ accentColor: 'var(--accent)' }}
+          />
+          <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--fg-1)' }}>Enabled</span>
+        </label>
+
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--fg-2)' }}>Bind Address</span>
+          <input
+            type="text"
+            value={bindAddress}
+            onChange={(e) => setBindAddress(e.target.value)}
+            spellCheck={false}
+            placeholder="127.0.0.1"
+            style={{
+              padding: '6px 8px',
+              fontSize: 12,
+              fontFamily: 'monospace',
+              background: 'var(--bg-0)',
+              border: '1px solid var(--panel-border)',
+              borderRadius: 'var(--r-sm)',
+              color: 'var(--fg-0)',
+            }}
+          />
+          <span style={{ fontSize: 10, color: 'var(--fg-3)' }}>
+            Use 127.0.0.1 for localhost only, or 0.0.0.0 to allow LAN clients. CAT grants full TX
+            control with no authentication — keep it on a trusted network.
+          </span>
+        </label>
+
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--fg-2)' }}>Port</span>
+          <input
+            type="number"
+            value={port}
+            onChange={(e) => setPort(e.target.value)}
+            min={1}
+            max={65535}
+            style={{
+              padding: '6px 8px',
+              fontSize: 12,
+              fontFamily: 'monospace',
+              background: 'var(--bg-0)',
+              border: '1px solid var(--panel-border)',
+              borderRadius: 'var(--r-sm)',
+              color: 'var(--fg-0)',
+            }}
+          />
+          <span style={{ fontSize: 10, color: 'var(--fg-3)' }}>
+            Default: 19090. Set this to match the port your client (WSJT-X, N1MM, Hamlib) is
+            pointed at. Changing requires restart.
+          </span>
+        </label>
+
+        {status?.error && (
+          <div
+            style={{
+              padding: 10,
+              fontSize: 12,
+              color: 'var(--tx)',
+              background: 'rgba(230, 58, 43, 0.1)',
+              border: '1px solid var(--tx)',
+              borderRadius: 'var(--r-sm)',
+            }}
+          >
+            {status.error}
+          </div>
+        )}
+
+        {lastTestResult && (
+          <div
+            style={{
+              padding: 10,
+              fontSize: 12,
+              color: lastTestResult.ok ? 'var(--accent)' : 'var(--tx)',
+              background: lastTestResult.ok
+                ? 'rgba(74, 158, 255, 0.1)'
+                : 'rgba(230, 58, 43, 0.1)',
+              border: `1px solid ${lastTestResult.ok ? 'var(--accent)' : 'var(--tx)'}`,
+              borderRadius: 'var(--r-sm)',
+            }}
+          >
+            {lastTestResult.ok
+              ? `✓ Port ${port} is available on ${bindAddress}`
+              : `✗ Test failed: ${lastTestResult.error ?? 'unknown error'}`}
+          </div>
+        )}
+
+        {requiresRestart && (
+          <div
+            style={{
+              padding: 10,
+              fontSize: 12,
+              color: 'var(--power)',
+              background: 'rgba(255, 201, 58, 0.1)',
+              border: '1px solid var(--power)',
+              borderRadius: 'var(--r-sm)',
+              fontWeight: 600,
+            }}
+          >
+            ⚠ Configuration changed — restart Zeus to apply
+          </div>
+        )}
+
+        {currentlyEnabled && !requiresRestart && (
+          <div
+            style={{
+              padding: 10,
+              background: 'var(--bg-0)',
+              border: '1px solid var(--panel-border)',
+              borderRadius: 'var(--r-sm)',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 10,
+              fontSize: 12,
+              color: 'var(--fg-1)',
+            }}
+          >
+            <span
+              style={{
+                width: 8,
+                height: 8,
+                borderRadius: '50%',
+                background: portAvailable ? 'var(--accent)' : 'var(--tx)',
+                flexShrink: 0,
+              }}
+            />
+            <span style={{ color: 'var(--fg-2)' }}>Status:</span>
+            <span style={{ fontWeight: 600, color: 'var(--accent)' }}>
+              {portAvailable ? 'Running' : 'Port unavailable'}
+            </span>
+            <span style={{ color: 'var(--fg-2)' }}>·</span>
+            <span style={{ color: 'var(--fg-2)' }}>Port:</span>
+            <span style={{ fontFamily: 'monospace', fontWeight: 600 }}>
+              {status?.currentPort ?? 19090}
+            </span>
+            <span style={{ color: 'var(--fg-2)' }}>·</span>
+            <span style={{ color: 'var(--fg-2)' }}>Clients:</span>
+            <span style={{ fontFamily: 'monospace', fontWeight: 600, color: clientCount > 0 ? 'var(--accent)' : 'var(--fg-2)' }}>
+              {clientCount}
+            </span>
+          </div>
+        )}
+
+        {!currentlyEnabled && !requiresRestart && (
+          <div
+            style={{
+              padding: 10,
+              background: 'var(--bg-0)',
+              border: '1px solid var(--panel-border)',
+              borderRadius: 'var(--r-sm)',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 10,
+              fontSize: 12,
+              color: 'var(--fg-2)',
+            }}
+          >
+            <span
+              style={{
+                width: 8,
+                height: 8,
+                borderRadius: '50%',
+                background: 'var(--fg-3)',
+                flexShrink: 0,
+              }}
+            />
+            CAT is currently disabled
+          </div>
+        )}
+
+        <div style={{ display: 'flex', gap: 6 }}>
+          <button
+            type="button"
+            onClick={onTest}
+            disabled={testInFlight}
+            className="btn sm"
+          >
+            {testInFlight ? 'TESTING…' : 'TEST PORT'}
+          </button>
+          <span style={{ flex: 1 }} />
+          <button type="submit" disabled={saving} className="btn sm active">
+            {saving ? 'SAVING…' : 'SAVE'}
+          </button>
+        </div>
+
+        <div
+          style={{
+            fontSize: 10,
+            lineHeight: 1.4,
+            color: 'var(--fg-3)',
+          }}
+        >
+          Connect via raw TCP at <span style={{ fontFamily: 'monospace' }}>host:port</span>.
+          Example: WSJT-X → Settings → Radio → Rig = Kenwood TS-2000, CAT = Network,
+          Network Server = Zeus IP:{port || '19090'}, PTT = CAT. Changing the port or bind address
+          requires restarting Zeus.
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/zeus-web/src/components/NetworkSettingsPanel.tsx
+++ b/zeus-web/src/components/NetworkSettingsPanel.tsx
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+import { CatSettingsPanel } from './CatSettingsPanel';
+import { TciSettingsPanel } from './TciSettingsPanel';
+
+// The Network tab hosts Zeus's external network-control servers. TCI (the
+// existing ExpertSDR3 WebSocket interface) and CAT (the Kenwood TS-2000 TCP
+// interface) are independent servers configured side by side. Each child panel
+// owns its own store, polling, and persistence — this container only stacks
+// them with a separating rule.
+export function NetworkSettingsPanel() {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+      <TciSettingsPanel />
+      <div style={{ borderTop: '1px solid var(--panel-border)' }} />
+      <CatSettingsPanel />
+    </div>
+  );
+}

--- a/zeus-web/src/components/SettingsMenu.tsx
+++ b/zeus-web/src/components/SettingsMenu.tsx
@@ -32,7 +32,7 @@ import { RadioSettingsPanel } from './RadioSettingsPanel';
 import { ReceiversPanel } from './ReceiversPanel';
 import { RotatorSettingsPanel } from './RotatorSettingsPanel';
 import { ServerUrlPanel } from './ServerUrlPanel';
-import { TciSettingsPanel } from './TciSettingsPanel';
+import { NetworkSettingsPanel } from './NetworkSettingsPanel';
 import { RadioSelector } from './RadioSelector';
 import { usePaStore } from '../state/pa-store';
 import { useRadioStore } from '../state/radio-store';
@@ -55,7 +55,7 @@ export type SettingsTabId =
   | 'bandplan'
   | 'qrz'
   | 'rotator'
-  | 'tci'
+  | 'network'
   | 'display'
   | 'plugins'
   | 'hamclock'
@@ -76,7 +76,7 @@ const TABS: ReadonlyArray<{ id: SettingsTabId; label: string }> = [
   { id: 'bandplan', label: 'BAND PLAN' },
   { id: 'qrz', label: 'QRZ' },
   { id: 'rotator', label: 'ROTATOR' },
-  { id: 'tci', label: 'TCI' },
+  { id: 'network', label: 'NETWORK' },
   { id: 'display', label: 'DISPLAY' },
   { id: 'plugins', label: 'PLUGINS' },
   { id: 'hamclock', label: 'HAMCLOCK' },
@@ -205,7 +205,7 @@ export function SettingsView({ initialTab, onClose }: Props) {
           {activeTab === 'bandplan' && <BandPlanEditor />}
           {activeTab === 'qrz' && <QrzSettingsPanel />}
           {activeTab === 'rotator' && <RotatorSettingsPanel />}
-          {activeTab === 'tci' && <TciSettingsPanel />}
+          {activeTab === 'network' && <NetworkSettingsPanel />}
           {activeTab === 'display' && <DisplayPanel />}
           {activeTab === 'plugins' && <PluginsPanel />}
           {activeTab === 'hamclock' && <HamClockSettingsPanel />}

--- a/zeus-web/src/state/cat-store.ts
+++ b/zeus-web/src/state/cat-store.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+import { create } from 'zustand';
+import {
+  getCatStatus,
+  postCatConfig,
+  testCatPort,
+  type CatConfig,
+  type CatStatus,
+  type CatTestResult,
+} from '../api/cat';
+
+// The backend (CatConfigStore on disk) is the source of truth for CAT runtime
+// config. The form initialises from /api/cat/status once it arrives; this
+// constant is only a transient placeholder until the first status refresh.
+// Do NOT seed from localStorage and do NOT auto-POST on load — that produced a
+// phantom "configuration changed — restart" warning every page load in TCI
+// when localStorage drifted from disk (same lesson).
+const DEFAULT_CONFIG: CatConfig = {
+  enabled: false,
+  bindAddress: '127.0.0.1',
+  port: 19090,
+};
+
+export type CatStoreState = {
+  config: CatConfig;
+  status: CatStatus | null;
+  testInFlight: boolean;
+  lastTestResult: CatTestResult | null;
+
+  refreshStatus: () => Promise<void>;
+  saveConfig: (cfg: CatConfig) => Promise<CatStatus>;
+  test: (bindAddress: string, port: number) => Promise<CatTestResult>;
+};
+
+export const useCatStore = create<CatStoreState>((set, get) => ({
+  config: DEFAULT_CONFIG,
+  status: null,
+  testInFlight: false,
+  lastTestResult: null,
+
+  refreshStatus: async () => {
+    try {
+      const status = await getCatStatus();
+      const current = get().config;
+      const synced =
+        current.enabled === status.pendingEnabled
+          && current.bindAddress === status.pendingBindAddress
+          && current.port === status.pendingPort;
+      set({
+        status,
+        config: synced ? current : {
+          enabled: status.pendingEnabled,
+          bindAddress: status.pendingBindAddress,
+          port: status.pendingPort,
+        },
+      });
+    } catch {
+      /* transient — next poll recovers */
+    }
+  },
+
+  saveConfig: async (cfg) => {
+    const status = await postCatConfig(cfg);
+    set({ config: cfg, status });
+    return status;
+  },
+
+  test: async (bindAddress, port) => {
+    set({ testInFlight: true, lastTestResult: null });
+    const result = await testCatPort(bindAddress, port);
+    set({ testInFlight: false, lastTestResult: result });
+    return result;
+  },
+}));
+
+// Initial status probe + 2 s polling while the page is alive AND CAT is
+// enabled (skip the fetch in the disabled-default case — nothing to show).
+if (typeof window !== 'undefined') {
+  void useCatStore.getState().refreshStatus();
+  window.setInterval(() => {
+    if (!useCatStore.getState().config.enabled) return;
+    void useCatStore.getState().refreshStatus();
+  }, 2000);
+}


### PR DESCRIPTION
**🚫 DO NOT MERGE — draft for KB2UKA sign-off.** Not yet bench-tested (see below).

## What & why
Adds **CAT (Computer Aided Transceiver) control** — a Kenwood TS-2000 ASCII protocol over a raw TCP socket — so loggers (**N1MM+**, Log4OM), digital-mode apps (**WSJT-X**, JTDX, fldigi), and the **Hamlib `net rigctl`** bridge can control Zeus. Zeus previously offered only TCI; CAT is the protocol most of the logging/digital ecosystem speaks via "Kenwood TS-2000".

It **mirrors the existing TCI server** seam-for-seam (`Zeus.Server.Hosting/Tci/`). The one structural difference: CAT owns its own `TcpListener` accept loop, because a raw line protocol can't ride Kestrel the way TCI's WebSocket does. Default port **19090**, **disabled by default**, **loopback** bind.

**UI:** a new **Network** settings tab absorbs the existing **TCI** tab (re-homed unchanged — zero TCI logic touched) and adds the CAT panel beside it.

## Board-agnostic — why G2-only bench is enough
CAT contains **zero board-specific code**. Every command routes through the same `RadioService`/`TxService` seams TCI and the UI already use (`SetVfo`/`SetVfoB`/`SetMode`/`SetDrive`/`Snapshot`/`TrySetMox`). The adversarial audit confirmed this with **high confidence**, so **G2 (P2) bench verification generalizes to all supported boards** and both Protocol 1 and Protocol 2. Per-board drive quantization etc. happens downstream of `SetDrive` (in `RadioDriveProfile`/`RecomputePaAndPush`) exactly as for the UI — CAT adds no new divergence.

## Command coverage
**Tier-1 (this PR):** `ID PS AI FA FB MD IF TX RX FR FT SM PC`. The 35-byte `IF` body is **byte-for-byte from Thetis `CATCommands.IF()`** and its offsets match Hamlib `kenwood.c`. CW polarity is `3`=CWU / `7`=CWL per Thetis/Hamlib.
**Tier-2 (next):** RIT/XIT, AF gain, AGC, filter width, CW keyer, true split (needs a RadioService split seam).
**Tier-3 (out of scope):** ZZ* extended set, memory channels, antenna, scan, band up/down.
Full table + IF field layout in `docs/references/cat-ts2000-parity.md`.

## 🟥 RED-LIGHT items for your sign-off
1. **`Zeus.Contracts/MoxSource.cs` — appended `Cat = 5`** (append-only; wire-stable). Audit confirmed no exhaustive switch/serialization mishandles it.
2. **New architecture — a raw `TcpListener` accept loop** (`CatServer`). New network listener/thread = architecture red-light.
3. **New "Network" settings tab** (replaces the standalone TCI tab). Visual/UX change — token-only styling, no palette invention.

## Safety
- **PureSignal: zero touches.** CAT keys **only** via `TxService.TrySetMox(.., MoxSource.Cat)` — never arms PS, **never auto-keys on connect** (unit-tested: enabling Auto-Information does not key). A CAT-keyed MOX is releasable only by CAT or the UI master override; SWR/timeout trips still bypass.
- **No new dependencies** (raw sockets + hand-written parser). **Cross-platform** (sockets/ASCII/`Interlocked` only).
- Loopback default; UI warns on non-loopback bind (no auth).

## Audit (adversarial swarm)
- **Board-agnostic:** SHIP (high confidence).
- **Protocol/IF:** SHIP-WITH-FIXES — caught a real **CW sideband inversion** (CWL↔CWU); **fixed** + tests corrected (the bug was symmetric so it hid on a Zeus↔Zeus round-trip — exactly the kind of thing a real CW logger would have surfaced).
- **Safety (PS/MOX/no-auto-key):** SHIP. **Wiring/frontend:** SHIP.
- One audit slice (server thread-safety) failed to emit structured output; I manually verified `CatServer`/`CatSession` mirror TCI's proven teardown patterns (linked-CTS, bounded accumulator, half-open handling, `Interlocked` meter read).

## Verification
- `dotnet build Zeus.slnx` — 0/0.
- Full `Zeus.Server.Tests` — **1794 pass, 0 fail** (incl. new CAT suites).
- `npm --prefix zeus-web run build` — clean.

## ⚠️ Not bench-tested — bench plan (G2)
Nothing here has talked to a real CAT client yet. On the G2:
- [ ] WSJT-X: Rig = Kenwood TS-2000, CAT = Network, Server = `ZeusIP:19090`, PTT = CAT → rig-detect, read/set freq+mode, PTT keys/unkeys.
- [ ] N1MM+ / fldigi: same TS-2000-over-network config.
- [ ] Hamlib: `rigctld -m 2014` at the port → `get_freq`/`set_freq`/`set_mode`/PTT.
- [ ] Confirm enabling the server then connecting a client does **not** auto-key, and PS is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)