### PR TITLE
fix(web): make FreeDV Stations panel list scroll

### DIFF
--- a/zeus-web/src/layout/panels/FreeDvStationsPanel.tsx
+++ b/zeus-web/src/layout/panels/FreeDvStationsPanel.tsx
@@ -513,7 +513,7 @@ function ReportSection({
             disabled={!canEnable || saving}
             onChange={(e) => persist({ reportEnabled: e.target.checked })}
           />
-          On the map
+          Enable
         </label>
 
         {reporting && (

--- a/zeus-web/src/styles/all-panels.css
+++ b/zeus-web/src/styles/all-panels.css
@@ -471,6 +471,7 @@
 .workspace-tile[data-panel-id='qrz'] > .workspace-tile-body,
 .workspace-tile[data-panel-id='dsp'] > .workspace-tile-body,
 .workspace-tile[data-panel-id='freedv'] > .workspace-tile-body,
+.workspace-tile[data-panel-id='freedvstations'] > .workspace-tile-body,
 .workspace-tile[data-panel-id='vfo'] > .workspace-tile-body,
 .workspace-tile[data-panel-id='chat'] > .workspace-tile-body,
 .workspace-tile[data-panel-id='filterpresets'] > .workspace-tile-body {
@@ -487,6 +488,7 @@
 .workspace-tile[data-panel-id='qrz'] > .workspace-tile-body > *,
 .workspace-tile[data-panel-id='dsp'] > .workspace-tile-body > *,
 .workspace-tile[data-panel-id='freedv'] > .workspace-tile-body > *,
+.workspace-tile[data-panel-id='freedvstations'] > .workspace-tile-body > *,
 .workspace-tile[data-panel-id='vfo'] > .workspace-tile-body > *,
 .workspace-tile[data-panel-id='chat'] > .workspace-tile-body > *,
 .workspace-tile[data-panel-id='filterpresets'] > .workspace-tile-body > * {


### PR DESCRIPTION
## Problem

The FreeDV Stations panel list doesn't scroll — when there are more stations than fit the tile, the overflow is unreachable.

## Root cause

The panel's table is already a correct inner scroll container (`flex: 1; overflow: auto; min-height: 0`), but it never gets a **bounded** height to fill. `.workspace-tile-body` defaults to `overflow: hidden` and only resolves a flex height for a hardcoded allow-list of panel ids in `all-panels.css`. The `freedvstations` id was missing from that list (it has `freedv`, the decoder panel, but not the stations panel), so the body never became a bounded flex column, the table grew to its natural height, and `overflow: auto` had nothing to clip.

## Fix

- Add `freedvstations` to both tile-body selectors so the panel gets the same bounded flex column the other 12 scrollable panels (`spots`, `logbook`, `qrz`, `freedv`, etc.) already use.
- Relabel the "Report me" toggle from "On the map" to "Enable" (the live broadcasting lamp still reads "● on the map").

CSS-only structural change that replicates an established, working pattern — low risk.