### PR TITLE
fix(freedv): show RX text from stations that send no line terminator

### DIFF
--- a/Zeus.Dsp.FreeDv/FreeDvModem.cs
+++ b/Zeus.Dsp.FreeDv/FreeDvModem.cs
@@ -126,6 +126,14 @@ public sealed class FreeDvModem : IDisposable
     // Hot path (inside freedv_rx). Single-byte lock-free enqueue; drop on overflow.
     private void OnRxTextChar(IntPtr state, byte c) => _rxTextRing.WriteByte(c);
 
+    // Test seam: feed bytes into the RX-text ring exactly as the native txt
+    // callback would, so the RxText reassembly (line completion, partial
+    // fallback, sliding-window cap) can be exercised without the codec2 lib.
+    internal void IngestRxTextForTest(string s)
+    {
+        foreach (char ch in s) _rxTextRing.WriteByte((byte)ch);
+    }
+
     // Hot path (inside freedv_tx). Returns the next char of the repeating TX text,
     // or 0 when no text is configured (codec2 sends an idle txt stream).
     private byte OnTxTextChar(IntPtr state)
@@ -161,10 +169,15 @@ public sealed class FreeDvModem : IDisposable
     }
 
     /// <summary>
-    /// Last fully-received line of RX text (callsign etc.), or null if none has
-    /// been decoded yet. Drains the lock-free RX-text ring and reassembles on the
-    /// caller's (status) thread — never touched by the hot path beyond the ring
-    /// enqueue. Guarded so concurrent status polls don't race the reassembly.
+    /// Most recent RX text (callsign etc.) decoded from the txt sidechannel, or
+    /// null if none has been received yet. Prefers a completed (CR/LF-terminated)
+    /// line; if no terminator has ever arrived — e.g. a station sending a bare,
+    /// repeating callsign with no line break, which a great many real FreeDV
+    /// stations do — it falls back to the live in-progress buffer so the operator
+    /// still sees the other station stream in. Drains the lock-free RX-text ring
+    /// and reassembles on the caller's (status) thread — never touched by the hot
+    /// path beyond the ring enqueue. Guarded so concurrent status polls don't race
+    /// the reassembly.
     /// </summary>
     public string? RxText
     {
@@ -189,12 +202,23 @@ public sealed class FreeDvModem : IDisposable
                         }
                         else if (c is >= ' ' and < (char)127)
                         {
-                            if (_rxTextWork.Length >= 64) _rxTextWork.Clear();
+                            // Bound the in-progress buffer. A terminator-less
+                            // sender never clears it via CR/LF, so slide a window
+                            // (drop the oldest half) instead of wiping the whole
+                            // buffer — a repeating callsign then stays continuously
+                            // visible through the partial fallback below rather
+                            // than blanking every 64 chars.
+                            if (_rxTextWork.Length >= 64) _rxTextWork.Remove(0, 32);
                             _rxTextWork.Append(c);
                         }
                     }
                 }
-                return _rxTextLine;
+                // A CR/LF-terminated sender snaps to its clean completed line the
+                // instant the terminator arrives, so this never degrades the
+                // well-behaved case; the partial only surfaces when no line has
+                // ever completed.
+                if (_rxTextLine is not null) return _rxTextLine;
+                return _rxTextWork.Length > 0 ? _rxTextWork.ToString() : null;
             }
         }
     }

--- a/tests/Zeus.Dsp.FreeDv.Tests/FreeDvModemTests.cs
+++ b/tests/Zeus.Dsp.FreeDv.Tests/FreeDvModemTests.cs
@@ -75,6 +75,55 @@ public class FreeDvModemTests
     }
 
     [Fact]
+    public void RxText_NullBeforeAnyDecode()
+    {
+        using var modem = new FreeDvModem();
+        Assert.Null(modem.RxText);
+    }
+
+    [Fact]
+    public void RxText_SurfacesCrTerminatedLine()
+    {
+        using var modem = new FreeDvModem();
+        modem.IngestRxTextForTest("N9WAR\r");
+        Assert.Equal("N9WAR", modem.RxText);
+    }
+
+    [Fact]
+    public void RxText_SurfacesPartial_WhenSenderSendsNoTerminator()
+    {
+        // Many real FreeDV stations send a bare repeating callsign with no CR/LF.
+        // The terminator-only readout used to show nothing for them; the partial
+        // fallback must surface the in-progress text so the operator sees it.
+        using var modem = new FreeDvModem();
+        modem.IngestRxTextForTest("VK5DGR");
+        Assert.Equal("VK5DGR", modem.RxText);
+    }
+
+    [Fact]
+    public void RxText_PrefersCompletedLine_OverLaterPartial()
+    {
+        // Once a clean line completes, a subsequent partial (the next callsign
+        // building up) must not clobber the stable readout with half-text.
+        using var modem = new FreeDvModem();
+        modem.IngestRxTextForTest("N9WAR\rVK");
+        Assert.Equal("N9WAR", modem.RxText);
+    }
+
+    [Fact]
+    public void RxText_SlidingWindow_KeepsRecentText_PastTheCap()
+    {
+        // A terminator-less sender must not blank out at the buffer cap; the
+        // sliding window keeps recent characters so the readout stays populated.
+        using var modem = new FreeDvModem();
+        modem.IngestRxTextForTest(new string('X', 80));
+        var text = modem.RxText;
+        Assert.False(string.IsNullOrEmpty(text));
+        Assert.True(text!.Length is > 0 and <= 64);
+        Assert.All(text, ch => Assert.Equal('X', ch));
+    }
+
+    [Fact]
     public void RadeV1_ReportsUnavailable_AndPassesThrough()
     {
         // RADE V1 has no native decoder yet. Selecting it must NOT mis-open a


### PR DESCRIPTION
## Problem

In a FreeDV QSO the **other station's callsign didn't appear in the RX Text field**, even though audio decoded fine. Operator report: *"the other station is not showing up in RX text."*

## Root cause

The txt-sidechannel reassembly only published a string once it saw a `\r`/`\n` **terminator** (`FreeDvModem.RxText`). Zeus appends a CR to its own TX text, so Zeus↔Zeus worked — but many real FreeDV stations (e.g. FreeDV-GUI sending a bare repeating callsign) send **no terminator**, so their text accumulated in the in-progress buffer and was never surfaced.

## Fix

- `RxText` prefers a completed (terminated) line as before, but **falls back to the live in-progress buffer** when no line has ever completed — so terminator-less senders appear as they stream in. A CR/LF sender still snaps to its clean line the instant the terminator arrives, so the well-behaved case is unchanged.
- The buffer cap now **slides a window** (drops the oldest half) instead of wiping, so a repeating callsign stays continuously visible rather than blanking every 64 chars.

## Tests

Adds an internal `IngestRxTextForTest` seam and `FreeDvModemTests` cases — terminated line, no-terminator partial, line-preferred-over-partial, and the sliding-window cap — all without requiring the codec2 native lib. **Full FreeDvModemTests suite: 11 passed, 1 skipped (native-missing path).**

## Known limitation (follow-up)

This covers the classic varicode txt channel. Stations using FreeDV's newer **reliable_text** API (and RADE's EOO callsign) go through a different decode path that Zeus doesn't yet wire (`FreeDvService` already reports RADE `RxText` as null by design). That's a separate piece of work.

## Scope

Backend FreeDV text decode only; no DSP/audio-path, wire-format, or default change.