### PR TITLE
feat(chat): inline photo sharing in the live chat (attach a photo like a text)

### DIFF
--- a/Zeus.Contracts/ChatDtos.cs
+++ b/Zeus.Contracts/ChatDtos.cs
@@ -53,15 +53,47 @@ namespace Zeus.Contracts;
 // names serialise camelCase on the wire (JsonSerializerDefaults.Web).
 
 /// <summary>
+/// An inline media attachment carried alongside a chat message. Photos are sent
+/// "like a text message": the bytes ride inside the message as a base64 data URL
+/// (<paramref name="DataUrl"/>, e.g. <c>data:image/jpeg;base64,…</c>) rather than
+/// via out-of-band blob storage. The web client downscales/compresses before
+/// sending so the encoded size stays within <see cref="MaxDataUrlLength"/> — the
+/// relay persists the whole message in a single Durable-Object value (128 KiB
+/// cap), so the attachment must comfortably fit under that with room to spare.
+/// <paramref name="Kind"/> is "image" for now (the only supported kind);
+/// unknown kinds are ignored by clients so future kinds stay compatible.
+/// </summary>
+public sealed record ChatAttachment(
+    string Kind,
+    string Mime,
+    string DataUrl,
+    string? Name = null,
+    int? Width = null,
+    int? Height = null,
+    int? Size = null)
+{
+    /// <summary>
+    /// Maximum accepted length of <see cref="DataUrl"/> (characters). Sized to
+    /// leave headroom under the relay's 128 KiB per-message storage value cap
+    /// once the surrounding JSON envelope is added. Enforced on both the Zeus
+    /// backend and the relay; the web client compresses to stay under it.
+    /// </summary>
+    public const int MaxDataUrlLength = 120_000;
+}
+
+/// <summary>
 /// A single chat message as broadcast by the relay (and echoed back to the
 /// sender for ordering). <paramref name="Ts"/> is epoch milliseconds.
+/// <paramref name="Attachment"/> is an optional inline photo (null for plain
+/// text messages — the overwhelming common case).
 /// </summary>
 public sealed record ChatMessage(
     string Id,
     string From,
     string Text,
     long Ts,
-    string Room);
+    string Room,
+    ChatAttachment? Attachment = null);
 
 /// <summary>
 /// A connected operator in the relay roster. <paramref name="FreqHz"/> is the
@@ -126,15 +158,19 @@ public sealed record ChatEnableRequest(bool Enabled);
 /// </summary>
 public sealed record ChatVisibleRequest(bool Visible);
 
-/// <summary>Outgoing message; <paramref name="Room"/> defaults to the public lobby.</summary>
-public sealed record ChatSendRequest(string Text, string? Room = null);
+/// <summary>Outgoing message; <paramref name="Room"/> defaults to the public lobby.
+/// <paramref name="Attachment"/> is an optional inline photo — when present the
+/// <paramref name="Text"/> may be empty (image-only message).</summary>
+public sealed record ChatSendRequest(string Text, string? Room = null, ChatAttachment? Attachment = null);
 
 /// <summary>A single-callsign request body for the friend endpoints
 /// (request / accept / deny / remove) and admin ban/unban.</summary>
 public sealed record ChatFriendRequest(string Callsign);
 
-/// <summary>Send a direct message to <paramref name="To"/>.</summary>
-public sealed record ChatDmRequest(string To, string Text);
+/// <summary>Send a direct message to <paramref name="To"/>.
+/// <paramref name="Attachment"/> is an optional inline photo — when present the
+/// <paramref name="Text"/> may be empty (image-only message).</summary>
+public sealed record ChatDmRequest(string To, string Text, ChatAttachment? Attachment = null);
 
 /// <summary>Admin: create a private group named <paramref name="Name"/>.</summary>
 public sealed record ChatRoomCreateRequest(string Name);

--- a/Zeus.Server.Hosting/ChatService.cs
+++ b/Zeus.Server.Hosting/ChatService.cs
@@ -191,24 +191,58 @@ public sealed class ChatService : BackgroundService
     /// <see cref="ArgumentException"/> when the text is empty — the endpoint
     /// maps these to 409 / 400.
     /// </summary>
-    public async Task SendMessageAsync(string text, string? room, CancellationToken ct)
+    public async Task SendMessageAsync(string text, string? room, ChatAttachment? attachment, CancellationToken ct)
     {
-        if (string.IsNullOrWhiteSpace(text))
+        attachment = ValidateAttachment(attachment);
+        // An attachment may stand on its own (image-only message); only require
+        // text when there is no attachment.
+        if (string.IsNullOrWhiteSpace(text) && attachment is null)
             throw new ArgumentException("message text is empty", nameof(text));
 
         var socket = RequireSocket();
         var roomId = string.IsNullOrWhiteSpace(room) ? "lobby" : room.Trim();
-        await SendFrameAsync(socket, new { t = "msg", text, room = roomId }, ct);
+        await SendFrameAsync(socket, attachment is null
+            ? new { t = "msg", text, room = roomId }
+            : new { t = "msg", text, room = roomId, attachment }, ct);
     }
 
     /// <summary>Sends a direct message to <paramref name="to"/> (creates the DM on demand).</summary>
-    public async Task SendDmAsync(string to, string text, CancellationToken ct)
+    public async Task SendDmAsync(string to, string text, ChatAttachment? attachment, CancellationToken ct)
     {
         var call = (to ?? string.Empty).Trim().ToUpperInvariant();
         if (call.Length == 0) throw new ArgumentException("recipient is empty", nameof(to));
-        if (string.IsNullOrWhiteSpace(text)) throw new ArgumentException("message text is empty", nameof(text));
+        attachment = ValidateAttachment(attachment);
+        if (string.IsNullOrWhiteSpace(text) && attachment is null)
+            throw new ArgumentException("message text is empty", nameof(text));
         var socket = RequireSocket();
-        await SendFrameAsync(socket, new { t = "dm", to = call, text }, ct);
+        await SendFrameAsync(socket, attachment is null
+            ? new { t = "dm", to = call, text }
+            : new { t = "dm", to = call, text, attachment }, ct);
+    }
+
+    /// <summary>
+    /// Validates an outgoing attachment: image kind, image/* MIME, non-empty
+    /// data URL within <see cref="ChatAttachment.MaxDataUrlLength"/>. Returns the
+    /// attachment unchanged (passthrough) or null when none was supplied. Throws
+    /// <see cref="ArgumentException"/> (mapped to 400 by the endpoint) on a bad
+    /// or oversized attachment so a buggy/hostile client can't push payloads the
+    /// relay would store. The web client downscales to fit before sending; this
+    /// is the backend guardrail, not the primary size control.
+    /// </summary>
+    private static ChatAttachment? ValidateAttachment(ChatAttachment? attachment)
+    {
+        if (attachment is null) return null;
+        if (!string.Equals(attachment.Kind, "image", StringComparison.Ordinal))
+            throw new ArgumentException("unsupported attachment kind", nameof(attachment));
+        if (string.IsNullOrEmpty(attachment.Mime) ||
+            !attachment.Mime.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+            throw new ArgumentException("attachment must be an image", nameof(attachment));
+        if (string.IsNullOrEmpty(attachment.DataUrl) ||
+            !attachment.DataUrl.StartsWith("data:image/", StringComparison.OrdinalIgnoreCase))
+            throw new ArgumentException("attachment data is empty or malformed", nameof(attachment));
+        if (attachment.DataUrl.Length > ChatAttachment.MaxDataUrlLength)
+            throw new ArgumentException("attachment is too large", nameof(attachment));
+        return attachment;
     }
 
     /// <summary>Asks the relay for recent history of a room (pushed back as a 0x35 frame).</summary>
@@ -612,7 +646,33 @@ public sealed class ChatService : BackgroundService
         From: ReadString(root, "from") ?? string.Empty,
         Text: ReadString(root, "text") ?? string.Empty,
         Ts: ReadLong(root, "ts") ?? DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-        Room: ReadString(root, "room") ?? "lobby");
+        Room: ReadString(root, "room") ?? "lobby",
+        Attachment: ParseAttachment(root));
+
+    /// <summary>
+    /// Parses an optional <c>attachment</c> object out of a relay message frame.
+    /// Returns null when absent, malformed, not an image, or oversized — a bad
+    /// attachment degrades to a plain message rather than dropping it. Internal
+    /// for unit tests.
+    /// </summary>
+    internal static ChatAttachment? ParseAttachment(JsonElement root)
+    {
+        if (!root.TryGetProperty("attachment", out var a) || a.ValueKind != JsonValueKind.Object)
+            return null;
+        var dataUrl = ReadString(a, "dataUrl");
+        var mime = ReadString(a, "mime");
+        if (string.IsNullOrEmpty(dataUrl) || string.IsNullOrEmpty(mime)) return null;
+        if (!dataUrl.StartsWith("data:image/", StringComparison.OrdinalIgnoreCase)) return null;
+        if (dataUrl.Length > ChatAttachment.MaxDataUrlLength) return null;
+        return new ChatAttachment(
+            Kind: ReadString(a, "kind") ?? "image",
+            Mime: mime,
+            DataUrl: dataUrl,
+            Name: ReadString(a, "name"),
+            Width: (int?)ReadLong(a, "width"),
+            Height: (int?)ReadLong(a, "height"),
+            Size: (int?)ReadLong(a, "size"));
+    }
 
     /// <summary>
     /// Parses the <paramref name="property"/> roster array out of a relay

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -3032,11 +3032,12 @@ public static class ZeusEndpoints
 
         app.MapPost("/api/chat/send", async (ChatSendRequest req, ChatService chat, HttpContext ctx) =>
         {
-            if (string.IsNullOrWhiteSpace(req.Text))
+            // Text is optional when an image is attached (image-only message).
+            if (string.IsNullOrWhiteSpace(req.Text) && req.Attachment is null)
                 return Results.BadRequest(new { error = "message text required" });
             try
             {
-                await chat.SendMessageAsync(req.Text, req.Room, ctx.RequestAborted);
+                await chat.SendMessageAsync(req.Text, req.Room, req.Attachment, ctx.RequestAborted);
                 return Results.Ok(new { ok = true });
             }
             catch (ArgumentException ex)
@@ -3103,7 +3104,7 @@ public static class ZeusEndpoints
         app.MapGet("/api/chat/rooms", (ChatService chat) => Results.Ok(new { rooms = chat.GetRooms() }));
 
         app.MapPost("/api/chat/dm", (ChatDmRequest req, ChatService chat, HttpContext ctx) =>
-            Run(() => chat.SendDmAsync(req.To, req.Text, ctx.RequestAborted)));
+            Run(() => chat.SendDmAsync(req.To, req.Text, req.Attachment, ctx.RequestAborted)));
 
         app.MapPost("/api/chat/history", (ChatRoomRequest req, ChatService chat, HttpContext ctx) =>
             Run(() => chat.RequestHistoryAsync(req.Room, ctx.RequestAborted)));

--- a/cloud/zeuschat-relay/src/chat-room.ts
+++ b/cloud/zeuschat-relay/src/chat-room.ts
@@ -7,8 +7,10 @@ import {
   type RoomInfo,
   type RoomKind,
   type Msg,
+  type Attachment,
   type PresenceStatus,
   MAX_MESSAGE_LEN,
+  MAX_ATTACHMENT_DATAURL_LEN,
   PUBLIC_ROOM,
   PUBLIC_RETENTION_MS,
   PRIVATE_RETENTION_MS,
@@ -201,9 +203,10 @@ export class ChatRoom extends DurableObject<Env> {
           return;
         }
         const text = (msg.text ?? '').slice(0, MAX_MESSAGE_LEN);
-        if (!text.trim()) return;
+        const attachment = sanitizeAttachment(msg.attachment);
+        if (!text.trim() && !attachment) return; // nothing to send
         if (!this.checkRate(ws, att)) return;
-        await this.postMessage(room, me, text);
+        await this.postMessage(room, me, text, attachment);
         return;
       }
 
@@ -212,10 +215,11 @@ export class ChatRoom extends DurableObject<Env> {
         const to = norm(msg.to ?? '');
         if (!to || to === me || this.bans.has(to)) return;
         const text = (msg.text ?? '').slice(0, MAX_MESSAGE_LEN);
-        if (!text.trim()) return;
+        const attachment = sanitizeAttachment(msg.attachment);
+        if (!text.trim() && !attachment) return;
         if (!this.checkRate(ws, att)) return;
         const room = await this.ensureDm(me, to);
-        await this.postMessage(room, me, text);
+        await this.postMessage(room, me, text, attachment);
         return;
       }
 
@@ -362,8 +366,14 @@ export class ChatRoom extends DurableObject<Env> {
 
   // --- messages --------------------------------------------------------------
 
-  private async postMessage(room: string, from: string, text: string): Promise<void> {
+  private async postMessage(
+    room: string,
+    from: string,
+    text: string,
+    attachment?: Attachment,
+  ): Promise<void> {
     const msg: Msg = { id: crypto.randomUUID(), from, text, ts: Date.now(), room };
+    if (attachment) msg.attachment = attachment;
     const key = `m:${room}:${String(msg.ts).padStart(15, '0')}:${crypto.randomUUID().slice(0, 8)}`;
     await this.ctx.storage.put(key, msg);
     this.deliverToRoom(room, { t: 'msg', ...msg });
@@ -712,6 +722,28 @@ export class ChatRoom extends DurableObject<Env> {
       this.send(ws, { t: 'roster', roster: this.rosterFor(att.callsign) });
     }
   }
+}
+
+/**
+ * Validate and normalize an inbound attachment. Returns a clean Attachment, or
+ * undefined when absent/malformed/oversized/not-an-image — in which case the
+ * message still delivers as text. Defensive: a backend or hostile client could
+ * send anything, and the result is persisted + broadcast to the whole room, so
+ * enforce the image-only + size invariants here regardless of the C# guard.
+ */
+function sanitizeAttachment(a: Attachment | undefined): Attachment | undefined {
+  if (!a || typeof a !== 'object') return undefined;
+  const mime = typeof a.mime === 'string' ? a.mime : '';
+  const dataUrl = typeof a.dataUrl === 'string' ? a.dataUrl : '';
+  if (!mime.startsWith('image/')) return undefined;
+  if (!dataUrl.startsWith('data:image/')) return undefined;
+  if (dataUrl.length > MAX_ATTACHMENT_DATAURL_LEN) return undefined;
+  const clean: Attachment = { kind: 'image', mime, dataUrl };
+  if (typeof a.name === 'string' && a.name) clean.name = a.name.slice(0, 200);
+  if (typeof a.width === 'number' && Number.isFinite(a.width)) clean.width = a.width;
+  if (typeof a.height === 'number' && Number.isFinite(a.height)) clean.height = a.height;
+  if (typeof a.size === 'number' && Number.isFinite(a.size)) clean.size = a.size;
+  return clean;
 }
 
 function addTo(map: Map<string, Set<string>>, key: string, value: string): void {

--- a/cloud/zeuschat-relay/src/protocol.ts
+++ b/cloud/zeuschat-relay/src/protocol.ts
@@ -51,6 +51,29 @@ export interface RoomInfo {
   members: string[];
 }
 
+/**
+ * An inline media attachment carried with a message. Photos are sent "like a
+ * text message": the bytes ride inside the message as a base64 data URL rather
+ * than via out-of-band blob storage. The Zeus web client downscales/compresses
+ * so `dataUrl` stays under MAX_ATTACHMENT_DATAURL_LEN — the whole message is
+ * stored in a single Durable-Object value (128 KiB cap), so it must fit with
+ * headroom. `kind` is "image" for now; unknown kinds are ignored by clients.
+ */
+export interface Attachment {
+  kind: string;
+  /** MIME type, e.g. "image/jpeg". Must start with "image/". */
+  mime: string;
+  /** Base64 data URL, e.g. "data:image/jpeg;base64,…". */
+  dataUrl: string;
+  /** Original filename, if known. */
+  name?: string;
+  /** Pixel dimensions, if known. */
+  width?: number;
+  height?: number;
+  /** Decoded byte size, if known. */
+  size?: number;
+}
+
 /** A stored/relayed chat message. */
 export interface Msg {
   id: string;
@@ -60,6 +83,8 @@ export interface Msg {
   ts: number;
   /** Room id this message belongs to. */
   room: string;
+  /** Optional inline photo (absent for the common text-only case). */
+  attachment?: Attachment;
 }
 
 /** Messages sent by a backend chat node TO the relay. */
@@ -80,10 +105,11 @@ export type ClientToRelay =
     }
   // Live presence update (frequency / mode / status / freq-visibility changed).
   | { t: 'presence'; freq?: number; mode?: string; status?: PresenceStatus; freqPublic?: boolean }
-  // Outgoing chat message to a room (defaults to the public lobby).
-  | { t: 'msg'; text: string; room?: string }
+  // Outgoing chat message to a room (defaults to the public lobby). `text` may
+  // be empty when an `attachment` (inline photo) is present.
+  | { t: 'msg'; text: string; room?: string; attachment?: Attachment }
   // Send a direct message to another operator (creates the DM room on demand).
-  | { t: 'dm'; to: string; text: string }
+  | { t: 'dm'; to: string; text: string; attachment?: Attachment }
   // Request recent history for a room the operator can see.
   | { t: 'history'; room: string }
   // --- friends (consent graph) ---------------------------------------------
@@ -122,7 +148,7 @@ export type RelayToClient =
   // join). Ordered oldest→newest.
   | { t: 'history'; room: string; messages: Msg[] }
   // A chat message in a room the operator is a member of (including own echo).
-  | { t: 'msg'; id: string; from: string; text: string; ts: number; room: string }
+  | { t: 'msg'; id: string; from: string; text: string; ts: number; room: string; attachment?: Attachment }
   // A room's history was wiped by an admin — clients should drop their scrollback.
   | { t: 'cleared'; room: string }
   // A one-off global announcement from an admin, shown to everyone regardless of
@@ -142,6 +168,15 @@ export type RelayToClient =
 
 /** Max accepted chat message length (characters); longer is truncated. */
 export const MAX_MESSAGE_LEN = 2000;
+
+/**
+ * Max accepted length of an attachment's base64 data URL (characters). Sized to
+ * leave headroom under the Durable-Object 128 KiB per-value storage cap once the
+ * surrounding message JSON is added. An attachment over this is dropped (the
+ * message still delivers as text). Mirrors ChatAttachment.MaxDataUrlLength on
+ * the C# side; keep the two in sync.
+ */
+export const MAX_ATTACHMENT_DATAURL_LEN = 120_000;
 
 /** The single room used in P0. Kept as an alias of PUBLIC_ROOM. */
 export const DEFAULT_ROOM = PUBLIC_ROOM;

--- a/tests/Zeus.Server.Tests/ChatServiceTests.cs
+++ b/tests/Zeus.Server.Tests/ChatServiceTests.cs
@@ -128,6 +128,41 @@ public class ChatServiceTests : IDisposable
         Assert.Equal("hello", msg.Text);
         Assert.True(msg.Ts > 0); // synthesised
         Assert.Equal("lobby", msg.Room); // defaulted
+        Assert.Null(msg.Attachment); // plain message has no attachment
+    }
+
+    [Fact]
+    public void ParseMessage_ReadsImageAttachment()
+    {
+        using var doc = JsonDocument.Parse(
+            """{"t":"msg","from":"N9WAR","text":"look","room":"lobby","attachment":{"kind":"image","mime":"image/jpeg","dataUrl":"data:image/jpeg;base64,/9j/AA==","name":"rig.jpg","width":1024,"height":768,"size":4096}}""");
+        var msg = ChatService.ParseMessage(doc.RootElement);
+
+        Assert.NotNull(msg.Attachment);
+        Assert.Equal("image", msg.Attachment!.Kind);
+        Assert.Equal("image/jpeg", msg.Attachment.Mime);
+        Assert.StartsWith("data:image/jpeg;base64,", msg.Attachment.DataUrl);
+        Assert.Equal("rig.jpg", msg.Attachment.Name);
+        Assert.Equal(1024, msg.Attachment.Width);
+        Assert.Equal(768, msg.Attachment.Height);
+        Assert.Equal("look", msg.Text); // text rides alongside the image (caption)
+    }
+
+    [Fact]
+    public void ParseAttachment_DropsNonImageOrOversize()
+    {
+        // Non-image data URL → dropped (message degrades to text-only).
+        using var bad = JsonDocument.Parse(
+            """{"t":"msg","from":"N9WAR","text":"x","attachment":{"kind":"image","mime":"application/pdf","dataUrl":"data:application/pdf;base64,AAAA"}}""");
+        Assert.Null(ChatService.ParseMessage(bad.RootElement).Attachment);
+
+        // Oversized data URL → dropped.
+        var huge = new string('A', ChatAttachment.MaxDataUrlLength + 1);
+        var bigJson =
+            "{\"t\":\"msg\",\"from\":\"N9WAR\",\"attachment\":{\"kind\":\"image\"," +
+            "\"mime\":\"image/png\",\"dataUrl\":\"data:image/png;base64," + huge + "\"}}";
+        using var big = JsonDocument.Parse(bigJson);
+        Assert.Null(ChatService.ParseMessage(big.RootElement).Attachment);
     }
 
     [Fact]
@@ -273,7 +308,7 @@ public class ChatServiceTests : IDisposable
 
         // Send must fail with 409-mapped exception when not connected.
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => chat.SendMessageAsync("hello", null, CancellationToken.None));
+            () => chat.SendMessageAsync("hello", null, null, CancellationToken.None));
     }
 
     [Fact]
@@ -290,7 +325,7 @@ public class ChatServiceTests : IDisposable
         Assert.True(store.GetEnabled());
 
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => chat.SendMessageAsync("hi", null, CancellationToken.None));
+            () => chat.SendMessageAsync("hi", null, null, CancellationToken.None));
 
         chat.SetEnabled(false);
         Assert.False(store.GetEnabled());
@@ -301,7 +336,7 @@ public class ChatServiceTests : IDisposable
     {
         using var chat = BuildChat();
         await Assert.ThrowsAsync<ArgumentException>(
-            () => chat.SendMessageAsync("   ", null, CancellationToken.None));
+            () => chat.SendMessageAsync("   ", null, null, CancellationToken.None));
     }
 
     [Fact]

--- a/zeus-web/src/api/chat.ts
+++ b/zeus-web/src/api/chat.ts
@@ -29,6 +29,30 @@ export type ChatOperator = {
   since: number;
 };
 
+/**
+ * An inline media attachment carried with a message. Photos are sent "like a
+ * text message": the bytes ride inside the message as a base64 data URL. The
+ * client downscales/compresses before sending (see util/chat-image.ts) so the
+ * encoded size stays within the relay's per-message storage cap.
+ */
+export type ChatAttachment = {
+  /** Only "image" today; unknown kinds are ignored when rendering. */
+  kind: string;
+  /** MIME type, e.g. "image/jpeg". */
+  mime: string;
+  /** Base64 data URL — usable directly as an <img> src. */
+  dataUrl: string;
+  /** Original filename, if known. */
+  name: string | null;
+  width: number | null;
+  height: number | null;
+  /** Decoded byte size, if known. */
+  size: number | null;
+};
+
+/** Max length of an attachment data URL (chars). Mirrors the C#/relay caps. */
+export const MAX_ATTACHMENT_DATAURL_LEN = 120_000;
+
 export type ChatMessage = {
   id: string;
   from: string;
@@ -36,6 +60,8 @@ export type ChatMessage = {
   /** Epoch ms. */
   ts: number;
   room: string;
+  /** Optional inline photo; null for plain text messages. */
+  attachment: ChatAttachment | null;
 };
 
 export type ChatStatus = {
@@ -131,6 +157,30 @@ export function normalizeFriends(raw: unknown): ChatFriends {
   };
 }
 
+/**
+ * Parse an optional attachment. Returns null unless it is a well-formed image
+ * data URL within the size cap — a malformed/oversized attachment degrades the
+ * message to text-only rather than rendering a broken image.
+ */
+export function normalizeAttachment(raw: unknown): ChatAttachment | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  const mime = typeof r.mime === 'string' ? r.mime : '';
+  const dataUrl = typeof r.dataUrl === 'string' ? r.dataUrl : '';
+  if (!mime.startsWith('image/')) return null;
+  if (!dataUrl.startsWith('data:image/')) return null;
+  if (dataUrl.length > MAX_ATTACHMENT_DATAURL_LEN) return null;
+  return {
+    kind: 'image',
+    mime,
+    dataUrl,
+    name: toStr(r.name),
+    width: toNum(r.width),
+    height: toNum(r.height),
+    size: toNum(r.size),
+  };
+}
+
 export function normalizeMessage(raw: unknown): ChatMessage {
   const r = (raw ?? {}) as Record<string, unknown>;
   return {
@@ -139,6 +189,7 @@ export function normalizeMessage(raw: unknown): ChatMessage {
     text: typeof r.text === 'string' ? r.text : '',
     ts: toNum(r.ts) ?? 0,
     room: typeof r.room === 'string' ? r.room : '',
+    attachment: normalizeAttachment(r.attachment),
   };
 }
 
@@ -203,13 +254,21 @@ export function chatSetVisible(visible: boolean, signal?: AbortSignal): Promise<
   );
 }
 
-export function chatSend(text: string, room?: string, signal?: AbortSignal): Promise<{ ok: boolean }> {
+export function chatSend(
+  text: string,
+  room?: string,
+  attachment?: ChatAttachment | null,
+  signal?: AbortSignal,
+): Promise<{ ok: boolean }> {
+  const body: Record<string, unknown> = { text };
+  if (room) body.room = room;
+  if (attachment) body.attachment = attachment;
   return jsonFetch(
     '/api/chat/send',
     {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(room ? { text, room } : { text }),
+      body: JSON.stringify(body),
       signal,
     },
     (raw) => ({ ok: Boolean((raw as { ok?: unknown } | null)?.ok) }),
@@ -282,8 +341,12 @@ export function chatRooms(signal?: AbortSignal): Promise<ChatRoom[]> {
   });
 }
 
-export const chatDm = (to: string, text: string, signal?: AbortSignal) =>
-  postOk('/api/chat/dm', { to, text }, signal);
+export const chatDm = (
+  to: string,
+  text: string,
+  attachment?: ChatAttachment | null,
+  signal?: AbortSignal,
+) => postOk('/api/chat/dm', attachment ? { to, text, attachment } : { to, text }, signal);
 
 export const chatRequestHistory = (room: string, signal?: AbortSignal) =>
   postOk('/api/chat/history', { room }, signal);

--- a/zeus-web/src/layout/panels/ChatPanel.tsx
+++ b/zeus-web/src/layout/panels/ChatPanel.tsx
@@ -24,7 +24,13 @@ import {
   PUBLIC_ROOM,
   type ChatMessage,
   type ChatOperator,
+  type ChatAttachment,
 } from '../../state/chat-store';
+import {
+  compressImageToAttachment,
+  ChatImageError,
+  CHAT_IMAGE_ACCEPT,
+} from '../../util/chat-image';
 import { useQrzStore } from '../../state/qrz-store';
 import { ConfirmDialog } from '../ConfirmDialog';
 import { QrzCard } from '../../components/design/QrzCard';
@@ -502,15 +508,42 @@ function RequestRow({
   );
 }
 
+/** Small paperclip glyph for the attach button (inherits text color). */
+function PaperclipIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      style={{ display: 'block' }}
+    >
+      <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+    </svg>
+  );
+}
+
 function MessageRow({
   msg,
   own,
   onOpen,
+  onExpandImage,
 }: {
   msg: ChatMessage;
   own: boolean;
   onOpen: (callsign: string) => void;
+  onExpandImage: (att: ChatAttachment) => void;
 }) {
+  const att = msg.attachment;
+  const hasText = msg.text.trim().length > 0;
+  // Constrain the thumbnail to the message's native aspect when known so the
+  // bubble doesn't jump as the image decodes.
+  const ratio = att && att.width && att.height ? att.width / att.height : undefined;
   return (
     <div
       style={{
@@ -533,19 +566,129 @@ function MessageRow({
       </div>
       <div
         style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: own ? 'flex-end' : 'flex-start',
+          gap: 4,
           maxWidth: '85%',
-          padding: '5px 10px',
-          borderRadius: 'var(--r-lg)',
-          background: own ? 'var(--accent-soft)' : 'var(--bg-2)',
-          border: own ? '1px solid var(--accent-line)' : '1px solid var(--line)',
-          color: 'var(--fg-1)',
-          fontSize: 12.5,
-          lineHeight: 1.45,
-          wordBreak: 'break-word',
-          whiteSpace: 'pre-wrap',
         }}
       >
-        {msg.text}
+        {att ? (
+          <button
+            type="button"
+            onClick={() => onExpandImage(att)}
+            title={att.name ?? 'Open image'}
+            style={{
+              display: 'block',
+              padding: 0,
+              margin: 0,
+              border: own ? '1px solid var(--accent-line)' : '1px solid var(--line)',
+              borderRadius: 'var(--r-lg)',
+              background: 'var(--bg-2)',
+              cursor: 'zoom-in',
+              overflow: 'hidden',
+              lineHeight: 0,
+              maxWidth: '100%',
+            }}
+          >
+            <img
+              src={att.dataUrl}
+              alt={att.name ?? 'Shared photo'}
+              loading="lazy"
+              style={{
+                display: 'block',
+                maxWidth: 280,
+                maxHeight: 280,
+                width: 'auto',
+                height: 'auto',
+                aspectRatio: ratio ? String(ratio) : undefined,
+                objectFit: 'cover',
+              }}
+            />
+          </button>
+        ) : null}
+        {hasText ? (
+          <div
+            style={{
+              padding: '5px 10px',
+              borderRadius: 'var(--r-lg)',
+              background: own ? 'var(--accent-soft)' : 'var(--bg-2)',
+              border: own ? '1px solid var(--accent-line)' : '1px solid var(--line)',
+              color: 'var(--fg-1)',
+              fontSize: 12.5,
+              lineHeight: 1.45,
+              wordBreak: 'break-word',
+              whiteSpace: 'pre-wrap',
+            }}
+          >
+            {msg.text}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Full-size image viewer. A dim backdrop with the photo centered; click anywhere
+ * (or Esc) to close. Kept deliberately simple — no zoom/pan, just "see it big".
+ */
+function ImageLightbox({ att, onClose }: { att: ChatAttachment; onClose: () => void }) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      onClick={onClose}
+      style={{
+        position: 'absolute',
+        inset: 0,
+        zIndex: 30,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 8,
+        padding: 16,
+        background: 'rgba(0,0,0,0.82)',
+        cursor: 'zoom-out',
+      }}
+    >
+      <img
+        src={att.dataUrl}
+        alt={att.name ?? 'Shared photo'}
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          maxWidth: '100%',
+          maxHeight: 'calc(100% - 56px)',
+          objectFit: 'contain',
+          borderRadius: 'var(--r-sm)',
+          cursor: 'default',
+        }}
+      />
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+        {att.name ? (
+          <span className="mono" style={{ fontSize: 10.5, color: 'var(--fg-2)' }}>
+            {att.name}
+          </span>
+        ) : null}
+        <a
+          href={att.dataUrl}
+          download={att.name ?? 'photo.jpg'}
+          onClick={(e) => e.stopPropagation()}
+          className="btn sm"
+        >
+          Download
+        </a>
+        <button type="button" className="btn sm" onClick={onClose}>
+          Close
+        </button>
       </div>
     </div>
   );
@@ -1424,8 +1567,16 @@ export function ChatPanel() {
 
   const [draft, setDraft] = useState('');
   const [profileCall, setProfileCall] = useState<string | null>(null);
+  // Pending inline photo: compressed and ready to send, shown as a preview chip
+  // above the composer until the operator sends or removes it.
+  const [pendingAttachment, setPendingAttachment] = useState<ChatAttachment | null>(null);
+  const [attaching, setAttaching] = useState(false);
+  const [attachError, setAttachError] = useState<string | null>(null);
+  // The image currently open full-size in the lightbox, if any.
+  const [lightbox, setLightbox] = useState<ChatAttachment | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   // Auto-grow textarea
   useEffect(() => {
@@ -1554,15 +1705,47 @@ export function ChatPanel() {
     return 'Message everyone (Enter to send, Shift+Enter for newline)';
   })();
 
-  const canSend = enabled && connected && draft.trim().length > 0 && draft.length <= MAX_MESSAGE_CHARS;
+  // Sendable when connected and there's either text within the limit or a
+  // pending photo (image-only messages are allowed).
+  const canSend =
+    enabled &&
+    connected &&
+    draft.length <= MAX_MESSAGE_CHARS &&
+    (draft.trim().length > 0 || pendingAttachment !== null);
 
   const doSend = useCallback(async () => {
     const text = draft.trim();
-    if (!text || !connected || text.length > MAX_MESSAGE_CHARS) return;
+    const att = pendingAttachment;
+    if (!connected || text.length > MAX_MESSAGE_CHARS) return;
+    if (!text && !att) return;
+    // Clear optimistically; restore on failure so nothing is silently lost.
     setDraft('');
-    const ok = await send(text);
-    if (!ok) setDraft(text);
-  }, [draft, connected, send]);
+    setPendingAttachment(null);
+    const ok = await send(text, att);
+    if (!ok) {
+      setDraft(text);
+      setPendingAttachment(att);
+    }
+  }, [draft, pendingAttachment, connected, send]);
+
+  // Compress a chosen/pasted/dropped image and stage it for sending.
+  const attachFile = useCallback(async (file: File | null | undefined) => {
+    if (!file) return;
+    setAttachError(null);
+    setAttaching(true);
+    try {
+      const att = await compressImageToAttachment(file);
+      setPendingAttachment(att);
+      // Return focus to the composer so a caption can be typed immediately.
+      inputRef.current?.focus();
+    } catch (err) {
+      setAttachError(
+        err instanceof ChatImageError ? err.message : "Couldn't attach that image.",
+      );
+    } finally {
+      setAttaching(false);
+    }
+  }, []);
 
   // Status pill
   const statusPill = (() => {
@@ -2030,6 +2213,7 @@ export function ChatPanel() {
                     msg={m}
                     own={own}
                     onOpen={openProfile}
+                    onExpandImage={setLightbox}
                   />
                 );
               })
@@ -2047,7 +2231,88 @@ export function ChatPanel() {
               flexShrink: 0,
             }}
           >
+            {/* Hidden file picker driven by the paperclip button. */}
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept={CHAT_IMAGE_ACCEPT}
+              style={{ display: 'none' }}
+              onChange={(e) => {
+                void attachFile(e.target.files?.[0]);
+                e.target.value = ''; // allow re-picking the same file
+              }}
+            />
+
+            {/* Pending photo preview + attach error. */}
+            {pendingAttachment ? (
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  padding: 4,
+                  borderRadius: 'var(--r-sm)',
+                  background: 'var(--bg-2)',
+                  border: '1px solid var(--line)',
+                }}
+              >
+                <img
+                  src={pendingAttachment.dataUrl}
+                  alt={pendingAttachment.name ?? 'Attached photo'}
+                  style={{
+                    width: 40,
+                    height: 40,
+                    objectFit: 'cover',
+                    borderRadius: 'var(--r-sm)',
+                    flexShrink: 0,
+                  }}
+                />
+                <span
+                  className="mono"
+                  style={{
+                    flex: 1,
+                    minWidth: 0,
+                    fontSize: 10.5,
+                    color: 'var(--fg-2)',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {pendingAttachment.name ?? 'photo.jpg'}
+                  {pendingAttachment.size
+                    ? ` · ${Math.max(1, Math.round(pendingAttachment.size / 1024))} KB`
+                    : ''}
+                </span>
+                <button
+                  type="button"
+                  className="btn sm"
+                  onClick={() => setPendingAttachment(null)}
+                  title="Remove photo"
+                >
+                  ✕
+                </button>
+              </div>
+            ) : null}
+            {attachError ? (
+              <div className="mono" style={{ fontSize: 10, color: 'var(--tx)', paddingLeft: 2 }}>
+                {attachError}
+              </div>
+            ) : null}
+
             <div style={{ display: 'flex', gap: 6, alignItems: 'flex-end' }}>
+              {/* Paperclip — attach a photo. */}
+              <button
+                type="button"
+                className="btn sm"
+                disabled={!connected || attaching}
+                onClick={() => fileInputRef.current?.click()}
+                title={connected ? 'Attach a photo' : 'Not connected'}
+                aria-label="Attach a photo"
+                style={{ flexShrink: 0, padding: '5px 8px' }}
+              >
+                {attaching ? '…' : <PaperclipIcon />}
+              </button>
               <textarea
                 ref={inputRef}
                 className="mono"
@@ -2057,6 +2322,16 @@ export function ChatPanel() {
                   if (e.key === 'Enter' && !e.shiftKey) {
                     e.preventDefault();
                     void doSend();
+                  }
+                }}
+                onPaste={(e) => {
+                  // Paste an image straight from the clipboard, like texting.
+                  const item = Array.from(e.clipboardData.items).find((it) =>
+                    it.type.startsWith('image/'),
+                  );
+                  if (item) {
+                    e.preventDefault();
+                    void attachFile(item.getAsFile());
                   }
                 }}
                 placeholder={composerPlaceholder}
@@ -2114,6 +2389,9 @@ export function ChatPanel() {
       {profileCall ? (
         <ProfileOverlay callsign={profileCall} onClose={() => setProfileCall(null)} />
       ) : null}
+
+      {/* ── Full-size photo viewer ── */}
+      {lightbox ? <ImageLightbox att={lightbox} onClose={() => setLightbox(null)} /> : null}
 
       {/* ── Moderation / room dialogs (proper in-app, not window.*) ── */}
       {banTarget ? (

--- a/zeus-web/src/state/chat-store.test.ts
+++ b/zeus-web/src/state/chat-store.test.ts
@@ -85,6 +85,38 @@ describe('chat-store ingest (0x35 live frames)', () => {
     expect(lobby().map((x) => x.id)).toEqual(['a', 'b']);
   });
 
+  it('preserves a valid image attachment and drops a malformed one', () => {
+    const ing = useChatStore.getState().ingest;
+    const dataUrl = 'data:image/jpeg;base64,/9j/AA==';
+    ing({
+      kind: 'message',
+      message: {
+        id: 'img1',
+        ts: 100,
+        from: 'N9WAR',
+        text: 'look',
+        room: PUBLIC_ROOM,
+        attachment: { kind: 'image', mime: 'image/jpeg', dataUrl, width: 800, height: 600 },
+      },
+    });
+    // A non-image data URL must not survive normalization.
+    ing({
+      kind: 'message',
+      message: {
+        id: 'img2',
+        ts: 200,
+        from: 'N9WAR',
+        text: 'nope',
+        room: PUBLIC_ROOM,
+        attachment: { kind: 'image', mime: 'application/pdf', dataUrl: 'data:application/pdf;base64,AAAA' },
+      },
+    });
+    const msgs = lobby();
+    expect(msgs.find((m) => m.id === 'img1')?.attachment?.dataUrl).toBe(dataUrl);
+    expect(msgs.find((m) => m.id === 'img1')?.attachment?.width).toBe(800);
+    expect(msgs.find((m) => m.id === 'img2')?.attachment).toBeNull();
+  });
+
   it('routes messages to the correct room and counts unread for inactive rooms', () => {
     const ing = useChatStore.getState().ingest;
     ing({ kind: 'message', message: msg('g1', 100, 'hi', 'W1ABC', 'g123') });

--- a/zeus-web/src/state/chat-store.ts
+++ b/zeus-web/src/state/chat-store.ts
@@ -55,6 +55,7 @@ import {
   normalizeRoom,
   type ChatOperator,
   type ChatMessage,
+  type ChatAttachment,
   type ChatStatus,
   type ChatRoom,
   type ChatFriends,
@@ -135,7 +136,9 @@ export type ChatStoreState = {
   setEnabled: (enabled: boolean) => Promise<void>;
   /** Report whether the Chat panel is currently displayed (gates presence). */
   setPanelVisible: (visible: boolean) => Promise<void>;
-  send: (text: string) => Promise<boolean>;
+  /** Send a message to the active room. `attachment` is an optional inline
+   *  photo; when present `text` may be empty (image-only message). */
+  send: (text: string, attachment?: ChatAttachment | null) => Promise<boolean>;
   loadHistory: () => Promise<void>;
   loadRoster: () => Promise<void>;
   loadRooms: () => Promise<void>;
@@ -250,17 +253,18 @@ export const useChatStore = create<ChatStoreState>((set, get) => ({
     }
   },
 
-  send: async (text) => {
+  send: async (text, attachment) => {
     const trimmed = text.trim();
-    if (!trimmed) return false;
+    // Allow an image-only message (empty text) when an attachment is present.
+    if (!trimmed && !attachment) return false;
     const { activeRoom, callsign } = get();
     try {
       if (activeRoom.startsWith('dm:')) {
         const other = dmOther(activeRoom, callsign);
         if (!other) return false;
-        await chatDm(other, trimmed);
+        await chatDm(other, trimmed, attachment);
       } else {
-        await chatSend(trimmed, activeRoom);
+        await chatSend(trimmed, activeRoom, attachment);
       }
       return true;
     } catch (err) {
@@ -492,4 +496,4 @@ export function ownCallsign(): string | null {
 }
 
 // Re-export the wire types so panels can import them from one place.
-export type { ChatOperator, ChatMessage, ChatStatus, ChatRoom } from '../api/chat';
+export type { ChatOperator, ChatMessage, ChatAttachment, ChatStatus, ChatRoom } from '../api/chat';

--- a/zeus-web/src/util/chat-image.ts
+++ b/zeus-web/src/util/chat-image.ts
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+// Client-side photo compression for ZeusChat inline attachments.
+//
+// Photos are sent "like a text message": the bytes ride inside the chat message
+// as a base64 data URL, which the relay persists in a single Durable-Object
+// value (128 KiB cap) and broadcasts to the whole room. A raw phone photo is
+// 2–8 MB — far too big — so before sending we downscale and JPEG-compress in the
+// browser until the encoded data URL fits comfortably under the cap.
+//
+// The strategy: cap the longest edge, then step quality (and, if needed, the
+// dimension) down until the result fits. This keeps the common case (a snapshot
+// of a rig / antenna / screen) legible while guaranteeing the wire size.
+
+import { MAX_ATTACHMENT_DATAURL_LEN, type ChatAttachment } from '../api/chat';
+
+/** Longest-edge starting cap (px). Most chat photos read fine at this size. */
+const MAX_EDGE_PX = 1280;
+/** Hard floor for the longest edge when shrinking to fit (px). */
+const MIN_EDGE_PX = 480;
+/** JPEG quality ladder, highest first. */
+const QUALITY_STEPS = [0.82, 0.72, 0.62, 0.5, 0.4];
+
+/** Accepted input types. HEIC isn't decodable by canvas in most browsers. */
+const ACCEPTED = /^image\/(jpeg|png|webp|gif|bmp)$/i;
+
+export class ChatImageError extends Error {}
+
+/** Human-facing accept attribute for the file picker. */
+export const CHAT_IMAGE_ACCEPT = 'image/jpeg,image/png,image/webp,image/gif,image/bmp';
+
+/** Rough decoded byte size of a base64 data URL (for the `size` hint). */
+function dataUrlBytes(dataUrl: string): number {
+  const comma = dataUrl.indexOf(',');
+  const b64 = comma >= 0 ? dataUrl.slice(comma + 1) : dataUrl;
+  return Math.floor((b64.length * 3) / 4);
+}
+
+/** Load a File into an HTMLImageElement via an object URL (revoked after). */
+function loadImage(file: File): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve(img);
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new ChatImageError("Couldn't read that image."));
+    };
+    img.src = url;
+  });
+}
+
+/** Draw `img` to a canvas scaled so its longest edge is `edge` px. */
+function drawScaled(img: HTMLImageElement, edge: number): HTMLCanvasElement {
+  const w = img.naturalWidth || img.width;
+  const h = img.naturalHeight || img.height;
+  const scale = Math.min(1, edge / Math.max(w, h));
+  const cw = Math.max(1, Math.round(w * scale));
+  const ch = Math.max(1, Math.round(h * scale));
+  const canvas = document.createElement('canvas');
+  canvas.width = cw;
+  canvas.height = ch;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new ChatImageError('Image processing is unavailable in this browser.');
+  // White matte so transparent PNGs don't turn black when flattened to JPEG.
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(0, 0, cw, ch);
+  ctx.drawImage(img, 0, 0, cw, ch);
+  return canvas;
+}
+
+/**
+ * Compress `file` into an inline image attachment whose data URL fits under the
+ * relay cap. Always re-encodes as JPEG (photos compress well; alpha is matted
+ * onto white). Throws {@link ChatImageError} for an unreadable/unsupported file
+ * or an image that can't be made small enough even at the floor settings.
+ */
+export async function compressImageToAttachment(file: File): Promise<ChatAttachment> {
+  if (!file.type || !ACCEPTED.test(file.type)) {
+    throw new ChatImageError('Only photos (JPEG, PNG, WebP, GIF) can be attached.');
+  }
+
+  const img = await loadImage(file);
+
+  // Walk the edge sizes from MAX down to MIN; at each, try the quality ladder.
+  // The first encoding under the cap wins. Larger edge + higher quality is
+  // preferred, so we only shrink the edge once a size's whole quality ladder
+  // overflows.
+  for (let edge = MAX_EDGE_PX; edge >= MIN_EDGE_PX; edge = Math.round(edge * 0.8)) {
+    const canvas = drawScaled(img, edge);
+    for (const q of QUALITY_STEPS) {
+      const dataUrl = canvas.toDataURL('image/jpeg', q);
+      if (dataUrl.length <= MAX_ATTACHMENT_DATAURL_LEN) {
+        return {
+          kind: 'image',
+          mime: 'image/jpeg',
+          dataUrl,
+          name: renameToJpeg(file.name),
+          width: canvas.width,
+          height: canvas.height,
+          size: dataUrlBytes(dataUrl),
+        };
+      }
+    }
+  }
+
+  throw new ChatImageError(
+    "That image is too detailed to send inline. Try a smaller crop or screenshot.",
+  );
+}
+
+/** Swap any extension for .jpg since we always re-encode as JPEG. */
+function renameToJpeg(name: string | undefined): string | null {
+  if (!name) return null;
+  const base = name.replace(/\.[^./\\]+$/, '');
+  return `${base || 'photo'}.jpg`;
+}


### PR DESCRIPTION
## Inline photo sharing in the live chat

Adds a **paperclip** to the Chat composer so an operator can attach a photo and send it inline with the message — the way you'd send a picture in a text. Photos are downscaled/compressed in the browser and ride **inside the chat message** (no R2, no external host). Image-only messages (no caption) and caption+image are both supported. Received photos render as a click-to-expand thumbnail with a full-size lightbox + download.

This is **Option 2 (inline)** of the two approaches considered — chosen to avoid standing up new cloud storage. The bytes travel as an optional `attachment` on the existing chat message; plain-text messages are byte-for-byte unchanged and the new field is optional everywhere, so all existing chat (text, DMs, groups, friends, moderation) is untouched.

### What changed
- **Zeus.Contracts** — `ChatAttachment` record + optional `Attachment` on `ChatMessage` / `ChatSendRequest` / `ChatDmRequest`. ⚠️ **Wire-format change (red-light)** — needs maintainer review.
- **Backend** (`ChatService`) — parses inbound attachments, forwards outbound ones, allows image-only sends, guards kind/MIME/size (defense-in-depth). Endpoints thread the field through.
- **Relay** (`cloud/zeuschat-relay`) — optional attachment on `msg`/`dm`, sanitized (image-only + size-capped) then stored + broadcast. **Requires a one-command redeploy — see below.**
- **Web** — client-side image compression util (`util/chat-image.ts`), paperclip + hidden picker + clipboard-paste, pending-photo preview chip, inline image bubble + lightbox viewer.
- **Tests** — backend attachment parse/drop coverage; frontend store attachment-ingest coverage.

### Size / transport
Each photo is auto-shrunk so its base64 data URL stays **≤ 120 000 chars**, comfortably under the relay's 128 KiB per-message Durable-Object storage value. Caps are enforced at three layers (client compress → backend guard → relay sanitize). A malformed/oversized/non-image attachment degrades the message to text-only rather than breaking it.

### ⚠️ Two prerequisites for a peer to actually SEE a photo
1. **The relay must be redeployed** with this code. The currently-deployed relay strips the unknown `attachment` field, so until it's updated, photos don't render for anyone (and an image-only message is dropped). **No R2 / bucket / new bindings — just a redeploy** (runbook below).
2. **Both operators must be on a build containing this PR.** The photo is an extra field on the message; an older Zeus build shows only the caption text. Existing text chat keeps working for them regardless.

### Relay redeploy runbook (for the Cloudflare account owner)
**No Cloudflare config changes** — `wrangler.toml` bindings, secrets, and migrations are all unchanged. Only the relay TS code changed.
```bash
cd cloud/zeuschat-relay
npm install            # if deps not already present
npm run typecheck      # optional sanity check
npx wrangler deploy    # deploys to chat.openhpsdrzeus.com
```
Requires being authenticated to the Cloudflare account that holds the `openhpsdrzeus.com` zone (already the case for whoever deploys the relay). The existing `RELAY_SHARED_SECRET` secret is untouched.

### Verification done locally
- `dotnet build Zeus.slnx` — clean (0/0).
- Backend chat tests — **21 passed** (3 new: attachment parse + drop/oversize).
- `zeus-web` `tsc --noEmit` clean, eslint clean, `npm run build` succeeds.
- Frontend chat-store tests — **10 passed** (1 new attachment-ingest test).

### Not bench-tested
End-to-end photo delivery between two operators needs the relay redeployed + two updated builds (per the prerequisites above). Not yet exercised against the live relay.

### Future (Option 1)
Full-resolution photos or arbitrary *file* sharing (PDFs/logs) would warrant Option 1 — upload bytes to Cloudflare R2 and send only a link. Free-tier-friendly, but needs an R2 bucket provisioned. Out of scope here.
