### PR TITLE
feat(web): transfer panels between layout tabs + persist detached workspace windows

### DIFF
--- a/OpenhpsdrZeus/Program.cs
+++ b/OpenhpsdrZeus/Program.cs
@@ -104,6 +104,17 @@ public partial class Program
         public string? Url { get; set; }
     }
 
+    // A live detached workspace frame plus the metadata needed to persist and
+    // re-open it (the native PhotinoWindow alone carries neither its layout id
+    // nor a clean title). Tracked in a managed list so the layout id survives
+    // even after the native window is torn down at shutdown.
+    private sealed class DetachedWorkspaceWindow
+    {
+        public required string LayoutId { get; init; }
+        public required string Title { get; init; }
+        public required PhotinoWindow Window { get; init; }
+    }
+
     // OpenhpsdrZeus.csproj defaults to OutputType=Exe (console subsystem) so that
     // headless service mode keeps a usable banner / log on stdout. On Windows that
     // also means a console window pops up alongside the Photino frame in --desktop
@@ -372,6 +383,7 @@ public partial class Program
         // size (and maximized state). Position is not restored — see
         // WindowGeometryStore for why (off-screen / monitor-layout safety).
         var geometryStore = app.Services.GetRequiredService<WindowGeometryStore>();
+        var openWindowsStore = app.Services.GetRequiredService<OpenWorkspaceWindowsStore>();
         var savedGeometry = geometryStore.Get();
         var initialWidth = savedGeometry.Width;
         var initialHeight = savedGeometry.Height;
@@ -385,7 +397,7 @@ public partial class Program
         // resolves correctly from `dotnet run` output and from a published bundle.
         var iconFileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "zeus.ico" : "zeus.png";
         var iconPath = Path.Combine(AppContext.BaseDirectory, iconFileName);
-        var detachedWorkspaceWindows = new List<PhotinoWindow>();
+        var detachedWorkspaceWindows = new List<DetachedWorkspaceWindow>();
 
         // The dark placeholder loaded as StartString carries a tiny script that,
         // once the page is live (i.e. WebView2 has finished initialising), posts a
@@ -607,11 +619,25 @@ public partial class Program
         // runs on its own thread-pool, untouched by the windowing loop.
         StartupDiagnostics.Phase("desktop: window created, entering message loop");
         window.WaitForClose();
+        // Persist the detached windows that are STILL open (operator-closed ones
+        // already removed themselves via their closing handler) so the next
+        // launch reopens them. Must run BEFORE the close-loop below — closing a
+        // child fires its handler, which removes it from this same list.
+        // Best-effort: never let a prefs write block shutdown.
+        try
+        {
+            openWindowsStore.Replace(detachedWorkspaceWindows
+                .Select(d => new OpenWorkspaceWindowDto(d.LayoutId, d.Title)));
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"workspace.windows.save failed: {ex.Message}");
+        }
         foreach (var child in detachedWorkspaceWindows.ToArray())
         {
             try
             {
-                child.Close();
+                child.Window.Close();
             }
             catch (Exception ex)
             {
@@ -721,14 +747,23 @@ public partial class Program
 
     private static void OpenWorkspaceWindow(
         PhotinoWindow owner,
-        List<PhotinoWindow> detachedWorkspaceWindows,
+        List<DetachedWorkspaceWindow> detachedWorkspaceWindows,
         WorkspaceWindowRequest request,
         string iconPath)
     {
         if (!Uri.TryCreate(request.Url, UriKind.Absolute, out var uri)) return;
+        var layoutId = request.LayoutId?.Trim() ?? string.Empty;
         var layoutTitle = string.IsNullOrWhiteSpace(request.Title)
             ? "Workspace"
             : request.Title.Trim();
+        // Startup restore reopens one frame per persisted layout; if one is
+        // already on screen for this layout (e.g. restore raced an operator
+        // drag-off) don't stack a duplicate.
+        if (layoutId.Length > 0 &&
+            detachedWorkspaceWindows.Any(d => d.LayoutId == layoutId))
+        {
+            return;
+        }
         var child = new PhotinoWindow(owner)
             .SetTitle($"Zeus - {layoutTitle}")
             .SetUseOsDefaultLocation(true)
@@ -738,20 +773,30 @@ public partial class Program
             .SetIconFile(iconPath)
             .RegisterWindowClosingHandler((sender, _) =>
             {
+                // An operator closing one detached window deliberately drops it
+                // from the live set, so it is NOT re-opened next launch. The
+                // shutdown close-loop persists the set BEFORE closing children,
+                // so those removals don't erase what we just saved.
                 if (sender is PhotinoWindow closed)
-                    detachedWorkspaceWindows.Remove(closed);
+                    detachedWorkspaceWindows.RemoveAll(d => ReferenceEquals(d.Window, closed));
                 return false;
             })
             .Load(uri);
 
-        detachedWorkspaceWindows.Add(child);
+        var entry = new DetachedWorkspaceWindow
+        {
+            LayoutId = layoutId,
+            Title = layoutTitle,
+            Window = child,
+        };
+        detachedWorkspaceWindows.Add(entry);
         try
         {
             child.WaitForClose();
         }
         catch (Exception ex)
         {
-            detachedWorkspaceWindows.Remove(child);
+            detachedWorkspaceWindows.Remove(entry);
             Console.Error.WriteLine($"detached workspace open failed: {ex.Message}");
         }
     }

--- a/Zeus.Server.Hosting/OpenWorkspaceWindowsStore.cs
+++ b/Zeus.Server.Hosting/OpenWorkspaceWindowsStore.cs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF), Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using LiteDB;
+
+namespace Zeus.Server;
+
+// Persists the set of DETACHED workspace windows (extra Photino frames an
+// operator pops off the dock by dragging a layout tab away) so they reopen on
+// the next desktop launch instead of being forgotten on shutdown.
+//
+// Shares the same zeus-prefs.db as WindowGeometryStore and the other UI prefs.
+// The persisted set is the windows that were OPEN at shutdown: the desktop
+// shell replaces the whole set once, from its live in-memory window list, when
+// the main window closes (see Program.RunDesktop). On the next launch the SPA
+// fetches the set via GET /api/ui/workspace-windows and reopens each one
+// through the same path a manual drag-off uses.
+//
+// Desktop-only consumer; registered unconditionally like WindowGeometryStore so
+// the endpoint always resolves. Service / headless modes simply never write to
+// it, and a web client never calls the restore path (it is gated on the Photino
+// shell bridge), so the set stays empty there.
+public sealed class OpenWorkspaceWindowsStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<OpenWorkspaceWindowEntry> _docs;
+    private readonly ILogger<OpenWorkspaceWindowsStore> _log;
+    private readonly object _sync = new();
+
+    public OpenWorkspaceWindowsStore(
+        ILogger<OpenWorkspaceWindowsStore> log,
+        string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _docs = _db.GetCollection<OpenWorkspaceWindowEntry>("open_workspace_windows");
+        _docs.EnsureIndex(x => x.LayoutId, unique: true);
+
+        _log.LogInformation("OpenWorkspaceWindowsStore initialized at {Path}", dbPath);
+    }
+
+    /// <summary>Every persisted detached-window record, in insertion order.</summary>
+    public IReadOnlyList<OpenWorkspaceWindowDto> GetAll()
+    {
+        lock (_sync)
+        {
+            return _docs.FindAll()
+                .Where(e => !string.IsNullOrWhiteSpace(e.LayoutId))
+                .Select(e => new OpenWorkspaceWindowDto(e.LayoutId, e.Title ?? string.Empty))
+                .ToList();
+        }
+    }
+
+    /// <summary>
+    /// Replace the persisted set with the windows currently open. Called once at
+    /// shutdown from the desktop shell's live window list, so the next launch
+    /// reopens exactly what was on screen. Duplicate layout ids collapse to one
+    /// (a layout can only meaningfully be restored to a single window) and blank
+    /// ids are dropped.
+    /// </summary>
+    public void Replace(IEnumerable<OpenWorkspaceWindowDto> windows)
+    {
+        lock (_sync)
+        {
+            _docs.DeleteAll();
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var w in windows)
+            {
+                if (string.IsNullOrWhiteSpace(w.LayoutId)) continue;
+                if (!seen.Add(w.LayoutId)) continue;
+                _docs.Insert(new OpenWorkspaceWindowEntry
+                {
+                    LayoutId = w.LayoutId,
+                    Title = w.Title ?? string.Empty,
+                    UpdatedUtc = DateTime.UtcNow,
+                });
+            }
+        }
+    }
+
+    public void Dispose() => _db.Dispose();
+}
+
+// Returned verbatim from GET /api/ui/workspace-windows (camelCased by the
+// minimal-API JSON serializer → { layoutId, title }). Not a Zeus.Contracts wire
+// type — it never crosses the SignalR boundary, only the local REST surface the
+// desktop shell reads at startup.
+public readonly record struct OpenWorkspaceWindowDto(string LayoutId, string Title);
+
+public sealed class OpenWorkspaceWindowEntry
+{
+    public int Id { get; set; }
+    public string LayoutId { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -2832,6 +2832,14 @@ public static class ZeusEndpoints
             return Results.Ok(store.DeleteNamed(radio ?? "default", id));
         });
 
+        // Detached workspace windows (extra Photino frames popped off the dock)
+        // that were open at the last desktop shutdown. The desktop shell reads
+        // this once on startup and reopens each; web/headless clients never call
+        // it (the restore path is gated on the Photino bridge), so it returns an
+        // empty list there.
+        app.MapGet("/api/ui/workspace-windows", (OpenWorkspaceWindowsStore store) =>
+            Results.Ok(store.GetAll()));
+
         // Prefs-database (profile) selector. All Zeus prefs/settings/layouts live
         // in a single LiteDB resolved by PrefsDbPath.Get() at startup; the active
         // choice is a pointer file (NOT inside any DB). Switching applies on the

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -595,6 +595,10 @@ public static class ZeusHost
         // Desktop main-window geometry (Photino). Only RunDesktop reads it; the
         // store is harmless to register in service/headless modes (no consumer).
         builder.Services.AddSingleton<WindowGeometryStore>();
+        // Detached workspace windows the operator left open at shutdown, reopened
+        // on the next desktop launch. Same desktop-only / harmless-elsewhere note
+        // as WindowGeometryStore above.
+        builder.Services.AddSingleton<OpenWorkspaceWindowsStore>();
         builder.Services.AddSingleton<RadioStateStore>();
         builder.Services.AddSingleton<QrzService>();
         builder.Services.AddSingleton<LogService>();

--- a/tests/Zeus.Server.Tests/OpenWorkspaceWindowsStoreTests.cs
+++ b/tests/Zeus.Server.Tests/OpenWorkspaceWindowsStoreTests.cs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF), Christian Suarez (N9WAR), and contributors.
+//
+// Detached workspace windows survive a desktop restart: the set persisted at
+// shutdown is what the next launch reopens.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class OpenWorkspaceWindowsStoreTests : IDisposable
+{
+    private readonly string _dbPath;
+
+    public OpenWorkspaceWindowsStoreTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"zeus-prefs-wswin-{Guid.NewGuid():N}.db");
+    }
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+    }
+
+    private OpenWorkspaceWindowsStore NewStore() =>
+        new(NullLogger<OpenWorkspaceWindowsStore>.Instance, _dbPath);
+
+    [Fact]
+    public void Empty_Store_Returns_No_Windows()
+    {
+        using var store = NewStore();
+        Assert.Empty(store.GetAll());
+    }
+
+    [Fact]
+    public void Replace_RoundTrips_Across_Restart()
+    {
+        using (var store = NewStore())
+        {
+            store.Replace(new[]
+            {
+                new OpenWorkspaceWindowDto("layout-a", "Bench"),
+                new OpenWorkspaceWindowDto("layout-b", "Mobile"),
+            });
+        }
+
+        // Reopen to prove it survives a backend restart — the whole point.
+        using var reopened = NewStore();
+        var all = reopened.GetAll();
+        Assert.Equal(2, all.Count);
+        Assert.Equal("layout-a", all[0].LayoutId);
+        Assert.Equal("Bench", all[0].Title);
+        Assert.Equal("layout-b", all[1].LayoutId);
+    }
+
+    [Fact]
+    public void Replace_Overwrites_The_Whole_Set()
+    {
+        using var store = NewStore();
+        store.Replace(new[] { new OpenWorkspaceWindowDto("layout-a", "A") });
+        store.Replace(new[] { new OpenWorkspaceWindowDto("layout-b", "B") });
+        var all = store.GetAll();
+        Assert.Single(all);
+        Assert.Equal("layout-b", all[0].LayoutId);
+    }
+
+    [Fact]
+    public void Replace_With_Empty_Clears_Everything()
+    {
+        using var store = NewStore();
+        store.Replace(new[] { new OpenWorkspaceWindowDto("layout-a", "A") });
+        store.Replace(Array.Empty<OpenWorkspaceWindowDto>());
+        Assert.Empty(store.GetAll());
+    }
+
+    [Fact]
+    public void Replace_Dedupes_LayoutIds_And_Drops_Blanks()
+    {
+        using var store = NewStore();
+        store.Replace(new[]
+        {
+            new OpenWorkspaceWindowDto("layout-a", "First"),
+            new OpenWorkspaceWindowDto("layout-a", "Duplicate"),
+            new OpenWorkspaceWindowDto("", "Blank"),
+            new OpenWorkspaceWindowDto("   ", "Whitespace"),
+        });
+        var all = store.GetAll();
+        Assert.Single(all);
+        Assert.Equal("layout-a", all[0].LayoutId);
+        Assert.Equal("First", all[0].Title);
+    }
+}

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -49,7 +49,10 @@ import { WorkspaceContext } from './layout/WorkspaceContext';
 import { FlexWorkspace } from './layout/FlexWorkspace';
 import { WorkspaceErrorBoundary } from './layout/WorkspaceErrorBoundary';
 import { AppErrorBoundary } from './layout/AppErrorBoundary';
-import { currentDetachedWorkspaceLayoutId } from './layout/workspace-windows';
+import {
+  currentDetachedWorkspaceLayoutId,
+  restorePersistedWorkspaceWindows,
+} from './layout/workspace-windows';
 import { ConfirmDialog } from './layout/ConfirmDialog';
 import { FreeDvWindow } from './components/FreeDvWindow';
 import { AfGainSlider } from './components/AfGainSlider';
@@ -139,6 +142,15 @@ export default function App() {
   // the broker instead of the local /ws; RemoteGate prompts for the session
   // password and owns that transport.
   const remoteMode = useMemo(() => isRemoteMode(), []);
+  // Reopen any detached workspace windows the operator left open at the last
+  // desktop shutdown. Main window only (a detached window must not re-spawn its
+  // siblings) and not in remote/web mode. Runs once on mount; the helper is a
+  // no-op outside the Photino desktop shell.
+  useEffect(() => {
+    if (detachedLayoutId || remoteMode) return;
+    void restorePersistedWorkspaceWindows();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   const settingsViewOpen = useLayoutStore((s) => s.settingsViewOpen);
   const settingsInitialTab = useLayoutStore((s) => s.settingsInitialTab);
   const setSettingsView = useLayoutStore((s) => s.setSettingsView);

--- a/zeus-web/src/components/LeftLayoutBar.tsx
+++ b/zeus-web/src/components/LeftLayoutBar.tsx
@@ -210,6 +210,7 @@ export function LeftLayoutBar() {
                     className="lb-tab"
                     role="tab"
                     aria-selected={active}
+                    data-layout-tab-id={l.id}
                     draggable
                     onDragStart={(e) => handleLayoutDragStart(e, l.id, l.name)}
                     onDragEnd={(e) => handleLayoutDragEnd(e, l)}

--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -54,6 +54,10 @@ import {
   type WorkspaceTile,
 } from './workspace';
 import { AddPanelModal } from './AddPanelModal';
+import {
+  findLayoutTabAtPoint,
+  setLayoutTabDropTarget,
+} from './layout-tab-dnd';
 import { ScaleToFitTile } from './ScaleToFitTile';
 import { TileChrome } from './TileChrome';
 import { ConfirmDialog } from './ConfirmDialog';
@@ -262,6 +266,28 @@ function WorkspaceCanvas({
   const draggingRef = useRef(false);
   const skipPostDropLayoutChangeRef = useRef(false);
   const dragStartRef = useRef<WorkspaceDragStartSnapshot | null>(null);
+  // Cross-layout panel transfer: while a tile drag is live, track the pointer
+  // and remember which LeftLayoutBar tab (if any) it's hovering, so releasing
+  // over another layout moves the panel there instead of repositioning it on
+  // this workspace.
+  const moveTileToLayout = useLayoutStore((s) => s.moveTileToLayout);
+  const tileDragActiveRef = useRef(false);
+  const dropTargetLayoutIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    const onPointerMove = (e: PointerEvent) => {
+      if (!tileDragActiveRef.current) return;
+      // A tab over THIS layout isn't a transfer target — dropping there is a
+      // normal reposition. Only foreign tabs arm the move.
+      const overId = findLayoutTabAtPoint(e.clientX, e.clientY);
+      const target = overId && overId !== layoutId ? overId : null;
+      if (dropTargetLayoutIdRef.current !== target) {
+        dropTargetLayoutIdRef.current = target;
+        setLayoutTabDropTarget(target);
+      }
+    };
+    window.addEventListener('pointermove', onPointerMove);
+    return () => window.removeEventListener('pointermove', onPointerMove);
+  }, [layoutId]);
   // Live viewport height of the (scrolling) workspace, in pixels. Only used to
   // report how many rows are currently visible to the add-panel pagination flow
   // (setViewportPage below); the fixed-cell geometry itself never depends on it.
@@ -514,6 +540,8 @@ function WorkspaceCanvas({
     oldItem: LayoutItem | null,
   ) => {
     draggingRef.current = true;
+    tileDragActiveRef.current = true;
+    dropTargetLayoutIdRef.current = null;
     skipPostDropLayoutChangeRef.current = false;
     dragStartRef.current = oldItem
       ? {
@@ -536,6 +564,32 @@ function WorkspaceCanvas({
     oldItem: LayoutItem | null,
     newItem: LayoutItem | null,
   ) => {
+    // Cross-layout transfer: the panel was released over a different layout's
+    // tab. Move it there and skip the normal reposition persist entirely — the
+    // tile no longer belongs to this workspace, so writing back the dragged
+    // geometry would resurrect it.
+    tileDragActiveRef.current = false;
+    const transferTarget = dropTargetLayoutIdRef.current;
+    dropTargetLayoutIdRef.current = null;
+    setLayoutTabDropTarget(null);
+    if (transferTarget && transferTarget !== layoutId) {
+      const movedUid =
+        dragStartRef.current?.item.i ?? oldItem?.i ?? newItem?.i ?? null;
+      draggingRef.current = false;
+      dragStartRef.current = null;
+      setGridInteraction(null);
+      if (movedUid) {
+        // Suppress the post-drop layout echo so RGL's re-render (which still
+        // momentarily holds the tile) doesn't re-persist it onto this layout.
+        skipPostDropLayoutChangeRef.current = true;
+        window.setTimeout(() => {
+          skipPostDropLayoutChangeRef.current = false;
+        }, 250);
+        moveTileToLayout(layoutId, transferTarget, movedUid);
+        return;
+      }
+    }
+
     const dragStart = dragStartRef.current;
     const finalItem = dragStart
       ? layout.find((item) => item.i === dragStart.item.i)
@@ -563,7 +617,7 @@ function WorkspaceCanvas({
         autoFitDroppedPanel(layout, colsRef.current, previousDropItem),
       );
     }
-  }, [persist]);
+  }, [persist, layoutId, moveTileToLayout]);
   const onResizeStop = useCallback((
     layout: Layout,
     oldItem: LayoutItem | null,

--- a/zeus-web/src/layout/__tests__/layout-tab-dnd.test.ts
+++ b/zeus-web/src/layout/__tests__/layout-tab-dnd.test.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF), Christian Suarez (N9WAR), and contributors.
+
+/** @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  LAYOUT_TAB_DROP_ACTIVE_ATTR,
+  findLayoutTabAtPoint,
+  setLayoutTabDropTarget,
+} from '../layout-tab-dnd';
+
+function makeTab(id: string, rect: { left: number; top: number; right: number; bottom: number }) {
+  const el = document.createElement('button');
+  el.setAttribute('data-layout-tab-id', id);
+  el.getBoundingClientRect = vi.fn(
+    () =>
+      ({
+        left: rect.left,
+        top: rect.top,
+        right: rect.right,
+        bottom: rect.bottom,
+        width: rect.right - rect.left,
+        height: rect.bottom - rect.top,
+        x: rect.left,
+        y: rect.top,
+        toJSON: () => ({}),
+      }) as DOMRect,
+  );
+  document.body.appendChild(el);
+  return el;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('layout-tab-dnd', () => {
+  it('findLayoutTabAtPoint returns the id of the tab under the point', () => {
+    makeTab('a', { left: 0, top: 0, right: 40, bottom: 40 });
+    makeTab('b', { left: 0, top: 40, right: 40, bottom: 80 });
+    expect(findLayoutTabAtPoint(20, 20)).toBe('a');
+    expect(findLayoutTabAtPoint(20, 60)).toBe('b');
+  });
+
+  it('findLayoutTabAtPoint returns null when the point is over no tab', () => {
+    makeTab('a', { left: 0, top: 0, right: 40, bottom: 40 });
+    expect(findLayoutTabAtPoint(200, 200)).toBeNull();
+  });
+
+  it('setLayoutTabDropTarget marks only the named tab and clears it again', () => {
+    const a = makeTab('a', { left: 0, top: 0, right: 40, bottom: 40 });
+    const b = makeTab('b', { left: 0, top: 40, right: 40, bottom: 80 });
+
+    setLayoutTabDropTarget('b');
+    expect(a.getAttribute(LAYOUT_TAB_DROP_ACTIVE_ATTR)).toBeNull();
+    expect(b.getAttribute(LAYOUT_TAB_DROP_ACTIVE_ATTR)).toBe('true');
+
+    // Switching target moves the mark.
+    setLayoutTabDropTarget('a');
+    expect(a.getAttribute(LAYOUT_TAB_DROP_ACTIVE_ATTR)).toBe('true');
+    expect(b.getAttribute(LAYOUT_TAB_DROP_ACTIVE_ATTR)).toBeNull();
+
+    // Null clears every mark.
+    setLayoutTabDropTarget(null);
+    expect(a.getAttribute(LAYOUT_TAB_DROP_ACTIVE_ATTR)).toBeNull();
+    expect(b.getAttribute(LAYOUT_TAB_DROP_ACTIVE_ATTR)).toBeNull();
+  });
+});

--- a/zeus-web/src/layout/layout-tab-dnd.ts
+++ b/zeus-web/src/layout/layout-tab-dnd.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF), Christian Suarez (N9WAR), and contributors.
+//
+// Cross-component glue for "drag a workspace panel onto a layout tab to move
+// it there." The workspace tiles drag via react-grid-layout's pointer-based
+// drag (not native HTML5 DnD), so the LeftLayoutBar never receives
+// dragenter/dragover events. Instead the workspace tracks the pointer during a
+// tile drag and geometrically hit-tests it against the layout tabs, which mark
+// themselves with `data-layout-tab-id`. These helpers keep that contract in
+// one place so the tab markup and the workspace drop logic agree on the
+// attribute names.
+
+/** Attribute carrying a layout id on each LeftLayoutBar tab — the drop target
+ *  identity the workspace reads at drop time. */
+export const LAYOUT_TAB_ID_ATTR = 'data-layout-tab-id';
+/** Attribute toggled on the tab currently under a dragged panel, so CSS can
+ *  highlight the drop target. */
+export const LAYOUT_TAB_DROP_ACTIVE_ATTR = 'data-panel-drop-active';
+
+/** Return the layout id of the tab whose bounding box contains (x, y), or null
+ *  when the point is over no tab. A plain rect hit-test (not elementFromPoint)
+ *  because the dragged tile sits under the cursor and would otherwise occlude
+ *  the tab beneath it. */
+export function findLayoutTabAtPoint(x: number, y: number): string | null {
+  if (typeof document === 'undefined') return null;
+  const tabs = document.querySelectorAll<HTMLElement>(`[${LAYOUT_TAB_ID_ATTR}]`);
+  for (const el of tabs) {
+    const r = el.getBoundingClientRect();
+    if (x >= r.left && x <= r.right && y >= r.top && y <= r.bottom) {
+      return el.getAttribute(LAYOUT_TAB_ID_ATTR);
+    }
+  }
+  return null;
+}
+
+/** Mark `layoutId`'s tab as the active drop target and clear the mark from all
+ *  others. Pass null to clear every highlight (drag ended / left the tabs). */
+export function setLayoutTabDropTarget(layoutId: string | null): void {
+  if (typeof document === 'undefined') return;
+  const tabs = document.querySelectorAll<HTMLElement>(`[${LAYOUT_TAB_ID_ATTR}]`);
+  for (const el of tabs) {
+    if (layoutId && el.getAttribute(LAYOUT_TAB_ID_ATTR) === layoutId) {
+      el.setAttribute(LAYOUT_TAB_DROP_ACTIVE_ATTR, 'true');
+    } else {
+      el.removeAttribute(LAYOUT_TAB_DROP_ACTIVE_ATTR);
+    }
+  }
+}

--- a/zeus-web/src/layout/workspace-windows.ts
+++ b/zeus-web/src/layout/workspace-windows.ts
@@ -29,6 +29,41 @@ export function currentDetachedWorkspaceLayoutId(): string | null {
     : null;
 }
 
+/** True when running inside the Photino desktop shell (the host bridge that
+ *  can open real OS windows). Detached "windows" only persist/restore there;
+ *  in a plain browser they'd be popups, which the restore path must not spawn
+ *  on load. */
+export function isDesktopShell(): boolean {
+  const external = (window as unknown as PhotinoWindowSurface).external;
+  return typeof external?.sendMessage === 'function';
+}
+
+interface PersistedWorkspaceWindow {
+  layoutId: string;
+  title: string;
+}
+
+/** Reopen the detached workspace windows the operator left open at the last
+ *  desktop shutdown. Desktop shell only (see isDesktopShell); a no-op in the
+ *  browser and remote clients. Best-effort — a fetch failure just means nothing
+ *  is restored. Call once, from the MAIN window only. */
+export async function restorePersistedWorkspaceWindows(): Promise<void> {
+  if (!isDesktopShell()) return;
+  try {
+    const res = await fetch('/api/ui/workspace-windows');
+    if (!res.ok) return;
+    const list = (await res.json()) as PersistedWorkspaceWindow[];
+    if (!Array.isArray(list)) return;
+    for (const w of list) {
+      if (w?.layoutId) {
+        openWorkspaceWindow(w.layoutId, w.title || 'Workspace');
+      }
+    }
+  } catch {
+    // Best-effort restore — never block app startup on it.
+  }
+}
+
 export function openWorkspaceWindow(layoutId: string, title: string): void {
   const url = detachedWorkspaceUrl(layoutId);
   const external = (window as unknown as PhotinoWindowSurface).external;

--- a/zeus-web/src/state/__tests__/layout-store.test.ts
+++ b/zeus-web/src/state/__tests__/layout-store.test.ts
@@ -361,6 +361,111 @@ describe('layout-store / workspace tile mutators', () => {
     expect(parsed.tiles[1]).toMatchObject({ uid, panelId: 'cw' });
   });
 
+  it('moveTileToLayout transfers a panel from the active layout to another', () => {
+    const activeWorkspace: WorkspaceLayout = {
+      schemaVersion: 8,
+      tiles: [
+        { uid: 'tile-keep', panelId: 'vfo', x: 0, y: 0, w: 6, h: 8 },
+        {
+          uid: 'tile-move',
+          panelId: 'cw',
+          x: 8,
+          y: 0,
+          w: 8,
+          h: 8,
+          instanceConfig: { foo: 1 },
+        },
+      ],
+    };
+    useLayoutStore.setState({
+      radioKey: 'radio-1',
+      layouts: [
+        { id: 'layout-a', name: 'A', layoutJson: JSON.stringify(activeWorkspace) },
+        {
+          id: 'layout-b',
+          name: 'B',
+          layoutJson: JSON.stringify(EMPTY_WORKSPACE_LAYOUT),
+        },
+      ],
+      activeLayoutId: 'layout-a',
+      workspace: activeWorkspace,
+      isLoaded: true,
+    });
+
+    const movedUid = useLayoutStore
+      .getState()
+      .moveTileToLayout('layout-a', 'layout-b', 'tile-move');
+
+    const state = useLayoutStore.getState();
+    expect(movedUid).toBe('tile-move');
+    // Active workspace (source) lost the tile, kept the other.
+    expect(state.workspace.tiles.map((t) => t.uid)).toEqual(['tile-keep']);
+    // Destination gained it, panel + instanceConfig preserved, re-placed.
+    const layoutB = state.layouts.find((l) => l.id === 'layout-b');
+    const parsed = JSON.parse(layoutB!.layoutJson) as WorkspaceLayout;
+    expect(parsed.tiles).toHaveLength(1);
+    expect(parsed.tiles[0]).toMatchObject({
+      uid: 'tile-move',
+      panelId: 'cw',
+      instanceConfig: { foo: 1 },
+      x: 0,
+      y: 0,
+    });
+  });
+
+  it('moveTileToLayout is a no-op for same source/target, missing target, or missing tile', () => {
+    const activeWorkspace: WorkspaceLayout = {
+      schemaVersion: 8,
+      tiles: [{ uid: 'tile-move', panelId: 'cw', x: 0, y: 0, w: 8, h: 8 }],
+    };
+    useLayoutStore.setState({
+      radioKey: 'radio-1',
+      layouts: [
+        { id: 'layout-a', name: 'A', layoutJson: JSON.stringify(activeWorkspace) },
+        {
+          id: 'layout-b',
+          name: 'B',
+          layoutJson: JSON.stringify(EMPTY_WORKSPACE_LAYOUT),
+        },
+      ],
+      activeLayoutId: 'layout-a',
+      workspace: activeWorkspace,
+      isLoaded: true,
+    });
+    const move = useLayoutStore.getState().moveTileToLayout;
+    expect(move('layout-a', 'layout-a', 'tile-move')).toBeNull();
+    expect(move('layout-a', 'no-such-layout', 'tile-move')).toBeNull();
+    expect(move('layout-a', 'layout-b', 'no-such-tile')).toBeNull();
+    // Source untouched after the failed moves.
+    expect(useLayoutStore.getState().workspace.tiles).toHaveLength(1);
+  });
+
+  it('moveTileToLayout refuses to move out of a locked source workspace', () => {
+    const activeWorkspace: WorkspaceLayout = {
+      schemaVersion: 8,
+      locked: true,
+      tiles: [{ uid: 'tile-move', panelId: 'cw', x: 0, y: 0, w: 8, h: 8 }],
+    };
+    useLayoutStore.setState({
+      radioKey: 'radio-1',
+      layouts: [
+        { id: 'layout-a', name: 'A', layoutJson: JSON.stringify(activeWorkspace) },
+        {
+          id: 'layout-b',
+          name: 'B',
+          layoutJson: JSON.stringify(EMPTY_WORKSPACE_LAYOUT),
+        },
+      ],
+      activeLayoutId: 'layout-a',
+      workspace: activeWorkspace,
+      isLoaded: true,
+    });
+    expect(
+      useLayoutStore.getState().moveTileToLayout('layout-a', 'layout-b', 'tile-move'),
+    ).toBeNull();
+    expect(useLayoutStore.getState().workspace.tiles).toHaveLength(1);
+  });
+
   it('debounced save persists the mutated layout after a quick layout switch', async () => {
     vi.useFakeTimers();
     const fetchMock = vi

--- a/zeus-web/src/state/layout-store.ts
+++ b/zeus-web/src/state/layout-store.ts
@@ -144,6 +144,18 @@ interface LayoutState {
     panelId: string,
     opts?: { instanceConfig?: unknown },
   ) => string | null;
+  /** Move a tile from one layout to another. Removes it from `fromLayoutId`
+   *  and re-places it (first-fit) in `toLayoutId`, preserving panelId,
+   *  instanceConfig, and lock state. No-op if the source/target is the same,
+   *  the target layout doesn't exist, either workspace is locked, or the tile
+   *  isn't found. Drives the "drag a panel onto a layout tab to transfer it"
+   *  gesture in the LeftLayoutBar. Returns the (possibly new) tile uid in the
+   *  target layout, or null when nothing moved. */
+  moveTileToLayout: (
+    fromLayoutId: string,
+    toLayoutId: string,
+    uid: string,
+  ) => string | null;
   /** Remove the tile with the given uid. */
   removeTile: (uid: string) => void;
   /** Remove a tile from a specific layout without making it active. */
@@ -495,6 +507,51 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
     };
     applyWorkspaceMutationForLayout(set, get, layoutId, next);
     return uid;
+  },
+
+  moveTileToLayout: (fromLayoutId, toLayoutId, uid) => {
+    if (fromLayoutId === toLayoutId) return null;
+    const state = get();
+    const fromTarget = findActive(state.layouts, fromLayoutId);
+    const fromIsActive = fromLayoutId === state.activeLayoutId;
+    if (!fromTarget && !fromIsActive) return null;
+    // The target must be a real saved layout — there's nowhere to put a tile
+    // in an unhydrated/unknown layout id.
+    const toTarget = findActive(state.layouts, toLayoutId);
+    if (!toTarget) return null;
+
+    const fromWorkspace = fromIsActive
+      ? state.workspace
+      : parseLayoutOrDefault(fromTarget!.layoutJson);
+    if (fromWorkspace.locked) return null;
+    const tile = fromWorkspace.tiles.find((t) => t.uid === uid);
+    if (!tile) return null;
+
+    const toIsActive = toLayoutId === state.activeLayoutId;
+    const toWorkspace = toIsActive
+      ? state.workspace
+      : parseLayoutOrDefault(toTarget.layoutJson);
+    if (toWorkspace.locked) return null;
+
+    // Place the incoming tile first-fit in the destination, carrying over its
+    // panel, per-instance config, and lock state. Geometry is recomputed for
+    // the destination grid — its origin in the source layout is meaningless
+    // there.
+    const placement = placeTileInGrid(tile.panelId, toWorkspace.tiles);
+    const moved: WorkspaceTile = { ...tile, ...placement };
+
+    // Two independent persists: drop from source, append to destination. The
+    // second get() inside applyWorkspaceMutationForLayout sees the first set's
+    // updated layouts, so the writes don't clobber one another.
+    applyWorkspaceMutationForLayout(set, get, fromLayoutId, {
+      ...fromWorkspace,
+      tiles: fromWorkspace.tiles.filter((t) => t.uid !== uid),
+    });
+    applyWorkspaceMutationForLayout(set, get, toLayoutId, {
+      ...toWorkspace,
+      tiles: [...toWorkspace.tiles, moved],
+    });
+    return moved.uid;
   },
 
   removeTile: (uid) => {

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -168,6 +168,15 @@
   color: var(--accent);
   opacity: 0.72;
 }
+/* A panel is being dragged over this layout tab — releasing here transfers
+   the panel to that layout. Mirror the active-tab accent so the drop target
+   reads as "this is where it lands." */
+.left-layout-bar .lb-tab[data-panel-drop-active='true'] {
+  background: var(--bg-2);
+  border-color: var(--accent);
+  color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent), 0 0 10px var(--accent);
+}
 .left-layout-bar .lb-item.active .lb-tab {
   background: var(--bg-2);
   border-color: var(--line-strong);


### PR DESCRIPTION
Two workspace/layout-management features, both requested by the operator.

## 1. Drag a panel onto a layout tab to move it there
Grab a workspace panel by its header and drop it on a different layout tab in the LeftLayoutBar — the panel is transferred to that layout.

- Workspace tiles drag via react-grid-layout (pointer-based, **not** HTML5 DnD), so the tab bar never receives `dragover` events. The workspace tracks the pointer during a tile drag and geometrically hit-tests it against the tabs (marked with `data-layout-tab-id`), highlighting the drop target.
- Releasing over a foreign tab calls the new `moveTileToLayout` layout-store action: it removes the tile from the source layout and first-fit re-places it in the target, preserving `panelId`, `instanceConfig`, and lock state.
- No-op when dropping on the current layout, a locked source/target workspace, or no tab.
- **Move** semantics (panel leaves the source); the app stays on the current layout after the move.

New: `layout-tab-dnd.ts` (DOM hit-test/highlight seam). Touched: `FlexWorkspace.tsx`, `LeftLayoutBar.tsx`, `layout-store.ts`, `layout.css`.

## 2. Persist detached workspace windows across desktop restarts
If you pop layouts off the dock into separate windows and quit, they reopen on next launch. Windows you close deliberately stay closed.

- New `OpenWorkspaceWindowsStore` (LiteDB, shared `zeus-prefs.db`) records the set of detached Photino frames open at shutdown.
- The desktop shell writes the live set once when the main window closes — **before** the child close-loop, so a child's closing handler can't erase what was just saved.
- On next launch the main-window SPA fetches `GET /api/ui/workspace-windows` and reopens each via the existing drag-off path. Gated on the Photino bridge, so web/remote clients never restore (no popup spam).

New: `OpenWorkspaceWindowsStore.cs`, endpoint in `ZeusEndpoints.cs`, DI reg in `ZeusHost.cs`, window tracking in `Program.cs`, restore helper in `workspace-windows.ts` + effect in `App.tsx`.

## Testing
- `dotnet build` (backend) — clean
- Frontend `tsc` + `eslint` — clean (pre-existing `pluginPanelKey` warnings only)
- 38 frontend unit tests pass (new `moveTileToLayout` + `layout-tab-dnd` tests)
- `OpenWorkspaceWindowsStore` round-trip tests pass (restart, overwrite, clear, dedupe)
- Production SPA build green

**Not yet bench-tested:** the live Photino window-reopen behaviour (no desktop GUI available in this environment). The persistence layer + wiring are covered by build + unit tests; worth a desktop run to confirm "quit with N windows → relaunch reopens N windows" before merge. The native shutdown/close-loop ordering is the sensitive part.

## Open questions for review
- One PR covers both features — happy to split if you'd prefer separate review.
- Move-vs-copy and stay-vs-follow on the panel transfer are the defaults I chose; trivial to flip if you want different UX.