### PR TITLE
docs(manual): document CAT (Kenwood TS-2000) control + bind-address safety

### DIFF
--- a/docs/manual/chapters/13-accessories.md
+++ b/docs/manual/chapters/13-accessories.md
@@ -200,7 +200,7 @@ join.
 **TCI** lets external programs control your radio: loggers (Log4OM, N1MM+),
 digital-mode software (WSJT-X, JTDX, MSHV), and other SDR display tools.
 Zeus speaks the ExpertSDR3-compatible TCI WebSocket protocol. Configure it
-under **Settings → TCI**: tick **Enabled**, choose a **bind address**
+under **Settings → Network ▸ TCI**: tick **Enabled**, choose a **bind address**
 (`127.0.0.1` for same-machine only, or `0.0.0.0` to allow LAN clients — note
 there's no authentication), and a **port** (the ExpertSDR3 standard is
 **40001**). **Test Port** checks availability. Changing the port or bind
@@ -209,6 +209,42 @@ running, a status line shows how many clients are connected. In your other
 software's TCI settings, point it at the Zeus machine's IP, the same port,
 over `ws://`. Digital clients key cleanly through TCI, and their transmit
 meters and SWR show on the Zeus panels during a transmission.
+
+### CAT — Kenwood TS-2000 Control
+
+**CAT** is a second way to let outside software drive Zeus, for the many
+programs that speak the classic **Kenwood TS-2000** command set rather than
+TCI — most loggers, and digital-mode apps (WSJT-X, fldigi, JS8Call) set up for
+a Kenwood rig. Zeus runs a TS-2000-compatible CAT server over plain TCP:
+external software connects to an IP and port — the same role a serial COM port
+plays for a real radio — and reads or sets frequency, mode, VFO A/B, split,
+S-meter, drive, and PTT (transmit/receive). On a rig-detect query Zeus answers
+`ID019;`, the TS-2000 identifier Hamlib and most loggers expect.
+
+Configure it under **Settings → Network ▸ CAT**: tick **Enabled**, choose a
+**Bind Address**, and a **Port** (default **19090**). **Test Port** checks the
+port is free. Changing the bind address or port requires a Zeus restart — the
+panel shows a reminder until you do — and once running, a status line shows
+whether the server is up and how many clients are connected.
+
+**The bind address is a safety choice, not just a convenience.** `127.0.0.1`
+(the default) accepts connections only from software on the *same machine* as
+Zeus. `0.0.0.0` opens the port to every machine on your LAN. CAT has **no
+authentication and grants full transmit control** — anything that can reach
+the port can key and tune your radio — so only choose `0.0.0.0` on a network
+you trust, and stay on `127.0.0.1` unless you specifically need to control
+Zeus from another computer.
+
+**Connecting software that only knows COM ports.** Unlike a serial radio, the
+CAT server has nothing to "select" — it is the radio side of the link, so the
+COM-port picker lives in *your* software, not in Zeus. Programs that talk to a
+rig over the network directly need no extra setup — give them the Zeus
+machine's IP and the port. Programs that only understand a serial COM port
+need a virtual serial bridge to the CAT socket: on Windows pair `com0com` with
+`com2tcp` (pointed at the Zeus host and port 19090); on macOS or Linux use
+`socat PTY,link=/dev/ttyCAT TCP:127.0.0.1:19090`. The program then opens that
+virtual COM port as if it were a real TS-2000. Two CAT clients at once means
+two listeners on two ports — the network equivalent of two COM ports.
 
 ### Voyeur — Unattended Net Monitor (plugin)
 

--- a/docs/manual/chapters/14-settings-diag.md
+++ b/docs/manual/chapters/14-settings-diag.md
@@ -19,7 +19,7 @@ A note on one tab in particular: **PA Settings** is the only tab with an explici
 | **Band Plan** | The frequency/mode band plan editor. |
 | **QRZ** | Sign in to QRZ.com for callsign lookups and your home grid. |
 | **Rotator** | Connect to a Hamlib `rotctld` antenna rotator. |
-| **TCI** | Expose Zeus over the TCI (Transceiver Control Interface) protocol for logging/contest software. |
+| **Network** | Expose Zeus to external software two ways: **TCI** (ExpertSDR3 Transceiver Control Interface) and **CAT** (Kenwood TS-2000 emulation), for logging, contest, and digital-mode programs. |
 | **Display** | Theme, panadapter background, trace color, spectrum scale, waterfall colormap. |
 | **Plugins** | Install and manage backend/UI/audio plugins from the registry or by URL. |
 | **HamClock** | Install and embed the OpenHamClock dashboard as a workspace panel. |
@@ -38,9 +38,9 @@ The DSP tab groups the receive and transmit signal-processing controls into card
 
 Enter your QRZ.com API key to enable callsign lookups. Once connected, the panel shows your sign-in callsign, home grid and coordinates, and whether your account has an active **XML subscription** (lookups need that subscription — without it, lookups are disabled even though sign-in succeeds). QRZ data also feeds the Beam Map background described below.
 
-#### Rotator and TCI
+#### Rotator and Network (TCI / CAT)
 
-**Rotator** connects Zeus to a Hamlib `rotctld` daemon: tick Enabled, set the host and port (default `127.0.0.1`), and test the connection. **TCI** lets external logging or contest programs control Zeus over the Transceiver Control Interface — set the bind address and port and test it. Both are network integrations; if the daemon or client is on another machine, use that machine's LAN address rather than `127.0.0.1`.
+**Rotator** connects Zeus to a Hamlib `rotctld` daemon: tick Enabled, set the host and port (default `127.0.0.1`), and test the connection. The **Network** tab lets external software control Zeus two ways: **TCI** (the ExpertSDR3 Transceiver Control Interface, for loggers and contest programs) and **CAT** (a Kenwood TS-2000 emulation over TCP, default port **19090**, for the many programs — including digital-mode apps configured for a serial Kenwood rig — that speak Kenwood CAT). For each, set the bind address and port and test it. Both are unauthenticated and CAT grants full transmit control, so a `0.0.0.0` (LAN-visible) binding belongs only on a trusted network; if the daemon or client is on another machine, use that machine's LAN address rather than `127.0.0.1`. CAT — including connecting software that only speaks serial COM ports — is covered in full in the Accessories chapter.
 
 #### HamClock and Spots
 


### PR DESCRIPTION
## What

Documents the **CAT control** feature (Kenwood TS-2000 emulation over TCP, default port **19090**) that shipped in #973 but was never added to the operator's manual. Also fixes stale settings-path references now that the old **TCI** tab is the **Network** tab (TCI + CAT stacked).

## Why

An operator asked where the COM-port selector was and whether the bind address was documented — it wasn't. CAT carries the same loopback-vs-LAN security tradeoff as TCI, but a sharper one: **the CAT port is unauthenticated and grants full transmit control** (it can key and tune the radio), so the bind-address choice needs to be spelled out for operators.

## Changes (docs only — no code touched)

`docs/manual/chapters/13-accessories.md`
- New **"CAT — Kenwood TS-2000 Control"** section covering:
  - What it does — freq / mode / VFO A·B / split / S-meter / drive / PTT read+write; answers `ID019;` on rig-detect.
  - How to enable — **Settings → Network ▸ CAT**, Enabled / Bind Address / Port (19090) / Test Port, restart-on-change reminder, client-count status line.
  - **Bind-address safety** — `127.0.0.1` (default, same-machine only) vs `0.0.0.0` (LAN); no auth, full TX control → trusted networks only.
  - **Connecting COM-port-only software** — virtual serial bridge (`com0com`+`com2tcp` on Windows, `socat` on macOS/Linux); multiple clients = multiple ports.
- Updated the TCI section's path `Settings → TCI` → `Settings → Network ▸ TCI`.

`docs/manual/chapters/14-settings-diag.md`
- Settings-tabs table: stale **TCI** row → **Network** (TCI + CAT).
- "Rotator and TCI" prose → "Rotator and Network (TCI / CAT)" with a CAT one-liner and the unauthenticated-binding caution.

## Verification

- Facts (tab name, panel labels, default port, restart behavior, command tier, ID019, no-auth) sourced directly from the shipped code: `CatSettingsPanel.tsx`, `NetworkSettingsPanel.tsx`, `SettingsMenu.tsx`, `Zeus.Server.Hosting/Cat/*`.
- Live-tested against the running CAT server on this machine: `ID;`→`ID019;`, `FA;`/`FB;`/`IF;`/`MD;`/`PS;` return real radio state; write round-trips (`FA`, `MD`) accepted.
- `node assemble.mjs` rebuilds the manual cleanly (14 chapters; CAT present in TOC + body).

🤖 Generated with [Claude Code](https://claude.com/claude-code)