### PR TITLE
fix(web): show RX preamp (PRE) button only on boards that support it

### DIFF
--- a/zeus-web/src/components/PreampButton.test.tsx
+++ b/zeus-web/src/components/PreampButton.test.tsx
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { useConnectionStore } from '../state/connection-store';
+import { PreampButton } from './PreampButton';
+
+// The boolean RX preamp bit is honored only by the original Mercury/Metis "G1"
+// firmware (Thetis console.cs:19223). Every other board uses the step
+// attenuator, so the PRE toggle must hide. These tests lock that gate.
+function preButton(container: HTMLElement): HTMLButtonElement | null {
+  return Array.from(container.querySelectorAll('button')).find(
+    (b) => b.textContent?.trim() === 'PRE',
+  ) as HTMLButtonElement | undefined ?? null;
+}
+
+describe('PreampButton visibility', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    useConnectionStore.setState({ status: 'Disconnected', boardId: null });
+  });
+
+  function renderFor(boardId: string | null) {
+    useConnectionStore.setState({ status: 'Connected', boardId });
+    act(() => {
+      root.render(<PreampButton />);
+    });
+  }
+
+  it('renders the PRE button on the original Mercury/Metis G1', () => {
+    renderFor('Metis');
+    expect(preButton(container)).not.toBeNull();
+  });
+
+  it('hides the PRE button on Orion-MkII / G2 (step attenuator only)', () => {
+    renderFor('OrionMkII');
+    expect(preButton(container)).toBeNull();
+  });
+
+  it('hides the PRE button on Hermes-Lite 2', () => {
+    renderFor('HermesLite2');
+    expect(preButton(container)).toBeNull();
+  });
+
+  it('hides the PRE button when no board is connected', () => {
+    renderFor(null);
+    expect(preButton(container)).toBeNull();
+  });
+});

--- a/zeus-web/src/components/PreampButton.tsx
+++ b/zeus-web/src/components/PreampButton.tsx
@@ -47,10 +47,15 @@ import { useCallback } from 'react';
 import { setPreamp } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
 
-// HermesLite2 has no hardware preamp — the RX gain path is firmware-controlled
-// through the attenuator register (CC0=0x14), so a preamp toggle is a no-op
-// that only confuses the user. Hide the button on HL2 entirely.
-const HL2_BOARD_ID = 'HermesLite2';
+// The boolean RX preamp bit (Mercury LNA — C3[4] of the C0=0x14 frame) is only
+// honored by the original HPSDR/Mercury "G1" stack. Thetis sends it solely for
+// HPSDRModel.HPSDR (console.cs:19223): every other board — Hermes, ANAN,
+// Orion-MkII / G2, HermesLite 2 — drives the RX front end through the step
+// attenuator instead, which Zeus surfaces as the S-ATT slider. On those boards
+// the preamp bit is inert on the wire, so the PRE toggle does nothing and only
+// confuses the operator. Show the button solely for the one board where it has
+// an effect; the step attenuator covers front-end gain everywhere else.
+const MERCURY_BOARD_ID = 'Metis';
 
 export function PreampButton() {
   const boardId = useConnectionStore((s) => s.boardId);
@@ -69,7 +74,7 @@ export function PreampButton() {
       });
   }, [applyState, preampOn, setPreampOn]);
 
-  if (boardId === HL2_BOARD_ID) return null;
+  if (boardId !== MERCURY_BOARD_ID) return null;
 
   return (
     <button


### PR DESCRIPTION
## Problem

Toggling the **PRE** button in the top-bar FRONT-END group does nothing on G2 / Orion-class radios — it highlights in the UI but the received signal is unchanged.

## Root cause

The PRE button sends the boolean **Mercury preamp bit** (`C3[4]` of the `C0=0x14` frame). Per Thetis ground truth, that bit is honored by **only one board** — the original HPSDR/Mercury "G1":

> `console.cs:19223` → `if (Model != HPSDRModel.HPSDR) { SetADCxStepAttenData(...) } else { SetRX1Preamp(...) }`

Every other board (Hermes, ANAN-10/100/100D/200D, Orion-MkII / G2 / 7000–8000DLE / G2-1K / Red Pitaya / Anvelina, HL2) drives RX front-end gain through the **step attenuator**, which Zeus already exposes as the **S-ATT** slider sitting right next to PRE. On those boards the preamp bit is inert on the wire, so the button is a no-op that only confuses the operator.

## Fix

Generalize the existing HL2-only hide so PRE is shown **only on the original Mercury/Metis** board — the one whose firmware acts on the bit. Hidden everywhere else; the step attenuator (S-ATT) covers front-end gain on those radios, matching Thetis.

| Radio | PRE button |
|---|---|
| Mercury / Metis (G1) | shown — has the hardware preamp |
| Hermes / ANAN-10/10E/100/100B/100D/200D | hidden — step attenuator only |
| Orion-MkII / G2 / 7000DLE / 8000DLE / G2-1K / Red Pitaya / Anvelina | hidden — step attenuator only |
| Hermes-Lite 2 | hidden (already was) |

## Testing

- `tsc --noEmit` clean
- New `PreampButton.test.tsx` locks per-board visibility (Metis shows; G2 / HL2 / disconnected hide) — 4/4 passing

No backend/wire behavior changed; this is purely a frontend visibility gate.