### PR TITLE
feat(web): Reset button for the lightning proximity alert

### DIFF
--- a/zeus-web/src/layout/panels/LightningMapPanel.css
+++ b/zeus-web/src/layout/panels/LightningMapPanel.css
@@ -170,14 +170,39 @@
   border: 1px solid var(--tx, #ff4a59);
   border-radius: 4px;
   box-shadow: 0 0 18px rgba(255, 74, 89, 0.5);
-  pointer-events: none;
+  pointer-events: auto; /* the Reset button inside needs to be clickable */
   white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 10px;
   animation: lm-alert-blink 1.1s steps(1) infinite;
 }
 
 @keyframes lm-alert-blink {
   0%, 60% { opacity: 1; }
   61%, 100% { opacity: 0.55; }
+}
+
+/* Reset/acknowledge — clears the in-radius tally back to 0 and stands the
+   alert down. Steady (no blink) so it stays an easy click target. */
+.lightning-map .lm-alert-reset {
+  flex: 0 0 auto;
+  padding: 2px 9px;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.28);
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  border-radius: 3px;
+  cursor: pointer;
+  animation: none; /* opt out of the banner blink so it reads as steady */
+}
+.lightning-map .lm-alert-reset:hover {
+  background: #fff;
+  color: var(--tx, #d6281e);
 }
 
 /* Alert settings — gear button bottom-right, above the recenter control. */

--- a/zeus-web/src/layout/panels/LightningMapPanel.tsx
+++ b/zeus-web/src/layout/panels/LightningMapPanel.tsx
@@ -598,6 +598,16 @@ export function LightningMapPanel() {
 
   const onUnitChange = (unit: 'km' | 'mi') => patchAlert({ unit });
 
+  // Acknowledge the alert: clear the in-radius tally so the count drops to 0 and
+  // the banner/ring stand down immediately. Resetting prevAlertingRef re-arms the
+  // chirp, so a fresh storm building back over threshold trips (and sounds) anew.
+  const resetAlert = () => {
+    nearRef.current.length = 0;
+    prevAlertingRef.current = false;
+    setNearCount(0);
+    setAlerting(false);
+  };
+
   return (
     <div className="lightning-map">
       <div ref={hostRef} className="lm-host" />
@@ -626,7 +636,17 @@ export function LightningMapPanel() {
 
       {alerting && (
         <div className="lm-alert-banner" role="status" aria-live="assertive">
-          ⚡ Lightning alert — {nearCount} strikes within {radiusLabel} of your QTH
+          <span className="lm-alert-text">
+            ⚡ Lightning alert — {nearCount} strikes within {radiusLabel} of your QTH
+          </span>
+          <button
+            type="button"
+            className="lm-alert-reset"
+            onClick={resetAlert}
+            title="Acknowledge the alert and reset the strike count to 0"
+          >
+            Reset
+          </button>
         </div>
       )}
 


### PR DESCRIPTION
## What

Follow-up to #968 (proximity strike alert). Adds a **Reset** button so the operator can acknowledge a tripped alert and clear the strike tally back to **0** without waiting for the cell to drift out of the rolling window.

- A steady **"Reset"** button sits on the red alert banner (opts out of the banner blink so it stays an easy click target).
- Clicking it clears the in-radius timestamp tally, drops the **Near** HUD count to 0, and stands the banner + red ring down immediately.
- A fresh storm building back over the threshold **re-arms and re-chirps** as normal (the rising-edge guard is reset too).

## Implementation
- New `resetAlert()` empties `nearRef`, resets `prevAlertingRef`, and zeroes the `nearCount`/`alerting` state.
- Banner became a small flex row (text + button) with `pointer-events: auto` so the button is clickable.

## Verification
`tsc -b` and ESLint pass clean. Not browser-verified end-to-end for the same reason as #968 (headless preview can'\''t drive this panel'\''s Leaflet/canvas/rAF + live-feed pipeline); the reset path is a straightforward state clear.