### PR TITLE
feat(web): autopan keeps the RX filter & dial in view under CTUN

### DIFF
--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -4056,6 +4056,45 @@ public class DspPipelineService : BackgroundService,
         rx.LoInit = true;
     }
 
+    /// <summary>
+    /// Pan a secondary receiver's DDC centre to <paramref name="hz"/> — the
+    /// client-side keep-in-view autopan's analogue of RX1's
+    /// <see cref="RadioService.SetRadioLo"/>. Under CTUN the centre is frozen and
+    /// the dial roams within the captured window, so the dial/filter can leave the
+    /// (much narrower) visible span long before <see cref="UpdateRxLo"/>'s
+    /// DDC-edge recentre fires; the client — which knows the visible span — calls
+    /// this to recentre before that happens.
+    ///
+    /// <para>Only meaningful for a true independent DDC (Protocol 2). P1 / synthetic
+    /// secondaries sub-receive RX1's shared NCO (their WDSP shift is RadioLoHz-
+    /// relative, see <see cref="ComputeSecondaryCtunShiftHz"/>), so their centre
+    /// can't move independently — no-op there. Also a no-op with CTUN off (the
+    /// centre follows the dial) or when the receiver is disabled.</para>
+    ///
+    /// <para>Re-applies the current state under <c>_engineLock</c> on the caller
+    /// thread, exactly like normal tuning via <see cref="RadioService.StateChanged"/>,
+    /// so the WDSP shift recompute and the P2 DDC retune land in lockstep with the
+    /// new centre. The new centre survives the <see cref="UpdateRxLo"/> calls inside
+    /// because the client keeps the dial within the captured window (visible span ⊆
+    /// DDC window), so the edge-recentre guard never trips.</para>
+    /// </summary>
+    public void RequestSecondaryLo(int rxIndex, long hz)
+    {
+        if (rxIndex < 1 || rxIndex >= MaxReceivers) return;
+        if (_p2Client is null) return; // P1 secondaries share RadioLoHz — not pannable
+        long clamped = Math.Clamp(hz, 0L, 60_000_000L);
+        lock (_engineLock)
+        {
+            var s = _radio.Snapshot();
+            if (!s.CtunEnabled || !SecondaryReceiverEnabled(rxIndex, s)) return;
+            var rx = _secondaryRx[rxIndex];
+            if (rx.LoInit && rx.LoHz == clamped) return; // already centred there
+            rx.LoHz = clamped;
+            rx.LoInit = true;
+            OnRadioStateChanged(s);
+        }
+    }
+
     internal static int ComputeRx2CtunShiftHz(
         StateDto s,
         long rx2LoHz,

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -1258,6 +1258,23 @@ public static class ZeusEndpoints
             return Results.Ok(r.SetRadioLo(req.Hz));
         });
 
+        // Per-receiver DDC-centre pan. Index 0 is RX1's hardware NCO (delegates to
+        // /api/radio/lo's setter); index >= 1 recentres a secondary DDC (the
+        // client keep-in-view autopan's analogue of SetRadioLo). No-op for P1
+        // secondaries (shared NCO) / CTUN-off / disabled — see RequestSecondaryLo.
+        app.MapPost("/api/receivers/{index:int}/lo", (int index, RadioLoSetRequest req, RadioService r, DspPipelineService pipe) =>
+        {
+            if (req.Hz < 0 || req.Hz > 60_000_000)
+            {
+                log.LogInformation("api.receivers.lo rejected index={Index} hz={Hz}", index, req.Hz);
+                return Results.BadRequest(new { error = "hz out of range [0, 60000000]" });
+            }
+            log.LogInformation("api.receivers.lo index={Index} hz={Hz}", index, req.Hz);
+            if (index <= 0) return Results.Ok(r.SetRadioLo(req.Hz));
+            pipe.RequestSecondaryLo(index, req.Hz);
+            return Results.Ok(r.Snapshot());
+        });
+
         // Toggle CTUN (click-tune / centred tuning). When enabled, panadapter
         // clicks move only the dial and leave the hardware NCO frozen so the
         // operator can tune off-centre; TX retunes to the dial on key-down.

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -109,6 +109,7 @@ import { useLayoutStore } from './state/layout-store';
 import { useDisplaySettingsStore } from './state/display-settings-store';
 import { useCapabilitiesStore } from './state/capabilities-store';
 import { useKeyboardShortcuts } from './util/use-keyboard-shortcuts';
+import { useFilterAutopan } from './util/filter-autopan';
 import { SpectrumWheelActionsContext, type SpectrumWheelActions } from './util/use-pan-tune-gesture';
 import { BandPlanProvider } from './context/BandPlanContext';
 import { registerServiceWorker } from './service-worker/registerSW';
@@ -210,6 +211,8 @@ export default function App() {
   useKeyboardShortcuts();
   useMicUplink();
   useFilterRibbonOpenSync();
+  // Keep the RX filter + dial crosshair inside the spectrum view under CTUN.
+  useFilterAutopan();
 
   const topbarControlsRef = useRef<HTMLDivElement | null>(null);
   const [topbarScroll, setTopbarScroll] = useState({ canLeft: false, canRight: false });

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -5461,6 +5461,28 @@ export function setRadioLo(
   );
 }
 
+// Pan a receiver's DDC centre (the keep-in-view autopan lever). Index 0 is
+// RX1's hardware NCO (→ /api/radio/lo); index >= 1 recentres a secondary DDC
+// via /api/receivers/{index}/lo. The server no-ops the secondary path for P1
+// (shared NCO), CTUN-off, or a disabled receiver — see RequestSecondaryLo.
+export function setReceiverLo(
+  index: number,
+  hz: number,
+  signal?: AbortSignal,
+): Promise<RadioStateDto> {
+  if (index <= 0) return setRadioLo(hz, signal);
+  return jsonFetch(
+    `/api/receivers/${index}/lo`,
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ hz }),
+      signal,
+    },
+    normalizeState,
+  );
+}
+
 // Toggle CTUN (click-tune / centred tuning). Server returns the full updated
 // StateDto; on enable the hardware NCO is frozen at its current centre, on
 // disable it snaps back to the dial. See use-pan-tune-gesture.ts for how the

--- a/zeus-web/src/util/ctun-zoom-center.ts
+++ b/zeus-web/src/util/ctun-zoom-center.ts
@@ -17,9 +17,10 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
-import { setRadioLo, type ZoomLevel } from '../api/client';
+import { setRadioLo, setReceiverLo, type ZoomLevel } from '../api/client';
 import { selectDisplaySlice, useDisplayStore } from '../state/display-store';
 import { useConnectionStore } from '../state/connection-store';
+import { rxIndexOf, type ReceiverKey } from '../state/receiver-state';
 import * as viewCenter from '../state/view-center';
 
 const MAX_HZ = 60_000_000;
@@ -71,6 +72,60 @@ export function centerCtunForZoomIn(
       .catch(() => {});
   }
   return targetLoHz;
+}
+
+// Coalesce overlapping autopan POSTs — a fast tune burst can queue several
+// recentre commands; only the last one's applied LO should win.
+let autopanAbort: AbortController | null = null;
+
+/** Glide the CTUN view centre (hardware LO) to `loHz`, locally and on the
+ *  backend. Shares applyLocalCtunZoomCenter so the view-centre tween and the
+ *  radioLoHz store stay in lockstep exactly like the zoom-in recentre path.
+ *  No-op when CTUN is off (the view follows the dial there, so there is
+ *  nothing to recentre). Used by the filter-autopan keep-in-view logic. */
+export function panCtunCenterTo(loHz: number): void {
+  if (!useConnectionStore.getState().ctunEnabled) return;
+  const next = clampHz(loHz);
+  applyLocalCtunZoomCenter(next);
+  autopanAbort?.abort();
+  const ctrl = new AbortController();
+  autopanAbort = ctrl;
+  setRadioLo(next, ctrl.signal)
+    .then((state) => {
+      if (!ctrl.signal.aborted) applyLocalCtunZoomCenter(state.radioLoHz);
+    })
+    .catch(() => {});
+}
+
+// Per-receiver autopan POST coalescing — one in-flight recentre per RX index.
+const secondaryLoAborts = new Map<number, AbortController>();
+
+/** Glide ANY receiver's view centre to `hz` to keep its dial/filter in view.
+ *  RX1 (index 0) recentres the hardware NCO via {@link panCtunCenterTo};
+ *  secondary receivers glide their own view-centre tween optimistically and
+ *  POST the new DDC centre (server no-ops on P1 / CTUN-off, where frames then
+ *  reconcile the glide back). No-op outside CTUN — the view follows the dial
+ *  there, so there is nothing to recentre. */
+export function panReceiverCenterTo(receiver: ReceiverKey, hz: number): void {
+  const idx = rxIndexOf(receiver);
+  if (idx === 0) {
+    panCtunCenterTo(hz);
+    return;
+  }
+  if (!useConnectionStore.getState().ctunEnabled) return;
+  const next = clampHz(hz);
+  const vc = viewCenter.viewCenterFor(receiver);
+  const s = selectDisplaySlice(useDisplayStore.getState(), receiver);
+  if (vc.isInitialized()) {
+    vc.nudgeTargetHz(next - vc.getTargetCenterHz());
+  } else {
+    vc.snapTo(next, s.hzPerPixel > 0 ? s.hzPerPixel : undefined);
+    vc.markOptimisticTune();
+  }
+  secondaryLoAborts.get(idx)?.abort();
+  const ctrl = new AbortController();
+  secondaryLoAborts.set(idx, ctrl);
+  setReceiverLo(idx, next, ctrl.signal).catch(() => {});
 }
 
 function applyLocalCtunZoomCenter(loHz: number): void {

--- a/zeus-web/src/util/filter-autopan.test.ts
+++ b/zeus-web/src/util/filter-autopan.test.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License v2 or later. See the
+// LICENSE file at the repository root, or https://www.gnu.org/licenses/.
+
+import { describe, expect, it } from 'vitest';
+import { computeAutopanCenterHz } from './filter-autopan';
+
+// 192 kHz span, USB 150..2850 filter, ~6% margin (11.52 kHz).
+const SPAN = 192_000;
+const MARGIN = SPAN * 0.06;
+const base = {
+  spanHz: SPAN,
+  filterLowHz: 150,
+  filterHighHz: 2850,
+  mode: 'USB',
+  cwPitchHz: 600,
+  marginHz: MARGIN,
+};
+
+describe('computeAutopanCenterHz — keep filter/dial in view', () => {
+  it('returns null when the dial sits on the view centre', () => {
+    expect(
+      computeAutopanCenterHz({ ...base, viewCenterHz: 14_200_000, vfoHz: 14_200_000 }),
+    ).toBeNull();
+  });
+
+  it('returns null while the filter is comfortably inside the margin', () => {
+    // Dial 50 kHz right of centre: filter high edge at ~+52.85 kHz, well within
+    // the usable half-window (96 - 11.52 = 84.48 kHz).
+    expect(
+      computeAutopanCenterHz({ ...base, viewCenterHz: 14_200_000, vfoHz: 14_250_000 }),
+    ).toBeNull();
+  });
+
+  it('pans right just enough to seat the filter high edge on the margin', () => {
+    // Dial 90 kHz right: filter high edge at 14_290_000 + 2850 = 14_292_850.
+    const viewCenterHz = 14_200_000;
+    const vfoHz = 14_290_000;
+    const next = computeAutopanCenterHz({ ...base, viewCenterHz, vfoHz });
+    expect(next).not.toBeNull();
+    // Edge-follow: high edge should now rest on the right margin line.
+    const viewHi = next! + SPAN / 2 - MARGIN;
+    expect(viewHi).toBeCloseTo(vfoHz + 2850, 3);
+    expect(next!).toBeGreaterThan(viewCenterHz); // panned toward the dial
+  });
+
+  it('pans left when the dial walks off the low edge (carrier kept in view)', () => {
+    // Dial 90 kHz left: carrier (vfo) is the leftmost extent for USB.
+    const viewCenterHz = 14_200_000;
+    const vfoHz = 14_110_000;
+    const next = computeAutopanCenterHz({ ...base, viewCenterHz, vfoHz });
+    expect(next).not.toBeNull();
+    const viewLo = next! - SPAN / 2 + MARGIN;
+    expect(viewLo).toBeCloseTo(vfoHz, 3); // carrier seated on the left margin
+    expect(next!).toBeLessThan(viewCenterHz);
+  });
+
+  it('anchors the passband on the LO in CW (pitch-shifted), not the VFO', () => {
+    // CWU: LO = vfo - pitch. With a symmetric narrow filter the band hangs off
+    // the LO; verify the recentre accounts for the pitch shift.
+    const cw = { ...base, mode: 'CWU', filterLowHz: -250, filterHighHz: 250 };
+    const viewCenterHz = 14_200_000;
+    const vfoHz = 14_295_000; // far right
+    const next = computeAutopanCenterHz({ ...cw, viewCenterHz, vfoHz });
+    expect(next).not.toBeNull();
+    // Rightmost extent is max(vfo, lo+250) = vfo (since lo = vfo-600).
+    const viewHi = next! + SPAN / 2 - MARGIN;
+    expect(viewHi).toBeCloseTo(vfoHz, 3);
+  });
+
+  it('ignores zero / invalid geometry', () => {
+    expect(computeAutopanCenterHz({ ...base, spanHz: 0, viewCenterHz: 1, vfoHz: 1 })).toBeNull();
+    expect(
+      computeAutopanCenterHz({ ...base, viewCenterHz: NaN, vfoHz: 14_200_000 }),
+    ).toBeNull();
+  });
+});

--- a/zeus-web/src/util/filter-autopan.ts
+++ b/zeus-web/src/util/filter-autopan.ts
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is an independent reimplementation in .NET — not a fork. See
+// ATTRIBUTIONS.md for the full provenance statement.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+// Filter / dial keep-in-view autopan (RX1).
+//
+// Under CTUN the hardware LO (display centre) is frozen while the dial roams,
+// so tuning toward a screen edge can walk the receive filter — and the dial
+// crosshair — off the panadapter/waterfall view. This module watches tuning
+// events and, when the dial+filter extent crosses the view edge, glides the
+// CTUN centre just enough to bring it back inside a margin ("edge-follow").
+//
+// Scope / behaviour decisions:
+// - All receivers. RX1 plus every active secondary (RX2, RX3+) is checked
+//   against its OWN displayed view, so a stitched/multi-RX layout keeps each
+//   half in view independently. RX1 pans its hardware NCO; secondaries pan
+//   their own DDC centre (panReceiverCenterTo → /api/receivers/{i}/lo, which is
+//   a true independent DDC on Protocol 2 and a no-op on P1's shared NCO).
+//   Outside CTUN the view already tracks the dial (offset ~0), so the geometry
+//   never asks for a pan there — but we still gate on ctunEnabled to keep the
+//   intent explicit.
+// - Triggered by TUNING only (vfo / filter / mode / cw-pitch / zoom span),
+//   never by a view-centre (radioLo) pan — so a deliberate ruler-pan away from
+//   the RX to inspect other spectrum is preserved; only re-tuning pulls the
+//   filter back into view.
+// - Trailing debounce: a continuous CTUN drag rewrites vfo every frame and maps
+//   the cursor against the frozen grab-time centre, so recentring mid-drag would
+//   fight the gesture. Waiting for tuning to settle (SETTLE_MS) fires the autopan
+//   after a drag releases and after each discrete wheel/key/CAT step.
+
+import { useEffect } from 'react';
+import { selectDisplaySliceByRxId, useDisplayStore } from '../state/display-store';
+import { useConnectionStore } from '../state/connection-store';
+import {
+  getReceiverFilterHighHz,
+  getReceiverFilterLowHz,
+  getReceiverMode,
+  getReceiverVfoHz,
+} from '../state/receiver-state';
+import * as viewCenter from '../state/view-center';
+import { panReceiverCenterTo } from './ctun-zoom-center';
+
+// Keep this fraction of the span between the dial/filter extent and the view
+// edge, so the passband never sits flush against the rail.
+const AUTOPAN_MARGIN_FRAC = 0.06;
+// Trailing settle window after the last tuning event before autopan fires.
+// Long enough that a continuous pointer drag (vfo changes every frame) does not
+// recentre mid-gesture; short enough to feel immediate after a wheel/key step.
+const SETTLE_MS = 90;
+
+/**
+ * Pure geometry: given the current view centre, span, dial, and filter, return
+ * the view centre (Hz) that brings the dial+filter extent back inside the
+ * margin, or null when it is already comfortably in view. Edge-follow — shifts
+ * just enough to seat the offending edge on the margin line, not a full
+ * recentre. Exported for unit testing.
+ */
+export function computeAutopanCenterHz(p: {
+  viewCenterHz: number;
+  spanHz: number;
+  vfoHz: number;
+  filterLowHz: number;
+  filterHighHz: number;
+  mode: string;
+  cwPitchHz: number;
+  marginHz: number;
+}): number | null {
+  const { viewCenterHz, spanHz, vfoHz, filterLowHz, filterHighHz, mode, cwPitchHz, marginHz } = p;
+  if (!(spanHz > 0) || !Number.isFinite(viewCenterHz) || !Number.isFinite(vfoHz)) return null;
+
+  // Filter edges are stored as audio offsets from the hardware LO, not the
+  // dial. In CW the LO sits ±cwPitch from the VFO, so anchor the passband on
+  // the LO (matches PassbandOverlay).
+  const cwOffset = mode === 'CWU' ? -cwPitchHz : mode === 'CWL' ? cwPitchHz : 0;
+  const loHz = vfoHz + cwOffset;
+  const filterLoAbs = loHz + filterLowHz;
+  const filterHiAbs = loHz + filterHighHz;
+  // Keep the dial crosshair (vfoHz) visible too, not only the passband — for
+  // SSB the carrier sits just outside the passband edge.
+  const extentLo = Math.min(vfoHz, filterLoAbs);
+  const extentHi = Math.max(vfoHz, filterHiAbs);
+
+  const halfSpan = spanHz / 2;
+  const margin = Math.max(0, Math.min(marginHz, halfSpan));
+
+  // Extent too wide to fit inside the usable window (very narrow span / very
+  // wide filter): best effort is to centre the extent.
+  if (extentHi - extentLo >= spanHz - 2 * margin) {
+    const mid = (extentLo + extentHi) / 2;
+    return Math.abs(mid - viewCenterHz) > 0.5 ? mid : null;
+  }
+
+  const viewLo = viewCenterHz - halfSpan + margin;
+  const viewHi = viewCenterHz + halfSpan - margin;
+  let shift = 0;
+  if (extentHi > viewHi) shift = extentHi - viewHi;
+  else if (extentLo < viewLo) shift = extentLo - viewLo; // negative
+  if (shift === 0) return null;
+  return viewCenterHz + shift;
+}
+
+/**
+ * Global hook: keeps each receiver's filter + dial crosshair inside its own
+ * panadapter/waterfall view under CTUN by gliding the frozen centre when tuning
+ * walks them off the edge. Covers RX1 and every active secondary. Mount once
+ * (App / MobileApp).
+ */
+export function useFilterAutopan(): void {
+  useEffect(() => {
+    let timer: number | null = null;
+
+    const check = () => {
+      timer = null;
+      const conn = useConnectionStore.getState();
+      // Only CTUN roams the dial off the view centre; otherwise the view
+      // already follows the dial and there is nothing to keep in view.
+      if (!conn.ctunEnabled) return;
+      const ds = useDisplayStore.getState();
+      // RX1 (0) plus every secondary that currently has a slice. A slice with
+      // no valid geometry (disabled / not yet streaming) is skipped below, so a
+      // bare index list is enough — no need for an explicit enabled flag.
+      const indices = [0, ...conn.receivers.map((r) => r.index).filter((i) => i >= 1)];
+      for (const idx of indices) {
+        const s = selectDisplaySliceByRxId(ds, idx);
+        if (!(s.width > 0) || !(s.hzPerPixel > 0)) continue;
+        const spanHz = s.width * s.hzPerPixel;
+        const vc = viewCenter.viewCenterFor(idx);
+        // Test against the COMMANDED centre (where the view is heading), not the
+        // gliding viewHz — otherwise a normal tune glide briefly reads off-centre.
+        const viewCenterHz = vc.isInitialized() ? vc.getTargetCenterHz() : Number(s.centerHz);
+        const next = computeAutopanCenterHz({
+          viewCenterHz,
+          spanHz,
+          vfoHz: getReceiverVfoHz(conn, idx),
+          filterLowHz: getReceiverFilterLowHz(conn, idx),
+          filterHighHz: getReceiverFilterHighHz(conn, idx),
+          mode: getReceiverMode(conn, idx),
+          cwPitchHz: conn.cwPitchHz,
+          marginHz: spanHz * AUTOPAN_MARGIN_FRAC,
+        });
+        if (next != null) panReceiverCenterTo(idx, next);
+      }
+    };
+
+    const schedule = () => {
+      if (timer !== null) window.clearTimeout(timer);
+      timer = window.setTimeout(check, SETTLE_MS);
+    };
+
+    // Tuning / geometry only — deliberately NOT radioLoHz / view-centre, so a
+    // ruler-pan away from the RX is left where the operator put it. `receivers`
+    // reference changes on any secondary vfo/filter/mode edit.
+    const unsubConn = useConnectionStore.subscribe((s, prev) => {
+      if (
+        s.vfoHz !== prev.vfoHz ||
+        s.filterLowHz !== prev.filterLowHz ||
+        s.filterHighHz !== prev.filterHighHz ||
+        s.mode !== prev.mode ||
+        s.cwPitchHz !== prev.cwPitchHz ||
+        s.ctunEnabled !== prev.ctunEnabled ||
+        s.receivers !== prev.receivers
+      ) {
+        schedule();
+      }
+    });
+    const unsubDisplay = useDisplayStore.subscribe((s, prev) => {
+      // Any receiver's span change (RX1 flat fields, or the rx2 / extra slices).
+      if (
+        s.width !== prev.width ||
+        s.hzPerPixel !== prev.hzPerPixel ||
+        s.rx2 !== prev.rx2 ||
+        s.extra !== prev.extra
+      ) {
+        schedule();
+      }
+    });
+
+    return () => {
+      if (timer !== null) window.clearTimeout(timer);
+      unsubConn();
+      unsubDisplay();
+    };
+  }, []);
+}


### PR DESCRIPTION
## What

Under CTUN the DDC centre is frozen while the dial roams, so tuning toward a screen edge can walk the receive filter — and the dial crosshair — off the panadapter/waterfall view. The server only recentres at the captured IQ/DDC-window edge (±0.45×sample-rate), which is far wider than the visible span, so the filter leaves view long before that fires.

This adds **autopan**: when tuning walks the dial+filter toward the edge, the view glides just enough to keep them inside a small margin ("edge-follow"). Works for **every receiver**.

## How

| Receiver | View centre | Pan lever |
|---|---|---|
| RX1 | hardware NCO (`radioLoHz`) | `setRadioLo` glide (existing CTUN-centre path) |
| Secondary, **P2** multi-DDC | own DDC `rx.LoHz` | **new** `POST /api/receivers/{index}/lo` → `DspPipelineService.RequestSecondaryLo` |
| Secondary, **P1** | shares RX1's NCO | not independently pannable — unchanged |

- `RequestSecondaryLo` recentres `rx.LoHz` under `_engineLock` and re-applies state, so the WDSP shift recompute and the P2 DDC retune land in lockstep with the new centre. No-op on P1 / CTUN-off / disabled.
- A small global hook (`useFilterAutopan`) checks RX1 + every active secondary against its own view and calls the appropriate pan lever.

## Behaviour decisions

- **Trigger:** tuning only (vfo / filter / mode / zoom span) — never a view pan, so a deliberate ruler-pan away from the RX to inspect other spectrum is preserved; only re-tuning pulls the filter back.
- **Edge-follow:** glides just enough to seat the offending edge on the margin (minimal motion), not a full recentre.
- **Trailing 90 ms settle:** a continuous pointer drag rewrites the VFO every frame and maps the cursor against the frozen grab-time centre, so recentring mid-drag would fight the gesture; autopan fires after a drag releases and after each discrete wheel/key/CAT step.
- Anchors the passband on the LO (CW pitch-aware) and keeps the dial crosshair visible too, matching `PassbandOverlay`.

## Test

- `dotnet build Zeus.slnx` — **0 warnings, 0 errors**
- `tsc --noEmit` — clean
- `vitest` — autopan geometry **6/6** (centred no-op, in-margin no-op, pan right/left to margin, CW LO anchoring, invalid geometry)

## Needs bench verification

I don't have a radio on this machine, so the **P2 multi-DDC** secondary path (recompute timing, smooth DDC retune without a signal hop) should be checked on real hardware. RX1 is fully exercisable. P1 secondaries are intentionally unchanged (shared NCO — protocol limitation, not a bug).
