### PR TITLE
fix(web): use in-app Zeus dialog for switch-database confirmation

### DIFF
--- a/zeus-web/src/components/ConnectPanel.tsx
+++ b/zeus-web/src/components/ConnectPanel.tsx
@@ -202,6 +202,7 @@ function PrefsDatabaseRow() {
   const [restarting, setRestarting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [newDialogOpen, setNewDialogOpen] = useState(false);
+  const [pendingSwitch, setPendingSwitch] = useState<string | null>(null);
 
   const refresh = useCallback(async (signal?: AbortSignal) => {
     try {
@@ -222,8 +223,8 @@ function PrefsDatabaseRow() {
 
   const onSwitch = useCallback(
     async (relativePath: string) => {
+      setPendingSwitch(null);
       if (relativePath === activeRel) return;
-      if (!window.confirm('Switch database and restart Zeus?')) return;
       setError(null);
       setBusy(true);
       try {
@@ -321,7 +322,10 @@ function PrefsDatabaseRow() {
           aria-label="Active prefs database"
           value={activeRel}
           disabled={disabled}
-          onChange={(e) => void onSwitch(e.target.value)}
+          onChange={(e) => {
+            const next = e.target.value;
+            if (next && next !== activeRel) setPendingSwitch(next);
+          }}
           style={{ ...prefsDbSelectStyle, flex: 1 }}
         >
           {databases === null && <option value="">Loading…</option>}
@@ -390,6 +394,23 @@ function PrefsDatabaseRow() {
           onSubmit={(name) => void onCreate(name)}
           onCancel={() => setNewDialogOpen(false)}
         />
+      )}
+      {pendingSwitch !== null && (
+        <ConfirmDialog
+          title="Switch Database"
+          confirmLabel="Switch & Restart"
+          intent="primary"
+          onConfirm={() => void onSwitch(pendingSwitch)}
+          onCancel={() => setPendingSwitch(null)}
+        >
+          <p style={{ margin: 0, fontSize: 12.5, color: 'var(--fg-1)' }}>
+            Switch to{' '}
+            <strong className="mono">
+              {(databases ?? []).find((db) => db.relativePath === pendingSwitch)?.name ?? pendingSwitch}
+            </strong>{' '}
+            and restart Zeus?
+          </p>
+        </ConfirmDialog>
       )}
     </div>
   );


### PR DESCRIPTION
## Problem

Switching the active prefs database (the Database dropdown on the connect screen) called `window.confirm('Switch database and restart Zeus?')` — a raw browser dialog. That breaks Zeus chrome and violates the project's hard no-browser-dialogs rule.

## Fix

Replaces the `window.confirm` with an in-app `ConfirmDialog` that names the target database. The `<select>`'s `onChange` now *stages* the chosen path (`setPendingSwitch`); the switch + restart runs only on confirm. On Cancel, the controlled select (`value={activeRel}`) naturally snaps back to the active DB.

## Stacked PR

This is stacked on **#979** (the new-database PromptDialog change) — it adds the switch dialog right beside that one, so the base is `fix/web-new-db-native-dialog`. GitHub will auto-retarget this to `develop` once #979 merges. The diff here is the switch-confirm change only.

## Testing

- `tsc --noEmit` passes (exit 0).

## Follow-up complete

This finishes converting the Database row's browser dialogs (create + switch) to Zeus chrome.