### PR TITLE
fix(web): make CTUN autopan follow a continuous tune (live, not on stop)

### DIFF
--- a/zeus-web/src/util/filter-autopan.ts
+++ b/zeus-web/src/util/filter-autopan.ts
@@ -30,7 +30,10 @@
 //   against its OWN displayed view, so a stitched/multi-RX layout keeps each
 //   half in view independently. RX1 pans its hardware NCO; secondaries pan
 //   their own DDC centre (panReceiverCenterTo → /api/receivers/{i}/lo, which is
-//   a true independent DDC on Protocol 2 and a no-op on P1's shared NCO).
+//   a true independent DDC on Protocol 2 and a no-op on P1's shared NCO). The
+//   Kiwi slice receiver routes the same /lo call to its waterfall centre
+//   (KiwiSdrService.SetCenter), so the Kiwi waterfall keeps the crosshair in
+//   view exactly like the hardware panes.
 //   Outside CTUN the view already tracks the dial (offset ~0), so the geometry
 //   never asks for a pan there — but we still gate on ctunEnabled to keep the
 //   intent explicit.
@@ -55,6 +58,7 @@ import {
   getReceiverFilterLowHz,
   getReceiverMode,
   getReceiverVfoHz,
+  KIWI_RECEIVER_INDEX,
 } from '../state/receiver-state';
 import * as viewCenter from '../state/view-center';
 import { panReceiverCenterTo } from './ctun-zoom-center';
@@ -198,17 +202,21 @@ export function useFilterAutopan(): void {
         schedule();
       }
     });
-    // View-centre motion (RX1 + RX2): catches a glide easing toward the dial and,
-    // crucially, a ruler-pan that scrolled the dial off-screen — so the crosshair
-    // is recovered once the drag releases, not just on the next tune.
-    const unsubVc0 = viewCenter.viewCenterFor(0).subscribe(schedule);
-    const unsubVc1 = viewCenter.viewCenterFor(1).subscribe(schedule);
+    // View-centre motion for every receiver index, including the Kiwi slice
+    // (KIWI_RECEIVER_INDEX) whose waterfall pans its own centre via SetCenter:
+    // catches a glide easing toward the dial and, crucially, a ruler-pan that
+    // scrolled the dial off-screen — so the crosshair is recovered once the drag
+    // releases on ANY pane, not only on the next tune. Subscribing to inactive
+    // indices is free: their view-centre never glides, so the listener never fires.
+    const unsubVcs: Array<() => void> = [];
+    for (let i = 0; i <= KIWI_RECEIVER_INDEX; i++) {
+      unsubVcs.push(viewCenter.viewCenterFor(i).subscribe(schedule));
+    }
 
     return () => {
       unsubConn();
       unsubDisplay();
-      unsubVc0();
-      unsubVc1();
+      for (const u of unsubVcs) u();
       cancelDrawBusFrame(check);
     };
   }, []);

--- a/zeus-web/src/util/filter-autopan.ts
+++ b/zeus-web/src/util/filter-autopan.ts
@@ -58,7 +58,6 @@ import {
   getReceiverFilterLowHz,
   getReceiverMode,
   getReceiverVfoHz,
-  KIWI_RECEIVER_INDEX,
 } from '../state/receiver-state';
 import * as viewCenter from '../state/view-center';
 import { panReceiverCenterTo } from './ctun-zoom-center';
@@ -72,6 +71,12 @@ const AUTOPAN_MARGIN_FRAC = 0.06;
 // the view-centre tween glides smoothly to the latest target in between, so a
 // throttled follow still looks continuous during a sustained tune.
 const PAN_THROTTLE_MS = 80;
+// Highest receiver index the view-centre-motion subscription covers: RX1 (0),
+// the hardware secondaries, and the reserved Kiwi slice slot (7), so the Kiwi
+// waterfall is kept in view exactly like the hardware panes once that feature
+// is present. Subscribing to inactive indices is free — their view-centre
+// controller stays idle and never glides, so the listener never fires.
+const MAX_AUTOPAN_RX_INDEX = 7;
 
 /**
  * Pure geometry: given the current view centre, span, dial, and filter, return
@@ -202,14 +207,15 @@ export function useFilterAutopan(): void {
         schedule();
       }
     });
-    // View-centre motion for every receiver index, including the Kiwi slice
-    // (KIWI_RECEIVER_INDEX) whose waterfall pans its own centre via SetCenter:
-    // catches a glide easing toward the dial and, crucially, a ruler-pan that
-    // scrolled the dial off-screen — so the crosshair is recovered once the drag
-    // releases on ANY pane, not only on the next tune. Subscribing to inactive
-    // indices is free: their view-centre never glides, so the listener never fires.
+    // View-centre motion for every receiver index, including the reserved Kiwi
+    // slice slot (MAX_AUTOPAN_RX_INDEX) whose waterfall pans its own centre via
+    // SetCenter: catches a glide easing toward the dial and, crucially, a
+    // ruler-pan that scrolled the dial off-screen — so the crosshair is
+    // recovered once the drag releases on ANY pane, not only on the next tune.
+    // Subscribing to inactive indices is free: their view-centre never glides,
+    // so the listener never fires.
     const unsubVcs: Array<() => void> = [];
-    for (let i = 0; i <= KIWI_RECEIVER_INDEX; i++) {
+    for (let i = 0; i <= MAX_AUTOPAN_RX_INDEX; i++) {
       unsubVcs.push(viewCenter.viewCenterFor(i).subscribe(schedule));
     }
 

--- a/zeus-web/src/util/filter-autopan.ts
+++ b/zeus-web/src/util/filter-autopan.ts
@@ -38,14 +38,18 @@
 //   never by a view-centre (radioLo) pan — so a deliberate ruler-pan away from
 //   the RX to inspect other spectrum is preserved; only re-tuning pulls the
 //   filter back into view.
-// - Trailing debounce: a continuous CTUN drag rewrites vfo every frame and maps
-//   the cursor against the frozen grab-time centre, so recentring mid-drag would
-//   fight the gesture. Waiting for tuning to settle (SETTLE_MS) fires the autopan
-//   after a drag releases and after each discrete wheel/key/CAT step.
+// - Evaluated per display frame (draw bus), so a continuous wheel/keyboard tune
+//   follows live instead of only catching up when the operator stops. It is
+//   suppressed only while an actual pointer DRAG is in progress
+//   (isSpectrumDragActive): a CTUN-sweep drag maps the cursor against the frozen
+//   grab-time centre, and a ruler-pan drag IS the user moving the view, so
+//   autopan stays out of both and recovers on release (the commit + view glide
+//   re-trigger it).
 
 import { useEffect } from 'react';
 import { selectDisplaySliceByRxId, useDisplayStore } from '../state/display-store';
 import { useConnectionStore } from '../state/connection-store';
+import { cancelDrawBusFrame, requestDrawBusFrame } from '../realtime/draw-bus';
 import {
   getReceiverFilterHighHz,
   getReceiverFilterLowHz,
@@ -54,14 +58,16 @@ import {
 } from '../state/receiver-state';
 import * as viewCenter from '../state/view-center';
 import { panReceiverCenterTo } from './ctun-zoom-center';
+import { isSpectrumDragActive } from './use-pan-tune-gesture';
 
 // Keep this fraction of the span between the dial/filter extent and the view
 // edge, so the passband never sits flush against the rail.
 const AUTOPAN_MARGIN_FRAC = 0.06;
-// Trailing settle window after the last tuning event before autopan fires.
-// Long enough that a continuous pointer drag (vfo changes every frame) does not
-// recentre mid-gesture; short enough to feel immediate after a wheel/key step.
-const SETTLE_MS = 90;
+// Min interval between actual recentres per receiver. Detection runs every
+// frame, but each pan posts a LO/DDC retune, so rate-limit the network side;
+// the view-centre tween glides smoothly to the latest target in between, so a
+// throttled follow still looks continuous during a sustained tune.
+const PAN_THROTTLE_MS = 80;
 
 /**
  * Pure geometry: given the current view centre, span, dial, and filter, return
@@ -116,16 +122,18 @@ export function computeAutopanCenterHz(p: {
 
 /**
  * Global hook: keeps each receiver's filter + dial crosshair inside its own
- * panadapter/waterfall view under CTUN by gliding the frozen centre when tuning
- * walks them off the edge. Covers RX1 and every active secondary. Mount once
- * (App / MobileApp).
+ * panadapter/waterfall view under CTUN. Evaluated per display frame so a
+ * continuous tune follows live; suppressed only during an active pointer drag.
+ * Covers RX1 and every active secondary. Mount once (App / MobileApp).
  */
 export function useFilterAutopan(): void {
   useEffect(() => {
-    let timer: number | null = null;
-
+    // Last recentre time per receiver index, for PAN_THROTTLE_MS rate-limiting.
+    const lastPanMs = new Map<number, number>();
     const check = () => {
-      timer = null;
+      // A ruler-pan / CTUN-sweep drag owns the view while held — recover on
+      // release (the commit + view glide re-trigger this check).
+      if (isSpectrumDragActive()) return;
       const conn = useConnectionStore.getState();
       // Only CTUN roams the dial off the view centre; otherwise the view
       // already follows the dial and there is nothing to keep in view.
@@ -153,18 +161,19 @@ export function useFilterAutopan(): void {
           cwPitchHz: conn.cwPitchHz,
           marginHz: spanHz * AUTOPAN_MARGIN_FRAC,
         });
-        if (next != null) panReceiverCenterTo(idx, next);
+        if (next == null) continue;
+        const nowMs = performance.now();
+        if (nowMs - (lastPanMs.get(idx) ?? 0) < PAN_THROTTLE_MS) continue;
+        lastPanMs.set(idx, nowMs);
+        panReceiverCenterTo(idx, next);
       }
     };
 
-    const schedule = () => {
-      if (timer !== null) window.clearTimeout(timer);
-      timer = window.setTimeout(check, SETTLE_MS);
-    };
+    // Coalesce to one evaluation per display frame (the draw bus dedupes repeat
+    // requests for the same callback).
+    const schedule = () => requestDrawBusFrame(check);
 
-    // Tuning / geometry only — deliberately NOT radioLoHz / view-centre, so a
-    // ruler-pan away from the RX is left where the operator put it. `receivers`
-    // reference changes on any secondary vfo/filter/mode edit.
+    // Tuning edits (vfo/filter/mode/cw-pitch) and CTUN/receiver-set changes.
     const unsubConn = useConnectionStore.subscribe((s, prev) => {
       if (
         s.vfoHz !== prev.vfoHz ||
@@ -189,11 +198,18 @@ export function useFilterAutopan(): void {
         schedule();
       }
     });
+    // View-centre motion (RX1 + RX2): catches a glide easing toward the dial and,
+    // crucially, a ruler-pan that scrolled the dial off-screen — so the crosshair
+    // is recovered once the drag releases, not just on the next tune.
+    const unsubVc0 = viewCenter.viewCenterFor(0).subscribe(schedule);
+    const unsubVc1 = viewCenter.viewCenterFor(1).subscribe(schedule);
 
     return () => {
-      if (timer !== null) window.clearTimeout(timer);
       unsubConn();
       unsubDisplay();
+      unsubVc0();
+      unsubVc1();
+      cancelDrawBusFrame(check);
     };
   }, []);
 }

--- a/zeus-web/src/util/use-pan-tune-gesture.ts
+++ b/zeus-web/src/util/use-pan-tune-gesture.ts
@@ -98,6 +98,16 @@ const NOTCH_CLICK_WIDTH_HZ = 150;
 const WHEEL_NOTCH_PX = 40;
 const SPECTRUM_TUNE_CURSOR = 'var(--spectrum-tune-cursor, default)';
 
+// Shared "a spectrum pan/tune drag is in progress" signal. filter-autopan reads
+// this so it never recentres the view mid-drag — a CTUN-sweep drag maps the
+// cursor against the frozen grab-time centre, and a ruler-pan drag IS the user
+// moving the view, so autopan must stay out of both and recover on release. A
+// depth counter tolerates overlapping gestures across receiver panes.
+let spectrumDragDepth = 0;
+export function isSpectrumDragActive(): boolean {
+  return spectrumDragDepth > 0;
+}
+
 // Grid snap helper for ordinary click/drag tuning. Snap-to-signal goes through
 // resolvePanTuneTarget so click and hover share the same carrier target.
 export function snapHz(hz: number): number {
@@ -364,6 +374,17 @@ export function usePanTuneGesture(
       raf: number;
     };
     let drag: Drag | null = null;
+    // Reflect this instance's drag state into the shared depth counter exactly
+    // once per transition, so filter-autopan can suppress recentring mid-drag.
+    let dragHeld = false;
+    const setDrag = (d: Drag | null) => {
+      drag = d;
+      const held = d !== null;
+      if (held !== dragHeld) {
+        dragHeld = held;
+        spectrumDragDepth += held ? 1 : -1;
+      }
+    };
     // Notch painting: while NOTCH is armed, a pointer drag defines a notch
     // band (start..current frequency) instead of tuning. startHz is captured
     // at pointerdown; the live preview is published to the notch store for
@@ -600,7 +621,7 @@ export function usePanTuneGesture(
       // single-pointer drag; we drop the drag state so the lifted finger
       // doesn't snap-tune on release.
       if (pointers.size >= 2) {
-        if (drag) drag = null;
+        if (drag) setDrag(null);
         if (mapDrag) mapDrag = null;
         canvas.style.cursor = '';
         if (!pinch) {
@@ -628,6 +649,17 @@ export function usePanTuneGesture(
         canvas.style.cursor = 'grabbing';
         return;
       }
+      // Focus the receiver whose pane you're interacting with, so the global
+      // mode / band / AF toolbar acts on it. Without this, those controls always
+      // targeted whatever the RX mixer last focused (RX1 by default), so RX2/RX3
+      // and the Kiwi slice couldn't have their mode changed by clicking into
+      // their pane — only via the mixer's focus button. Gated below the pinch/
+      // alt-drag early-returns so multi-touch zoom and map-drag are unaffected.
+      {
+        const tuneIdx = rxIndexOf(tuneReceiver);
+        if (useConnectionStore.getState().focusedRxIndex !== tuneIdx)
+          useConnectionStore.getState().setFocusedRxIndex(tuneIdx);
+      }
       const view = readView(receiver);
       if (!view) return;
       // NOTCH armed: paint a notch band instead of tuning. Capture the start
@@ -649,13 +681,13 @@ export function usePanTuneGesture(
       } catch {
         /* synthetic events don't have an active pointer; real mouse/touch does */
       }
-      drag = {
+      setDrag({
         startX: e.clientX,
         startHz: dragView.centerHz,
         spanHz: dragView.spanHz,
         moved: false,
         mode: dragMode,
-      };
+      });
       canvas.style.cursor = dragMode === 'ruler-pan' ? 'grabbing' : SPECTRUM_TUNE_CURSOR;
     };
 
@@ -802,7 +834,7 @@ export function usePanTuneGesture(
       }
       const d = drag;
       if (!d) return;
-      drag = null;
+      setDrag(null);
       canvas.style.cursor = idleCursor();
       if (canvas.hasPointerCapture(e.pointerId)) {
         canvas.releasePointerCapture(e.pointerId);
@@ -903,6 +935,8 @@ export function usePanTuneGesture(
     canvas.addEventListener('wheel', onWheel, { passive: false });
 
     return () => {
+      // Release any drag depth this instance still holds (unmount mid-drag).
+      setDrag(null);
       if (pendingRaf !== 0) cancelAnimationFrame(pendingRaf);
       if (pendingPanRaf !== 0) cancelAnimationFrame(pendingPanRaf);
       cancelPinchRaf();


### PR DESCRIPTION
## Problem

Follow-up to the keep-in-view autopan ([#982](https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus/pull/982)). It only recentred **after** tuning settled (90 ms trailing debounce), so a *continuous* wheel/keyboard tune under CTUN just kept scrolling the dial off the edge and never panned until you stopped — reported as "it just keeps scrolling without panning automatically."

## Fix

- **Evaluate every display frame** (draw bus) instead of on a trailing debounce, so the view follows the dial **live** during a sustained tune.
- **Suppress only during an actual pointer drag**, via a shared `isSpectrumDragActive()` flag set by `use-pan-tune-gesture`. A CTUN-sweep drag maps the cursor against the frozen grab-time centre, and a ruler-pan drag *is* the user moving the view — so autopan stays out of both and **recovers on release** (the commit + view-centre glide re-trigger the check). Wheel/keyboard/CAT tuning is not a drag, so it follows continuously.
- **Subscribe to view-centre motion** so a ruler-pan that scrolled the crosshair off-screen is brought back once the drag releases, not only on the next tune.
- **Per-receiver 80 ms throttle** on the actual LO/DDC-retune POST so a per-frame follow doesn't spam the backend; the view-centre tween glides smoothly to the latest target in between.

## Test

- `tsc --noEmit` — clean
- `vitest` — autopan geometry **6/6** (unchanged; pure geometry)

## Needs bench verification

Same as #982: the live-follow feel and the P2 multi-DDC secondary path should be checked on real hardware. I can't drive a radio from here.
