### PR TITLE
feat(radio): recall per-band mode on any band change, not just band buttons

### DIFF
--- a/Zeus.Server.Hosting/BandMemoryStore.cs
+++ b/Zeus.Server.Hosting/BandMemoryStore.cs
@@ -58,10 +58,10 @@ public sealed class BandMemoryStore : IDisposable
     private readonly ILiteCollection<BandMemoryEntry> _entries;
     private readonly ILogger<BandMemoryStore> _log;
 
-    public BandMemoryStore(ILogger<BandMemoryStore> log)
+    public BandMemoryStore(ILogger<BandMemoryStore> log, string? dbPathOverride = null)
     {
         _log = log;
-        var dbPath = PrefsDbPath.Get();
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
 
         var dir = Path.GetDirectoryName(dbPath);
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -83,6 +83,12 @@ public sealed class RadioService : IDisposable
     private readonly PsSettingsStore? _psStore;
     private readonly FilterPresetStore? _filterPresetStore;
     private readonly RadioStateStore? _radioStateStore;
+    // Per-band last-used (hz, mode) register. Read on a band crossing in SetVfo
+    // to recall that band's demod mode server-authoritatively, so mode follows
+    // the band no matter how the operator got there — band buttons, favorites,
+    // the physical front panel, the VFO knob, or a typed frequency (KB2UKA
+    // 2026-06-25). Writes stay frontend/front-panel driven; this is read-only.
+    private readonly BandMemoryStore? _bandMemoryStore;
     // Global (per-radio, NOT per-band) TX-audio source selection. Pushed via
     // PushAudioFrontEnd on store edit + connect (external-audio-jacks re-port).
     private readonly AudioSettingsStore? _audioStore;
@@ -350,7 +356,7 @@ public sealed class RadioService : IDisposable
     // to its internal test-tone generator (dev / tests without a hub).
     private readonly Zeus.Protocol1.ITxIqSource? _txIqSource;
 
-    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, FilterPresetStore? filterPresetStore = null, Zeus.Protocol1.ITxIqSource? txIqSource = null, PreferredRadioStore? preferredRadioStore = null, PsSettingsStore? psStore = null, RadioStateStore? radioStateStore = null, CwSettingsStore? cwSettingsStore = null, TxAudioProfileStore? txAudioProfileStore = null, AntennaSettingsStore? antennaStore = null, AudioSettingsStore? audioStore = null, Nr3ModelStore? nr3ModelStore = null, Hl2GpioSettingsStore? hl2GpioStore = null)
+    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, FilterPresetStore? filterPresetStore = null, Zeus.Protocol1.ITxIqSource? txIqSource = null, PreferredRadioStore? preferredRadioStore = null, PsSettingsStore? psStore = null, RadioStateStore? radioStateStore = null, CwSettingsStore? cwSettingsStore = null, TxAudioProfileStore? txAudioProfileStore = null, AntennaSettingsStore? antennaStore = null, AudioSettingsStore? audioStore = null, Nr3ModelStore? nr3ModelStore = null, Hl2GpioSettingsStore? hl2GpioStore = null, BandMemoryStore? bandMemoryStore = null)
     {
         _loggerFactory = loggerFactory;
         _log = loggerFactory.CreateLogger<RadioService>();
@@ -362,6 +368,7 @@ public sealed class RadioService : IDisposable
         _psStore = psStore;
         _filterPresetStore = filterPresetStore;
         _radioStateStore = radioStateStore;
+        _bandMemoryStore = bandMemoryStore;
         _audioStore = audioStore;
         _paStore.Changed += RecomputePaAndPush;
         // An antenna edit re-pushes the active band's selection server-
@@ -1360,6 +1367,8 @@ public sealed class RadioService : IDisposable
                 if (BandUtils.FreqToBand(previous) != BandUtils.FreqToBand(clamped))
                 {
                     RecomputePaAndPush();
+                    if (!fromExternal && RestoreBandMode(BandUtils.FreqToBand(clamped)) is { } recalled)
+                        return recalled;
                 }
                 return Snapshot();
             }
@@ -1376,12 +1385,51 @@ public sealed class RadioService : IDisposable
         ActiveClient?.SetVfoAHz(radioLoNew);
         // Band edge crossed? Per-band PA gain / OC bits may have swapped — push
         // the new snapshot before the next TX frame ships. Cheap when no
-        // crossing occurred (same bytes re-pushed).
+        // crossing occurred (same bytes re-pushed). Also recall the new band's
+        // last-used demod mode (operator tunes only — fromExternal CAT/TCI keep
+        // their own mode).
         if (BandUtils.FreqToBand(previous) != BandUtils.FreqToBand(clamped))
         {
             RecomputePaAndPush();
+            if (!fromExternal && RestoreBandMode(BandUtils.FreqToBand(clamped)) is { } recalled)
+                return recalled;
         }
         return Snapshot();
+    }
+
+    /// <summary>
+    /// Server-authoritative per-band mode recall. When the operator's dial
+    /// crosses into a different band — by ANY means: band buttons, favorites,
+    /// the physical front panel, the VFO knob/wheel, a panadapter click, or a
+    /// typed frequency — restore that band's last-used demod mode from
+    /// <see cref="BandMemoryStore"/> so mode follows the band everywhere, not
+    /// just on the band-selector UIs (KB2UKA 2026-06-25). The caller excludes
+    /// external sources (CAT/TCI/calibration, <c>fromExternal=true</c>): they
+    /// manage their own mode and a recall would fight them.
+    ///
+    /// <para>No-op (returns null) when band memory is unavailable, the target
+    /// band has no remembered entry (first visit → the current mode simply
+    /// carries over), or the remembered mode already matches the current one.
+    /// RX1 / VFO A only — the per-band entry is a single register keyed by band
+    /// name and <see cref="SetVfo"/> owns the VFO-A dial. Reuses
+    /// <see cref="SetMode(RxMode, TxVfo)"/> so the per-mode filter memory,
+    /// CW dial bump, and LO push all fire exactly as a manual mode change.</para>
+    ///
+    /// <para>The band string comes from <see cref="BandUtils.FreqToBand"/>,
+    /// which produces the same canonical "40m"-style key the frontend used when
+    /// it persisted the entry (web <c>bandOf</c>) for every in-band frequency,
+    /// so the lookup matches.</para>
+    /// </summary>
+    private StateDto? RestoreBandMode(string? newBand)
+    {
+        if (_bandMemoryStore is null || newBand is null) return null;
+        var mem = _bandMemoryStore.Get(newBand);
+        if (mem is null) return null;
+        RxMode current;
+        lock (_sync) { current = _state.Mode; }
+        if (mem.Mode == current) return null;
+        _log.LogInformation("band.mode.recall band={Band} mode={Mode}", newBand, mem.Mode);
+        return SetMode(mem.Mode, TxVfo.A);
     }
 
     /// <summary>

--- a/tests/Zeus.Server.Tests/RadioServicePerBandModeTests.cs
+++ b/tests/Zeus.Server.Tests/RadioServicePerBandModeTests.cs
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Server-authoritative per-band mode recall (KB2UKA 2026-06-25). When the
+/// operator's dial crosses into a different band, <see cref="RadioService.SetVfo"/>
+/// restores that band's last-used demod mode from <see cref="BandMemoryStore"/>
+/// so mode follows the band no matter how the band changed — the band-selector
+/// UIs already did this; this closes the gap for the VFO knob / typed frequency.
+///
+/// Invariants pinned here:
+///   1. Crossing into a band with a remembered mode recalls it.
+///   2. A band with no remembered entry leaves the current mode untouched
+///      (first visit → the current mode simply carries over).
+///   3. Tuning within the same band never recalls.
+///   4. External sources (CAT/TCI/calibration, fromExternal=true) keep their
+///      own mode — no recall.
+///   5. The full back-and-forth: each band remembers its own mode independently.
+///   6. With no BandMemoryStore wired, SetVfo is unchanged (recall no-ops).
+/// </summary>
+public sealed class RadioServicePerBandModeTests : IDisposable
+{
+    // Server BandUtils.FreqToBand ranges — pick a comfortably in-band frequency
+    // per band so the key matches the frontend's "40m"/"20m"/"17m" save key.
+    private const long Hz40m = 7_100_000;   // FreqToBand -> "40m"
+    private const long Hz20m = 14_200_000;  // FreqToBand -> "20m"
+    private const long Hz17m = 18_100_000;  // FreqToBand -> "17m" (no seeded entry)
+
+    private readonly string _dbPath;
+    private readonly PaSettingsStore _paStore;
+    private readonly DspSettingsStore _dspStore;
+    private readonly BandMemoryStore _bandMemory;
+
+    public RadioServicePerBandModeTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"zeus-prefs-bandmode-{Guid.NewGuid():N}.db");
+        _paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance, _dbPath + ".pa");
+        _dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance, _dbPath + ".dsp");
+        _bandMemory = new BandMemoryStore(NullLogger<BandMemoryStore>.Instance, _dbPath + ".bm");
+    }
+
+    public void Dispose()
+    {
+        _paStore.Dispose();
+        _dspStore.Dispose();
+        _bandMemory.Dispose();
+        foreach (var suffix in new[] { "", ".pa", ".dsp", ".bm" })
+        {
+            try { if (File.Exists(_dbPath + suffix)) File.Delete(_dbPath + suffix); } catch { }
+        }
+    }
+
+    private RadioService BuildRadio(BandMemoryStore? bandMemory) =>
+        new RadioService(
+            NullLoggerFactory.Instance, _dspStore, _paStore, bandMemoryStore: bandMemory);
+
+    // Land the radio on a known band/mode with the store still empty, so the
+    // positioning tune itself never recalls. Seed memory afterwards.
+    private RadioService LandOn40mLsb(BandMemoryStore? bandMemory)
+    {
+        var radio = BuildRadio(bandMemory);
+        radio.SetMode(RxMode.LSB);
+        radio.SetVfo(Hz40m);
+        Assert.Equal(RxMode.LSB, radio.Snapshot().Mode);
+        return radio;
+    }
+
+    [Fact]
+    public void CrossingIntoBand_WithRememberedMode_RecallsIt()
+    {
+        using var radio = LandOn40mLsb(_bandMemory);
+        _bandMemory.Upsert("20m", Hz20m, RxMode.USB);
+
+        var after = radio.SetVfo(Hz20m);
+
+        Assert.Equal(Hz20m, after.VfoHz);
+        Assert.Equal(RxMode.USB, after.Mode);
+    }
+
+    [Fact]
+    public void CrossingIntoBand_WithNoEntry_CarriesModeOver()
+    {
+        using var radio = LandOn40mLsb(_bandMemory);
+        // 17m has no seeded entry — the current mode must simply carry over.
+        var after = radio.SetVfo(Hz17m);
+
+        Assert.Equal(Hz17m, after.VfoHz);
+        Assert.Equal(RxMode.LSB, after.Mode);
+    }
+
+    [Fact]
+    public void TuningWithinSameBand_NeverRecalls()
+    {
+        using var radio = LandOn40mLsb(_bandMemory);
+        // Memory disagrees with the live mode, but no band edge is crossed, so
+        // the recall must not fire.
+        _bandMemory.Upsert("40m", Hz40m, RxMode.USB);
+
+        var after = radio.SetVfo(Hz40m + 50_000);
+
+        Assert.Equal(RxMode.LSB, after.Mode);
+    }
+
+    [Fact]
+    public void ExternalSource_DoesNotRecall()
+    {
+        using var radio = LandOn40mLsb(_bandMemory);
+        _bandMemory.Upsert("20m", Hz20m, RxMode.USB);
+
+        // CAT/TCI manage their own mode — a recall here would fight them.
+        var after = radio.SetVfo(Hz20m, fromExternal: true);
+
+        Assert.Equal(Hz20m, after.VfoHz);
+        Assert.Equal(RxMode.LSB, after.Mode);
+    }
+
+    [Fact]
+    public void BackAndForth_RemembersEachBandIndependently()
+    {
+        // The exact KB2UKA scenario: LSB on 40m, USB on 20m, hop back and forth.
+        using var radio = LandOn40mLsb(_bandMemory);
+        _bandMemory.Upsert("40m", Hz40m, RxMode.LSB);
+        _bandMemory.Upsert("20m", Hz20m, RxMode.USB);
+
+        Assert.Equal(RxMode.USB, radio.SetVfo(Hz20m).Mode);
+        Assert.Equal(RxMode.LSB, radio.SetVfo(Hz40m).Mode);
+        Assert.Equal(RxMode.USB, radio.SetVfo(Hz20m).Mode);
+        Assert.Equal(RxMode.LSB, radio.SetVfo(Hz40m).Mode);
+    }
+
+    [Fact]
+    public void NoBandMemoryStore_LeavesSetVfoUnchanged()
+    {
+        // Mirrors every existing RadioService test that constructs without a
+        // BandMemoryStore: recall must no-op and mode must not change.
+        using var radio = LandOn40mLsb(bandMemory: null);
+
+        var after = radio.SetVfo(Hz20m);
+
+        Assert.Equal(Hz20m, after.VfoHz);
+        Assert.Equal(RxMode.LSB, after.Mode);
+    }
+}


### PR DESCRIPTION
## What

Make the demod **mode follow the band** whenever the operator lands on a different band — no matter *how* they got there.

### The problem
Per-band last-used mode is already persisted in `BandMemoryStore` and restored by the band-selector UIs (desktop band buttons, toolbar band favorites, the G2 physical front panel). But when you change band by **tuning the VFO across a band edge** — the knob/wheel, a panadapter click, or typing a frequency — nothing restored that band's mode. So if you tune from 40 m into 20 m instead of pressing the 20 m button, your mode stays put. That's the gap that makes mode feel like it "doesn't persist per band."

### The fix
Per-band mode recall is now **server-authoritative**. `RadioService.SetVfo` restores the new band's saved mode from `BandMemoryStore` on a band crossing, reusing `SetMode` so the per-mode filter memory, the CW dial bump, and the LO push all fire exactly as a manual mode change does. One mechanism now covers **every** operator band-change vector uniformly (band buttons, favorites, front panel, knob, panadapter, typed frequency).

- **First visit to a band with no saved mode** → current mode simply carries over (unchanged behavior).
- **Returning to a band** → its last-used mode comes back.
- **CAT / TCI / frequency-calibration** (`fromExternal=true`) are excluded — they manage their own mode, and a recall would fight them.

`BandMemoryStore` gains an optional db-path override for test isolation, matching `PaSettingsStore`/`DspSettingsStore`.

## Why server-side
Decision confirmed with KB2UKA: mode should recall on **any** band change, not only explicit band-selector clicks. Doing it once in `SetVfo`'s existing band-crossing branch is a single source of truth (correct by construction), instead of re-implementing recall in every band-change path.

## Scope
RX1 / VFO A — the single per-band mode register. RX2 band **selection** already restores via the receiver-aware frontend; RX2 *VFO-tune-across-edge* recall is intentionally not in scope here.

The existing frontend band-selector logic is left untouched: it still owns the per-band **frequency** recall and the optimistic UI, and the server recall simply no-ops there because the mode already matches.

## Tests
New `RadioServicePerBandModeTests` (6, all green): recall on crossing, carry-over on first visit, no recall within a band, no recall for external sources, the full back-and-forth round-trip, and a no-`BandMemoryStore` safety case.

- `dotnet build Zeus.slnx` ✅
- `Zeus.Server.Tests`: **1800 passed, 0 failed**, 5 skipped ✅

## Bench check (draft — needs G2)
Logic verified by unit tests; **draft pending a live G2 sanity pass**: set LSB on 40 m, USB on 20 m, then hop between them by (a) band buttons and (b) spinning/typing the VFO across the edge — confirm each band recalls its own mode and CAT-driven tuning is unaffected.