### PR TITLE
fix(web): serve fresh index.html/sw.js so new features show without a hard refresh

### DIFF
--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -928,7 +928,28 @@ public static class ZeusHost
         staticContentTypes.Mappings[".onnx"] = "application/octet-stream";
         staticContentTypes.Mappings[".wasm"] = "application/wasm";
         staticContentTypes.Mappings[".mjs"] = "text/javascript";
-        app.UseStaticFiles(new Microsoft.AspNetCore.Builder.StaticFileOptions { ContentTypeProvider = staticContentTypes });
+        app.UseStaticFiles(new Microsoft.AspNetCore.Builder.StaticFileOptions
+        {
+            ContentTypeProvider = staticContentTypes,
+            // Cache policy is load-bearing for the "new features don't show up until
+            // Ctrl+Shift+R" bug. Without an explicit Cache-Control, ASP.NET only emits
+            // ETag/Last-Modified and the browser heuristically caches index.html AND
+            // sw.js — so a new deploy serves a stale index (old hashed chunks) and the
+            // service-worker update check never sees a fresh sw.js, so the "RELOAD NOW"
+            // prompt never fires. Content-hashed Vite output under /assets/ is safe to
+            // cache forever (the URL changes when the content does); everything else
+            // (index.html, sw.js, the web manifest, icons, the ONNX model) must
+            // revalidate every load. ETag keeps revalidation cheap (304s).
+            // See docs/lessons/service-worker-updates.md.
+            OnPrepareResponse = static ctx =>
+            {
+                var requestPath = ctx.Context.Request.Path.Value ?? string.Empty;
+                ctx.Context.Response.Headers.CacheControl =
+                    requestPath.StartsWith("/assets/", StringComparison.OrdinalIgnoreCase)
+                        ? "public, max-age=31536000, immutable"
+                        : "no-cache";
+            },
+        });
 
         // WDSP NR2 EMNR fopen()s "zetaHat.bin" and "calculus" by bare relative name
         // (native/wdsp/emnr.c:215,397). Anchor cwd to the assembly dir so those files

--- a/docs/lessons/service-worker-updates.md
+++ b/docs/lessons/service-worker-updates.md
@@ -82,6 +82,30 @@ To test the update mechanism:
 
 **Note**: During development (Vite dev server), service workers are disabled. Testing must be done with production builds.
 
+## Cache headers are a prerequisite (the "Ctrl+Shift+R fixes it" bug)
+
+The prompt flow above only works if the browser actually revalidates `sw.js` and
+`index.html` on each load. ASP.NET's `UseStaticFiles` sets `ETag`/`Last-Modified`
+but **no `Cache-Control`**, so the browser applies *heuristic* caching and holds
+both files without revalidating. Symptoms:
+
+- New visitors load a **stale `index.html`** referencing old hashed chunks → new
+  features are missing until a hard reload.
+- `reg.update()` fetches a **cached `sw.js`**, never detects the new worker, so the
+  "RELOAD NOW" prompt never appears. `Ctrl+Shift+R` "fixes" it only because a hard
+  reload bypasses the HTTP cache.
+
+Fix lives in `Zeus.Server.Hosting/ZeusHost.cs` (`UseStaticFiles.OnPrepareResponse`):
+content-hashed `/assets/*` get `public, max-age=31536000, immutable`; everything
+else (`index.html`, `sw.js`, manifest, icons, the ONNX model) gets `no-cache` so it
+revalidates every load (cheap 304s via ETag). The client also checks for updates on
+tab focus/visibility (`registerSW.ts`), not just the 60s poll, so a new deploy is
+picked up "when they open" the app.
+
+We deliberately did **not** switch to forced auto-reload: Zeus is a live radio
+control surface and reloading mid-TX/tune would be unsafe. The operator-confirmed
+"RELOAD NOW" prompt stays.
+
 ## References
 
 - [Vite PWA Plugin - Prompt for Update](https://vite-pwa-org.netlify.app/guide/prompt-for-update.html)

--- a/zeus-web/src/service-worker/registerSW.ts
+++ b/zeus-web/src/service-worker/registerSW.ts
@@ -100,14 +100,21 @@ export function registerServiceWorker(
         registration = reg;
         console.log('Service worker registered successfully');
 
-        // Check for updates every 60 seconds when the page is visible
-        setInterval(() => {
-          if (document.visibilityState === 'visible') {
-            reg?.update().catch((err) => {
-              console.warn('SW update check failed:', err);
-            });
-          }
-        }, 60000);
+        const checkForUpdate = () => {
+          if (document.visibilityState !== 'visible') return;
+          reg?.update().catch((err) => {
+            console.warn('SW update check failed:', err);
+          });
+        };
+
+        // Check on a 60s heartbeat AND whenever the operator returns to the tab
+        // (refocus / un-hide), so a new deploy is picked up "when they open" the
+        // app instead of waiting up to a minute for the next poll. The no-cache
+        // header on sw.js (see ZeusHost.cs UseStaticFiles) is what lets update()
+        // actually see a fresh worker. See docs/lessons/service-worker-updates.md.
+        setInterval(checkForUpdate, 60000);
+        document.addEventListener('visibilitychange', checkForUpdate);
+        window.addEventListener('focus', checkForUpdate);
       })
       .catch((err) => {
         console.error('Service worker registration failed:', err);


### PR DESCRIPTION
## Problem

Some users couldn't see newly deployed features until they did a manual **Ctrl+Shift+R**. After that, everything worked.

## Root cause

`app.UseStaticFiles()` emitted **no `Cache-Control`** header — ASP.NET only added `ETag`/`Last-Modified`, so browsers applied *heuristic* caching and held onto **`index.html`** and **`sw.js`** without revalidating. Two consequences:

- A fresh/returning visitor loaded a **stale `index.html`** → old content-hashed JS chunks → missing features.
- The existing service-worker update flow relies on `reg.update()` fetching a fresh `sw.js`. With `sw.js` HTTP-cached, the update was **never detected**, so the "RELOAD NOW" prompt never appeared.

`Ctrl+Shift+R` "fixed" it only because a hard reload bypasses the HTTP cache.

## Fix

1. **Server (root cause)** — `ZeusHost.cs` `UseStaticFiles.OnPrepareResponse`:
   - Content-hashed `/assets/*` → `public, max-age=31536000, immutable` (URL changes when content does).
   - Everything else (`index.html`, `sw.js`, manifest, icons, ONNX model) → `no-cache`, so it revalidates every load. ETag keeps revalidation cheap (304s).
   - New visitors now get fresh code automatically, and the SW update check can finally see a new `sw.js`.

2. **Client ("when they open")** — `registerSW.ts` now also checks for SW updates on tab **focus / visibilitychange**, not just the 60s poll, so a returning operator is offered the update immediately on reopening the tab.

3. **Docs** — `docs/lessons/service-worker-updates.md` documents the cache-header prerequisite.

## Deliberately NOT changed

No forced auto-reload. Zeus is a live radio control surface — reloading mid-TX/tune would be unsafe — so the operator-confirmed "RELOAD NOW" prompt stays (consistent with the existing `prompt`-mode design called out as load-bearing in `vite.config.ts`). New visitors get fresh code with zero clicks via the cache headers; returning users get a one-click prompt the moment they refocus.

## Scope / cross-platform

Targets the desktop/LAN ASP.NET host (`Zeus.Server.Hosting`) where most users run; the hosted Cloudflare Pages SPA serves its own headers. Platform-agnostic C#/TS — no native or path concerns.

## Verification

- `dotnet build Zeus.Server.Hosting` — clean (0 warnings, 0 errors).
- `tsc --noEmit` on `zeus-web` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)