### PR TITLE
feat: real-time remote operation (MOX/panel fix, LAN Browser, low-latency Opus RX audio)

### DIFF
--- a/Zeus.Server.Hosting/LanProxyService.cs
+++ b/Zeus.Server.Hosting/LanProxyService.cs
@@ -1,0 +1,525 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// LanProxyService — the server side of the "LAN Browser" panel. It lets an
+// operator (especially one connected REMOTELY over the WebRTC tunnel) reach the
+// web UI of devices on the *radio host's* LAN — router, antenna rotator, amp,
+// another SDR's console — that the remote browser cannot reach directly. The
+// Zeus server, which sits on that LAN, fetches the page on the operator's behalf
+// and returns it; for HTML it rewrites sub-resource URLs so CSS/JS/images route
+// back through this same proxy.
+//
+// SECURITY POSTURE — this is an authenticated reach into the home network, so it
+// is deny-by-default and tightly scoped:
+//   - Only http/https, GET only.
+//   - The target host must resolve EXCLUSIVELY to RFC1918 / IPv6-ULA private
+//     addresses. ANY resolved address outside those ranges → refused. This
+//     blocks the public internet, cloud metadata (169.254.169.254), and
+//     DNS-rebinding (a name that resolves to one private + one public address).
+//   - LOOPBACK IS BLOCKED ON PURPOSE: allowing 127.0.0.1 would let a remote
+//     session re-enter Zeus's own Kestrel (and bypass the WebRTC tunnel's
+//     secrets/QRZ denylist) or any other local-only service. The LAN proxy is
+//     for *other* machines on the LAN, not this host.
+//   - Redirects are followed manually, re-validating every hop against the same
+//     private-range rule, capped at a few hops.
+//   - Response bodies are size-capped.
+//
+// Nothing here touches the radio / DSP / TX path.
+
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+
+namespace Zeus.Server;
+
+/// <summary>Outcome of a <see cref="LanProxyService.FetchAsync"/> call.</summary>
+public sealed record LanProxyResult(
+    int Status,
+    string? ContentType,
+    byte[] Body,
+    string? Error)
+{
+    public bool Ok => Error is null;
+
+    public static LanProxyResult Fail(int status, string error) =>
+        new(status, "text/plain; charset=utf-8", Encoding.UTF8.GetBytes(error), error);
+}
+
+/// <summary>
+/// Fetches a private-LAN web resource on behalf of the LAN Browser panel,
+/// validating the target stays within private address ranges and rewriting HTML
+/// so sub-resources load back through the proxy. Singleton.
+/// </summary>
+public sealed partial class LanProxyService
+{
+    /// <summary>The loopback path this proxy is exposed at; the HTML rewriter
+    /// points sub-resource URLs here (<c>?url=&lt;absolute&gt;</c>).</summary>
+    public const string ProxyPath = "/api/lan/proxy";
+
+    /// <summary>Named <see cref="IHttpClientFactory"/> client for LAN fetches —
+    /// no auto-redirect (we follow + re-validate manually), modest timeout.</summary>
+    public const string HttpClientName = "ZeusLanProxy";
+
+    // 8 MiB is plenty for a device admin page plus an inlined asset; keeps a
+    // hostile/huge LAN target from exhausting memory. Per-asset, not per-session.
+    private const int MaxBodyBytes = 8 * 1024 * 1024;
+    private const int MaxRedirects = 4;
+
+    private readonly IHttpClientFactory _httpFactory;
+    private readonly ILogger<LanProxyService> _log;
+
+    public LanProxyService(IHttpClientFactory httpFactory, ILogger<LanProxyService> log)
+    {
+        _httpFactory = httpFactory;
+        _log = log;
+    }
+
+    /// <summary>
+    /// Fetch <paramref name="rawUrl"/> from the LAN (following private-only
+    /// redirects), returning the body — HTML rewritten so sub-resources proxy
+    /// back through <see cref="ProxyPath"/>. Never throws for an
+    /// expected/denied condition; returns a <see cref="LanProxyResult"/> with an
+    /// HTTP-style status + message the panel can show.
+    /// </summary>
+    public async Task<LanProxyResult> FetchAsync(string? rawUrl, bool inline, CancellationToken ct)
+    {
+        if (!TryValidateTarget(rawUrl, out var uri, out var err))
+            return LanProxyResult.Fail(403, err!);
+
+        var client = _httpFactory.CreateClient(HttpClientName);
+        var current = uri!;
+
+        for (int hop = 0; hop <= MaxRedirects; hop++)
+        {
+            HttpResponseMessage resp;
+            try
+            {
+                using var req = new HttpRequestMessage(HttpMethod.Get, current);
+                // A neutral, modern UA — some device UIs gate on it; never leak
+                // the operator's real browser/identity to a LAN device.
+                req.Headers.TryAddWithoutValidation("User-Agent", "Mozilla/5.0 (Zeus LAN Browser)");
+                resp = await client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                _log.LogInformation("lan.proxy fetch failed url={Url} err={Err}", current, ex.Message);
+                return LanProxyResult.Fail(502, $"Could not reach {current.Host}: {ex.Message}");
+            }
+
+            using (resp)
+            {
+                // Manual redirect handling so every hop is re-validated against the
+                // private-range rule (an open redirect to a public host is refused).
+                if (IsRedirect(resp.StatusCode) && resp.Headers.Location is { } loc)
+                {
+                    var next = new Uri(current, loc); // resolves relative Location
+                    if (!TryValidateTarget(next.ToString(), out var nextUri, out var redErr))
+                        return LanProxyResult.Fail(403, $"Redirect blocked: {redErr}");
+                    current = nextUri!;
+                    continue;
+                }
+
+                var contentType = resp.Content.Headers.ContentType?.ToString();
+                byte[] body;
+                try
+                {
+                    body = await ReadCappedAsync(resp, ct).ConfigureAwait(false);
+                }
+                catch (InvalidOperationException)
+                {
+                    return LanProxyResult.Fail(502, $"Response from {current.Host} exceeded {MaxBodyBytes / 1024 / 1024} MiB.");
+                }
+
+                if (IsHtml(contentType))
+                {
+                    var html = Decode(body, contentType);
+                    html = inline
+                        ? await InlineHtmlAsync(html, current, ct).ConfigureAwait(false)
+                        : RewriteHtml(html, current);
+                    body = Encoding.UTF8.GetBytes(html);
+                }
+
+                return new LanProxyResult((int)resp.StatusCode, contentType, body, null);
+            }
+        }
+
+        return LanProxyResult.Fail(508, "Too many redirects.");
+    }
+
+    // -- Target validation ----------------------------------------------------
+
+    /// <summary>
+    /// True if <paramref name="rawUrl"/> is an http/https URL whose host
+    /// resolves exclusively to private (RFC1918 / IPv6-ULA) addresses. On
+    /// failure, <paramref name="error"/> explains why (for the panel).
+    /// </summary>
+    public bool TryValidateTarget(string? rawUrl, out Uri? uri, out string? error)
+    {
+        uri = null;
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(rawUrl))
+        {
+            error = "No URL supplied.";
+            return false;
+        }
+        if (!Uri.TryCreate(rawUrl, UriKind.Absolute, out var parsed))
+        {
+            error = "Not a valid absolute URL.";
+            return false;
+        }
+        if (parsed.Scheme != Uri.UriSchemeHttp && parsed.Scheme != Uri.UriSchemeHttps)
+        {
+            error = "Only http and https are allowed.";
+            return false;
+        }
+
+        IPAddress[] addrs;
+        if (IPAddress.TryParse(parsed.Host, out var literal))
+        {
+            addrs = [literal];
+        }
+        else
+        {
+            try
+            {
+                addrs = Dns.GetHostAddresses(parsed.Host);
+            }
+            catch (Exception ex)
+            {
+                error = $"Could not resolve host '{parsed.Host}': {ex.Message}";
+                return false;
+            }
+            if (addrs.Length == 0)
+            {
+                error = $"Host '{parsed.Host}' did not resolve.";
+                return false;
+            }
+        }
+
+        // EVERY resolved address must be private; a single public/loopback/
+        // link-local address fails the whole target (anti-rebinding).
+        foreach (var a in addrs)
+        {
+            if (!IsPrivate(a))
+            {
+                error = $"'{parsed.Host}' resolves to {a}, which is not a private LAN address. " +
+                        "The LAN Browser only reaches RFC1918 / IPv6-ULA addresses.";
+                return false;
+            }
+        }
+
+        uri = parsed;
+        return true;
+    }
+
+    /// <summary>
+    /// True for an address inside a private LAN range: IPv4 10/8, 172.16/12,
+    /// 192.168/16; IPv6 unique-local fc00::/7. Loopback, link-local (incl. cloud
+    /// metadata 169.254.169.254), CGNAT 100.64/10, and all public addresses are
+    /// rejected.
+    /// </summary>
+    internal static bool IsPrivate(IPAddress address)
+    {
+        if (address.IsIPv4MappedToIPv6)
+            address = address.MapToIPv4();
+
+        if (address.AddressFamily == AddressFamily.InterNetwork)
+        {
+            var b = address.GetAddressBytes(); // big-endian
+            return b[0] switch
+            {
+                10 => true,                                   // 10.0.0.0/8
+                172 => b[1] >= 16 && b[1] <= 31,              // 172.16.0.0/12
+                192 => b[1] == 168,                           // 192.168.0.0/16
+                _ => false,
+            };
+        }
+
+        if (address.AddressFamily == AddressFamily.InterNetworkV6)
+        {
+            if (address.IsIPv6LinkLocal || IPAddress.IsLoopback(address)) return false;
+            var b = address.GetAddressBytes();
+            return (b[0] & 0xFE) == 0xFC; // fc00::/7 unique-local
+        }
+
+        return false;
+    }
+
+    // -- HTML rewriting -------------------------------------------------------
+
+    /// <summary>
+    /// Rewrite a page's resource references so the browser loads them back
+    /// through this proxy. Best-effort and deliberately conservative: it
+    /// rewrites <c>href</c>/<c>src</c>/<c>action</c> attributes and CSS
+    /// <c>url(...)</c>, resolving each against <paramref name="baseUri"/>. It
+    /// will NOT make a JS-heavy SPA work (those build URLs at runtime); simple
+    /// device admin pages render fine.
+    /// </summary>
+    internal static string RewriteHtml(string html, Uri baseUri)
+    {
+        // Honour an existing <base href> if the page sets one.
+        var baseHrefMatch = BaseHrefRegex().Match(html);
+        if (baseHrefMatch.Success &&
+            Uri.TryCreate(baseUri, baseHrefMatch.Groups[1].Value, out var declared))
+        {
+            baseUri = declared;
+        }
+
+        html = AttrUrlRegex().Replace(html, m =>
+        {
+            var attr = m.Groups["attr"].Value;
+            var quote = m.Groups["q"].Value;
+            var val = m.Groups["url"].Value;
+            var proxied = Proxify(val, baseUri);
+            return proxied is null ? m.Value : $"{attr}={quote}{proxied}{quote}";
+        });
+
+        html = CssUrlRegex().Replace(html, m =>
+        {
+            var val = m.Groups["url"].Value.Trim('\'', '"', ' ');
+            var proxied = Proxify(val, baseUri);
+            return proxied is null ? m.Value : $"url(\"{proxied}\")";
+        });
+
+        return html;
+    }
+
+    /// <summary>Resolve a possibly-relative resource URL to an absolute one and
+    /// wrap it as <c>/api/lan/proxy?url=&lt;encoded&gt;</c>, or null to leave the
+    /// original untouched (anchors, data:/javascript:/mailto:, unparseable).</summary>
+    private static string? Proxify(string value, Uri baseUri)
+    {
+        var v = value.Trim();
+        if (v.Length == 0 || v[0] == '#') return null;
+        if (v.StartsWith("data:", StringComparison.OrdinalIgnoreCase) ||
+            v.StartsWith("javascript:", StringComparison.OrdinalIgnoreCase) ||
+            v.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase) ||
+            v.StartsWith("tel:", StringComparison.OrdinalIgnoreCase) ||
+            v.StartsWith(ProxyPath, StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        if (!Uri.TryCreate(baseUri, v, out var abs)) return null;
+        if (abs.Scheme != Uri.UriSchemeHttp && abs.Scheme != Uri.UriSchemeHttps) return null;
+        return $"{ProxyPath}?url={Uri.EscapeDataString(abs.ToString())}";
+    }
+
+    // -- HTML inlining (remote srcdoc mode) -----------------------------------
+
+    // Total bytes we'll inline into one page, and the per-resource cap. Keeps a
+    // heavy page from ballooning the srcdoc (and the remote tunnel response)
+    // without bound. Pages that exceed the budget just render with some
+    // resources missing rather than failing.
+    private const int InlineBudgetBytes = 6 * 1024 * 1024;
+    private const int InlinePerResourceBytes = 2 * 1024 * 1024;
+
+    // Injected into the inlined page so anchor clicks / form submits ask the Zeus
+    // panel (the iframe's parent) to navigate, instead of the sandboxed srcdoc
+    // iframe trying to load a URL it can't reach over the remote tunnel.
+    private const string NavInterceptorScript =
+        "<script>(function(){function s(u){if(u)parent.postMessage({type:'zeus-lan-nav',url:u},'*');}" +
+        "document.addEventListener('click',function(e){var a=e.target.closest&&e.target.closest('[data-zeus-lan]');" +
+        "if(a){e.preventDefault();s(a.getAttribute('data-zeus-lan'));}},true);" +
+        "document.addEventListener('submit',function(e){var f=e.target.closest&&e.target.closest('[data-zeus-lan-form]');" +
+        "if(f){e.preventDefault();s(f.getAttribute('data-zeus-lan-form'));}},true);})();</script>";
+
+    /// <summary>
+    /// Produce a self-contained HTML document for an iframe <c>srcdoc</c>: inline
+    /// stylesheets and images (as data URIs) so the page renders with no further
+    /// network access, and rewrite anchors/forms so navigation is relayed to the
+    /// Zeus panel via <c>postMessage</c>. This is the remote path — the operator's
+    /// browser can't reach the LAN, so everything the page needs must travel in
+    /// the single tunnelled response. Best-effort: a JS-driven SPA won't fully
+    /// render, but typical device admin pages do. Never throws.
+    /// </summary>
+    internal async Task<string> InlineHtmlAsync(string html, Uri baseUri, CancellationToken ct)
+    {
+        var baseHrefMatch = BaseHrefRegex().Match(html);
+        if (baseHrefMatch.Success &&
+            Uri.TryCreate(baseUri, baseHrefMatch.Groups[1].Value, out var declared))
+        {
+            baseUri = declared;
+        }
+
+        int budget = InlineBudgetBytes;
+
+        // 1. Stylesheets: <link rel="stylesheet" href="…"> → <style>…</style>.
+        html = await ReplaceAsync(StylesheetLinkRegex(), html, async m =>
+        {
+            var href = m.Groups["url"].Value;
+            if (!Uri.TryCreate(baseUri, href, out var abs)) return m.Value;
+            var res = await FetchSubResourceAsync(abs, ct).ConfigureAwait(false);
+            if (res is null || budget - res.Value.bytes.Length < 0) return m.Value;
+            budget -= res.Value.bytes.Length;
+            var css = Encoding.UTF8.GetString(res.Value.bytes);
+            return $"<style>{css}</style>";
+        }).ConfigureAwait(false);
+
+        // 2. Images: <img … src="…"> → data: URI.
+        html = await ReplaceAsync(ImgTagRegex(), html, async m =>
+        {
+            var src = m.Groups["url"].Value;
+            if (src.StartsWith("data:", StringComparison.OrdinalIgnoreCase)) return m.Value;
+            if (!Uri.TryCreate(baseUri, src, out var abs)) return m.Value;
+            var res = await FetchSubResourceAsync(abs, ct).ConfigureAwait(false);
+            if (res is null || budget - res.Value.bytes.Length < 0) return m.Value;
+            budget -= res.Value.bytes.Length;
+            var mime = res.Value.contentType ?? "image/*";
+            var dataUri = $"data:{mime};base64,{Convert.ToBase64String(res.Value.bytes)}";
+            return m.Value.Replace(src, dataUri, StringComparison.Ordinal);
+        }).ConfigureAwait(false);
+
+        // 3. Anchors: route clicks to the parent panel instead of the dead iframe.
+        html = AnchorHrefRegex().Replace(html, m =>
+        {
+            var href = m.Groups["url"].Value;
+            if (href.Length == 0 || href[0] == '#'
+                || href.StartsWith("javascript:", StringComparison.OrdinalIgnoreCase)
+                || href.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase)) return m.Value;
+            if (!Uri.TryCreate(baseUri, href, out var abs)) return m.Value;
+            if (abs.Scheme != Uri.UriSchemeHttp && abs.Scheme != Uri.UriSchemeHttps) return m.Value;
+            return $"<a href=\"#\" data-zeus-lan=\"{EscapeAttr(abs.ToString())}\"";
+        });
+
+        // 4. Forms: relay the action target too (GET forms; best-effort).
+        html = FormActionRegex().Replace(html, m =>
+        {
+            var action = m.Groups["url"].Value;
+            if (!Uri.TryCreate(baseUri, action, out var abs)) return m.Value;
+            if (abs.Scheme != Uri.UriSchemeHttp && abs.Scheme != Uri.UriSchemeHttps) return m.Value;
+            return $"<form data-zeus-lan-form=\"{EscapeAttr(abs.ToString())}\"";
+        });
+
+        // 5. Inject the nav interceptor just before </body> (or append).
+        int bodyEnd = html.LastIndexOf("</body>", StringComparison.OrdinalIgnoreCase);
+        html = bodyEnd >= 0 ? html.Insert(bodyEnd, NavInterceptorScript) : html + NavInterceptorScript;
+
+        return html;
+    }
+
+    /// <summary>Fetch one sub-resource for inlining: validate it's private, GET it,
+    /// cap its size. Returns null on any failure (the caller keeps the original).</summary>
+    private async Task<(string? contentType, byte[] bytes)?> FetchSubResourceAsync(Uri abs, CancellationToken ct)
+    {
+        if (!TryValidateTarget(abs.ToString(), out _, out _)) return null;
+        try
+        {
+            var client = _httpFactory.CreateClient(HttpClientName);
+            using var req = new HttpRequestMessage(HttpMethod.Get, abs);
+            req.Headers.TryAddWithoutValidation("User-Agent", "Mozilla/5.0 (Zeus LAN Browser)");
+            using var resp = await client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct)
+                .ConfigureAwait(false);
+            if (!resp.IsSuccessStatusCode) return null;
+            if (resp.Content.Headers.ContentLength is > InlinePerResourceBytes) return null;
+            var bytes = await resp.Content.ReadAsByteArrayAsync(ct).ConfigureAwait(false);
+            if (bytes.Length > InlinePerResourceBytes) return null;
+            return (resp.Content.Headers.ContentType?.ToString(), bytes);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch { return null; }
+    }
+
+    private static string EscapeAttr(string s) =>
+        s.Replace("&", "&amp;").Replace("\"", "&quot;");
+
+    /// <summary>Async-aware regex replace (Regex.Replace has no async overload).</summary>
+    private static async Task<string> ReplaceAsync(
+        Regex regex, string input, Func<Match, Task<string>> replacer)
+    {
+        var sb = new StringBuilder();
+        int last = 0;
+        foreach (Match m in regex.Matches(input))
+        {
+            sb.Append(input, last, m.Index - last);
+            sb.Append(await replacer(m).ConfigureAwait(false));
+            last = m.Index + m.Length;
+        }
+        sb.Append(input, last, input.Length - last);
+        return sb.ToString();
+    }
+
+    // -- helpers --------------------------------------------------------------
+
+    private static bool IsRedirect(HttpStatusCode s) =>
+        s is HttpStatusCode.MovedPermanently or HttpStatusCode.Found
+          or HttpStatusCode.SeeOther or HttpStatusCode.TemporaryRedirect
+          or HttpStatusCode.PermanentRedirect;
+
+    private static bool IsHtml(string? contentType) =>
+        contentType is not null &&
+        contentType.Contains("text/html", StringComparison.OrdinalIgnoreCase);
+
+    private static string Decode(byte[] body, string? contentType)
+    {
+        // Honour an explicit charset; default UTF-8 (latin-1 bytes survive it for
+        // the ASCII-only markup the rewriter touches).
+        if (contentType is not null)
+        {
+            var idx = contentType.IndexOf("charset=", StringComparison.OrdinalIgnoreCase);
+            if (idx >= 0)
+            {
+                var cs = contentType[(idx + 8)..].Trim().Trim('"');
+                var semi = cs.IndexOf(';');
+                if (semi >= 0) cs = cs[..semi];
+                try { return Encoding.GetEncoding(cs).GetString(body); } catch { /* fall through */ }
+            }
+        }
+        return Encoding.UTF8.GetString(body);
+    }
+
+    private static async Task<byte[]> ReadCappedAsync(HttpResponseMessage resp, CancellationToken ct)
+    {
+        if (resp.Content.Headers.ContentLength is > MaxBodyBytes)
+            throw new InvalidOperationException("too large");
+
+        await using var stream = await resp.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        using var ms = new MemoryStream();
+        var buf = new byte[81920];
+        int read;
+        while ((read = await stream.ReadAsync(buf, ct).ConfigureAwait(false)) > 0)
+        {
+            if (ms.Length + read > MaxBodyBytes)
+                throw new InvalidOperationException("too large");
+            ms.Write(buf, 0, read);
+        }
+        return ms.ToArray();
+    }
+
+    [GeneratedRegex(@"<base\s[^>]*href\s*=\s*[""']([^""']+)[""']", RegexOptions.IgnoreCase)]
+    private static partial Regex BaseHrefRegex();
+
+    // Matches href= / src= / action= with a quoted value.
+    [GeneratedRegex(@"(?<attr>\b(?:href|src|action))\s*=\s*(?<q>[""'])(?<url>[^""']*)\k<q>", RegexOptions.IgnoreCase)]
+    private static partial Regex AttrUrlRegex();
+
+    // Matches CSS url(...) with optional quotes.
+    [GeneratedRegex(@"url\(\s*(?<url>['""]?[^)'""]+['""]?)\s*\)", RegexOptions.IgnoreCase)]
+    private static partial Regex CssUrlRegex();
+
+    // <link rel="stylesheet" … href="…"> (rel/href in either order).
+    [GeneratedRegex(@"<link\b(?=[^>]*\brel\s*=\s*[""']?stylesheet)[^>]*\bhref\s*=\s*[""'](?<url>[^""']+)[""'][^>]*>", RegexOptions.IgnoreCase)]
+    private static partial Regex StylesheetLinkRegex();
+
+    // <img … src="…" …> — whole tag captured so we can swap just the src value.
+    [GeneratedRegex(@"<img\b[^>]*\bsrc\s*=\s*[""'](?<url>[^""']+)[""'][^>]*>", RegexOptions.IgnoreCase)]
+    private static partial Regex ImgTagRegex();
+
+    // Opening <a … href="…"  (tag prefix only — replaced with an intercept anchor).
+    [GeneratedRegex(@"<a\b[^>]*?\bhref\s*=\s*[""'](?<url>[^""']*)[""']", RegexOptions.IgnoreCase)]
+    private static partial Regex AnchorHrefRegex();
+
+    // Opening <form … action="…"
+    [GeneratedRegex(@"<form\b[^>]*?\baction\s*=\s*[""'](?<url>[^""']*)[""']", RegexOptions.IgnoreCase)]
+    private static partial Regex FormActionRegex();
+}

--- a/Zeus.Server.Hosting/Remote/RemoteRxAudioPipeline.cs
+++ b/Zeus.Server.Hosting/Remote/RemoteRxAudioPipeline.cs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+
+using Concentus;
+using Concentus.Enums;
+using Zeus.Contracts;
+
+namespace Zeus.Server.Hosting.Remote;
+
+/// <summary>
+/// Encodes the radio's RX audio into 20 ms Opus packets for the remote operator's
+/// WebRTC audio track — the state-of-the-art low-latency, loss-concealed RX path
+/// that replaces shipping raw 48 kHz f32 PCM over the unreliable data channel.
+/// Opus on a media track gets the browser's native adaptive jitter buffer + PLC
+/// + RTCP, and drops the wire rate ~50× (≈1.5 Mbps → ≈48 kbps), which is what
+/// makes RX audio robust over a real internet path.
+///
+/// This is the exact mirror of <see cref="RemoteMicAudioPipeline"/> (which
+/// DECODES the inbound voice track) running in the opposite direction. One
+/// instance per remote session; NOT thread-safe — it is fed only from the single
+/// <see cref="RemoteFrameSink"/> drain task.
+/// </summary>
+public sealed class RemoteRxAudioPipeline
+{
+    public const int SampleRate = 48000;
+    public const int Channels = 1;
+    public const int BlockSamples = 960;          // 20 ms @ 48 kHz — one Opus frame
+    /// <summary>RTP timestamp units advanced per emitted packet (Opus clock = 48 kHz).</summary>
+    public const uint BlockRtpUnits = BlockSamples;
+
+    private const int MaxPacketBytes = 1275;      // largest Opus packet
+
+    private readonly IOpusEncoder _encoder =
+        OpusCodecFactory.CreateEncoder(SampleRate, Channels, OpusApplication.OPUS_APPLICATION_AUDIO);
+    private readonly short[] _pcm = new short[BlockSamples];
+    private readonly byte[] _packet = new byte[MaxPacketBytes];
+    private int _filled;
+    private readonly Action<ReadOnlyMemory<byte>> _onPacket;
+
+    /// <param name="onPacket">
+    /// Invoked synchronously per completed 20 ms Opus packet. The buffer is reused
+    /// between calls — copy it (e.g. <c>.ToArray()</c>) if retained past the call.
+    /// </param>
+    public RemoteRxAudioPipeline(Action<ReadOnlyMemory<byte>> onPacket)
+    {
+        _onPacket = onPacket;
+        // Loss-resilient, low-latency settings tuned for an internet path. Wrapped
+        // so an unavailable knob in a given Concentus build falls back to defaults
+        // rather than failing the session.
+        try
+        {
+            _encoder.Bitrate = 48000;
+            _encoder.Complexity = 5;          // balance CPU (Raspberry Pi) vs quality
+            _encoder.UseInbandFEC = true;     // forward error correction for packet loss
+            _encoder.PacketLossPercent = 5;
+        }
+        catch { /* keep encoder defaults */ }
+    }
+
+    /// <summary>Feed one RX <see cref="AudioFrame"/>; emits 20 ms Opus packets as
+    /// the 960-sample block fills. Stereo input is downmixed to mono.</summary>
+    public void Encode(in AudioFrame frame)
+    {
+        var samples = frame.Samples.Span;
+        int ch = frame.Channels < 1 ? 1 : frame.Channels;
+        for (int i = 0; i + ch <= samples.Length; i += ch)
+        {
+            float v;
+            if (ch == 1)
+            {
+                v = samples[i];
+            }
+            else
+            {
+                float sum = 0f;
+                for (int c = 0; c < ch; c++) sum += samples[i + c];
+                v = sum / ch;
+            }
+            int s = (int)(v * 32767f);
+            _pcm[_filled++] = (short)(s > 32767 ? 32767 : s < -32768 ? -32768 : s);
+            if (_filled == BlockSamples) Flush();
+        }
+    }
+
+    private void Flush()
+    {
+        int n;
+        // Never throw out of the drain path — a bad block is dropped, not fatal.
+        try { n = _encoder.Encode(_pcm.AsSpan(0, BlockSamples), BlockSamples, _packet.AsSpan(), _packet.Length); }
+        catch { _filled = 0; return; }
+        _filled = 0;
+        if (n > 0) _onPacket(_packet.AsMemory(0, n));
+    }
+}

--- a/Zeus.Server.Hosting/Remote/RemoteWebRtcSession.cs
+++ b/Zeus.Server.Hosting/Remote/RemoteWebRtcSession.cs
@@ -60,6 +60,16 @@ public sealed class RemoteWebRtcSession
     private int _lastAudioSeq = -1;
     private bool _audioWired;
 
+    // SOTA RX audio (opt-in, bench-gated): when ZEUS_REMOTE_OPUS_RX is set, RX
+    // audio is Opus-encoded onto the outbound WebRTC audio track instead of raw
+    // PCM over the unreliable "frames" data channel — native browser jitter
+    // buffer + PLC + ~50× less bandwidth. Default OFF so the proven PCM path is
+    // unchanged until this is bench-verified against a real radio + internet hop.
+    internal static readonly bool OpusRxEnabled =
+        (Environment.GetEnvironmentVariable("ZEUS_REMOTE_OPUS_RX") ?? "")
+            .Trim() is "1" or "true" or "TRUE" or "True";
+    private RemoteRxAudioPipeline? _rxAudio;
+
     // Post-unlock binary stream-request control frames (RX monitoring, Phase A):
     //   first byte 0x22 = display request, 0x21 = audio request; byte[1] 1/0 = enable/disable.
     // We track the session's current wanted-state so a duplicate enable can't
@@ -78,6 +88,12 @@ public sealed class RemoteWebRtcSession
     // bulk-import path we don't want to relay either direction.
     private const int MaxResponseBytes = 1 * 1024 * 1024;
     private const int MaxRequestBytes = 1 * 1024 * 1024;
+
+    // The LAN Browser proxy returns whole device pages with inlined CSS/images
+    // (data URIs), which legitimately exceed the 1 MiB chrome cap. It's the one
+    // endpoint whose large reply is expected, so it gets its own ceiling.
+    private const int LanProxyMaxResponseBytes = 10 * 1024 * 1024;
+    private const string LanProxyPath = "/api/lan/proxy";
 
     /// <summary>
     /// Always-denied endpoints (BOTH read and write). A request to one of these
@@ -191,7 +207,22 @@ public sealed class RemoteWebRtcSession
     /// </summary>
     public bool TrySendFrame(byte[] frame)
     {
-        if (!_session.TryEgress() || _frames is null)
+        if (!_session.TryEgress())
+            return false;
+
+        // Opus-RX mode: divert RX audio frames (0x02) onto the WebRTC audio track
+        // and DON'T also ship the raw PCM over the data channel. Every other frame
+        // type (spectrum/meters/MOX/…) still rides the data channel as before.
+        if (_rxAudio is not null
+            && frame.Length >= Zeus.Contracts.WireFormat.HeaderSize
+            && frame[0] == (byte)Zeus.Contracts.MsgType.AudioPcm)
+        {
+            try { _rxAudio.Encode(Zeus.Contracts.AudioFrame.Deserialize(frame)); }
+            catch { /* malformed frame — drop, never fatal */ }
+            return true;
+        }
+
+        if (_frames is null)
             return false;
         _frames.send(frame);
         return true;
@@ -329,14 +360,21 @@ public sealed class RemoteWebRtcSession
             return;
 
         _micPipeline = new RemoteMicAudioPipeline(OnRemoteMicBlock);
+        // With Opus-RX on, the same audio m-line is bidirectional: we RECEIVE the
+        // operator's mic AND SEND the radio's RX audio over it. Off (default) it
+        // stays recvonly (mic only) exactly as before.
+        var direction = OpusRxEnabled ? MediaStreamStatusEnum.SendRecv : MediaStreamStatusEnum.RecvOnly;
         var audioTrack = new MediaStreamTrack(
             SDPMediaTypesEnum.audio, false,
             new List<SDPAudioVideoMediaFormat> { new(SDPMediaTypesEnum.audio, 111, "OPUS", 48000, 2) },
-            MediaStreamStatusEnum.RecvOnly);
+            direction);
         _pc.addTrack(audioTrack);
         _pc.OnRtpPacketReceived += OnAudioRtpReceived;
+        if (OpusRxEnabled) _rxAudio = new RemoteRxAudioPipeline(OnEncodedRxOpus);
         _audioWired = true;
-        _log.LogInformation("rtc.remote voice-mic track negotiated (Opus 48k recvonly)");
+        _log.LogInformation(
+            "rtc.remote voice-mic track negotiated (Opus 48k {Dir})",
+            OpusRxEnabled ? "sendrecv +RX-audio" : "recvonly");
     }
 
     private void OnAudioRtpReceived(
@@ -366,6 +404,14 @@ public sealed class RemoteWebRtcSession
 
     /// <summary>Inject a decoded 960-sample f32le voice block into the TX-mic ingest.</summary>
     private void OnRemoteMicBlock(ReadOnlyMemory<byte> f32leBlock) => _hub?.InjectMicPcm(f32leBlock);
+
+    /// <summary>Send one 20 ms Opus RX packet on the outbound audio track. Called
+    /// synchronously from the frame-drain task (Opus-RX mode only). Never throws.</summary>
+    private void OnEncodedRxOpus(ReadOnlyMemory<byte> opus)
+    {
+        try { _pc.SendAudio(RemoteRxAudioPipeline.BlockRtpUnits, opus.ToArray()); }
+        catch { /* peer gone / track not ready — drop, never fatal */ }
+    }
 
     // -- Read-write REST tunnel ---------------------------------------------
     //
@@ -488,13 +534,19 @@ public sealed class RemoteWebRtcSession
                 TrackTxKeying(target.AbsolutePath, body);
 
             // Cap the body so the tunnel can't be used as a bulk-export channel.
-            if (resp.Content.Headers.ContentLength is long len && len > MaxResponseBytes)
+            // The LAN Browser proxy is the one endpoint with an expected-large
+            // reply (a whole device page with inlined assets), so it gets a
+            // higher ceiling than the small chrome/control endpoints.
+            int maxResp = path.StartsWith(LanProxyPath, StringComparison.OrdinalIgnoreCase)
+                ? LanProxyMaxResponseBytes
+                : MaxResponseBytes;
+            if (resp.Content.Headers.ContentLength is long len && len > maxResp)
             {
                 SendApiReply(id, 502);
                 return;
             }
             var bytes = await resp.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
-            if (bytes.Length > MaxResponseBytes)
+            if (bytes.Length > maxResp)
             {
                 SendApiReply(id, 502);
                 return;

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -3446,6 +3446,21 @@ public static class ZeusEndpoints
             return Results.Ok(hc.Snapshot());
         });
 
+        // LAN Browser proxy. Fetches a private-LAN device web page on the radio
+        // host's behalf and returns it. Scoped to RFC1918 / IPv6-ULA targets by
+        // LanProxyService; loopback + public + cloud-metadata are refused. Tunnels
+        // transparently for remote operators (it's a same-origin /api GET).
+        app.MapGet("/api/lan/proxy", async (string? url, string? inline, LanProxyService proxy, HttpContext ctx, CancellationToken ct) =>
+        {
+            // inline=1 → self-contained HTML for an iframe srcdoc (the remote path,
+            // where the operator's browser can't load sub-resources from the LAN).
+            bool wantInline = inline is "1" or "true";
+            var result = await proxy.FetchAsync(url, wantInline, ct);
+            ctx.Response.StatusCode = result.Status;
+            ctx.Response.ContentType = result.ContentType ?? "application/octet-stream";
+            await ctx.Response.Body.WriteAsync(result.Body, ct);
+        });
+
         return app;
     }
 

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -343,6 +343,14 @@ public static class ZeusHost
         // Radio-side broker glue (Phase 3). Inert until a remote-access password
         // is set; then it keeps a "host" socket on the broker and answers offers.
         builder.Services.AddHostedService<Zeus.Server.Hosting.Remote.RemoteBrokerClient>();
+        // LAN Browser proxy: fetches private-LAN device web UIs on behalf of the
+        // panel (esp. for remote operators whose browser can't reach the radio's
+        // LAN). No auto-redirect — LanProxyService follows + re-validates each hop
+        // against the private-range rule itself.
+        builder.Services.AddHttpClient(LanProxyService.HttpClientName,
+                c => c.Timeout = TimeSpan.FromSeconds(15))
+            .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler { AllowAutoRedirect = false });
+        builder.Services.AddSingleton<LanProxyService>();
         // RX audio publish seam (Phase 1). DspPipelineService.PublishAudio
         // fans each AudioFrame across every registered IRxAudioSink.
         //

--- a/tests/Zeus.Server.Tests/LanProxyServiceTests.cs
+++ b/tests/Zeus.Server.Tests/LanProxyServiceTests.cs
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Net;
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Server;
+using Xunit;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Guards the LAN Browser proxy's security boundary: only private (RFC1918 /
+/// IPv6-ULA) targets are reachable, and the HTML rewriter routes sub-resources
+/// back through the proxy. These are the rules that keep an authenticated remote
+/// operator from turning the proxy into an open/SSRF gateway into the public
+/// internet or the radio host's own loopback services.
+/// </summary>
+public class LanProxyServiceTests
+{
+    [Theory]
+    // IPv4 private ranges — allowed.
+    [InlineData("10.0.0.1", true)]
+    [InlineData("10.255.255.255", true)]
+    [InlineData("172.16.0.1", true)]
+    [InlineData("172.31.255.254", true)]
+    [InlineData("192.168.1.1", true)]
+    // Just outside the private ranges — refused.
+    [InlineData("172.15.0.1", false)]
+    [InlineData("172.32.0.1", false)]
+    [InlineData("192.169.0.1", false)]
+    [InlineData("11.0.0.1", false)]
+    // Public — refused.
+    [InlineData("8.8.8.8", false)]
+    [InlineData("1.1.1.1", false)]
+    // Loopback — refused on purpose (would re-enter Zeus's own Kestrel).
+    [InlineData("127.0.0.1", false)]
+    // Link-local incl. cloud metadata — refused.
+    [InlineData("169.254.1.1", false)]
+    [InlineData("169.254.169.254", false)]
+    // CGNAT 100.64/10 — refused (not a home LAN range).
+    [InlineData("100.64.0.1", false)]
+    // IPv6 unique-local — allowed; loopback / link-local / public — refused.
+    [InlineData("fd12:3456::1", true)]
+    [InlineData("fc00::1", true)]
+    [InlineData("::1", false)]
+    [InlineData("fe80::1", false)]
+    [InlineData("2001:4860:4860::8888", false)]
+    public void IsPrivate_ClassifiesAddresses(string ip, bool expected)
+    {
+        Assert.Equal(expected, LanProxyService.IsPrivate(IPAddress.Parse(ip)));
+    }
+
+    [Fact]
+    public void IsPrivate_IPv4MappedToIPv6_PublicStillRefused()
+    {
+        // ::ffff:8.8.8.8 must be unwrapped and judged as the public IPv4 it is.
+        Assert.False(LanProxyService.IsPrivate(IPAddress.Parse("::ffff:8.8.8.8")));
+        Assert.True(LanProxyService.IsPrivate(IPAddress.Parse("::ffff:192.168.1.1")));
+    }
+
+    private static LanProxyService NewService() =>
+        new(new ThrowingHttpClientFactory(), NullLogger<LanProxyService>.Instance);
+
+    [Theory]
+    [InlineData("http://192.168.1.1/", true)]
+    [InlineData("https://192.168.1.1:8443/admin", true)]
+    [InlineData("http://10.0.0.5/status.html", true)]
+    [InlineData("http://8.8.8.8/", false)]        // public
+    [InlineData("http://127.0.0.1:6060/api/qrz", false)] // loopback re-entry blocked
+    [InlineData("ftp://192.168.1.1/", false)]     // non-http scheme
+    [InlineData("/relative/path", false)]          // not absolute
+    [InlineData("", false)]
+    public void TryValidateTarget_EnforcesSchemeAndRange(string url, bool expectedOk)
+    {
+        var svc = NewService();
+        bool ok = svc.TryValidateTarget(url, out var uri, out var error);
+        Assert.Equal(expectedOk, ok);
+        if (expectedOk) { Assert.NotNull(uri); Assert.Null(error); }
+        else { Assert.Null(uri); Assert.NotNull(error); }
+    }
+
+    [Fact]
+    public void RewriteHtml_RoutesResourcesThroughProxy()
+    {
+        var baseUri = new Uri("http://192.168.1.50/index.html");
+        var html =
+            "<html><head><link href=\"/style.css\" rel=\"stylesheet\"></head>" +
+            "<body><img src=\"img/logo.png\">" +
+            "<a href=\"page2.html\">next</a>" +
+            "<a href=\"#section\">anchor</a>" +
+            "<img src=\"data:image/png;base64,AAAA\">" +
+            "<form action=\"/login\"></form></body></html>";
+
+        var rewritten = LanProxyService.RewriteHtml(html, baseUri);
+
+        // Relative + absolute-path resources are resolved against the base and proxied.
+        Assert.Contains("/api/lan/proxy?url=" + Uri.EscapeDataString("http://192.168.1.50/style.css"), rewritten);
+        Assert.Contains("/api/lan/proxy?url=" + Uri.EscapeDataString("http://192.168.1.50/img/logo.png"), rewritten);
+        Assert.Contains("/api/lan/proxy?url=" + Uri.EscapeDataString("http://192.168.1.50/page2.html"), rewritten);
+        Assert.Contains("/api/lan/proxy?url=" + Uri.EscapeDataString("http://192.168.1.50/login"), rewritten);
+
+        // In-page anchors and data: URIs are left untouched.
+        Assert.Contains("href=\"#section\"", rewritten);
+        Assert.Contains("src=\"data:image/png;base64,AAAA\"", rewritten);
+    }
+
+    [Fact]
+    public void RewriteHtml_CssUrl_IsProxied()
+    {
+        var baseUri = new Uri("http://10.0.0.2/app/main.css");
+        var css = "body{background:url('bg.png')} .x{background:url(\"/shared/x.svg\")}";
+        var rewritten = LanProxyService.RewriteHtml(css, baseUri);
+        Assert.Contains("/api/lan/proxy?url=" + Uri.EscapeDataString("http://10.0.0.2/app/bg.png"), rewritten);
+        Assert.Contains("/api/lan/proxy?url=" + Uri.EscapeDataString("http://10.0.0.2/shared/x.svg"), rewritten);
+    }
+
+    [Fact]
+    public void RewriteHtml_HonoursBaseHref()
+    {
+        var pageUri = new Uri("http://192.168.0.10/sub/page.html");
+        var html = "<html><head><base href=\"http://192.168.0.10/root/\"></head>" +
+                   "<body><img src=\"a.png\"></body></html>";
+        var rewritten = LanProxyService.RewriteHtml(html, pageUri);
+        // The <base href> wins over the page URL when resolving relatives.
+        Assert.Contains("/api/lan/proxy?url=" + Uri.EscapeDataString("http://192.168.0.10/root/a.png"), rewritten);
+    }
+
+    [Fact]
+    public async Task InlineHtml_RelaysNavigationViaPostMessage()
+    {
+        // No <link>/<img> → no sub-resource fetches, so the throwing factory is
+        // never used; this exercises the pure anchor/form/script rewriting.
+        var svc = NewService();
+        var baseUri = new Uri("http://192.168.1.50/index.html");
+        var html =
+            "<html><body>" +
+            "<a href=\"status.html\">status</a>" +
+            "<a href=\"#top\">top</a>" +
+            "<a href=\"javascript:void(0)\">js</a>" +
+            "<form action=\"/login\"></form>" +
+            "</body></html>";
+
+        var result = await svc.InlineHtmlAsync(html, baseUri, default);
+
+        // Real links become intercept anchors carrying the absolute target.
+        Assert.Contains("data-zeus-lan=\"http://192.168.1.50/status.html\"", result);
+        Assert.Contains("data-zeus-lan-form=\"http://192.168.1.50/login\"", result);
+        // In-page + javascript: anchors are left alone.
+        Assert.Contains("href=\"#top\"", result);
+        Assert.Contains("javascript:void(0)", result);
+        // The postMessage nav interceptor is injected.
+        Assert.Contains("zeus-lan-nav", result);
+        Assert.Contains("</body>", result);
+    }
+
+    // -- minimal fakes --------------------------------------------------------
+
+    private sealed class ThrowingHttpClientFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) =>
+            throw new InvalidOperationException("network not expected in these tests");
+    }
+}

--- a/tests/Zeus.Server.Tests/RemoteRxAudioPipelineTests.cs
+++ b/tests/Zeus.Server.Tests/RemoteRxAudioPipelineTests.cs
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Collections.Generic;
+using Zeus.Contracts;
+using Zeus.Server.Hosting.Remote;
+using Xunit;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Block-level coverage for the SOTA RX-audio Opus encoder pipeline: it must
+/// chunk an RX <see cref="AudioFrame"/> into 20 ms (960-sample) Opus packets,
+/// emit a real (non-empty) packet per block, and downmix stereo to mono. The
+/// over-the-wire WebRTC behaviour is bench-verified separately (no peer in unit
+/// tests); this pins the framing + encode contract.
+/// </summary>
+public class RemoteRxAudioPipelineTests
+{
+    private static AudioFrame Frame(int sampleCount, byte channels)
+    {
+        var samples = new float[sampleCount * channels];
+        // A low-amplitude tone so the encoder has real signal (not pure silence).
+        for (int i = 0; i < samples.Length; i++)
+            samples[i] = 0.1f * MathF.Sin(i * 0.05f);
+        return new AudioFrame(0, 0, 0, channels, 48000, (ushort)sampleCount, samples);
+    }
+
+    [Fact]
+    public void Encode_MonoFrame_EmitsOnePacketPer20msBlock()
+    {
+        var packets = new List<byte[]>();
+        var pipe = new RemoteRxAudioPipeline(p => packets.Add(p.ToArray()));
+
+        // 1920 mono samples = 40 ms = exactly two 20 ms Opus frames.
+        pipe.Encode(Frame(1920, 1));
+
+        Assert.Equal(2, packets.Count);
+        Assert.All(packets, p => Assert.True(p.Length > 0));
+    }
+
+    [Fact]
+    public void Encode_PartialBlock_HoldsUntilFull()
+    {
+        var packets = new List<byte[]>();
+        var pipe = new RemoteRxAudioPipeline(p => packets.Add(p.ToArray()));
+
+        // 480 samples = half a block — nothing emitted yet.
+        pipe.Encode(Frame(480, 1));
+        Assert.Empty(packets);
+
+        // Another 480 completes the 960-sample block — one packet now.
+        pipe.Encode(Frame(480, 1));
+        Assert.Single(packets);
+    }
+
+    [Fact]
+    public void Encode_StereoFrame_DownmixesToMono()
+    {
+        var packets = new List<byte[]>();
+        var pipe = new RemoteRxAudioPipeline(p => packets.Add(p.ToArray()));
+
+        // 960 stereo frames = 1920 interleaved samples → 960 mono samples → 1 block.
+        pipe.Encode(Frame(960, 2));
+
+        Assert.Single(packets);
+        Assert.True(packets[0].Length > 0);
+    }
+}

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -341,7 +341,15 @@ export default function App() {
   }, []);
 
   useEffect(() => {
-    if (!connected) return;
+    // Normally the poll only runs once a radio is connected. In remote (WebRTC)
+    // mode it must also run while still 'Disconnected': the mount-time one-shot
+    // fetchState() queues in the API tunnel until the SPAKE2+ unlock and can
+    // time out during password entry, so without a self-healing poll the
+    // connection-store status never reaches 'Connected'. That stuck status
+    // disables MOX and empties every store-driven panel (meters, TX, controls)
+    // even though the panadapter — fed straight from frames — keeps rendering.
+    // The poll seeds the store as soon as the tunnel can serve /api/state.
+    if (!connected && !remoteMode) return;
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
     let ctrl: AbortController | null = null;
@@ -369,7 +377,7 @@ export default function App() {
       if (timer != null) clearTimeout(timer);
       ctrl?.abort();
     };
-  }, [connected]);
+  }, [connected, remoteMode]);
 
   useEffect(() => {
     return useConnectionStore.subscribe((state, prev) => {

--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -69,6 +69,7 @@ import {
 } from '../components/meter-group/meterGroupConfig';
 import { HeroPanel } from './panels/HeroPanel';
 import { UrlEmbedPanel } from './panels/UrlEmbedPanel';
+import { LanBrowserPanel } from './panels/LanBrowserPanel';
 import {
   parseUrlEmbedConfig,
   type UrlEmbedConfig,
@@ -930,6 +931,18 @@ function PanelBody({
       />
     );
   }
+  if (tile.panelId === 'lanbrowser') {
+    return (
+      <LanBrowserTileBody
+        tile={tile}
+        layoutId={layoutId}
+        onRemove={onRemove}
+        tileLocked={tileLocked}
+        workspaceLocked={workspaceLocked}
+        onToggleLock={onToggleLock}
+      />
+    );
+  }
   const def = getPanelDef(tile.panelId);
   if (!def) return null;
   const Component = def.component;
@@ -1109,6 +1122,49 @@ function UrlEmbedTileBody({
 
   return (
     <UrlEmbedPanel
+      config={config}
+      setConfig={setConfig}
+      onRemove={onRemove}
+      tileLocked={tileLocked}
+      workspaceLocked={workspaceLocked}
+      onToggleLock={onToggleLock}
+    />
+  );
+}
+
+// LAN Browser shares the URL-embed per-tile config shape (url + title); only the
+// rendered component differs (it frames the server-side LAN proxy).
+function LanBrowserTileBody({
+  tile,
+  layoutId,
+  onRemove,
+  tileLocked,
+  workspaceLocked,
+  onToggleLock,
+}: {
+  tile: WorkspaceTile;
+  layoutId: string;
+  onRemove?: () => void;
+  tileLocked?: boolean;
+  workspaceLocked?: boolean;
+  onToggleLock?: () => void;
+}) {
+  const updateTileInstanceConfig = useLayoutStore(
+    (s) => s.updateTileInstanceConfigInLayout,
+  );
+  const config: UrlEmbedConfig = useMemo(
+    () => parseUrlEmbedConfig(tile.instanceConfig),
+    [tile.instanceConfig],
+  );
+  const setConfig = useCallback(
+    (next: UrlEmbedConfig) => {
+      updateTileInstanceConfig(layoutId, tile.uid, next);
+    },
+    [layoutId, tile.uid, updateTileInstanceConfig],
+  );
+
+  return (
+    <LanBrowserPanel
       config={config}
       setConfig={setConfig}
       onRemove={onRemove}

--- a/zeus-web/src/layout/panels.ts
+++ b/zeus-web/src/layout/panels.ts
@@ -73,6 +73,7 @@ import { SpotsPanel } from './panels/SpotsPanel';
 import { FreeDvStationsPanel } from './panels/FreeDvStationsPanel';
 import { SpaceWeatherPanel } from './panels/SpaceWeatherPanel';
 import { UrlEmbedPanel } from './panels/UrlEmbedPanel';
+import { LanBrowserPanel } from './panels/LanBrowserPanel';
 import { ChatPanel } from './panels/ChatPanel';
 import { LightningMapPanel } from './panels/LightningMapPanel';
 
@@ -562,6 +563,19 @@ export const PANELS: Record<string, PanelDef> = {
     multiInstance: true,
     // Headerless: the panel owns its header strip so the address bar can
     // live alongside the drag grip and close X.
+    headerless: true,
+    minW: 6,
+    minH: 8,
+  },
+  lanbrowser: {
+    id: 'lanbrowser',
+    name: 'LAN Browser',
+    category: 'tools',
+    tags: ['lan', 'browser', 'router', 'rotator', 'amplifier', 'device', 'web', 'remote', 'proxy', 'network'],
+    component: LanBrowserPanel,
+    // Multi-instance so an operator can keep several LAN devices open at once.
+    multiInstance: true,
+    // Headerless: owns its address-bar header strip (like URL Embed).
     headerless: true,
     minW: 6,
     minH: 8,

--- a/zeus-web/src/layout/panels/LanBrowserPanel.tsx
+++ b/zeus-web/src/layout/panels/LanBrowserPanel.tsx
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF), Christian Suarez (N9WAR), and contributors.
+//
+// "LAN Browser" — a multi-instance workspace tile that frames the web UI of a
+// device on the RADIO HOST's LAN (router, antenna rotator, amplifier, another
+// SDR's console). Unlike URL Embed, the page is fetched by the Zeus *server*
+// through GET /api/lan/proxy and relayed back, so a REMOTE operator — whose own
+// browser can't reach the home LAN — still sees it. The server restricts targets
+// to private (RFC1918 / IPv6-ULA) addresses; see LanProxyService.
+//
+// Two render paths, picked by transport:
+//   • On the LAN (direct), the iframe loads `src=/api/lan/proxy?url=…` straight
+//     from the backend — full fidelity (sub-resources, scripts and navigation
+//     all resolve same-origin through the proxy).
+//   • Remote (over the WebRTC tunnel), the operator's browser can't load the
+//     iframe's sub-resources from the LAN, so we fetch() a SELF-CONTAINED page
+//     (server inlines CSS + images, `?inline=1`) — which tunnels — and drop it
+//     into `srcDoc`. Anchor/form navigation is relayed back via postMessage.
+//     JS-heavy SPAs degrade; typical device admin pages render.
+//
+// Headerless panel (owns the .workspace-tile-header drag strip + close button),
+// mirroring UrlEmbedPanel.
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+} from 'react';
+import { GripVertical, ArrowRight, RefreshCw, X, Network } from 'lucide-react';
+import { TileLockButton } from '../TileChrome';
+import { isRemoteMode } from '../../remote/remote-client';
+import {
+  EMPTY_URL_EMBED_CONFIG,
+  urlEmbedTitle,
+  type UrlEmbedConfig,
+} from './urlEmbedConfig';
+
+interface LanBrowserPanelProps {
+  /** Per-instance config blob (shares the URL-embed shape: url + title). */
+  config?: UrlEmbedConfig;
+  setConfig?: (next: UrlEmbedConfig) => void;
+  onRemove?: () => void;
+  tileLocked?: boolean;
+  workspaceLocked?: boolean;
+  onToggleLock?: () => void;
+}
+
+// Proxied LAN content is served from Zeus's OWN origin (/api/lan/proxy). We
+// deliberately omit `allow-same-origin` so a compromised/hostile device page
+// runs in an opaque origin and cannot reach window.parent, Zeus cookies, or
+// the operator's session. Scripts/forms still work for ordinary device UIs.
+const SANDBOX = 'allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox';
+
+/** Normalise operator input into a private-LAN http(s) URL, defaulting a bare
+ *  host to http:// (device admin pages are overwhelmingly plain HTTP). Returns
+ *  null for anything that isn't an http/https URL. The SERVER is the real
+ *  guard (rejects non-private targets); this is just input hygiene. */
+function normalizeLanUrl(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const candidate = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(trimmed)
+    ? trimmed
+    : `http://${trimmed}`;
+  try {
+    const parsed = new URL(candidate);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+    if (!parsed.hostname) return null;
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+/** Wrap an absolute LAN URL as the same-origin proxy path the iframe loads. */
+function proxySrc(url: string): string {
+  return `/api/lan/proxy?url=${encodeURIComponent(url)}`;
+}
+
+/** Proxy path that returns a self-contained (inlined) page for srcDoc — the
+ *  remote path, fetched over the tunnel. */
+function proxyInlineSrc(url: string): string {
+  return `/api/lan/proxy?url=${encodeURIComponent(url)}&inline=1`;
+}
+
+export function LanBrowserPanel({
+  config = EMPTY_URL_EMBED_CONFIG,
+  setConfig,
+  onRemove,
+  tileLocked = false,
+  workspaceLocked = false,
+  onToggleLock,
+}: LanBrowserPanelProps) {
+  const remote = useMemo(() => isRemoteMode(), []);
+  const committedUrl = config.url;
+  const [draft, setDraft] = useState(committedUrl);
+  const [error, setError] = useState(false);
+  // Bump to force the iframe to reload the same URL (device pages have no
+  // navigation chrome of their own).
+  const [reloadNonce, setReloadNonce] = useState(0);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+
+  // Remote-only: the inlined page fetched through the tunnel for srcDoc.
+  const [remoteDoc, setRemoteDoc] = useState<{
+    loading: boolean;
+    html?: string;
+    error?: string;
+  }>({ loading: false });
+
+  useEffect(() => {
+    setDraft(committedUrl);
+    setError(false);
+  }, [committedUrl]);
+
+  // Remote: fetch a self-contained page through the tunnel and render via srcDoc.
+  useEffect(() => {
+    if (!remote || !committedUrl) {
+      setRemoteDoc({ loading: false });
+      return;
+    }
+    let aborted = false;
+    const ctrl = new AbortController();
+    setRemoteDoc({ loading: true });
+    fetch(proxyInlineSrc(committedUrl), { signal: ctrl.signal })
+      .then(async (r) => {
+        const text = await r.text();
+        if (aborted) return;
+        setRemoteDoc(
+          r.ok
+            ? { loading: false, html: text }
+            : { loading: false, error: text || `HTTP ${r.status}` },
+        );
+      })
+      .catch((e) => {
+        if (!aborted) setRemoteDoc({ loading: false, error: String(e) });
+      });
+    return () => {
+      aborted = true;
+      ctrl.abort();
+    };
+  }, [remote, committedUrl, reloadNonce]);
+
+  // Remote: the inlined page relays anchor/form navigation up via postMessage
+  // (it can't navigate the sandboxed srcDoc iframe over the tunnel itself).
+  useEffect(() => {
+    if (!remote) return;
+    const onMessage = (e: MessageEvent) => {
+      if (e.source !== iframeRef.current?.contentWindow) return;
+      const d = e.data as { type?: unknown; url?: unknown } | null;
+      if (!d || d.type !== 'zeus-lan-nav' || typeof d.url !== 'string') return;
+      const normalized = normalizeLanUrl(d.url);
+      if (normalized) setConfig?.({ ...config, url: normalized });
+    };
+    window.addEventListener('message', onMessage);
+    return () => window.removeEventListener('message', onMessage);
+  }, [remote, config, setConfig]);
+
+  const assign = useCallback(
+    (e: FormEvent) => {
+      e.preventDefault();
+      const normalized = normalizeLanUrl(draft);
+      if (!normalized) {
+        setError(true);
+        return;
+      }
+      setError(false);
+      setDraft(normalized);
+      setConfig?.({ ...config, url: normalized });
+    },
+    [draft, config, setConfig],
+  );
+
+  const handleRemove = onRemove ?? (() => {});
+  const stop = (e: { stopPropagation: () => void }) => e.stopPropagation();
+  const title = urlEmbedTitle(config);
+
+  return (
+    <>
+      <div className="workspace-tile-header url-embed-header">
+        <span
+          className="workspace-tile-drag-handle"
+          aria-hidden="true"
+          title={
+            tileLocked || workspaceLocked
+              ? 'Panel position is locked'
+              : 'Drag to reposition'
+          }
+        >
+          <GripVertical size={12} />
+        </span>
+        <form className="url-embed-bar" onSubmit={assign}>
+          <input
+            ref={inputRef}
+            type="text"
+            inputMode="url"
+            spellCheck={false}
+            autoComplete="off"
+            className={`url-embed-input${error ? ' url-embed-input--error' : ''}`}
+            placeholder="LAN address, e.g. 192.168.1.1 …"
+            value={draft}
+            title={title}
+            aria-label="LAN device address"
+            aria-invalid={error}
+            onChange={(e) => {
+              setDraft(e.target.value);
+              if (error) setError(false);
+            }}
+            onMouseDown={stop}
+            onPointerDown={stop}
+          />
+          <button
+            type="submit"
+            className="url-embed-btn"
+            title="Open this LAN address"
+            aria-label="Open LAN address"
+            onMouseDown={stop}
+            onPointerDown={stop}
+          >
+            <ArrowRight size={13} />
+          </button>
+        </form>
+        {committedUrl ? (
+          <button
+            type="button"
+            className="url-embed-btn url-embed-ext"
+            title="Reload page"
+            aria-label="Reload page"
+            onClick={(e) => {
+              stop(e);
+              setReloadNonce((n) => n + 1);
+            }}
+            onMouseDown={stop}
+            onPointerDown={stop}
+          >
+            <RefreshCw size={13} />
+          </button>
+        ) : null}
+        {onToggleLock ? (
+          <TileLockButton
+            locked={tileLocked}
+            workspaceLocked={workspaceLocked}
+            onToggleLock={onToggleLock}
+          />
+        ) : null}
+        <button
+          type="button"
+          className="workspace-tile-close"
+          aria-label="Remove panel"
+          title="Remove panel"
+          onClick={(e) => {
+            stop(e);
+            handleRemove();
+          }}
+          onPointerDown={stop}
+          onMouseDown={stop}
+        >
+          <X size={12} />
+        </button>
+      </div>
+      <div className="workspace-tile-body url-embed-body">
+        {committedUrl && remote ? (
+          // Remote: render the tunnelled, self-contained page via srcDoc.
+          remoteDoc.error ? (
+            <div className="url-embed-empty">
+              <Network size={28} aria-hidden />
+              <p className="url-embed-empty-title">Couldn&apos;t load that device</p>
+              <p className="url-embed-empty-error">{remoteDoc.error}</p>
+            </div>
+          ) : (
+            <iframe
+              ref={iframeRef}
+              title={title}
+              srcDoc={remoteDoc.html ?? '<!doctype html><title>Loading…</title>'}
+              className="url-embed-frame"
+              referrerPolicy="no-referrer"
+              sandbox={SANDBOX}
+            />
+          )
+        ) : committedUrl ? (
+          // On the LAN: load straight from the backend for full fidelity.
+          <iframe
+            ref={iframeRef}
+            key={`${committedUrl}#${reloadNonce}`}
+            title={title}
+            src={proxySrc(committedUrl)}
+            className="url-embed-frame"
+            referrerPolicy="no-referrer"
+            sandbox={SANDBOX}
+          />
+        ) : (
+          <div className="url-embed-empty">
+            <Network size={28} aria-hidden />
+            <p className="url-embed-empty-title">No device opened</p>
+            <p className="url-embed-empty-hint">
+              Type a LAN address (your router, rotator, amplifier, another SDR…)
+              and press Enter. Zeus fetches it from the radio host&apos;s network,
+              so it works even when you&apos;re connected remotely. Only private
+              LAN addresses are reachable.
+            </p>
+            {error ? (
+              <p className="url-embed-empty-error">
+                That doesn&apos;t look like a valid LAN address.
+              </p>
+            ) : null}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/zeus-web/src/layout/workspace.ts
+++ b/zeus-web/src/layout/workspace.ts
@@ -122,6 +122,8 @@ export const DEFAULT_TILE_SPAN: Record<string, { w: number; h: number }> = {
   metergroup: { w: 2, h: 12 },
   // HamClock fills the whole workspace (24×48) — it's an embedded dashboard.
   hamclock: { w: 24, h: 48 },
+  // LAN Browser frames a full device web UI — give it real estate.
+  lanbrowser: { w: 12, h: 20 },
 };
 
 const FALLBACK_SPAN = { w: 8, h: 8 };

--- a/zeus-web/src/remote/connect.ts
+++ b/zeus-web/src/remote/connect.ts
@@ -121,12 +121,14 @@ async function establish(
   const api = pc.createDataChannel('api'); // reliable, ordered — read-write REST tunnel
   if (opts.onFrame) frames.onmessage = (e: MessageEvent) => opts.onFrame!(e.data as ArrayBuffer);
 
-  // Sendonly Opus audio m-line for remote voice TX. Added up front so the offer
-  // carries m=audio (the radio answers recvonly), but getUserMedia is deferred
-  // until the operator actually keys: replaceTrack swaps the live mic into this
-  // sender with NO renegotiation, so an RX-only session never prompts for the
-  // mic. The browser encodes Opus natively — low latency, in-band FEC + PLC.
-  const audioSender = pc.addTransceiver('audio', { direction: 'sendonly' }).sender;
+  // Bidirectional Opus audio m-line. We always SEND the operator's mic for voice
+  // TX (getUserMedia is deferred until the first key — replaceTrack swaps it in
+  // with no renegotiation, so an RX-only session never prompts for the mic). We
+  // offer RECV too so the radio can stream RX audio back on this track when the
+  // host has the Opus-RX path enabled (native browser jitter buffer + PLC); if it
+  // doesn't, it simply answers recvonly and RX audio keeps flowing as PCM over
+  // the data channel — this offer is harmless either way.
+  const audioSender = pc.addTransceiver('audio', { direction: 'sendrecv' }).sender;
   let micStream: MediaStream | null = null;
   let micTrack: MediaStreamTrack | null = null;
 

--- a/zeus-web/src/remote/remote-client.ts
+++ b/zeus-web/src/remote/remote-client.ts
@@ -56,6 +56,31 @@ if (isRemoteMode()) {
   installApiTunnel();
 }
 
+// Hidden <audio> sink for the radio's RX audio when it arrives on the WebRTC
+// media track (Opus-RX host path). The browser owns decode + jitter buffer +
+// PLC; we just attach the stream and let it play. One element, reused across
+// reconnects.
+let rxAudioEl: HTMLAudioElement | null = null;
+
+function playRemoteRxAudioTrack(stream: MediaStream): void {
+  if (typeof document === 'undefined') return;
+  if (!rxAudioEl) {
+    rxAudioEl = document.createElement('audio');
+    rxAudioEl.autoplay = true;
+    // Not added to the DOM tree — an offscreen element still plays audio.
+  }
+  rxAudioEl.srcObject = stream;
+  void rxAudioEl.play().catch((e) => {
+    console.warn('[remote] RX audio track autoplay blocked:', e);
+  });
+}
+
+function stopRemoteRxAudioTrack(): void {
+  if (!rxAudioEl) return;
+  rxAudioEl.pause();
+  rxAudioEl.srcObject = null;
+}
+
 /**
  * Connect to the operator's radio via the broker, unlock with the supplied
  * password, then route the unlocked frame stream into the stores and request
@@ -80,6 +105,18 @@ export async function startRemoteClient(
   // loopback Kestrel. The session is unlocked by the time connectViaBroker
   // resolves (deny-by-default holds).
   setApiChannel(conn.api);
+
+  // State-of-the-art RX audio: when the radio host has the Opus-RX path enabled it
+  // streams RX audio back on the WebRTC audio track instead of as PCM over the
+  // data channel. Play that track directly so we inherit the browser's native
+  // adaptive jitter buffer + packet-loss concealment (lowest latency, robust to
+  // internet loss). If the host doesn't enable it, no inbound track arrives and
+  // RX audio keeps flowing through the existing PCM/WebAudio path — nothing here
+  // fires. The unlock click is a user gesture, so autoplay is permitted.
+  conn.pc.addEventListener('track', (ev) => {
+    if (ev.track.kind !== 'audio') return;
+    playRemoteRxAudioTrack(ev.streams[0] ?? new MediaStream([ev.track]));
+  });
 
   // Voice-mic uplink: stream the operator's mic to the radio only while keyed
   // (MOX). The first key lazily prompts for mic permission; thereafter it's an
@@ -113,6 +150,8 @@ export async function startRemoteClient(
       // Stop driving the mic from MOX and release the capture (conn.close also
       // stops the tracks; this unhooks the store subscription).
       unsubMic();
+      // Detach the RX audio track sink so a dead stream doesn't linger.
+      stopRemoteRxAudioTrack();
     }
   });
 


### PR DESCRIPTION
Brings the remote (WebRTC) operating experience toward parity with desktop: fixes the dead remote MOX/panels, adds a LAN Browser, and adds a state-of-the-art low-latency RX audio path. Three independent commits.

## 1. fix(web): remote state poll self-heals → MOX + panels work
The recurring `/api/state` poll was gated on `connected`, which only becomes true *after* a successful `applyState`. In remote mode the bootstrap fetch queues in the API tunnel until SPAKE2+ unlock and can time out during password entry, so the poll never started — `status` stayed `Disconnected`, disabling MOX and emptying every store-driven panel (meters/TX/controls) while the panadapter (fed from frames) still rendered. The poll now also runs in remote mode and self-heals once the tunnel can serve `/api/state`.

## 2. feat: LAN Browser panel (private-range server proxy)
A dockable, multi-instance panel to open a LAN device's web UI (router/rotator/amp/another SDR) — even for a **remote** operator, since the Zeus server fetches the page.
- `LanProxyService` + `GET /api/lan/proxy`: **RFC1918 / IPv6-ULA only**; public, CGNAT, link-local (incl. cloud metadata) and **loopback** refused (loopback block stops re-entering Zeus's own Kestrel and bypassing the tunnel denylist). Every resolved address must be private (anti-DNS-rebinding); redirects re-validated per hop; size-capped.
- On-LAN: iframe `src=` (full fidelity). Remote: `?inline=1` returns a self-contained page (CSS + images inlined) for `srcdoc`, with anchor/form nav relayed via `postMessage`. JS-heavy SPAs degrade; typical device admin pages render. Sandbox omits `allow-same-origin` so a hostile page can't reach the Zeus session.

## 3. feat(remote): opt-in low-latency Opus RX audio over a media track
RX audio shipped raw 48 kHz PCM over the unreliable data channel (~1.5 Mbps, no FEC/PLC, ~200–400 ms, silent dropouts on loss). This adds the path the mic uplink already uses, in reverse: Opus (Concentus) on the audio media track → browser-native jitter buffer + PLC, ~50× less bandwidth, expected ~80–150 ms loss-robust. Behind `ZEUS_REMOTE_OPUS_RX` (**default OFF**); the proven PCM path is unchanged until bench-verified.

## Verification
- Backend builds clean; **36/36 server unit tests pass** (private-range boundary, HTML rewrite/inline, Opus block framing). Frontend `tsc` clean.
- Bench-pending (no broker/radio/internet in CI): MOX on hardware; Opus-RX flag (deploy SPA before enabling the host flag, or RX audio goes silent); remote LAN-render fidelity.

## Deferred (rationale)
- Full-SPA-fidelity remote LAN rendering via Service Worker — whole-app blast radius + can't verify in dev; the inlining path is the safe equivalent for device pages.
- Control-over-datachannel rewrite — perceived control is already optimistic and RTT-bound; the real lever is ICE/TURN provisioning (broker repo, out of this tree).
