### PR TITLE
fix(web): draw FreeDV passband/crosshair on the band-convention sideband

### DIFF
--- a/zeus-web/src/components/FilterCursorOverlay.tsx
+++ b/zeus-web/src/components/FilterCursorOverlay.tsx
@@ -19,9 +19,11 @@ import { useSignalEnhanceStore } from '../dsp/signal-estimator';
 import { useConnectionStore } from '../state/connection-store';
 import { selectDisplaySlice, useDisplayStore } from '../state/display-store';
 import {
+  displayFilterEdgesHz,
   getReceiverFilterHighHz,
   getReceiverFilterLowHz,
   getReceiverMode,
+  getReceiverVfoHz,
   type ReceiverKey,
 } from '../state/receiver-state';
 import { resolvePanTuneTarget } from '../util/use-pan-tune-gesture';
@@ -122,9 +124,16 @@ export function FilterCursorOverlay({ containerRef, receiver = 'A' }: FilterCurs
       const band = bandRef.current;
       if (band) {
         if (hzPerPixel > 0 && len > 0 && rectW > 0) {
-          const filterLowHz = getReceiverFilterLowHz(conn, receiver);
-          const filterHighHz = getReceiverFilterHighHz(conn, receiver);
           const mode = getReceiverMode(conn, receiver);
+          // FreeDV stores its passband USB-positive; re-sign to the convention
+          // sideband (LSB < 10 MHz) so the hover preview matches the real demod
+          // side. No-op for every other mode.
+          const { lowHz: filterLowHz, highHz: filterHighHz } = displayFilterEdgesHz(
+            mode,
+            getReceiverVfoHz(conn, receiver),
+            getReceiverFilterLowHz(conn, receiver),
+            getReceiverFilterHighHz(conn, receiver),
+          );
           const hzPerCssPx = (len * hzPerPixel) / rectW;
           const lowPx = filterLowHz / hzPerCssPx;
           const highPx = filterHighHz / hzPerCssPx;

--- a/zeus-web/src/components/PassbandOverlay.tsx
+++ b/zeus-web/src/components/PassbandOverlay.tsx
@@ -48,6 +48,7 @@ import { selectDisplaySlice, useDisplayStore } from '../state/display-store';
 import { useConnectionStore } from '../state/connection-store';
 import { cancelDrawBusFrame, requestDrawBusFrame } from '../realtime/draw-bus';
 import {
+  displayFilterEdgesHz,
   getReceiverFilterHighHz,
   getReceiverFilterLowHz,
   getReceiverFilterPresetName,
@@ -233,9 +234,16 @@ export function PassbandOverlay({
       // ~0 and the filter stays pinned to the zero line during a glide; under
       // CTUN the dial roams off-centre and the passband tracks it.
       const vfoHz = getReceiverVfoHz(conn, receiver);
-      const filterLowHz = getReceiverFilterLowHz(conn, receiver);
-      const filterHighHz = getReceiverFilterHighHz(conn, receiver);
       const rxMode = getReceiverMode(conn, receiver);
+      // FreeDV stores its passband USB-positive regardless of band; re-sign it
+      // to the convention sideband (LSB < 10 MHz) so the rect lands where the
+      // demod actually is. No-op for every other mode.
+      const { lowHz: filterLowHz, highHz: filterHighHz } = displayFilterEdgesHz(
+        rxMode,
+        vfoHz,
+        getReceiverFilterLowHz(conn, receiver),
+        getReceiverFilterHighHz(conn, receiver),
+      );
       // filterLow/HighHz are audio offsets from the hardware LO, not the VFO
       // dial. In CW modes the LO is shifted by ±cwPitchHz from VFO, so
       // passCenter must land on the LO (not VFO) to place the rect correctly.
@@ -289,8 +297,16 @@ export function PassbandOverlay({
 
   // Initial (pre-draw-bus) geometry; the callback refines it next frame.
   const cwOffset = mode === 'CWU' ? -cwPitchHz : mode === 'CWL' ? cwPitchHz : 0;
-  const passLowHz = selectedVfoHz + cwOffset + filterLowHz;
-  const passHighHz = selectedVfoHz + cwOffset + filterHighHz;
+  // Re-sign FreeDV's USB-positive stored passband to the convention sideband
+  // (LSB < 10 MHz) for display — same as the draw-bus path. No-op otherwise.
+  const { lowHz: dispLowHz, highHz: dispHighHz } = displayFilterEdgesHz(
+    mode,
+    selectedVfoHz,
+    filterLowHz,
+    filterHighHz,
+  );
+  const passLowHz = selectedVfoHz + cwOffset + dispLowHz;
+  const passHighHz = selectedVfoHz + cwOffset + dispHighHz;
   const leftPct = ((passLowHz - startHz) / spanHz) * 100;
   const rightPct = ((passHighHz - startHz) / spanHz) * 100;
   const widthPct = rightPct - leftPct;

--- a/zeus-web/src/components/filter/FilterMiniPan.tsx
+++ b/zeus-web/src/components/filter/FilterMiniPan.tsx
@@ -57,6 +57,7 @@ import {
   type DetectedPeak,
 } from '../../dsp/signal-estimator';
 import {
+  displayFilterEdgesHz,
   getReceiverFilterHighHz,
   getReceiverFilterLowHz,
   getReceiverFilterPresetName,
@@ -288,12 +289,26 @@ function miniPanFilterForReceiver(
   c: ConnSnapshot,
   receiver: SpectrumReceiver,
 ): ActiveMiniPanFilter {
+  const mode = getReceiverMode(c, receiver);
+  const vfoHz = getReceiverVfoHz(c, receiver);
+  // FreeDV stores its passband USB-positive; re-sign to the band-convention
+  // sideband (LSB < 10 MHz) so the mini-pan window, walls, EQ bands and cut
+  // callouts all land on the side the demod actually is — matching the main
+  // panadapter passband/crosshair. Posting these signed edges on drag/wheel is
+  // safe: the backend takes abs() and re-signs from (mode, vfo) at the WDSP
+  // seam. No-op for every non-FreeDV mode. See displayFilterEdgesHz.
+  const { lowHz, highHz } = displayFilterEdgesHz(
+    mode,
+    vfoHz,
+    getReceiverFilterLowHz(c, receiver),
+    getReceiverFilterHighHz(c, receiver),
+  );
   return {
     receiver,
-    vfoHz: getReceiverVfoHz(c, receiver),
-    mode: getReceiverMode(c, receiver),
-    filterLowHz: getReceiverFilterLowHz(c, receiver),
-    filterHighHz: getReceiverFilterHighHz(c, receiver),
+    vfoHz,
+    mode,
+    filterLowHz: lowHz,
+    filterHighHz: highHz,
     filterPresetName: getReceiverFilterPresetName(c, receiver),
   };
 }

--- a/zeus-web/src/state/freedv-display-filter.test.ts
+++ b/zeus-web/src/state/freedv-display-filter.test.ts
@@ -1,0 +1,58 @@
+// FreeDV display-sideband convention for the panadapter/waterfall overlays.
+//
+// FreeDV carries no sideband of its own: the radio runs a real SSB demod on the
+// band convention (LSB below 10 MHz, USB at/above), and the backend re-signs the
+// WDSP bandpass at the engine seam while leaving the STORED filter USB-positive.
+// displayFilterEdgesHz applies the same convention for the overlays so the
+// passband/cursor draw on the side the demod is actually on. Mirrors the server
+// FreeDvSidebandConventionTests + RadioService.SignedFilterForMode.
+
+import { describe, expect, it } from 'vitest';
+import { displayFilterEdgesHz } from './receiver-state';
+
+describe('displayFilterEdgesHz — FreeDV band-convention sideband', () => {
+  // Stored FreeDV passband is USB-positive (e.g. 200..2800 Hz).
+  const LO = 200;
+  const HI = 2800;
+
+  it.each([
+    ['160m', 1_800_000],
+    ['80m', 3_573_000],
+    ['40m', 7_177_000],
+    ['just below 10 MHz', 9_999_999],
+  ])('signs FreeDV LSB below 10 MHz (%s)', (_label, vfoHz) => {
+    expect(displayFilterEdgesHz('FREEDV', vfoHz, LO, HI)).toEqual({
+      lowHz: -HI,
+      highHz: -LO,
+    });
+  });
+
+  it.each([
+    ['10 MHz boundary (inclusive → USB)', 10_000_000],
+    ['20m', 14_236_000],
+    ['10m', 28_330_000],
+  ])('keeps FreeDV USB at/above 10 MHz (%s)', (_label, vfoHz) => {
+    expect(displayFilterEdgesHz('FREEDV', vfoHz, LO, HI)).toEqual({
+      lowHz: LO,
+      highHz: HI,
+    });
+  });
+
+  it('is sign-agnostic about the stored edges (uses magnitudes)', () => {
+    // Even if state ever carried a negative-signed pair, the magnitudes decide.
+    expect(displayFilterEdgesHz('FREEDV', 7_177_000, -HI, -LO)).toEqual({
+      lowHz: -HI,
+      highHz: -LO,
+    });
+  });
+
+  it.each(['USB', 'LSB', 'CWU', 'CWL', 'AM', 'DIGU', 'DIGL'] as const)(
+    'is a no-op for non-FreeDV mode %s (stored width passes through)',
+    (mode) => {
+      expect(displayFilterEdgesHz(mode, 7_177_000, -2800, -100)).toEqual({
+        lowHz: -2800,
+        highHz: -100,
+      });
+    },
+  );
+});

--- a/zeus-web/src/state/receiver-state.ts
+++ b/zeus-web/src/state/receiver-state.ts
@@ -58,6 +58,18 @@ import {
  *  RX3+); `'A'`/`'B'` are legacy aliases for 0/1. */
 export type ReceiverKey = 'A' | 'B' | number;
 
+/** Reserved high index for the KiwiSDR slice receiver (mirrors
+ *  WireContract.KiwiReceiverIndex = MaxReceivers-1 = 7). It is a software
+ *  receiver, not a hardware DDC — it never counts toward the multi-RX count
+ *  stepper or the ADC-source list. */
+export const KIWI_RECEIVER_INDEX = 7;
+
+/** Operator-facing label for a receiver. Hardware DDCs carry no name and fall
+ *  back to "RX{n}" (1-based); the Kiwi slice receiver carries "Kiwi". */
+export function receiverLabel(r: { index: number; name?: string | null }): string {
+  return r.name ?? `RX${r.index + 1}`;
+}
+
 /** 0-based receiver index for a key. A → 0, B → 1, number → itself. */
 export function rxIndexOf(key: ReceiverKey): number {
   if (key === 'A') return 0;
@@ -116,6 +128,32 @@ export function getReceiverFilterHighHz(state: ConnState, key: ReceiverKey): num
   const idx = rxIndexOf(key);
   if (idx === 0) return state.filterHighHz;
   return receiverEntry(state, idx)?.filterHighHz ?? state.filterHighHz;
+}
+
+// FreeDV carries no sideband of its own: the radio runs a real SSB demod
+// underneath on the FreeDV band convention — LSB below 10 MHz, USB at/above —
+// and the backend re-signs the WDSP bandpass to match at the engine seam. It
+// deliberately leaves the STORED filterLow/HighHz USB-positive so a dial that
+// crosses 10 MHz while parked in FreeDV doesn't have to rewrite state on every
+// retune. Display overlays must therefore apply the same convention themselves,
+// or the passband/cursor draws on the USB (positive) side even when the demod
+// is LSB (operator report: "waterfall crosshair shows USB" at 7.18 MHz). This
+// mirrors RadioService.EffectiveEngineMode + SignedFilterForMode on the server
+// and is a no-op for every non-FreeDV mode (whose stored width is already
+// correctly signed for its sideband).
+export const FREEDV_USB_THRESHOLD_HZ = 10_000_000;
+export function displayFilterEdgesHz(
+  mode: RxMode,
+  vfoHz: number,
+  lowHz: number,
+  highHz: number,
+): { lowHz: number; highHz: number } {
+  if (mode !== 'FREEDV') return { lowHz, highHz };
+  const loAbs = Math.min(Math.abs(lowHz), Math.abs(highHz));
+  const hiAbs = Math.max(Math.abs(lowHz), Math.abs(highHz));
+  return vfoHz < FREEDV_USB_THRESHOLD_HZ
+    ? { lowHz: -hiAbs, highHz: -loAbs } // LSB: negative-frequency passband
+    : { lowHz: loAbs, highHz: hiAbs }; // USB: positive-frequency passband
 }
 
 /** Read a receiver's VFO out of a server RadioStateDto (e.g. to reconcile the


### PR DESCRIPTION
## Problem

In FreeDV below 10 MHz (e.g. **7.180 MHz, 40 m**) the demod is correctly **LSB** (audio decodes), but the filter UI rendered on the **USB side**: the panadapter passband box, the click-tune crosshair, and the advanced filter **mini-pan** (window, walls, EQ bands, LOW/HIGH CUT callouts showing +300 Hz / +2.70 kHz). Operator reports: *"waterfall crosshair shows USB"* and *"the bandwidth filter is not lining up in FreeDV."*

## Root cause

FreeDV carries no sideband of its own — the radio runs a real SSB demod on the FreeDV band convention (**LSB below 10 MHz, USB at/above**), and the backend re-signs the WDSP bandpass at the engine seam (`RadioService.EffectiveEngineMode` + `SignedFilterForMode`). But it deliberately leaves the **stored** `filterLowHz/HighHz` USB-positive so a dial crossing 10 MHz while parked in FreeDV doesn't have to rewrite state on every retune. Every display consumer therefore has to apply the convention itself — and none did.

## Fix (display-only)

- New `displayFilterEdgesHz()` in `receiver-state.ts` — a mirror of the server's `EffectiveEngineMode` + `SignedFilterForMode`. Re-signs FreeDV's passband to the convention sideband for rendering; **no-op for every non-FreeDV mode**.
- Applied in:
  - `PassbandOverlay` (both render paths) and `FilterCursorOverlay` (hover crosshair) — the main panadapter/waterfall.
  - `FilterMiniPan` — at the single chokepoint every consumer reads through (`miniPanFilterForReceiver`), so window, walls, EQ bands, cut callouts, drag, wheel and fit all follow the sideband.
- **Safe by construction:** stored values stay magnitude-based; the DSP path already takes `abs()` and re-signs from `(mode, vfo)`, so posting signed edges on a mini-pan drag/wheel can't change DSP/TX behavior — every path derives the sideband identically.

## Tests

- `freedv-display-filter.test.ts` (new): 160/80/40 m → LSB, the 10 MHz boundary (inclusive → USB), 20/10 m → USB, and the non-FreeDV pass-through. **15/15 pass.**
- `tsc -b` clean.

## Scope

Frontend display only; no backend, wire-format, or DSP change. Matches the existing server-side `FreeDvSidebandConventionTests`.