### PR TITLE
feat(web): KiwiSDR slice receiver with map picker

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -891,6 +891,15 @@ public static class WireContract
     /// <c>Zeus.Protocol2.Protocol2Client.MaxRxDdc</c> references it so the wire
     /// foundation and the contract can never drift apart.</summary>
     public const int MaxReceivers = 8;
+
+    /// <summary>Reserved receiver index for the non-hardware KiwiSDR slice. It
+    /// sits at the very top of the DDC range so it never collides with the
+    /// contiguous hardware run (RX1..RX6, practical max 6 on a G2/Saturn).
+    /// Frames for the Kiwi receiver are broadcast with this value as their
+    /// <c>RxId</c>; the frontend routes them through the same per-RX render path
+    /// as a hardware DDC and labels the entry from <see cref="ReceiverDto.Name"/>
+    /// ("Kiwi") instead of "RX{Index+1}".</summary>
+    public const int KiwiReceiverIndex = MaxReceivers - 1;
 }
 
 /// <summary>Per-receiver (per-DDC) state for the multi-DDC model. Index 0 is
@@ -921,7 +930,13 @@ public sealed record ReceiverDto(
     // contribution while leaving every other receiver audible. Defaults false so
     // pre-mute wire frames deserialize unchanged. Mirrors the per-RX MUTE_RX1/
     // RX2 keypad controls.
-    bool Muted = false);
+    bool Muted = false,
+    // Optional human-facing label. Null for hardware DDC receivers — the UI
+    // derives their label from the index ("RX{Index+1}"). Set to a name (e.g.
+    // "Kiwi") for non-hardware software receivers such as the KiwiSDR slice that
+    // occupy a reserved high index (WireContract.KiwiReceiverIndex). Defaulted so
+    // pre-name wire frames deserialize unchanged.
+    string? Name = null);
 
 public sealed record StateDto(
     ConnectionStatus Status,
@@ -1384,6 +1399,30 @@ public sealed record ReceiverSetRequest(
     // label the operator picked, exactly as RX2 carries FilterPresetNameB. The
     // cuts in FilterLowHz/FilterHighHz remain authoritative for the DSP.
     string? FilterPresetName = null);
+
+/// <summary>Body of <c>POST /api/kiwi</c> — configure the KiwiSDR slice
+/// receiver. Every field is optional; only supplied fields change.
+/// <para><see cref="Url"/> is the KiwiSDR base URL or host:port (e.g.
+/// <c>sdr.example.org:8073</c> or <c>http://sdr.example.org:8073</c>). An empty
+/// <see cref="Password"/> string clears any stored password; null leaves it
+/// unchanged. Setting <see cref="Enabled"/> true with a URL present opens the
+/// connection; false tears it down.</para></summary>
+public sealed record KiwiSetRequest(
+    bool? Enabled = null,
+    string? Url = null,
+    string? Password = null);
+
+/// <summary>Status of the KiwiSDR slice receiver — the body of
+/// <c>GET /api/kiwi</c> and the value returned from <c>POST /api/kiwi</c>.
+/// <see cref="HasPassword"/> avoids ever returning the stored secret to the
+/// client; <see cref="Status"/> is a short connection-state word
+/// ("disabled", "connecting", "connected", "error").</summary>
+public sealed record KiwiConfigDto(
+    bool Enabled,
+    string? Url,
+    bool HasPassword,
+    string Status,
+    string? StatusDetail = null);
 
 /// <summary>Operator settings for the POTA/SOTA Spots feature. Persisted in
 /// zeus-prefs.db (<c>SpotsSettingsStore</c>) and shared with the frontend.

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -728,9 +728,17 @@ public class DspPipelineService : BackgroundService,
     // allocation (the scratch span below is reused every tick).
     internal readonly record struct RxAudioSlice(float[] Buffer, int Count);
     // Reused each tick to collect the enabled secondary RX audio blocks for the
-    // mixer. Sized for every secondary slot (1..N-1); only the populated prefix
-    // is passed to MixRxAudioN.
-    private readonly RxAudioSlice[] _mixSlices = new RxAudioSlice[MaxReceivers];
+    // mixer. Sized for every secondary slot (1..N-1) PLUS the Kiwi slice, which
+    // is mixed in on the same bus; only the populated prefix is passed to
+    // MixRxAudioN.
+    private readonly RxAudioSlice[] _mixSlices = new RxAudioSlice[MaxReceivers + 1];
+
+    // The Kiwi slice receiver feeds its demodulated audio onto the SAME RX mix
+    // bus as the hardware receivers (IKiwiAudioBus). Optional — null in tests and
+    // when no Kiwi service is registered. Drained into _kiwiMixBuf each tick,
+    // clocked by RX1, then averaged in by MixRxAudioN alongside RX2..RXn.
+    private readonly IKiwiAudioBus? _kiwiAudioBus;
+    private readonly float[] _kiwiMixBuf = new float[AudioDrainCapacity];
 
     // Protocol 2 path (parallel to the RadioService-owned P1 path). Held
     // directly here because RadioService is Protocol1Client-shaped and
@@ -1206,11 +1214,13 @@ public class DspPipelineService : BackgroundService,
         DisplaySettingsStore? displaySettings = null,
         FreeDvService? freeDv = null,
         Func<TxAudioIngest?>? txIngestFactory = null,
-        Nr3ModelStore? nr3ModelStore = null)
+        Nr3ModelStore? nr3ModelStore = null,
+        IKiwiAudioBus? kiwiAudioBus = null)
     {
         _radio = radio;
         _hub = hub;
         _freeDv = freeDv;
+        _kiwiAudioBus = kiwiAudioBus;
         // Materialise once at construction so the per-tick fan-out is an
         // array-index loop (no enumerator allocation, no LINQ on the hot path).
         _audioSinks = audioSinks.ToArray();
@@ -5657,6 +5667,20 @@ public class DspPipelineService : BackgroundService,
             // receivers you can still hear).
             if (IsReceiverMuted(state, ri)) continue;
             _mixSlices[mixSliceCount++] = new RxAudioSlice(sec.AudioBuf, n);
+        }
+
+        // Kiwi slice (RxId 7): an INDEPENDENT remote receiver that rides the same
+        // RX1-clocked mix bus as the hardware secondaries. Drain at most
+        // audioSampleCount samples so it's fed at exactly the RX rate (its own
+        // clock differs from the radio ADC; IKiwiAudioBus.ReadAudio caps buffered
+        // latency to bound that drift), then average it in via MixRxAudioN. When
+        // the slice is disabled/muted AudioActive is false and this is one bool
+        // read. RX1 silent (audioSampleCount==0) reads nothing this tick.
+        if (audioSampleCount > 0 && _kiwiAudioBus is { AudioActive: true })
+        {
+            int want = Math.Min(audioSampleCount, _kiwiMixBuf.Length);
+            int n = _kiwiAudioBus.ReadAudio(_kiwiMixBuf.AsSpan(0, want));
+            if (n > 0) _mixSlices[mixSliceCount++] = new RxAudioSlice(_kiwiMixBuf, n);
         }
 
         // RX1's own samples were already zeroed above when it's muted; tell the

--- a/Zeus.Server.Hosting/Kiwi/KiwiDirectoryService.cs
+++ b/Zeus.Server.Hosting/Kiwi/KiwiDirectoryService.cs
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using System.Globalization;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace Zeus.Server;
+
+/// <summary>One public KiwiSDR from the kiwisdr.com directory, reshaped for the
+/// map picker. <paramref name="Url"/> is the address Zeus connects to (the same
+/// form <see cref="KiwiSdrService.TryParseEndpoint"/> accepts).</summary>
+public sealed record KiwiDirectoryEntry(
+    string Name,
+    string Url,
+    double Lat,
+    double Lon,
+    int Users,
+    int UsersMax,
+    bool Online,
+    string? Location,
+    string? Snr);
+
+/// <summary>
+/// Proxies the public KiwiSDR directory (the kiwisdr.com receiver list, mirrored
+/// as <c>rx.linkfanel.net/kiwisdr_com.js</c> for the "dyatlov" map maker) so the
+/// frontend can render a world map of selectable receivers. Server-side because
+/// the source is plain HTTP — a desktop SPA served over LAN HTTPS would have the
+/// browser block it as mixed content, and CORS would block it regardless. We
+/// fetch, strip the <c>var kiwisdr_com = [...]</c> JS wrapper, parse, reshape to
+/// <see cref="KiwiDirectoryEntry"/>, and cache for a few minutes (the upstream
+/// regenerates ~once/minute; a short cache collapses repeated panel opens).
+///
+/// <para>Never throws to the caller: on any upstream failure it returns the last
+/// good cache if present, else an empty list.</para>
+/// </summary>
+public sealed class KiwiDirectoryService
+{
+    // The kiwisdr.com list, mirrored as a JS array for the dyatlov map maker.
+    private const string DirectoryUrl = "http://rx.linkfanel.net/kiwisdr_com.js";
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(2);
+
+    private readonly IHttpClientFactory _httpFactory;
+    private readonly ILogger<KiwiDirectoryService> _log;
+    private readonly object _gate = new();
+    private (DateTimeOffset At, IReadOnlyList<KiwiDirectoryEntry> List)? _cache;
+
+    public KiwiDirectoryService(IHttpClientFactory httpFactory, ILogger<KiwiDirectoryService> log)
+    {
+        _httpFactory = httpFactory;
+        _log = log;
+    }
+
+    public async Task<IReadOnlyList<KiwiDirectoryEntry>> GetAsync(CancellationToken ct = default)
+    {
+        lock (_gate)
+        {
+            if (_cache is { } c && DateTimeOffset.UtcNow - c.At < CacheTtl)
+                return c.List;
+        }
+
+        try
+        {
+            var http = _httpFactory.CreateClient();
+            http.Timeout = TimeSpan.FromSeconds(20);
+            using var req = new HttpRequestMessage(HttpMethod.Get, DirectoryUrl);
+            req.Headers.TryAddWithoutValidation("User-Agent", "OpenHPSDR-Zeus");
+            using var resp = await http.SendAsync(req, ct).ConfigureAwait(false);
+            if (!resp.IsSuccessStatusCode)
+            {
+                _log.LogDebug("kiwi.directory upstream HTTP {Status}", (int)resp.StatusCode);
+                return CachedOrEmpty();
+            }
+
+            var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            var list = Parse(body);
+            if (list.Count == 0) return CachedOrEmpty();
+            lock (_gate) { _cache = (DateTimeOffset.UtcNow, list); }
+            _log.LogInformation("kiwi.directory fetched {Count} receivers", list.Count);
+            return list;
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _log.LogDebug(ex, "kiwi.directory fetch failed");
+            return CachedOrEmpty();
+        }
+    }
+
+    private IReadOnlyList<KiwiDirectoryEntry> CachedOrEmpty()
+    {
+        lock (_gate) { return _cache?.List ?? Array.Empty<KiwiDirectoryEntry>(); }
+    }
+
+    // The file is JS: a banner of `//` comments then `var kiwisdr_com = [ {...}, ... ]`.
+    // Slice out the JSON array (first '[' .. last ']') and parse. All field values
+    // are JSON strings (e.g. "users":"4"), so numbers are parsed leniently.
+    internal static List<KiwiDirectoryEntry> Parse(string body)
+    {
+        var result = new List<KiwiDirectoryEntry>();
+        if (string.IsNullOrEmpty(body)) return result;
+        int lb = body.IndexOf('[');
+        int rb = body.LastIndexOf(']');
+        if (lb < 0 || rb <= lb) return result;
+
+        JsonDocument doc;
+        try
+        {
+            // The generator emits a TRAILING COMMA before the closing ']' (and
+            // banner // comments precede the array) — both rejected by
+            // System.Text.Json's strict defaults, so opt into them.
+            doc = JsonDocument.Parse(
+                body.AsMemory(lb, rb - lb + 1),
+                new JsonDocumentOptions
+                {
+                    AllowTrailingCommas = true,
+                    CommentHandling = JsonCommentHandling.Skip,
+                });
+        }
+        catch (JsonException) { return result; }
+        using (doc)
+        {
+            if (doc.RootElement.ValueKind != JsonValueKind.Array) return result;
+            foreach (var el in doc.RootElement.EnumerateArray())
+            {
+                if (el.ValueKind != JsonValueKind.Object) continue;
+                var url = Str(el, "url");
+                if (string.IsNullOrWhiteSpace(url)) continue;
+                if (!TryParseGps(Str(el, "gps"), out var lat, out var lon)) continue;
+
+                result.Add(new KiwiDirectoryEntry(
+                    Name: Str(el, "name") ?? url!,
+                    Url: url!,
+                    Lat: lat,
+                    Lon: lon,
+                    Users: Int(el, "users"),
+                    UsersMax: Int(el, "users_max"),
+                    // The directory marks dead receivers with offline="yes" /
+                    // status!="active"; treat anything else as reachable.
+                    Online: !string.Equals(Str(el, "offline"), "yes", StringComparison.OrdinalIgnoreCase)
+                            && !string.Equals(Str(el, "status"), "offline", StringComparison.OrdinalIgnoreCase),
+                    Location: Str(el, "loc"),
+                    Snr: Str(el, "snr")));
+            }
+        }
+        return result;
+    }
+
+    private static string? Str(JsonElement el, string name) =>
+        el.TryGetProperty(name, out var p) && p.ValueKind == JsonValueKind.String ? p.GetString() : null;
+
+    private static int Int(JsonElement el, string name) =>
+        int.TryParse(Str(el, name), NumberStyles.Integer, CultureInfo.InvariantCulture, out var v) ? v : 0;
+
+    // GPS is "(lat, lon)" with invariant decimals, e.g. "(50.850000, -0.660000)".
+    internal static bool TryParseGps(string? gps, out double lat, out double lon)
+    {
+        lat = 0; lon = 0;
+        if (string.IsNullOrWhiteSpace(gps)) return false;
+        var s = gps.Trim().TrimStart('(').TrimEnd(')');
+        int comma = s.IndexOf(',');
+        if (comma <= 0) return false;
+        if (!double.TryParse(s.AsSpan(0, comma).Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out lat))
+            return false;
+        if (!double.TryParse(s.AsSpan(comma + 1).Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out lon))
+            return false;
+        // Reject the (0,0) placeholder many un-GPS'd receivers report — it would
+        // pile every such Kiwi onto Null Island.
+        if (lat == 0 && lon == 0) return false;
+        return Math.Abs(lat) <= 90 && Math.Abs(lon) <= 180;
+    }
+}

--- a/Zeus.Server.Hosting/Kiwi/KiwiSdrClient.cs
+++ b/Zeus.Server.Hosting/Kiwi/KiwiSdrClient.cs
@@ -1,0 +1,546 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using System.Buffers.Binary;
+using System.Globalization;
+using System.Net.WebSockets;
+using System.Text;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// A single KiwiSDR streaming connection. KiwiSDR speaks a dual-WebSocket
+/// protocol: one socket for demodulated audio (<c>/SND</c>) and one for the
+/// wide waterfall FFT (<c>/W/F</c>), both carrying a plain-text <c>SET ...</c>
+/// command channel. The Kiwi performs demodulation server-side, so Zeus drives
+/// it like a remote front-end: tuning / mode / passband are pushed as SET
+/// commands and the decoded audio + waterfall stream back.
+///
+/// <para>This client speaks the cleartext, uncompressed dialect:
+/// <c>SET compression=0</c> so the SND payload is raw signed-16 PCM (no IMA
+/// ADPCM running decoder needed) and <c>SET wf_comp=0</c> so waterfall rows are
+/// one unsigned byte per FFT bin. Reference implementation:
+/// <c>jks-prv/kiwiclient</c> (kiwi/client.py).</para>
+///
+/// <para>All decode callbacks fire on the receive-loop tasks — keep them cheap
+/// and non-blocking (the consumer copies into its own buffers).</para>
+/// </summary>
+public sealed class KiwiSdrClient : IAsyncDisposable
+{
+    private readonly string _host;
+    private readonly int _port;
+    private readonly bool _secure;
+    private readonly string? _password;
+    private readonly string _identUser;
+    private readonly ILogger _log;
+
+    private ClientWebSocket? _snd;
+    private ClientWebSocket? _wf;
+    private CancellationTokenSource? _cts;
+    private Task? _sndLoop;
+    private Task? _wfLoop;
+    private Task? _keepalive;
+
+    // Live tuning, guarded by _sync. The receive loops re-issue the current
+    // tune once the channel is authenticated (sample_rate known), and Tune()
+    // pushes deltas live.
+    private readonly object _sync = new();
+    private long _freqHz = 14_200_000;        // demod (dial) frequency → SET freq
+    private long _centerHz = 14_200_000;      // waterfall centre → SET cf (frozen under CTUN)
+    private string _mode = "usb";
+    private int _lowCutHz = 100;
+    private int _highCutHz = 2_850;
+    private double _displaySpanHz = 24_000;
+
+    // Captured from the server handshake.
+    private volatile int _audioRateHz; // native SND rate, ~12000
+    private double _wfFullSpanHz = 30_000_000; // full waterfall span at zoom 0
+    private bool _wfStarted;
+    private bool _handshakeReady;
+    private int _lastWfZoom = -1;       // last SET zoom step pushed to the W/F socket
+    private double _lastWfCfKHz = -1;   // last SET cf (kHz) pushed; de-dupes rebases
+    private const int PushThrottleMs = 70; // min gap between remote re-tunes
+    private int _pushBusy;                  // 0/1 — a coalescing push loop is running
+    private int _pushDirty;                 // 0/1 — newer tune fields await sending
+    private long _lastPushMs;              // TickCount64 of the last re-tune sent
+    private bool _loggedFirstSnd;
+    private bool _loggedFirstWf;
+    private int _msgLogCount;
+
+    /// <summary>Decoded audio: mono float samples in -1..1 (first arg) at the
+    /// native Kiwi rate in Hz (second arg). Fires once per SND frame.</summary>
+    public Action<float[], int>? AudioReceived;
+
+    /// <summary>One waterfall row: per-bin power in dBm, plus the row's center
+    /// frequency and Hz-per-bin so the consumer can build a DisplayFrame.</summary>
+    public Action<float[], long, double>? WaterfallReceived;
+
+    /// <summary>RX signal level in dBm, from the SND frame S-meter.</summary>
+    public Action<double>? SignalLevel;
+
+    /// <summary>Connection state word ("connecting" / "connected" / "error" /
+    /// "closed") plus an optional human-readable detail.</summary>
+    public Action<string, string?>? StatusChanged;
+
+    public KiwiSdrClient(string host, int port, bool secure, string? password, string identUser, ILogger log)
+    {
+        _host = host;
+        _port = port;
+        _secure = secure;
+        _password = string.IsNullOrEmpty(password) ? null : password;
+        _identUser = string.IsNullOrWhiteSpace(identUser) ? "ZeusSDR" : identUser;
+        _log = log;
+    }
+
+    /// <summary>Open both sockets and start the receive + keepalive loops. The
+    /// returned task completes once the loops are running; streaming continues
+    /// until <see cref="StopAsync"/> / disposal.</summary>
+    public async Task StartAsync(CancellationToken ct)
+    {
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        var token = _cts.Token;
+        StatusChanged?.Invoke("connecting", $"{_host}:{_port}");
+
+        // KiwiSDR uses an integer cache-buster / channel token in the path; the
+        // exact value is irrelevant as long as the two sockets differ.
+        long stamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+        _snd = await OpenSocketAsync(stamp, "SND", token).ConfigureAwait(false);
+        _wf = await OpenSocketAsync(stamp, "W/F", token).ConfigureAwait(false);
+
+        _sndLoop = Task.Run(() => SndLoopAsync(token), token);
+        _wfLoop = Task.Run(() => WfLoopAsync(token), token);
+        _keepalive = Task.Run(() => KeepaliveLoopAsync(token), token);
+    }
+
+    private async Task<ClientWebSocket> OpenSocketAsync(long stamp, string which, CancellationToken ct)
+    {
+        var ws = new ClientWebSocket();
+        ws.Options.SetRequestHeader("User-Agent", "OpenHPSDR-Zeus");
+        var scheme = _secure ? "wss" : "ws";
+        var uri = new Uri($"{scheme}://{_host}:{_port}/{stamp}/{which}");
+        await ws.ConnectAsync(uri, ct).ConfigureAwait(false);
+
+        // Auth first ("#" password = public receiver), then etiquette identity.
+        await SendAsync(ws, $"SET auth t=kiwi p={_password ?? "#"}", ct).ConfigureAwait(false);
+        await SendAsync(ws, $"SET ident_user={_identUser}", ct).ConfigureAwait(false);
+        await SendAsync(ws, "SET geo=", ct).ConfigureAwait(false);
+        return ws;
+    }
+
+    private static async Task SendAsync(ClientWebSocket ws, string command, CancellationToken ct)
+    {
+        if (ws.State != WebSocketState.Open) return;
+        var bytes = Encoding.ASCII.GetBytes(command);
+        await ws.SendAsync(bytes, WebSocketMessageType.Text, endOfMessage: true, ct).ConfigureAwait(false);
+    }
+
+    // -------------------------------------------------------------------------
+    // SND (audio) receive loop.
+    // -------------------------------------------------------------------------
+    private async Task SndLoopAsync(CancellationToken ct)
+    {
+        var buf = new byte[64 * 1024];
+        try
+        {
+            while (!ct.IsCancellationRequested && _snd is { State: WebSocketState.Open })
+            {
+                var (count, isText) = await ReceiveMessageAsync(_snd, buf, ct).ConfigureAwait(false);
+                if (count < 0) break;
+                // KiwiSDR delivers MSG/SND/W/F as BINARY frames led by a 3-byte
+                // ASCII tag (never WebSocket text frames). The "MSG" frames carry
+                // the audio_rate/sample_rate handshake that flips us to connected.
+                if (isText) { await HandleTextAsync(buf.AsMemory(0, count), ct).ConfigureAwait(false); continue; }
+                if (count < 3) continue;
+                if (IsTag(buf, 'M', 'S', 'G')) await HandleTextAsync(buf.AsMemory(3, count - 3), ct).ConfigureAwait(false);
+                else if (IsTag(buf, 'S', 'N', 'D')) DecodeSndFrame(buf.AsSpan(0, count));
+            }
+        }
+        catch (OperationCanceledException) { /* shutting down */ }
+        catch (Exception ex)
+        {
+            _log.LogWarning("kiwi.snd.loop ended host={Host} err={Err}", _host, ex.Message);
+            StatusChanged?.Invoke("error", ex.Message);
+        }
+    }
+
+    // SND binary frame layout (compression=0):
+    //   [0..3)  ASCII tag "SND"
+    //   [3]     flags (bit 0x80 = little-endian PCM, 0x08 = IQ/stereo)
+    //   [4..8)  seq (uint32 LE)
+    //   [8..10) S-meter (uint16 BE)
+    //   [10..]  signed 16-bit PCM payload
+    private void DecodeSndFrame(ReadOnlySpan<byte> msg)
+    {
+        if (msg.Length < 10) return;
+        byte flags = msg[3];
+        ushort smeter = BinaryPrimitives.ReadUInt16BigEndian(msg.Slice(8, 2));
+        // KiwiSDR S-meter encodes (dBm + 127) * 10.
+        double dbm = smeter * 0.1 - 127.0;
+        SignalLevel?.Invoke(dbm);
+
+        var pcm = msg.Slice(10);
+        int n = pcm.Length / 2;
+        if (n <= 0) return;
+        bool little = (flags & 0x80) != 0;
+        var samples = new float[n];
+        for (int i = 0; i < n; i++)
+        {
+            short s = little
+                ? BinaryPrimitives.ReadInt16LittleEndian(pcm.Slice(i * 2, 2))
+                : BinaryPrimitives.ReadInt16BigEndian(pcm.Slice(i * 2, 2));
+            samples[i] = s / 32768f;
+        }
+        int rate = _audioRateHz > 0 ? _audioRateHz : 12_000;
+        if (!_loggedFirstSnd) { _loggedFirstSnd = true; _log.LogDebug("kiwi.snd.first samples={N} rate={Rate}", n, rate); }
+        AudioReceived?.Invoke(samples, rate);
+    }
+
+    // -------------------------------------------------------------------------
+    // W/F (waterfall) receive loop.
+    // -------------------------------------------------------------------------
+    private async Task WfLoopAsync(CancellationToken ct)
+    {
+        var buf = new byte[64 * 1024];
+        try
+        {
+            while (!ct.IsCancellationRequested && _wf is { State: WebSocketState.Open })
+            {
+                var (count, isText) = await ReceiveMessageAsync(_wf, buf, ct).ConfigureAwait(false);
+                if (count < 0) break;
+                if (isText) { await HandleTextAsync(buf.AsMemory(0, count), ct).ConfigureAwait(false); continue; }
+                if (count < 3) continue;
+                if (IsTag(buf, 'M', 'S', 'G')) await HandleTextAsync(buf.AsMemory(3, count - 3), ct).ConfigureAwait(false);
+                else if (IsTag(buf, 'W', (char)'/', 'F')) DecodeWfFrame(buf.AsSpan(0, count));
+            }
+        }
+        catch (OperationCanceledException) { /* shutting down */ }
+        catch (Exception ex)
+        {
+            _log.LogWarning("kiwi.wf.loop ended host={Host} err={Err}", _host, ex.Message);
+        }
+    }
+
+    // W/F binary frame layout (wf_comp=0):
+    //   [0..3)   ASCII tag "W/F"
+    //   [3..15)  three uint32 LE: x-bin start, packed flags/zoom, seq
+    //   [15..]   one unsigned byte per FFT bin; dBm = byte - 255
+    private void DecodeWfFrame(ReadOnlySpan<byte> msg)
+    {
+        const int header = 15;
+        if (msg.Length <= header) return;
+        var bins = msg.Slice(header);
+        int n = bins.Length;
+        var db = new float[n];
+        for (int i = 0; i < n; i++)
+            db[i] = bins[i] - 255f;
+
+        long centerHz;
+        double hzPerBin;
+        lock (_sync)
+        {
+            centerHz = _centerHz;
+            double span = CurrentWfSpanHz();
+            hzPerBin = n > 0 ? span / n : 1.0;
+        }
+        if (!_loggedFirstWf) { _loggedFirstWf = true; _log.LogDebug("kiwi.wf.first bins={N} hzPerBin={Hpb:F1} centerHz={C}", n, hzPerBin, centerHz); }
+        WaterfallReceived?.Invoke(db, centerHz, hzPerBin);
+    }
+
+    // -------------------------------------------------------------------------
+    // Text (MSG) handling + handshake completion.
+    // -------------------------------------------------------------------------
+    private async Task HandleTextAsync(ReadOnlyMemory<byte> msg, CancellationToken ct)
+    {
+        var text = Encoding.ASCII.GetString(msg.Span);
+        // Log the wire during bring-up: the exact handshake-key spellings differ
+        // across KiwiSDR firmware/proxy versions, so log the first messages
+        // verbatim rather than guessing.
+        if (_msgLogCount < 40)
+        {
+            _msgLogCount++;
+            _log.LogDebug("kiwi.msg #{N} {Text}", _msgLogCount,
+                text.Length > 300 ? text[..300] : text);
+        }
+        // Frames look like "MSG audio_rate=12000.000 sample_rate=12000.000 ...".
+        foreach (var tok in text.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            int eq = tok.IndexOf('=');
+            if (eq <= 0) continue;
+            var key = tok.AsSpan(0, eq);
+            var val = tok.AsSpan(eq + 1);
+
+            if (key.SequenceEqual("audio_rate"))
+            {
+                if (TryParseDouble(val, out var r) && r > 0)
+                {
+                    _audioRateHz = (int)Math.Round(r);
+                    // Acknowledge the rate so the server starts the audio stream.
+                    // Echo the native rate as the output rate too: the Kiwi always
+                    // delivers SND at its native audio_rate (~12 kHz) and we
+                    // resample to 48 kHz ourselves, so we never want the server to
+                    // resample on its side regardless of how it reads `out`.
+                    if (_snd is not null)
+                        await SendAsync(_snd, $"SET AR OK in={_audioRateHz} out={_audioRateHz}", ct).ConfigureAwait(false);
+                    // audio_rate arrives on the SND socket itself, so this is the
+                    // reliable cue that the audio path is live — drive the rest of
+                    // the audio handshake (squelch/compression/agc/tune) from here,
+                    // not from sample_rate (which is also echoed on the W/F socket
+                    // and would race ahead with no audio rate known yet).
+                    await OnHandshakeReadyAsync(ct).ConfigureAwait(false);
+                }
+            }
+            else if (key.SequenceEqual("sample_rate") || key.SequenceEqual("wf_setup") || key.SequenceEqual("wf_fps"))
+            {
+                // sample_rate / wf_* arrive even when the RX channel is ultimately
+                // denied, so they only start the waterfall — NOT the "connected"
+                // signal. We mark connected on audio_rate (the audio-granted cue).
+                await EnsureWaterfallStartedAsync(ct).ConfigureAwait(false);
+            }
+            else if (key.SequenceEqual("badp"))
+            {
+                // Auth/availability verdict. 0 = granted; anything else means the
+                // receiver refused the channel (full, password required, or
+                // registration-only). Surface it instead of hanging on "connecting".
+                if (int.TryParse(val, out var bp) && bp != 0)
+                {
+                    _log.LogWarning("kiwi.rejected host={Host} badp={Badp}", _host, bp);
+                    StatusChanged?.Invoke("error",
+                        $"receiver refused the connection (badp={bp}) — it is likely full or requires a password");
+                }
+            }
+        }
+    }
+
+    // Once the SND channel reports its sample rate it is ready for tuning +
+    // stream config. Idempotent — the server may repeat handshake MSGs.
+    private async Task OnHandshakeReadyAsync(CancellationToken ct)
+    {
+        if (_snd is null || _handshakeReady) return;
+        _handshakeReady = true;
+        await SendAsync(_snd, "SET squelch=0 max=0", ct).ConfigureAwait(false);
+        await SendAsync(_snd, "SET compression=0", ct).ConfigureAwait(false);
+        await SendAsync(_snd, "SET agc=1 hang=0 thresh=-100 slope=6 decay=1000 manGain=50", ct).ConfigureAwait(false);
+        await PushTuneAsync(ct).ConfigureAwait(false);
+        await EnsureWaterfallStartedAsync(ct).ConfigureAwait(false);
+        _log.LogInformation("kiwi.handshake.ready host={Host} audioRate={Rate}", _host, _audioRateHz);
+        StatusChanged?.Invoke("connected", null);
+    }
+
+    private async Task EnsureWaterfallStartedAsync(CancellationToken ct)
+    {
+        if (_wf is null || _wfStarted) return;
+        _wfStarted = true;
+        await SendAsync(_wf, "SET wf_comp=0", ct).ConfigureAwait(false);
+        // wf_speed selects the KiwiSDR waterfall cadence: 1=1 fps (slowest),
+        // 4=fast (~max ~23 fps). The panadapter trace is driven off this same
+        // stream, so 1 fps made both crawl while the hardware RX runs ~20 fps.
+        // Use fast so the Kiwi updates smoothly like every other receiver.
+        await SendAsync(_wf, "SET wf_speed=4", ct).ConfigureAwait(false);
+        await SendAsync(_wf, "SET maxdb=0 mindb=-120", ct).ConfigureAwait(false);
+        await PushWaterfallZoomAsync(ct).ConfigureAwait(false);
+    }
+
+    // -------------------------------------------------------------------------
+    // Tuning.
+    // -------------------------------------------------------------------------
+    /// <summary>Retune the Kiwi. <paramref name="freqHz"/> is the demod (dial)
+    /// frequency; <paramref name="centerHz"/> is the waterfall centre — they
+    /// differ under CTUN (centre frozen, dial roams). <paramref name="mode"/> is a
+    /// Kiwi mode word (usb/lsb/am/cw/cwn/nbfm/iq/sam). Cuts are passband edges in
+    /// Hz relative to the carrier. <paramref name="displaySpanHz"/> drives the
+    /// waterfall zoom.</summary>
+    public void Tune(long freqHz, long centerHz, string mode, int lowCutHz, int highCutHz, double displaySpanHz)
+    {
+        lock (_sync)
+        {
+            _freqHz = freqHz;
+            _centerHz = centerHz > 0 ? centerHz : freqHz;
+            _mode = string.IsNullOrWhiteSpace(mode) ? _mode : mode;
+            _lowCutHz = lowCutHz;
+            _highCutHz = highCutHz;
+            if (displaySpanHz > 0) _displaySpanHz = displaySpanHz;
+        }
+        SchedulePush();
+    }
+
+    // Throttle the remote re-tune. A filter / VFO drag calls Tune() up to ~60×/s;
+    // re-tuning the remote KiwiSDR that fast spams it and the audio can't keep up
+    // (the "filter isn't smooth" symptom). Coalesce into at most one push per
+    // PushThrottleMs window, always carrying the LATEST fields (PushTuneAsync
+    // reads them under _sync at send time), with a trailing push so the final
+    // drag position always lands.
+    private void SchedulePush()
+    {
+        // Mark work pending. If a push loop is already running it will pick up the
+        // latest fields on its next iteration; only start a new loop otherwise.
+        Interlocked.Exchange(ref _pushDirty, 1);
+        if (Interlocked.CompareExchange(ref _pushBusy, 1, 0) != 0) return;
+        _ = RunPushLoopAsync();
+    }
+
+    private async Task RunPushLoopAsync()
+    {
+        var ct = _cts?.Token ?? CancellationToken.None;
+        try
+        {
+            // Drain pending tunes, never faster than one per PushThrottleMs. Each
+            // pass sends the LATEST fields (PushTuneAsync reads under _sync), so a
+            // drag collapses to ~14 re-tunes/s and the final position always lands.
+            while (Interlocked.Exchange(ref _pushDirty, 0) == 1)
+            {
+                long since = Environment.TickCount64 - Interlocked.Read(ref _lastPushMs);
+                int wait = (int)Math.Max(0, PushThrottleMs - since);
+                if (wait > 0) await Task.Delay(wait, ct).ConfigureAwait(false);
+                await PushTuneAsync(ct).ConfigureAwait(false);
+                await PushWaterfallZoomAsync(ct).ConfigureAwait(false);
+                Interlocked.Exchange(ref _lastPushMs, Environment.TickCount64);
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception ex) { _log.LogDebug("kiwi.tune.push err={Err}", ex.Message); }
+        finally
+        {
+            Interlocked.Exchange(ref _pushBusy, 0);
+            // A tune that arrived between the loop's last dirty-check and here would
+            // otherwise be lost — re-arm if so and we can re-acquire the loop slot.
+            if (Volatile.Read(ref _pushDirty) == 1 && Interlocked.CompareExchange(ref _pushBusy, 1, 0) == 0)
+                _ = RunPushLoopAsync();
+        }
+    }
+
+    private async Task PushTuneAsync(CancellationToken ct)
+    {
+        if (_snd is null) return;
+        long freq;
+        string mode;
+        int lo, hi;
+        lock (_sync) { freq = _freqHz; mode = _mode; lo = _lowCutHz; hi = _highCutHz; }
+        // freq is the dial frequency in kHz with 3 decimals.
+        double freqKHz = freq / 1000.0;
+        var cmd = string.Create(CultureInfo.InvariantCulture,
+            $"SET mod={mode} low_cut={lo} high_cut={hi} freq={freqKHz:F3}");
+        _log.LogDebug("kiwi.tune {Cmd}", cmd);
+        await SendAsync(_snd, cmd, ct).ConfigureAwait(false);
+    }
+
+    private async Task PushWaterfallZoomAsync(CancellationToken ct)
+    {
+        if (_wf is null || !_wfStarted) return;
+        long center;
+        int zoom;
+        lock (_sync)
+        {
+            center = _centerHz;
+            zoom = CurrentZoom();
+        }
+        double cfKHz = center / 1000.0;
+        // De-dupe: the server REBASES its whole waterfall history on every
+        // `SET zoom/cf`, so re-sending an unchanged value (e.g. on a filter-only
+        // tune, which leaves zoom + centre alone) makes the waterfall flicker /
+        // stutter. Only push when the zoom step or centre actually moved.
+        if (zoom == _lastWfZoom && Math.Abs(cfKHz - _lastWfCfKHz) < 0.0005) return;
+        _lastWfZoom = zoom;
+        _lastWfCfKHz = cfKHz;
+        var cmd = string.Create(CultureInfo.InvariantCulture, $"SET zoom={zoom} cf={cfKHz:F3}");
+        _log.LogDebug("kiwi.wf {Cmd}", cmd);
+        await SendAsync(_wf, cmd, ct).ConfigureAwait(false);
+    }
+
+    // Pick the zoom level whose span is the closest >= the desired display span,
+    // clamped to the Kiwi's 0..14 range. Caller holds _sync.
+    private int CurrentZoom()
+    {
+        if (_displaySpanHz <= 0) return 10;
+        double ratio = _wfFullSpanHz / _displaySpanHz;
+        if (ratio <= 1) return 0;
+        int z = (int)Math.Floor(Math.Log2(ratio));
+        return Math.Clamp(z, 0, 14);
+    }
+
+    // Actual waterfall span at the current zoom. Caller holds _sync.
+    private double CurrentWfSpanHz() => _wfFullSpanHz / Math.Pow(2, CurrentZoom());
+
+    // -------------------------------------------------------------------------
+    // Keepalive + receive plumbing + teardown.
+    // -------------------------------------------------------------------------
+    private async Task KeepaliveLoopAsync(CancellationToken ct)
+    {
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1), ct).ConfigureAwait(false);
+                if (_snd is { State: WebSocketState.Open }) await SendAsync(_snd, "SET keepalive", ct).ConfigureAwait(false);
+                if (_wf is { State: WebSocketState.Open }) await SendAsync(_wf, "SET keepalive", ct).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception ex) { _log.LogDebug("kiwi.keepalive ended err={Err}", ex.Message); }
+    }
+
+    // Reads one full WebSocket message into buf. Returns (byteCount, isText);
+    // byteCount < 0 signals the socket closed.
+    private static async Task<(int, bool)> ReceiveMessageAsync(ClientWebSocket ws, byte[] buf, CancellationToken ct)
+    {
+        int offset = 0;
+        while (true)
+        {
+            var seg = new ArraySegment<byte>(buf, offset, buf.Length - offset);
+            WebSocketReceiveResult res;
+            try { res = await ws.ReceiveAsync(seg, ct).ConfigureAwait(false); }
+            catch (WebSocketException) { return (-1, false); }
+            if (res.MessageType == WebSocketMessageType.Close) return (-1, false);
+            offset += res.Count;
+            if (res.EndOfMessage)
+                return (offset, res.MessageType == WebSocketMessageType.Text);
+            if (offset >= buf.Length) return (offset, res.MessageType == WebSocketMessageType.Text); // drop overflow
+        }
+    }
+
+    private static bool TryParseDouble(ReadOnlySpan<char> s, out double v) =>
+        double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out v);
+
+    private static bool IsTag(byte[] b, char a, char c, char d) =>
+        b[0] == (byte)a && b[1] == (byte)c && b[2] == (byte)d;
+
+    public async Task StopAsync()
+    {
+        try { _cts?.Cancel(); } catch { /* already disposed */ }
+        await CloseSocketAsync(_snd).ConfigureAwait(false);
+        await CloseSocketAsync(_wf).ConfigureAwait(false);
+        StatusChanged?.Invoke("closed", null);
+    }
+
+    private static async Task CloseSocketAsync(ClientWebSocket? ws)
+    {
+        if (ws is null) return;
+        try
+        {
+            if (ws.State == WebSocketState.Open)
+                await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "bye", CancellationToken.None)
+                    .ConfigureAwait(false);
+        }
+        catch { /* best effort */ }
+        finally { ws.Dispose(); }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await StopAsync().ConfigureAwait(false);
+        _cts?.Dispose();
+    }
+}

--- a/Zeus.Server.Hosting/Kiwi/KiwiSdrService.cs
+++ b/Zeus.Server.Hosting/Kiwi/KiwiSdrService.cs
@@ -1,0 +1,599 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using Microsoft.Extensions.Hosting;
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Projects the optional KiwiSDR slice receiver into the unified
+/// <see cref="StateDto.Receivers"/> list. RadioService consumes this so the Kiwi
+/// receiver appears alongside the hardware DDCs without coupling RadioService to
+/// the Kiwi transport.
+/// </summary>
+public interface IKiwiReceiverProvider
+{
+    /// <summary>The Kiwi receiver entry, or null when the slice is disabled.</summary>
+    ReceiverDto? GetKiwiReceiver();
+
+    /// <summary>Fires whenever the Kiwi receiver entry changes (enable/disable,
+    /// tuning, mute) so RadioService can re-broadcast state.</summary>
+    event Action? KiwiReceiverChanged;
+}
+
+/// <summary>
+/// Pull-source for the Kiwi slice's demodulated audio. The Kiwi rides the SAME
+/// RX-audio mix bus as the hardware receivers: <c>DspPipelineService</c> drains
+/// this once per tick (clocked by RX1) and averages it into the single
+/// <c>RxId 0</c> output, so every sink (native + WebSocket) hears the Kiwi mixed
+/// with the local RX. This is why the Kiwi is NOT published as a second
+/// independent <see cref="AudioFrame"/> — two streams on one device ring would
+/// concatenate (the "super choppy" symptom) instead of mixing.
+/// </summary>
+public interface IKiwiAudioBus
+{
+    /// <summary>True when the slice is enabled, connected and un-muted — i.e.
+    /// it should contribute to the mix. A single relaxed read; when false the
+    /// DSP tick skips the Kiwi entirely.</summary>
+    bool AudioActive { get; }
+
+    /// <summary>Consumer side (DSP tick thread only). Drain up to
+    /// <c>dst.Length</c> resampled 48 kHz mono samples for mixing; returns the
+    /// count read. Lock-free.</summary>
+    int ReadAudio(Span<float> dst);
+}
+
+/// <summary>
+/// Owns the lifecycle of the KiwiSDR slice receiver: it opens a
+/// <see cref="KiwiSdrClient"/> to a remote KiwiSDR, turns the decoded audio +
+/// waterfall into the same <see cref="DisplayFrame"/> / <see cref="AudioFrame"/>
+/// wire frames a hardware DDC produces (tagged with
+/// <see cref="WireContract.KiwiReceiverIndex"/> so the frontend renders it as
+/// "Kiwi" beside RX1..RX6), and pushes Zeus tuning down to the Kiwi as SET
+/// commands. The Kiwi demodulates server-side, so this is a remote front-end —
+/// no WDSP channel is involved.
+/// </summary>
+public sealed class KiwiSdrService : BackgroundService, IKiwiReceiverProvider, IKiwiAudioBus
+{
+    private const int RxId = WireContract.KiwiReceiverIndex;
+    private const int OutRateHz = 48_000;
+    // Lock-free SPSC handoff from the Kiwi audio receive loop (producer) to the
+    // DSP mix tick (consumer). Power of two (~1.36 s @ 48 kHz). The Kiwi rides
+    // the same RX-audio mix bus as the hardware RXs (see IKiwiAudioBus).
+    private const int AudioBusCapacity = 65_536;
+    // Waterfall span at zoom level 1 (widest). The slider's zoom level (1..32,
+    // shared with the hardware RXs) divides this, so zoom 1 ≈ 192 kHz of band
+    // down to ≈ 6 kHz (single-signal) at zoom 32 — the Kiwi follows the same
+    // zoom gesture as every other receiver.
+    private const double FullSpanHz = 192_000;
+    // Fixed panadapter/waterfall width, matching the hardware DDC DisplayFrame
+    // width so the frontend renderer treats the Kiwi identically (and never
+    // resets on a per-row bin-count wobble).
+    private const ushort DisplayWidth = 2048;
+
+    private readonly KiwiSettingsStore _store;
+    private readonly StreamingHub _hub;
+    // Demodulated 48 kHz mono audio bus, drained by DspPipelineService each tick
+    // and averaged into the RX1-clocked mix (IKiwiAudioBus). Single producer
+    // (the SND receive loop, via OnAudio), single consumer (the DSP tick).
+    private readonly FloatSpscRing _audioBus = new(AudioBusCapacity);
+    // Reusable consumer-thread scratch for the drift drop in ReadAudio.
+    private readonly float[] _drainScratch = new float[2048];
+    private readonly ILogger<KiwiSdrService> _log;
+    private readonly ILoggerFactory _loggerFactory;
+
+    private readonly object _sync = new();
+    private KiwiSdrClient? _client;
+    private string _status = "disabled";
+    private string? _statusDetail;
+
+    // Projected Kiwi receiver tuning/state.
+    private bool _enabled;
+    private long _vfoHz = 14_200_000;       // demod (dial) frequency
+    private long _centerHz = 14_200_000;    // waterfall centre; frozen under CTUN
+    private RxMode _mode = RxMode.USB;
+    private int _filterLowHz = 100;
+    private int _filterHighHz = 2_850;
+    private bool _muted;
+    private int _zoomLevel = 1; // 1..32, shared zoom level (see /api/rx/zoom)
+
+    // Waterfall span for the current zoom level. Caller need not hold _sync.
+    private double CurrentSpanHz()
+    {
+        int z = Math.Clamp(Volatile.Read(ref _zoomLevel), 1, 32);
+        return FullSpanHz / z;
+    }
+
+    // Frame sequencing + audio resampling (48 kHz output from the ~12 kHz Kiwi).
+    private uint _displaySeq;
+    // 1 Hz rate instrumentation (bring-up): WF frames/s, audio frames/s, audio
+    // samples/s. All touched from both socket loop threads → Interlocked.
+    private long _rateWindowStartMs;
+    private int _wfFramesWindow;
+    private int _audioFramesWindow;
+    private long _audioSamplesWindow;
+    private double _resamplePhase;
+    private float _resamplePrev;
+    private int _resampleInRate;
+
+    public event Action? KiwiReceiverChanged;
+
+    public KiwiSdrService(
+        KiwiSettingsStore store,
+        StreamingHub hub,
+        ILoggerFactory loggerFactory)
+    {
+        _store = store;
+        _hub = hub;
+        _loggerFactory = loggerFactory;
+        _log = loggerFactory.CreateLogger<KiwiSdrService>();
+    }
+
+    // -------------------------------------------------------------------------
+    // IKiwiAudioBus — the Kiwi rides the SAME mix bus as the hardware RXs.
+    // -------------------------------------------------------------------------
+    public bool AudioActive
+    {
+        get { lock (_sync) return _enabled && !_muted && _client is not null; }
+    }
+
+    public int ReadAudio(Span<float> dst)
+    {
+        if (dst.Length == 0) return 0;
+        // Independent-clock drift guard. The remote KiwiSDR ADC runs on its own
+        // clock, so over a long session the bus slowly fills or drains relative
+        // to the radio that clocks the mix. If it has run ahead past the latency
+        // cap, drop the oldest excess so the monitor delay stays bounded (a
+        // remote RX tolerates a small fixed delay, but not an unbounded one).
+        int cap = OutRateHz / 4; // ~250 ms
+        int over = _audioBus.Count - (cap + dst.Length);
+        for (int dropped = 0; dropped < over;)
+        {
+            int chunk = Math.Min(over - dropped, _drainScratch.Length);
+            int n = _audioBus.Read(_drainScratch.AsSpan(0, chunk));
+            if (n <= 0) break;
+            dropped += n;
+        }
+        return _audioBus.Read(dst);
+    }
+
+    // Test seam: feed the audio bus directly (bypassing the live KiwiSdrClient)
+    // so the mix-bus drain + drift-cap behaviour of ReadAudio is unit-testable.
+    internal int EnqueueAudioForTest(ReadOnlySpan<float> samples) => _audioBus.Write(samples);
+    internal int AudioBusDepthForTest => _audioBus.Count;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Hydrate from persisted settings: reconnect a previously-enabled slice
+        // on startup (no hardware-safety constraint — unlike PureSignal — so a
+        // remote receiver may auto-resume).
+        var s = _store.Get();
+        lock (_sync) { _enabled = s.Enabled; }
+        if (s.Enabled && !string.IsNullOrWhiteSpace(s.Url))
+        {
+            try { await StartClientAsync(s.Url!, s.Password, stoppingToken).ConfigureAwait(false); }
+            catch (Exception ex) { _log.LogWarning("kiwi.startup.connect failed err={Err}", ex.Message); }
+        }
+        // Idle until shutdown; all work is event-driven off the client callbacks.
+        try { await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false); }
+        catch (OperationCanceledException) { }
+        await StopClientAsync().ConfigureAwait(false);
+    }
+
+    // -------------------------------------------------------------------------
+    // Public API (driven by the REST endpoints).
+    // -------------------------------------------------------------------------
+    public KiwiConfigDto GetConfig()
+    {
+        var s = _store.Get();
+        lock (_sync)
+            return new KiwiConfigDto(_enabled, s.Url, s.Password is not null, _status, _statusDetail);
+    }
+
+    public async Task<KiwiConfigDto> SetConfigAsync(bool? enabled, string? url, string? password, CancellationToken ct)
+    {
+        var s = _store.Set(enabled, url, password);
+        bool wantOn = s.Enabled && !string.IsNullOrWhiteSpace(s.Url);
+
+        await StopClientAsync().ConfigureAwait(false);
+        lock (_sync) { _enabled = s.Enabled; }
+
+        if (wantOn)
+        {
+            try { await StartClientAsync(s.Url!, s.Password, ct).ConfigureAwait(false); }
+            catch (Exception ex)
+            {
+                _log.LogWarning("kiwi.connect failed url={Url} err={Err}", s.Url, ex.Message);
+                lock (_sync) { _status = "error"; _statusDetail = ex.Message; }
+            }
+        }
+        else
+        {
+            lock (_sync) { _status = "disabled"; _statusDetail = null; }
+        }
+
+        RaiseChanged();
+        return GetConfig();
+    }
+
+    /// <summary>Apply tuning/mode/filter from the focused-RX controls (the
+    /// <c>/api/receivers/{KiwiReceiverIndex}</c> endpoint routes here).</summary>
+    public void SetTuning(long? vfoHz, RxMode? mode, int? filterLowHz, int? filterHighHz, bool ctun = false)
+    {
+        KiwiSdrClient? client;
+        long freq, center; RxMode m; int lo, hi;
+        lock (_sync)
+        {
+            if (vfoHz.HasValue)
+            {
+                _vfoHz = vfoHz.Value;
+                // CTUN off: the waterfall re-centres on the dial. CTUN on: the
+                // centre is frozen and only the demod (dial) moves within the
+                // displayed span — the whole point of click-tune.
+                if (!ctun) _centerHz = _vfoHz;
+            }
+            bool modeChanged = mode.HasValue && mode.Value != _mode;
+            if (mode.HasValue) _mode = mode.Value;
+            if (filterLowHz.HasValue) _filterLowHz = filterLowHz.Value;
+            if (filterHighHz.HasValue) _filterHighHz = filterHighHz.Value;
+            // On a mode change with no explicit filter, load that mode's default
+            // passband. The cuts are SIGNED for the KiwiSDR sideband convention
+            // (LSB/CWL are negative), so USB/LSB/AM/CW demod the correct sideband
+            // AND the projected ReceiverDto drives a matching on-screen overlay.
+            if (modeChanged && !filterLowHz.HasValue && !filterHighHz.HasValue)
+                (_filterLowHz, _filterHighHz) = DefaultPassband(_mode);
+            client = _client;
+            freq = _vfoHz; center = _centerHz; m = _mode; lo = _filterLowHz; hi = _filterHighHz;
+        }
+        client?.Tune(freq, center, KiwiMode(m), lo, hi, CurrentSpanHz());
+        RaiseChanged();
+    }
+
+    /// <summary>Pan the waterfall centre (the CTUN "LO"). The demod (dial) is
+    /// left where it is; only the displayed window moves. Routed from
+    /// <c>/api/receivers/{KiwiReceiverIndex}/lo</c>.</summary>
+    public void SetCenter(long centerHz)
+    {
+        KiwiSdrClient? client;
+        long freq, center; RxMode m; int lo, hi;
+        lock (_sync)
+        {
+            _centerHz = centerHz;
+            client = _client;
+            freq = _vfoHz; center = _centerHz; m = _mode; lo = _filterLowHz; hi = _filterHighHz;
+        }
+        client?.Tune(freq, center, KiwiMode(m), lo, hi, CurrentSpanHz());
+        RaiseChanged();
+    }
+
+    // Per-mode default passband edges (Hz, relative to carrier) in the KiwiSDR
+    // signed convention: upper-sideband positive, lower-sideband negative,
+    // double-sideband symmetric. low &lt; high always.
+    internal static (int Low, int High) DefaultPassband(RxMode mode) => mode switch
+    {
+        RxMode.LSB or RxMode.DIGL => (-2850, -100),
+        RxMode.USB or RxMode.DIGU or RxMode.FreeDv => (100, 2850),
+        RxMode.CWL => (-700, -300),
+        RxMode.CWU => (300, 700),
+        RxMode.AM or RxMode.SAM or RxMode.DSB => (-4000, 4000),
+        RxMode.FM => (-6000, 6000),
+        _ => (100, 2850),
+    };
+
+    public void SetMuted(bool muted)
+    {
+        lock (_sync) _muted = muted;
+        // Not clearing the bus here on purpose: SetMuted runs on the REST thread,
+        // and FloatSpscRing.Clear is a CONSUMER-side reset — racing it with the
+        // DSP tick's ReadAudio would break the single-consumer contract. While
+        // muted the producer stops writing and the consumer stops draining, so
+        // the bus simply freezes; on un-mute ReadAudio's drift cap trims it back
+        // to ~250 ms, bounding any stale-audio replay safely.
+        RaiseChanged();
+    }
+
+    /// <summary>Apply the global zoom level (1..32) to the Kiwi waterfall. The
+    /// span shrinks as the level grows (<see cref="FullSpanHz"/> / level); the
+    /// client re-tunes the remote KiwiSDR's <c>SET zoom</c> and starts emitting
+    /// frames at the new Hz/pixel, which the self-scaled frontend renders.</summary>
+    public void SetZoom(int level)
+    {
+        Volatile.Write(ref _zoomLevel, Math.Clamp(level, 1, 32));
+        KiwiSdrClient? client;
+        long freq, center; RxMode m; int lo, hi;
+        lock (_sync) { client = _client; freq = _vfoHz; center = _centerHz; m = _mode; lo = _filterLowHz; hi = _filterHighHz; }
+        double span = CurrentSpanHz();
+        _log.LogInformation("kiwi.zoom level={Level} spanHz={Span:F0}", _zoomLevel, span);
+        client?.Tune(freq, center, KiwiMode(m), lo, hi, span);
+    }
+
+    // -------------------------------------------------------------------------
+    // IKiwiReceiverProvider.
+    // -------------------------------------------------------------------------
+    public ReceiverDto? GetKiwiReceiver()
+    {
+        lock (_sync)
+        {
+            if (!_enabled) return null;
+            return new ReceiverDto(
+                Index: RxId,
+                Enabled: true,
+                AdcSource: 0,
+                VfoHz: _vfoHz,
+                Mode: _mode,
+                FilterLowHz: _filterLowHz,
+                FilterHighHz: _filterHighHz,
+                FilterPresetName: null,
+                AfGainDb: 0.0,
+                SampleRateHz: OutRateHz,
+                Muted: _muted,
+                Name: "Kiwi");
+        }
+    }
+
+    private void RaiseChanged()
+    {
+        try { KiwiReceiverChanged?.Invoke(); }
+        catch (Exception ex) { _log.LogDebug("kiwi.changed handler threw err={Err}", ex.Message); }
+    }
+
+    // -------------------------------------------------------------------------
+    // Client lifecycle + frame production.
+    // -------------------------------------------------------------------------
+    private async Task StartClientAsync(string url, string? password, CancellationToken ct)
+    {
+        if (!TryParseEndpoint(url, out var host, out var port, out var secure))
+        {
+            lock (_sync) { _status = "error"; _statusDetail = "invalid URL"; }
+            return;
+        }
+
+        var client = new KiwiSdrClient(host, port, secure, password, "ZeusSDR", _loggerFactory.CreateLogger<KiwiSdrClient>());
+        client.AudioReceived = OnAudio;
+        client.WaterfallReceived = OnWaterfall;
+        client.StatusChanged = OnClientStatus;
+        // SignalLevel is intentionally not wired: RxMeterFrame carries no RxId,
+        // so a Kiwi S-meter broadcast would overwrite RX1's meter. The
+        // panadapter/waterfall convey the Kiwi signal level visually.
+
+        lock (_sync)
+        {
+            _client = client;
+            _status = "connecting";
+            _statusDetail = $"{host}:{port}";
+            _resamplePhase = 0; _resamplePrev = 0; _resampleInRate = 0;
+        }
+        await client.StartAsync(ct).ConfigureAwait(false);
+
+        // Push the current tuning so the freshly-opened channel lands on the
+        // operator's frequency.
+        long freq, center; RxMode m; int lo, hi;
+        lock (_sync) { freq = _vfoHz; center = _centerHz; m = _mode; lo = _filterLowHz; hi = _filterHighHz; }
+        client.Tune(freq, center, KiwiMode(m), lo, hi, CurrentSpanHz());
+    }
+
+    private async Task StopClientAsync()
+    {
+        KiwiSdrClient? client;
+        lock (_sync) { client = _client; _client = null; }
+        if (client is not null)
+        {
+            try { await client.DisposeAsync().ConfigureAwait(false); }
+            catch (Exception ex) { _log.LogDebug("kiwi.stop err={Err}", ex.Message); }
+        }
+    }
+
+    private void OnClientStatus(string status, string? detail)
+    {
+        lock (_sync) { _status = status; _statusDetail = detail; }
+        RaiseChanged();
+    }
+
+    private void OnWaterfall(float[] binsDb, long centerHz, double hzPerBin)
+    {
+        if (binsDb.Length == 0) return;
+        // Resample the Kiwi's native bin count (~1024, and it can wobble by ±1
+        // between rows) to the fixed 2048-wide frame a hardware DDC produces.
+        // A constant width is load-bearing: the frontend renderer does a full
+        // reset (texture realloc) on any width change, so a per-row-varying width
+        // would thrash it (the "extremely laggy" symptom). hzPerPixel scales with
+        // the new width so the frequency mapping is unchanged.
+        Interlocked.Increment(ref _wfFramesWindow);
+        double span = binsDb.Length * hzPerBin;
+        var db = ResampleBins(binsDb, DisplayWidth);
+        var frame = new DisplayFrame(
+            Seq: unchecked(++_displaySeq),
+            TsUnixMs: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            RxId: RxId,
+            BodyFlags: DisplayBodyFlags.PanValid | DisplayBodyFlags.WfValid,
+            Width: DisplayWidth,
+            CenterHz: centerHz,
+            HzPerPixel: (float)(span / DisplayWidth),
+            // The Kiwi waterfall row is the spectrum; reuse it for both the
+            // panadapter trace and the waterfall history.
+            PanDb: db,
+            WfDb: db);
+        _hub.Broadcast(frame);
+    }
+
+    // Linear-interpolate a per-bin dB array to a fixed destination length.
+    private static float[] ResampleBins(float[] src, int dstLen)
+    {
+        var dst = new float[dstLen];
+        if (src.Length == dstLen) { Array.Copy(src, dst, dstLen); return dst; }
+        if (src.Length == 1) { Array.Fill(dst, src[0]); return dst; }
+        double scale = (double)(src.Length - 1) / (dstLen - 1);
+        for (int i = 0; i < dstLen; i++)
+        {
+            double pos = i * scale;
+            int i0 = (int)pos;
+            int i1 = Math.Min(i0 + 1, src.Length - 1);
+            float frac = (float)(pos - i0);
+            dst[i] = src[i0] + frac * (src[i1] - src[i0]);
+        }
+        return dst;
+    }
+
+    private void OnAudio(float[] samples, int inRateHz)
+    {
+        if (samples.Length == 0) return;
+        // Per-RX mute, mirroring the hardware secondary-RX path
+        // (DspPipelineService skips a muted receiver's audio contribution): when
+        // the Kiwi is muted we simply stop publishing its frames so it drops out
+        // of the client-side mix.
+        bool muted;
+        lock (_sync) muted = _muted;
+        if (muted) return;
+        var output = Resample(samples, inRateHz);
+        if (output.Length == 0) return;
+
+        // Hand the demodulated audio to the RX mix bus; DspPipelineService drains
+        // and averages it into the single RxId-0 output (IKiwiAudioBus), so the
+        // Kiwi mixes with the local RX instead of fighting it on the device ring.
+        // On overflow (no consumer draining — e.g. no radio connected to clock
+        // the mix) the ring drops the excess, the right bounded-latency policy
+        // for a live monitor receiver.
+        _audioBus.Write(output);
+
+        Interlocked.Increment(ref _audioFramesWindow);
+        Interlocked.Add(ref _audioSamplesWindow, output.Length);
+        LogRatesIfDue();
+    }
+
+    // Emit a 1 Hz rate line so we can see the real WF/audio cadence (audioSps
+    // should sit near 48000; a large excess means we're over-feeding the client
+    // audio buffer, the usual cause of growing latency / "lag").
+    private void LogRatesIfDue()
+    {
+        long now = Environment.TickCount64;
+        long start = Interlocked.Read(ref _rateWindowStartMs);
+        if (start == 0) { Interlocked.CompareExchange(ref _rateWindowStartMs, now, 0); return; }
+        if (now - start < 1000) return;
+        if (Interlocked.CompareExchange(ref _rateWindowStartMs, now, start) != start) return;
+        int wf = Interlocked.Exchange(ref _wfFramesWindow, 0);
+        int af = Interlocked.Exchange(ref _audioFramesWindow, 0);
+        long sps = Interlocked.Exchange(ref _audioSamplesWindow, 0);
+        double dt = (now - start) / 1000.0;
+        _log.LogDebug("kiwi.rate wfFps={Wf:F1} audioFps={Af:F1} audioSps={Sps:F0}",
+            wf / dt, af / dt, sps / dt);
+    }
+
+    // Linear-interpolation resampler from the native Kiwi rate (~12 kHz) to
+    // 48 kHz, carrying the fractional phase + last sample across frames so the
+    // stream stays continuous (no per-frame discontinuity click).
+    private float[] Resample(float[] input, int inRateHz)
+    {
+        if (inRateHz <= 0) inRateHz = 12_000;
+        if (inRateHz != _resampleInRate)
+        {
+            // Rate changed (or first frame): reset phase to avoid a transient.
+            _resampleInRate = inRateHz;
+            _resamplePhase = 0;
+            _resamplePrev = input[0];
+        }
+        double step = (double)inRateHz / OutRateHz; // input samples per output sample
+        // Worst-case output length plus a little slack.
+        var outList = new List<float>((int)(input.Length / step) + 2);
+        double phase = _resamplePhase;
+        float prev = _resamplePrev;
+        for (int i = 0; i < input.Length; i++)
+        {
+            float cur = input[i];
+            // Emit every output sample whose source position falls in [i-1, i].
+            while (phase < 1.0)
+            {
+                outList.Add(prev + (float)phase * (cur - prev));
+                phase += step;
+            }
+            phase -= 1.0;
+            prev = cur;
+        }
+        _resamplePhase = phase;
+        _resamplePrev = prev;
+        return outList.ToArray();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers.
+    // -------------------------------------------------------------------------
+    // Map a Zeus RX mode to a KiwiSDR demod word. The Kiwi demodulates
+    // server-side, so this is what the slice actually decodes.
+    internal static string KiwiMode(RxMode mode) => mode switch
+    {
+        RxMode.LSB or RxMode.DIGL => "lsb",
+        RxMode.USB or RxMode.DIGU or RxMode.FreeDv => "usb",
+        RxMode.CWL or RxMode.CWU => "cw",
+        RxMode.AM or RxMode.DSB => "am",
+        RxMode.SAM => "sam",
+        RxMode.FM => "nbfm",
+        _ => "usb",
+    };
+
+    // Back-compat overload (drops the secure flag) for call sites/tests that
+    // only need host+port.
+    internal static bool TryParseEndpoint(string url, out string host, out int port) =>
+        TryParseEndpoint(url, out host, out port, out _);
+
+    // Accepts "host", "host:port", "ws[s]://host[:port]", "http[s]://host[:port][/path]".
+    //
+    // The default port follows the URL SCHEME, which is load-bearing: ~half of
+    // the public KiwiSDR directory is published as "http://<id>.proxy.kiwisdr.com"
+    // with NO explicit port, and the kiwi proxy serves those on port 80 (the http
+    // default) — NOT 8073. Defaulting a scheme-less "http://" host to 8073 made
+    // every proxied receiver fail to connect (it would hang on the wrong port and
+    // the pane kept showing the previously-tuned receiver). So: http/ws → 80,
+    // https/wss → 443, and a BARE host with no scheme keeps the KiwiSDR default
+    // 8073. An explicit ":port" always wins. <paramref name="secure"/> selects
+    // ws:// vs wss:// for the actual socket.
+    internal static bool TryParseEndpoint(string url, out string host, out int port, out bool secure)
+    {
+        host = string.Empty;
+        port = 8073;
+        secure = false;
+        if (string.IsNullOrWhiteSpace(url)) return false;
+        var s = url.Trim();
+
+        int defaultPort = 8073;
+        int scheme = s.IndexOf("://", StringComparison.Ordinal);
+        if (scheme >= 0)
+        {
+            switch (s[..scheme].ToLowerInvariant())
+            {
+                case "https" or "wss": secure = true; defaultPort = 443; break;
+                case "http" or "ws": secure = false; defaultPort = 80; break;
+            }
+            s = s[(scheme + 3)..];
+        }
+        int slash = s.IndexOf('/');
+        if (slash >= 0) s = s[..slash];
+        if (s.Length == 0) return false;
+
+        int colon = s.LastIndexOf(':');
+        if (colon > 0)
+        {
+            var portStr = s[(colon + 1)..];
+            port = int.TryParse(portStr, out var p) && p is > 0 and <= 65535 ? p : defaultPort;
+            host = s[..colon];
+        }
+        else
+        {
+            host = s;
+            port = defaultPort;
+        }
+        return host.Length > 0;
+    }
+}

--- a/Zeus.Server.Hosting/Kiwi/KiwiSettingsStore.cs
+++ b/Zeus.Server.Hosting/Kiwi/KiwiSettingsStore.cs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+using LiteDB;
+
+namespace Zeus.Server;
+
+/// <summary>Persisted operator settings for the KiwiSDR slice receiver — the
+/// remote SDR URL, an optional password, and the enable flag. Lives in
+/// zeus-prefs.db (single global row) alongside the other non-sensitive
+/// preferences. The password is stored in clear text exactly as the QRZ / TCI
+/// stores keep their secrets in this DB; the API never returns it to clients
+/// (only a <c>HasPassword</c> bool).</summary>
+public sealed class KiwiSettingsStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<KiwiSettingsEntry> _entries;
+    private readonly ILogger<KiwiSettingsStore> _log;
+    private readonly object _sync = new();
+
+    /// <summary>Raised after a successful <see cref="Set"/>.</summary>
+    public event Action? Changed;
+
+    public KiwiSettingsStore(ILogger<KiwiSettingsStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _entries = _db.GetCollection<KiwiSettingsEntry>("kiwi_settings");
+        _log.LogInformation("KiwiSettingsStore initialized at {Path}", dbPath);
+    }
+
+    public KiwiSettings Get()
+    {
+        lock (_sync)
+        {
+            var e = _entries.FindAll().FirstOrDefault();
+            return e is null
+                ? new KiwiSettings(false, null, null)
+                : new KiwiSettings(e.Enabled, e.Url, e.Password);
+        }
+    }
+
+    /// <summary>Patch the stored settings. Null fields are left unchanged; an
+    /// empty <paramref name="password"/> string clears the stored password.</summary>
+    public KiwiSettings Set(bool? enabled = null, string? url = null, string? password = null)
+    {
+        lock (_sync)
+        {
+            var e = _entries.FindAll().FirstOrDefault() ?? new KiwiSettingsEntry { Id = 1 };
+            if (enabled.HasValue) e.Enabled = enabled.Value;
+            if (url is not null) e.Url = string.IsNullOrWhiteSpace(url) ? null : url.Trim();
+            if (password is not null) e.Password = password.Length == 0 ? null : password;
+            _entries.Upsert(e);
+            _log.LogInformation("kiwi.settings.set enabled={Enabled} url={Url} hasPw={HasPw}",
+                e.Enabled, e.Url, e.Password is not null);
+            Changed?.Invoke();
+            return new KiwiSettings(e.Enabled, e.Url, e.Password);
+        }
+    }
+
+    public void Dispose() => _db.Dispose();
+}
+
+/// <summary>Immutable snapshot of the persisted Kiwi settings.</summary>
+public sealed record KiwiSettings(bool Enabled, string? Url, string? Password);
+
+/// <summary>LiteDB row for <see cref="KiwiSettingsStore"/>.</summary>
+public sealed class KiwiSettingsEntry
+{
+    [BsonId] public int Id { get; set; } = 1;
+    public bool Enabled { get; set; }
+    public string? Url { get; set; }
+    public string? Password { get; set; }
+}

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -356,7 +356,13 @@ public sealed class RadioService : IDisposable
     // to its internal test-tone generator (dev / tests without a hub).
     private readonly Zeus.Protocol1.ITxIqSource? _txIqSource;
 
-    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, FilterPresetStore? filterPresetStore = null, Zeus.Protocol1.ITxIqSource? txIqSource = null, PreferredRadioStore? preferredRadioStore = null, PsSettingsStore? psStore = null, RadioStateStore? radioStateStore = null, CwSettingsStore? cwSettingsStore = null, TxAudioProfileStore? txAudioProfileStore = null, AntennaSettingsStore? antennaStore = null, AudioSettingsStore? audioStore = null, Nr3ModelStore? nr3ModelStore = null, Hl2GpioSettingsStore? hl2GpioStore = null, BandMemoryStore? bandMemoryStore = null)
+    // Optional non-hardware KiwiSDR slice receiver. When present its entry is
+    // appended to the projected receiver list (reserved index
+    // WireContract.KiwiReceiverIndex) and a change re-broadcasts state. Null in
+    // tests / hosts without the Kiwi feature wired.
+    private readonly IKiwiReceiverProvider? _kiwiReceiverProvider;
+
+    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, FilterPresetStore? filterPresetStore = null, Zeus.Protocol1.ITxIqSource? txIqSource = null, PreferredRadioStore? preferredRadioStore = null, PsSettingsStore? psStore = null, RadioStateStore? radioStateStore = null, CwSettingsStore? cwSettingsStore = null, TxAudioProfileStore? txAudioProfileStore = null, AntennaSettingsStore? antennaStore = null, AudioSettingsStore? audioStore = null, Nr3ModelStore? nr3ModelStore = null, Hl2GpioSettingsStore? hl2GpioStore = null, BandMemoryStore? bandMemoryStore = null, IKiwiReceiverProvider? kiwiReceiverProvider = null)
     {
         _loggerFactory = loggerFactory;
         _log = loggerFactory.CreateLogger<RadioService>();
@@ -390,6 +396,12 @@ public sealed class RadioService : IDisposable
             _hl2GpioStore.Changed += PushHl2Gpio;
         if (_preferredRadioStore is not null)
             _preferredRadioStore.Changed += RecomputePaAndPush;
+        // KiwiSDR slice: a change to the Kiwi receiver (enable/disable, tune,
+        // mute) re-projects + re-broadcasts state so the "Kiwi" entry appears /
+        // updates live on every client, exactly like a hardware DDC mutation.
+        _kiwiReceiverProvider = kiwiReceiverProvider;
+        if (_kiwiReceiverProvider is not null)
+            _kiwiReceiverProvider.KiwiReceiverChanged += () => StateChanged?.Invoke(Snapshot());
         _txIqSource = txIqSource;
         // Seed the on-board CW keyer config from persisted settings so a
         // reconnect after restart re-applies the operator's mode/speed
@@ -3761,6 +3773,12 @@ public sealed class RadioService : IDisposable
                 AfGainDb: e.AfGainDb, SampleRateHz: s.SampleRate,
                 Muted: e.Muted));
         }
+        // Non-hardware KiwiSDR slice (reserved index KiwiReceiverIndex). Appended
+        // out of the contiguous DDC run — it is a remote receiver, not a DDC, so
+        // it never participates in the no-gap cascade above. Null when disabled.
+        var kiwi = _kiwiReceiverProvider?.GetKiwiReceiver();
+        if (kiwi is not null)
+            list.Add(kiwi);
         return list;
     }
 

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -1152,10 +1152,23 @@ public static class ZeusEndpoints
         // Configure any receiver by index for full multi-DDC (RX1=0, RX2=1,
         // RX3+=2..). Index 0/1 delegate to the RX1/RX2 setters; index >= 2 drives
         // an extra hardware DDC. Only supplied fields change.
-        app.MapPost("/api/receivers/{index:int}", (int index, ReceiverSetRequest req, RadioService r) =>
+        app.MapPost("/api/receivers/{index:int}", (int index, ReceiverSetRequest req, RadioService r, KiwiSdrService kiwi) =>
         {
             if (index < 0 || index >= Zeus.Contracts.WireContract.MaxReceivers)
                 return Results.BadRequest(new { error = $"receiver index out of range (0..{Zeus.Contracts.WireContract.MaxReceivers - 1})" });
+            // The reserved Kiwi slot is a remote receiver, not a hardware DDC:
+            // route tuning/mode/filter to the Kiwi service (enable/disable + URL
+            // live on /api/kiwi). Returns the same StateDto so the projected Kiwi
+            // entry round-trips back to the client.
+            if (index == Zeus.Contracts.WireContract.KiwiReceiverIndex)
+            {
+                log.LogInformation("api.receivers.kiwi vfoHz={VfoHz} mode={Mode} low={Low} high={High}",
+                    req.VfoHz, req.Mode, req.FilterLowHz, req.FilterHighHz);
+                // CTUN on → freeze the waterfall centre and roam the dial within
+                // the displayed span; off → re-centre on the dial.
+                kiwi.SetTuning(req.VfoHz, req.Mode, req.FilterLowHz, req.FilterHighHz, r.Snapshot().CtunEnabled);
+                return Results.Ok(r.Snapshot());
+            }
             log.LogInformation(
                 "api.receivers index={Index} enabled={Enabled} vfoHz={VfoHz} adc={Adc} mode={Mode}",
                 index, req.Enabled, req.VfoHz, req.AdcSource, req.Mode);
@@ -1173,13 +1186,36 @@ public static class ZeusEndpoints
 
         // Per-RX audio mute (RX1=0, RX2=1, RX3+=2..). Mirrors Thetis chkMUT /
         // chkRX2Mute — silences only this receiver's contribution to the mix.
-        app.MapPost("/api/receivers/{index:int}/mute", (int index, MuteSetRequest req, RadioService r) =>
+        app.MapPost("/api/receivers/{index:int}/mute", (int index, MuteSetRequest req, RadioService r, KiwiSdrService kiwi) =>
         {
             if (index < 0 || index >= Zeus.Contracts.WireContract.MaxReceivers)
                 return Results.BadRequest(new { error = $"receiver index out of range (0..{Zeus.Contracts.WireContract.MaxReceivers - 1})" });
             log.LogInformation("api.receivers.mute index={Index} muted={Muted}", index, req.Muted);
+            if (index == Zeus.Contracts.WireContract.KiwiReceiverIndex)
+            {
+                kiwi.SetMuted(req.Muted);
+                return Results.Ok(r.Snapshot());
+            }
             return Results.Ok(r.SetReceiverMuted(index, req.Muted));
         });
+
+        // KiwiSDR slice receiver config. GET returns current status (never the
+        // stored password — only HasPassword); POST patches enable/url/password
+        // and (re)connects. The Kiwi appears as the "Kiwi" receiver beside the
+        // hardware RXs once enabled with a URL.
+        app.MapGet("/api/kiwi", (KiwiSdrService kiwi) => Results.Ok(kiwi.GetConfig()));
+        app.MapPost("/api/kiwi", async (KiwiSetRequest req, KiwiSdrService kiwi) =>
+        {
+            log.LogInformation("api.kiwi enabled={Enabled} url={Url} pwSet={PwSet}",
+                req.Enabled, req.Url, req.Password is not null);
+            return Results.Ok(await kiwi.SetConfigAsync(req.Enabled, req.Url, req.Password, default));
+        });
+
+        // Public KiwiSDR directory for the Settings → KIWI map picker. Proxied
+        // server-side (the source is plain HTTP — mixed-content/CORS blocked in
+        // the browser); cached a couple of minutes in KiwiDirectoryService.
+        app.MapGet("/api/kiwi/directory", async (KiwiDirectoryService dir, HttpContext ctx) =>
+            Results.Ok(await dir.GetAsync(ctx.RequestAborted)));
 
         // VFO lock (Thetis chkVFOLock): blocks operator dial tuning; CAT/TCI
         // still tune. Pure software guard, no hardware effect.
@@ -1262,7 +1298,7 @@ public static class ZeusEndpoints
         // /api/radio/lo's setter); index >= 1 recentres a secondary DDC (the
         // client keep-in-view autopan's analogue of SetRadioLo). No-op for P1
         // secondaries (shared NCO) / CTUN-off / disabled — see RequestSecondaryLo.
-        app.MapPost("/api/receivers/{index:int}/lo", (int index, RadioLoSetRequest req, RadioService r, DspPipelineService pipe) =>
+        app.MapPost("/api/receivers/{index:int}/lo", (int index, RadioLoSetRequest req, RadioService r, DspPipelineService pipe, KiwiSdrService kiwi) =>
         {
             if (req.Hz < 0 || req.Hz > 60_000_000)
             {
@@ -1270,6 +1306,12 @@ public static class ZeusEndpoints
                 return Results.BadRequest(new { error = "hz out of range [0, 60000000]" });
             }
             log.LogInformation("api.receivers.lo index={Index} hz={Hz}", index, req.Hz);
+            // Kiwi slice: pan its waterfall centre (no hardware DDC behind it).
+            if (index == Zeus.Contracts.WireContract.KiwiReceiverIndex)
+            {
+                kiwi.SetCenter(req.Hz);
+                return Results.Ok(r.Snapshot());
+            }
             if (index <= 0) return Results.Ok(r.SetRadioLo(req.Hz));
             pipe.RequestSecondaryLo(index, req.Hz);
             return Results.Ok(r.Snapshot());
@@ -2012,11 +2054,15 @@ public static class ZeusEndpoints
             return Results.Ok(saved);
         });
 
-        app.MapPost("/api/rx/zoom", (ZoomSetRequest req, RadioService r) =>
+        app.MapPost("/api/rx/zoom", (ZoomSetRequest req, RadioService r, KiwiSdrService kiwi) =>
         {
             log.LogInformation("api.rx.zoom level={Level}", req.Level);
             if (req.Level < SyntheticDspEngine.MinZoomLevel || req.Level > SyntheticDspEngine.MaxZoomLevel)
                 return Results.BadRequest(new { error = $"zoom level must be in [{SyntheticDspEngine.MinZoomLevel},{SyntheticDspEngine.MaxZoomLevel}]; got {req.Level}" });
+            // Zoom is a global setting; mirror it onto the Kiwi slice so its
+            // waterfall span follows the slider too (it re-tunes the remote
+            // KiwiSDR's SET zoom and re-emits frames at the new Hz/pixel).
+            kiwi.SetZoom(req.Level);
             return Results.Ok(r.SetZoom(req.Level));
         });
 

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -311,6 +311,24 @@ public static class ZeusHost
         // resolves it and wires the Changed → PushHl2Gpio push. Shares
         // zeus-prefs.db (single global row); HL2-only on the wire.
         builder.Services.AddSingleton<Hl2GpioSettingsStore>();
+        // KiwiSDR slice receiver. The settings store persists the URL/password/
+        // enable flag; KiwiSdrService owns the remote connection and projects the
+        // "Kiwi" receiver into RadioService's receiver list via
+        // IKiwiReceiverProvider (registered below, BEFORE RadioService resolves so
+        // its optional ctor param is satisfied). Hosted so it (re)connects at
+        // startup and tears down on shutdown. No DI cycle: it depends only on the
+        // hub + settings store, never on RadioService. Its demodulated audio is
+        // pulled onto the shared RX mix bus by DspPipelineService via
+        // IKiwiAudioBus (registered here so the DSP service's optional ctor param
+        // resolves) — so the Kiwi mixes with the local RX rather than being a
+        // second device stream.
+        builder.Services.AddSingleton<KiwiSettingsStore>();
+        builder.Services.AddSingleton<KiwiSdrService>();
+        // Public KiwiSDR directory proxy for the Settings map picker.
+        builder.Services.AddSingleton<KiwiDirectoryService>();
+        builder.Services.AddSingleton<IKiwiReceiverProvider>(sp => sp.GetRequiredService<KiwiSdrService>());
+        builder.Services.AddSingleton<IKiwiAudioBus>(sp => sp.GetRequiredService<KiwiSdrService>());
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<KiwiSdrService>());
         builder.Services.AddSingleton<RadioService>();
         // Frees a Busy radio (drops its current owner) so the operator can take
         // it over from the Connect panel. Stateless — opens its own socket.

--- a/tests/Zeus.Server.Tests/KiwiSdrTests.cs
+++ b/tests/Zeus.Server.Tests/KiwiSdrTests.cs
@@ -1,0 +1,299 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+// KiwiSDR slice receiver: the Zeus-mode -> Kiwi demod word mapping, URL/endpoint
+// parsing, the persisted settings round-trip, and the IKiwiReceiverProvider
+// projection into RadioService's unified receiver list (reserved index
+// WireContract.KiwiReceiverIndex, labelled "Kiwi").
+public sealed class KiwiSdrTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-kiwi-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        foreach (var suffix in new[] { "", ".pa", ".dsp", ".kiwi" })
+        {
+            try { if (File.Exists(_dbPath + suffix)) File.Delete(_dbPath + suffix); } catch { }
+        }
+    }
+
+    [Theory]
+    [InlineData(RxMode.USB, "usb")]
+    [InlineData(RxMode.DIGU, "usb")]
+    [InlineData(RxMode.FreeDv, "usb")]
+    [InlineData(RxMode.LSB, "lsb")]
+    [InlineData(RxMode.DIGL, "lsb")]
+    [InlineData(RxMode.AM, "am")]
+    [InlineData(RxMode.DSB, "am")]
+    [InlineData(RxMode.SAM, "sam")]
+    [InlineData(RxMode.FM, "nbfm")]
+    [InlineData(RxMode.CWL, "cw")]
+    [InlineData(RxMode.CWU, "cw")]
+    public void KiwiMode_maps_zeus_mode_to_kiwi_word(RxMode mode, string expected)
+    {
+        Assert.Equal(expected, KiwiSdrService.KiwiMode(mode));
+    }
+
+    [Theory]
+    [InlineData("sdr.example.org", "sdr.example.org", 8073)]
+    [InlineData("sdr.example.org:8074", "sdr.example.org", 8074)]
+    [InlineData("ws://sdr.example.org:8075", "sdr.example.org", 8075)]
+    [InlineData("http://sdr.example.org:8076/", "sdr.example.org", 8076)]
+    [InlineData("http://sdr.example.org:8077/path/here", "sdr.example.org", 8077)]
+    [InlineData("  sdr.example.org:8078  ", "sdr.example.org", 8078)]
+    public void TryParseEndpoint_handles_url_forms(string url, string expHost, int expPort)
+    {
+        Assert.True(KiwiSdrService.TryParseEndpoint(url, out var host, out var port));
+        Assert.Equal(expHost, host);
+        Assert.Equal(expPort, port);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("ws://")]
+    public void TryParseEndpoint_rejects_empty(string url)
+    {
+        Assert.False(KiwiSdrService.TryParseEndpoint(url, out _, out _));
+    }
+
+    [Theory]
+    // A bare host (no scheme, no port) keeps the KiwiSDR default 8073.
+    [InlineData("sdr.example.org", "sdr.example.org", 8073, false)]
+    // http/ws with NO port → 80 (the kiwi proxy default — ~half the directory).
+    [InlineData("http://pb8w.proxy.kiwisdr.com", "pb8w.proxy.kiwisdr.com", 80, false)]
+    [InlineData("ws://sdr.example.org", "sdr.example.org", 80, false)]
+    // https/wss with NO port → 443 + secure.
+    [InlineData("https://sdr.example.org", "sdr.example.org", 443, true)]
+    [InlineData("wss://sdr.example.org/path", "sdr.example.org", 443, true)]
+    // An explicit :port always wins over the scheme default.
+    [InlineData("http://sdr.example.org:8076/", "sdr.example.org", 8076, false)]
+    [InlineData("sdr.example.org:8074", "sdr.example.org", 8074, false)]
+    public void TryParseEndpoint_port_follows_scheme(string url, string expHost, int expPort, bool expSecure)
+    {
+        Assert.True(KiwiSdrService.TryParseEndpoint(url, out var host, out var port, out var secure));
+        Assert.Equal(expHost, host);
+        Assert.Equal(expPort, port);
+        Assert.Equal(expSecure, secure);
+    }
+
+    [Theory]
+    [InlineData(RxMode.USB, 100, 2850)]
+    [InlineData(RxMode.DIGU, 100, 2850)]
+    [InlineData(RxMode.LSB, -2850, -100)]
+    [InlineData(RxMode.DIGL, -2850, -100)]
+    [InlineData(RxMode.AM, -4000, 4000)]
+    [InlineData(RxMode.SAM, -4000, 4000)]
+    [InlineData(RxMode.CWU, 300, 700)]
+    [InlineData(RxMode.CWL, -700, -300)]
+    [InlineData(RxMode.FM, -6000, 6000)]
+    public void DefaultPassband_is_signed_for_the_sideband(RxMode mode, int low, int high)
+    {
+        var (lo, hi) = KiwiSdrService.DefaultPassband(mode);
+        Assert.Equal(low, lo);
+        Assert.Equal(high, hi);
+        Assert.True(lo < hi); // KiwiSDR requires low_cut < high_cut
+    }
+
+    [Fact]
+    public void SettingsStore_round_trips_and_empty_password_clears()
+    {
+        using var store = new KiwiSettingsStore(NullLogger<KiwiSettingsStore>.Instance, _dbPath + ".kiwi");
+
+        // Default: disabled, nothing stored.
+        var def = store.Get();
+        Assert.False(def.Enabled);
+        Assert.Null(def.Url);
+        Assert.Null(def.Password);
+
+        store.Set(enabled: true, url: "sdr.example.org:8073", password: "secret");
+        var s1 = store.Get();
+        Assert.True(s1.Enabled);
+        Assert.Equal("sdr.example.org:8073", s1.Url);
+        Assert.Equal("secret", s1.Password);
+
+        // null password leaves it unchanged; empty string clears it.
+        store.Set(enabled: null, url: null, password: null);
+        Assert.Equal("secret", store.Get().Password);
+        store.Set(password: "");
+        Assert.Null(store.Get().Password);
+    }
+
+    [Fact]
+    public void RadioService_appends_kiwi_receiver_when_provider_returns_one()
+    {
+        using var pa = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance, _dbPath + ".pa");
+        using var dsp = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance, _dbPath + ".dsp");
+        var provider = new FakeKiwiProvider();
+        var radio = new RadioService(NullLoggerFactory.Instance, dsp, pa, kiwiReceiverProvider: provider);
+
+        // Disabled: no Kiwi entry in the projected list.
+        Assert.DoesNotContain(
+            radio.Snapshot().Receivers!,
+            r => r.Index == WireContract.KiwiReceiverIndex);
+
+        // Enabled: the projected list carries the named entry at the reserved index.
+        provider.Receiver = new ReceiverDto(
+            Index: WireContract.KiwiReceiverIndex, Enabled: true, AdcSource: 0,
+            VfoHz: 7_055_000, Mode: RxMode.AM,
+            FilterLowHz: -4_000, FilterHighHz: 4_000, FilterPresetName: null,
+            AfGainDb: 0, SampleRateHz: 48_000, Muted: false, Name: "Kiwi");
+
+        var kiwi = radio.Snapshot().Receivers!.Single(r => r.Index == WireContract.KiwiReceiverIndex);
+        Assert.Equal("Kiwi", kiwi.Name);
+        Assert.Equal(7_055_000, kiwi.VfoHz);
+        Assert.Equal(RxMode.AM, kiwi.Mode);
+    }
+
+    // ---- IKiwiAudioBus: the Kiwi rides the shared RX mix bus ----------------
+
+    private KiwiSdrService NewService() => new(
+        new KiwiSettingsStore(NullLogger<KiwiSettingsStore>.Instance, _dbPath + ".kiwi"),
+        new StreamingHub(NullLogger<StreamingHub>.Instance),
+        NullLoggerFactory.Instance);
+
+    [Fact]
+    public void AudioActive_is_false_until_enabled_and_connected()
+    {
+        using var svc = NewService();
+        // Disabled by default → nothing to mix; the DSP tick skips the Kiwi.
+        Assert.False(svc.AudioActive);
+    }
+
+    [Fact]
+    public void ReadAudio_drains_what_was_enqueued_in_order()
+    {
+        using var svc = NewService();
+        svc.EnqueueAudioForTest(new float[] { 0.1f, 0.2f, 0.3f });
+
+        var dst = new float[5];
+        int n = svc.ReadAudio(dst);
+
+        Assert.Equal(3, n);
+        Assert.Equal(0.1f, dst[0]);
+        Assert.Equal(0.2f, dst[1]);
+        Assert.Equal(0.3f, dst[2]);
+        // Fully drained.
+        Assert.Equal(0, svc.ReadAudio(dst));
+    }
+
+    [Fact]
+    public void ReadAudio_drops_oldest_when_over_the_latency_cap()
+    {
+        using var svc = NewService();
+        // The remote runs on its own clock; if the bus runs far ahead of the
+        // radio that drains it, ReadAudio caps buffered latency to ~250 ms
+        // (12 000 samples @ 48 kHz) + the read size, dropping the OLDEST excess.
+        const int total = 30_000;
+        var enq = new float[total];
+        for (int i = 0; i < total; i++) enq[i] = i;        // ascending = age marker
+        svc.EnqueueAudioForTest(enq);
+
+        var dst = new float[1024];
+        int n = svc.ReadAudio(dst);
+
+        Assert.Equal(1024, n);
+        // After the drop, buffered depth must be within the cap (not the full
+        // 30 000) so monitor latency stays bounded.
+        Assert.True(svc.AudioBusDepthForTest <= 12_000,
+            $"expected bounded buffer, got {svc.AudioBusDepthForTest}");
+        // The samples returned are the NEWEST, not the stale head: the oldest
+        // were discarded, so the first returned sample is well past index 0.
+        Assert.True(dst[0] >= total - 12_000 - 1024,
+            $"expected freshest samples, got {dst[0]}");
+    }
+
+    // ---- KiwiDirectoryService: parse the public receiver list ---------------
+
+    [Theory]
+    [InlineData("(50.850000, -0.660000)", 50.85, -0.66)]
+    [InlineData("( 12.0 , -3.5 )", 12.0, -3.5)]
+    public void TryParseGps_parses_lat_lon(string gps, double lat, double lon)
+    {
+        Assert.True(KiwiDirectoryService.TryParseGps(gps, out var la, out var lo));
+        Assert.Equal(lat, la, 3);
+        Assert.Equal(lon, lo, 3);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("(0, 0)")]          // Null Island placeholder — rejected
+    [InlineData("(200, 5)")]        // out of range
+    [InlineData("not coords")]
+    public void TryParseGps_rejects_bad_or_placeholder(string gps)
+    {
+        Assert.False(KiwiDirectoryService.TryParseGps(gps, out _, out _));
+    }
+
+    [Fact]
+    public void Parse_extracts_receivers_from_the_js_wrapper()
+    {
+        const string body = """
+            // KiwiSDR.com receiver list
+            // banner comment
+            var kiwisdr_com =
+            [
+                {"name":"Chichester UK","url":"http://g8ure.ddns.net:8077","gps":"(50.85, -0.66)","users":"2","users_max":"4","offline":"no","status":"active","loc":"Chichester UK","snr":"42,45"},
+                {"name":"No GPS","url":"http://nogps.example:8073","users":"0","users_max":"8"},
+                {"name":"No URL","gps":"(10, 10)"},
+                {"name":"Dead","url":"http://dead.example:8073","gps":"(5, 5)","offline":"yes"}
+            ]
+            """;
+
+        var list = KiwiDirectoryService.Parse(body);
+
+        // Only the two entries with BOTH url and valid gps survive.
+        Assert.Equal(2, list.Count);
+        var ch = list[0];
+        Assert.Equal("Chichester UK", ch.Name);
+        Assert.Equal("http://g8ure.ddns.net:8077", ch.Url);
+        Assert.Equal(50.85, ch.Lat, 3);
+        Assert.Equal(-0.66, ch.Lon, 3);
+        Assert.Equal(2, ch.Users);
+        Assert.Equal(4, ch.UsersMax);
+        Assert.True(ch.Online);
+        // The url survives KiwiSdrService's own endpoint parser (round-trip).
+        Assert.True(KiwiSdrService.TryParseEndpoint(ch.Url, out _, out var port));
+        Assert.Equal(8077, port);
+        // The offline="yes" receiver is parsed but flagged not-online.
+        Assert.False(list[1].Online);
+    }
+
+    [Fact]
+    public void Parse_returns_empty_on_garbage()
+    {
+        Assert.Empty(KiwiDirectoryService.Parse(""));
+        Assert.Empty(KiwiDirectoryService.Parse("not json at all"));
+    }
+
+    [Fact]
+    public void Parse_tolerates_the_trailing_comma_the_generator_emits()
+    {
+        // The real rx.linkfanel.net file ends the array with `},\n]` — a trailing
+        // comma that System.Text.Json rejects by default. Regression guard.
+        const string body = """
+            // banner
+            var kiwisdr_com =
+            [
+                {"name":"A","url":"http://a.example:8073","gps":"(1, 2)"},
+                {"name":"B","url":"http://b.example:8073","gps":"(3, 4)"},
+            ]
+            ;
+            """;
+        var list = KiwiDirectoryService.Parse(body);
+        Assert.Equal(2, list.Count);
+        Assert.Equal("http://b.example:8073", list[1].Url);
+    }
+
+    private sealed class FakeKiwiProvider : IKiwiReceiverProvider
+    {
+        public ReceiverDto? Receiver;
+        public event Action? KiwiReceiverChanged;
+        public ReceiverDto? GetKiwiReceiver() => Receiver;
+        public void Raise() => KiwiReceiverChanged?.Invoke();
+    }
+}

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -418,6 +418,10 @@ export type RadioStateDto = {
 export type ReceiverDto = {
   index: number;
   enabled: boolean;
+  // Operator-facing display name. Hardware DDCs leave this null and fall back to
+  // an "RX{n}" label; the reserved KiwiSDR slice receiver (index
+  // WireContract.KiwiReceiverIndex) carries "Kiwi". See receiverLabel().
+  name?: string | null;
   // Which phase-synchronous 16-bit ADC feeds this DDC (0 or 1).
   adcSource: number;
   vfoHz: number;
@@ -430,6 +434,31 @@ export type ReceiverDto = {
   // Per-receiver audio mute (Thetis chkMUT/chkRX2Mute). The hero mixer + VFO
   // panel drive this via POST /api/receivers/{index}/mute.
   muted: boolean;
+};
+
+// Mirrors Zeus.Contracts.KiwiConfigDto — status of the KiwiSDR slice receiver.
+// `hasPassword` avoids ever shipping the stored secret to the client; `status`
+// is one of "disabled" | "connecting" | "connected" | "error" | "closed".
+export type KiwiConfigDto = {
+  enabled: boolean;
+  url: string | null;
+  hasPassword: boolean;
+  status: string;
+  statusDetail: string | null;
+};
+
+// Mirrors Zeus.Server.KiwiDirectoryEntry — one public KiwiSDR for the map
+// picker. `url` is the address to store/connect; `lat`/`lon` place the marker.
+export type KiwiDirectoryEntry = {
+  name: string;
+  url: string;
+  lat: number;
+  lon: number;
+  users: number;
+  usersMax: number;
+  online: boolean;
+  location: string | null;
+  snr: string | null;
 };
 
 // CFC mirrors Zeus.Contracts.CfcConfig. Bands array is fixed at 10 entries
@@ -2327,6 +2356,7 @@ function normalizeReceiver(raw: unknown, fallbackIndex: number): ReceiverDto {
   return {
     index: typeof r.index === 'number' ? r.index : fallbackIndex,
     enabled: typeof r.enabled === 'boolean' ? r.enabled : false,
+    name: typeof r.name === 'string' ? r.name : null,
     adcSource: typeof r.adcSource === 'number' ? r.adcSource : 0,
     vfoHz: typeof r.vfoHz === 'number' ? r.vfoHz : 0,
     mode: normalizeMode(r.mode),
@@ -6806,6 +6836,50 @@ export async function setTwoTone(
       signal,
     },
     (raw) => raw as RadioStateDto,
+  );
+}
+
+// Normalise a wire KiwiConfigDto, tolerating an older/partial server response.
+function normalizeKiwiConfig(raw: unknown): KiwiConfigDto {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  return {
+    enabled: typeof r.enabled === 'boolean' ? r.enabled : false,
+    url: typeof r.url === 'string' ? r.url : null,
+    hasPassword: typeof r.hasPassword === 'boolean' ? r.hasPassword : false,
+    status: typeof r.status === 'string' ? r.status : 'disabled',
+    statusDetail: typeof r.statusDetail === 'string' ? r.statusDetail : null,
+  };
+}
+
+// KiwiSDR slice receiver: GET /api/kiwi → current config + connection status.
+export async function getKiwiConfig(signal?: AbortSignal): Promise<KiwiConfigDto> {
+  return jsonFetch('/api/kiwi', { signal }, (raw) => normalizeKiwiConfig(raw));
+}
+
+// KiwiSDR slice receiver: POST /api/kiwi → apply config, returns updated status.
+// Only supplied fields change. An empty-string `password` clears the stored
+// password; omitting it leaves it unchanged.
+export async function setKiwiConfig(
+  req: { enabled?: boolean; url?: string; password?: string },
+  signal?: AbortSignal,
+): Promise<KiwiConfigDto> {
+  return jsonFetch(
+    '/api/kiwi',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(req),
+      signal,
+    },
+    (raw) => normalizeKiwiConfig(raw),
+  );
+}
+
+// Public KiwiSDR directory: GET /api/kiwi/directory → receivers for the map
+// picker. Proxied + cached server-side. Returns [] on any upstream failure.
+export async function getKiwiDirectory(signal?: AbortSignal): Promise<KiwiDirectoryEntry[]> {
+  return jsonFetch('/api/kiwi/directory', { signal }, (raw) =>
+    Array.isArray(raw) ? (raw as KiwiDirectoryEntry[]) : [],
   );
 }
 

--- a/zeus-web/src/components/KiwiMapPicker.tsx
+++ b/zeus-web/src/components/KiwiMapPicker.tsx
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// KiwiMapPicker — a world map of public KiwiSDR receivers for Settings → KIWI.
+// Each marker is one receiver from the kiwisdr.com directory (proxied + cached
+// by the server at /api/kiwi/directory). Clicking a marker passes its address
+// up to the panel, which stores it as the Kiwi URL. Reuses the same Leaflet +
+// CARTO dark basemap the Lightning map uses; marker colours are hex (SVG stroke
+// attributes can't resolve CSS vars) but track the Zeus palette: accent blue =
+// free slot, tx red = full, grey = offline.
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import { getKiwiDirectory, type KiwiDirectoryEntry } from '../api/client';
+
+const TILE_URL = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
+const TILE_ATTRIBUTION =
+  '&copy; <a href="https://www.openstreetmap.org/copyright">OSM</a> &copy; ' +
+  '<a href="https://carto.com/attributions">CARTO</a> · receivers &copy; ' +
+  '<a href="http://kiwisdr.com/public/">kiwisdr.com</a>';
+
+// Palette-matched hex (tokens.css): --accent, --tx, --power, plus a neutral grey.
+const COLOR_FREE = '#4a9eff';
+const COLOR_FULL = '#e63a2b';
+const COLOR_OFFLINE = '#6b7280';
+const COLOR_SELECTED = '#ffc93a';
+
+function baseColor(e: KiwiDirectoryEntry): string {
+  if (!e.online) return COLOR_OFFLINE;
+  if (e.usersMax > 0 && e.users >= e.usersMax) return COLOR_FULL;
+  return COLOR_FREE;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c] ?? c,
+  );
+}
+
+export function KiwiMapPicker({
+  selectedUrl,
+  onSelect,
+}: {
+  selectedUrl: string;
+  onSelect: (url: string) => void;
+}) {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<L.Map | null>(null);
+  const layerRef = useRef<L.LayerGroup | null>(null);
+  const markersRef = useRef<Map<string, L.CircleMarker>>(new Map());
+
+  // Keep the latest onSelect in a ref so the mount-once marker handlers never
+  // capture a stale closure.
+  const onSelectRef = useRef(onSelect);
+  useEffect(() => {
+    onSelectRef.current = onSelect;
+  }, [onSelect]);
+
+  const [entries, setEntries] = useState<KiwiDirectoryEntry[]>([]);
+  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+
+  const counts = useMemo(() => {
+    let free = 0;
+    let online = 0;
+    for (const e of entries) {
+      if (e.online) online += 1;
+      if (e.online && (e.usersMax === 0 || e.users < e.usersMax)) free += 1;
+    }
+    return { total: entries.length, online, free };
+  }, [entries]);
+
+  // ── Leaflet map init (mount once) ──────────────────────────────────────────
+  useEffect(() => {
+    const el = hostRef.current;
+    if (!el || mapRef.current) return;
+    const map = L.map(el, {
+      center: [25, 5],
+      zoom: 2,
+      minZoom: 1,
+      maxZoom: 12,
+      worldCopyJump: true,
+      zoomControl: true,
+      attributionControl: true,
+      maxBounds: L.latLngBounds([-85, -220], [85, 220]),
+      maxBoundsViscosity: 0.7,
+    });
+    L.tileLayer(TILE_URL, {
+      attribution: TILE_ATTRIBUTION,
+      subdomains: 'abcd',
+      maxZoom: 19,
+      detectRetina: true,
+    }).addTo(map);
+    layerRef.current = L.layerGroup().addTo(map);
+    mapRef.current = map;
+
+    const ro = new ResizeObserver(() => map.invalidateSize());
+    ro.observe(el);
+    return () => {
+      ro.disconnect();
+      map.remove();
+      mapRef.current = null;
+      layerRef.current = null;
+      markersRef.current.clear();
+    };
+  }, []);
+
+  // ── Fetch the public directory once ────────────────────────────────────────
+  useEffect(() => {
+    const ctrl = new AbortController();
+    setStatus('loading');
+    getKiwiDirectory(ctrl.signal)
+      .then((list) => {
+        setEntries(list);
+        setStatus(list.length > 0 ? 'ready' : 'error');
+      })
+      .catch(() => setStatus('error'));
+    return () => ctrl.abort();
+  }, []);
+
+  // ── (Re)build markers when the directory changes ───────────────────────────
+  useEffect(() => {
+    const layer = layerRef.current;
+    if (!layer) return;
+    layer.clearLayers();
+    markersRef.current.clear();
+    for (const e of entries) {
+      const color = baseColor(e);
+      const m = L.circleMarker([e.lat, e.lon], {
+        radius: 5,
+        color,
+        weight: 1.5,
+        fillColor: color,
+        fillOpacity: 0.55,
+      });
+      const usersLabel = e.usersMax > 0 ? `${e.users}/${e.usersMax} users` : `${e.users} users`;
+      m.bindTooltip(
+        `<b>${escapeHtml(e.name)}</b><br>` +
+          (e.location ? `${escapeHtml(e.location)}<br>` : '') +
+          `${usersLabel}${e.snr ? ` · SNR ${escapeHtml(e.snr)}` : ''}<br>` +
+          `<span style="opacity:.65">${escapeHtml(e.url)}</span>`,
+        { direction: 'top', opacity: 0.95 },
+      );
+      m.on('click', () => onSelectRef.current(e.url));
+      m.addTo(layer);
+      markersRef.current.set(e.url, m);
+    }
+  }, [entries]);
+
+  // ── Highlight the currently-selected receiver ──────────────────────────────
+  useEffect(() => {
+    for (const [url, m] of markersRef.current) {
+      const e = entries.find((x) => x.url === url);
+      const base = e ? baseColor(e) : COLOR_FREE;
+      if (url === selectedUrl) {
+        m.setStyle({ radius: 8, weight: 3, color: COLOR_SELECTED, fillColor: base, fillOpacity: 0.85 });
+        m.bringToFront();
+      } else {
+        m.setStyle({ radius: 5, weight: 1.5, color: base, fillColor: base, fillOpacity: 0.55 });
+      }
+    }
+  }, [selectedUrl, entries]);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      <div
+        ref={hostRef}
+        style={{
+          height: 360,
+          width: '100%',
+          borderRadius: 'var(--r-sm)',
+          overflow: 'hidden',
+          border: '1px solid var(--panel-border)',
+          background: 'var(--bg-0)',
+        }}
+      />
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          fontSize: 10,
+          color: 'var(--fg-3)',
+        }}
+      >
+        {status === 'loading' && <span>Loading public KiwiSDR directory…</span>}
+        {status === 'error' && (
+          <span style={{ color: 'var(--tx)' }}>
+            Directory unavailable — enter a URL manually below.
+          </span>
+        )}
+        {status === 'ready' && (
+          <>
+            <span>
+              {counts.total} receivers · {counts.free} with free slots
+            </span>
+            <span style={{ flex: 1 }} />
+            <Legend color={COLOR_FREE} label="free" />
+            <Legend color={COLOR_FULL} label="full" />
+            <Legend color={COLOR_OFFLINE} label="offline" />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Legend({ color, label }: { color: string; label: string }) {
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+      <span
+        style={{
+          width: 8,
+          height: 8,
+          borderRadius: '50%',
+          background: color,
+          display: 'inline-block',
+        }}
+      />
+      {label}
+    </span>
+  );
+}

--- a/zeus-web/src/components/KiwiSettingsPanel.tsx
+++ b/zeus-web/src/components/KiwiSettingsPanel.tsx
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// KiwiSettingsPanel — Settings → KIWI SDR tab. Configures the KiwiSDR slice
+// receiver: enable/disable, the KiwiSDR base URL or host:port, an optional
+// password, and the live connection status. The Kiwi appears alongside the
+// hardware RXs (reserved index WireContract.KiwiReceiverIndex) and renders its
+// own panadapter/waterfall/audio like a hardware DDC.
+//
+// Wires to GET/POST /api/kiwi via getKiwiConfig()/setKiwiConfig(). Mirrors the
+// RotatorSettingsPanel card idiom (tokens only — no raw hex).
+
+import { useEffect, useState } from 'react';
+import { ApiError, getKiwiConfig, setKiwiConfig, type KiwiConfigDto } from '../api/client';
+import { KiwiMapPicker } from './KiwiMapPicker';
+
+export function KiwiSettingsPanel() {
+  const [config, setConfig] = useState<KiwiConfigDto | null>(null);
+  const [enabled, setEnabled] = useState(false);
+  const [url, setUrl] = useState('');
+  // The password is write-only from the client's view — the server returns only
+  // `hasPassword`, never the secret. Empty input + hasPassword means "keep the
+  // stored password"; the operator types a new one only to change/clear it.
+  const [password, setPassword] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showMap, setShowMap] = useState(false);
+
+  // Adopt a server snapshot as the form baseline.
+  function adopt(cfg: KiwiConfigDto): void {
+    setConfig(cfg);
+    setEnabled(cfg.enabled);
+    setUrl(cfg.url ?? '');
+    setPassword('');
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const cfg = await getKiwiConfig();
+        if (!cancelled) adopt(cfg);
+      } catch {
+        // Read-only probe — leave the form empty on a transient fetch failure.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function onSave(): Promise<void> {
+    setSaving(true);
+    setError(null);
+    try {
+      // Only send the password when the operator typed something — an empty
+      // input keeps the stored password (the server clears it only on an
+      // explicit empty string, which we never send unless cleared deliberately).
+      const req: { enabled: boolean; url: string; password?: string } = {
+        enabled,
+        url: url.trim(),
+      };
+      if (password !== '') req.password = password;
+      const cfg = await setKiwiConfig(req);
+      adopt(cfg);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  // Map pick: pass the chosen receiver's address into the URL field AND persist
+  // it immediately (the operator "selects from the map" and Zeus stores it until
+  // the next selection). Keeps the current enabled state, so picking a new Kiwi
+  // while enabled switches the live connection.
+  async function onPickFromMap(pickedUrl: string): Promise<void> {
+    setUrl(pickedUrl);
+    setSaving(true);
+    setError(null);
+    try {
+      const cfg = await setKiwiConfig({ enabled, url: pickedUrl });
+      adopt(cfg);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function onClearPassword(): Promise<void> {
+    setSaving(true);
+    setError(null);
+    try {
+      const cfg = await setKiwiConfig({ password: '' });
+      adopt(cfg);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div style={{ maxWidth: 720 }}>
+      <h3
+        style={{
+          margin: '0 0 14px',
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: '0.12em',
+          textTransform: 'uppercase',
+          color: 'var(--fg-2)',
+        }}
+      >
+        KIWI SDR (REMOTE SLICE RECEIVER)
+      </h3>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+        <div
+          style={{
+            padding: 12,
+            background: 'var(--bg-1)',
+            border: '1px solid var(--panel-border)',
+            borderRadius: 'var(--r-md)',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 10,
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <label
+              style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 11, color: 'var(--fg-2)' }}
+            >
+              <input
+                type="checkbox"
+                checked={enabled}
+                onChange={(e) => setEnabled(e.target.checked)}
+                style={{ accentColor: 'var(--accent)' }}
+              />
+              ENABLED
+            </label>
+            <span style={{ flex: 1 }} />
+            <StatusPill status={config?.status ?? 'disabled'} />
+          </div>
+
+          <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--fg-2)' }}>KiwiSDR URL</span>
+            <input
+              type="text"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="sdr.example.org:8073"
+              spellCheck={false}
+              autoComplete="off"
+              style={{
+                padding: '6px 8px',
+                fontSize: 12,
+                fontFamily: 'monospace',
+                background: 'var(--bg-0)',
+                border: '1px solid var(--panel-border)',
+                borderRadius: 'var(--r-sm)',
+                color: 'var(--fg-0)',
+              }}
+            />
+          </label>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <button
+              type="button"
+              onClick={() => setShowMap((v) => !v)}
+              className={`btn sm${showMap ? ' active' : ''}`}
+              style={{ alignSelf: 'flex-start' }}
+              aria-expanded={showMap}
+            >
+              {showMap ? '▾ HIDE MAP' : '🌐 SELECT FROM MAP'}
+            </button>
+            {showMap && <KiwiMapPicker selectedUrl={url.trim()} onSelect={(u) => void onPickFromMap(u)} />}
+          </div>
+
+          <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--fg-2)' }}>
+              Password{' '}
+              <span style={{ fontWeight: 400, color: 'var(--fg-3)' }}>
+                {config?.hasPassword
+                  ? '(stored — leave blank to keep)'
+                  : '(optional — only for password-protected KiwiSDRs)'}
+              </span>
+            </span>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder={config?.hasPassword ? '••••••••' : ''}
+              spellCheck={false}
+              autoComplete="off"
+              style={{
+                padding: '6px 8px',
+                fontSize: 12,
+                fontFamily: 'monospace',
+                background: 'var(--bg-0)',
+                border: '1px solid var(--panel-border)',
+                borderRadius: 'var(--r-sm)',
+                color: 'var(--fg-0)',
+              }}
+            />
+          </label>
+
+          {config?.statusDetail && (
+            <div
+              style={{
+                padding: 8,
+                fontSize: 12,
+                color: config.status === 'error' ? 'var(--tx)' : 'var(--fg-1)',
+                background: config.status === 'error' ? 'rgba(230, 58, 43, 0.1)' : 'var(--bg-0)',
+                border: `1px solid ${config.status === 'error' ? 'var(--tx)' : 'var(--panel-border)'}`,
+                borderRadius: 'var(--r-sm)',
+              }}
+            >
+              {config.statusDetail}
+            </div>
+          )}
+
+          {error && (
+            <div
+              style={{
+                padding: 8,
+                fontSize: 12,
+                color: 'var(--tx)',
+                background: 'rgba(230, 58, 43, 0.1)',
+                border: '1px solid var(--tx)',
+                borderRadius: 'var(--r-sm)',
+              }}
+            >
+              {error}
+            </div>
+          )}
+
+          <div style={{ display: 'flex', gap: 6 }}>
+            <button
+              type="button"
+              onClick={() => void onSave()}
+              disabled={saving}
+              className="btn sm active"
+            >
+              {saving ? 'SAVING…' : 'SAVE'}
+            </button>
+            {config?.hasPassword && (
+              <button
+                type="button"
+                onClick={() => void onClearPassword()}
+                disabled={saving}
+                className="btn sm"
+                style={{ borderColor: 'var(--tx)', color: 'var(--tx)' }}
+              >
+                CLEAR PASSWORD
+              </button>
+            )}
+          </div>
+        </div>
+
+        <div style={{ fontSize: 10, lineHeight: 1.4, color: 'var(--fg-3)' }}>
+          The KiwiSDR slice receiver streams a remote KiwiSDR&apos;s audio + spectrum into Zeus as
+          an extra receiver alongside RX1–RX6. Enter the KiwiSDR&apos;s URL or{' '}
+          <span style={{ fontFamily: 'monospace' }}>host:port</span> (e.g.{' '}
+          <span style={{ fontFamily: 'monospace' }}>sdr.example.org:8073</span>), enable it, and
+          save — the Kiwi pane renders its own panadapter and waterfall. Tune it like any other RX.
+          Settings are stored server-side in zeus-prefs.db.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StatusPill({ status }: { status: string }) {
+  const map: Record<string, { color: string; bg: string; label: string }> = {
+    connected: { color: 'var(--accent)', bg: 'rgba(74,158,255,0.12)', label: 'CONNECTED' },
+    connecting: { color: 'var(--power)', bg: 'rgba(255,201,58,0.12)', label: 'CONNECTING' },
+    error: { color: 'var(--tx)', bg: 'rgba(230,58,43,0.12)', label: 'ERROR' },
+    closed: { color: 'var(--fg-3)', bg: 'var(--bg-2)', label: 'CLOSED' },
+    disabled: { color: 'var(--fg-3)', bg: 'var(--bg-2)', label: 'DISABLED' },
+  };
+  const s = map[status] ?? map.disabled!;
+  return (
+    <span
+      style={{
+        padding: '2px 8px',
+        borderRadius: 10,
+        fontSize: 11,
+        fontWeight: 600,
+        color: s.color,
+        background: s.bg,
+        border: `1px solid ${s.color}`,
+      }}
+    >
+      {s.label}
+    </span>
+  );
+}

--- a/zeus-web/src/components/Panadapter.tsx
+++ b/zeus-web/src/components/Panadapter.tsx
@@ -57,7 +57,7 @@ import { useDisplaySettingsStore, shouldTxAutoRange } from '../state/display-set
 import { useConnectionStore } from '../state/connection-store';
 import { enhanceInto, useSignalEnhanceStore } from '../dsp/signal-estimator';
 import { normalizeStitchedBins, stitchFloorShiftDb } from '../dsp/stitch-normalizer';
-import { getReceiverVfoHz, rxIndexOf, type ReceiverKey } from '../state/receiver-state';
+import { getReceiverVfoHz, receiverLabel, rxIndexOf, type ReceiverKey } from '../state/receiver-state';
 import * as viewCenter from '../state/view-center';
 import * as viewZoom from '../state/view-zoom';
 import { useTxStore } from '../state/tx-store';
@@ -94,6 +94,11 @@ export function Panadapter({
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const rxIndex = rxIndexOf(receiver);
   const vfoHz = useConnectionStore((s) => getReceiverVfoHz(s, receiver));
+  // Operator-facing label for the overlay. Hardware DDCs fall back to "RX{n}";
+  // the Kiwi slice receiver carries a name ("Kiwi") on its receivers[] entry.
+  const rxLabel = useConnectionStore((s) =>
+    receiverLabel({ index: rxIndex, name: s.receivers.find((r) => r.index === rxIndex)?.name }),
+  );
   const popEnabled = useSignalEnhanceStore((s) => s.popEnabled);
   const popRenderIntensity = useSignalEnhanceStore((s) => s.popRenderIntensity);
   const moxOn = useTxStore((s) => s.moxOn);
@@ -227,9 +232,14 @@ export function Panadapter({
       // Draw-time zoom (view-zoom.ts): scale the trace about the view centre
       // when the animated display span lags the span this anchor was captured
       // at, so the trace scales in lock-step with the waterfall during a zoom.
+      // The Kiwi slice receiver self-scales to its OWN frame Hz/pixel (it has an
+      // independent span the RX1-driven global tween knows nothing about), which
+      // makes scaleX resolve to 1 (full width); every hardware DDC follows the
+      // shared zoom tween exactly as before. See displayedHzPerPixelFor.
+      const displayedHzPerPixel = viewZoom.displayedHzPerPixelFor(rxIndex, anchorHzPerPixel);
       const scaleX =
-        viewZoom.isInitialized() && anchorHzPerPixel > 0
-          ? anchorHzPerPixel / viewZoom.getDisplayedHzPerPixel()
+        displayedHzPerPixel > 0 && anchorHzPerPixel > 0
+          ? anchorHzPerPixel / displayedHzPerPixel
           : 1;
       renderer.draw(anchorPan, dbMin, dbMax, offsetPx, scaleX);
     };
@@ -490,7 +500,7 @@ export function Panadapter({
           border: '1px solid rgba(255,255,255,0.16)',
         }}
       >
-        {`RX${rxIndex + 1}`} · {(vfoHz / 1e6).toFixed(6)}
+        {rxLabel} · {(vfoHz / 1e6).toFixed(6)}
         {stitched && foreground ? ' · FOCUS' : ''}
       </div>
       {/* Passband + hover crosshair render on BOTH halves (RX2), each tracking

--- a/zeus-web/src/components/SettingsMenu.tsx
+++ b/zeus-web/src/components/SettingsMenu.tsx
@@ -42,6 +42,7 @@ import { TxAudioToolsPanel } from './TxAudioToolsPanel';
 import { DspSettingsPanel } from './DspSettingsPanel';
 import { PluginsPanel } from '../plugins/components/PluginsPanel';
 import { HamClockSettingsPanel } from './HamClockSettingsPanel';
+import { KiwiSettingsPanel } from './KiwiSettingsPanel';
 import { SpotsSettingsPanel } from './SpotsSettingsPanel';
 import { UpdatesPanel } from './UpdatesPanel';
 import { HardwareDiagnosticsPanel } from './HardwareDiagnosticsPanel';
@@ -59,6 +60,7 @@ export type SettingsTabId =
   | 'display'
   | 'plugins'
   | 'hamclock'
+  | 'kiwi'
   | 'spots'
   | 'server'
   | 'radio'
@@ -80,6 +82,7 @@ const TABS: ReadonlyArray<{ id: SettingsTabId; label: string }> = [
   { id: 'display', label: 'DISPLAY' },
   { id: 'plugins', label: 'PLUGINS' },
   { id: 'hamclock', label: 'HAMCLOCK' },
+  { id: 'kiwi', label: 'KIWI SDR' },
   { id: 'spots', label: 'SPOTS' },
   { id: 'server', label: 'SERVER' },
   { id: 'radio', label: 'RADIO' },
@@ -209,6 +212,7 @@ export function SettingsView({ initialTab, onClose }: Props) {
           {activeTab === 'display' && <DisplayPanel />}
           {activeTab === 'plugins' && <PluginsPanel />}
           {activeTab === 'hamclock' && <HamClockSettingsPanel />}
+          {activeTab === 'kiwi' && <KiwiSettingsPanel />}
           {activeTab === 'spots' && <SpotsSettingsPanel />}
           {activeTab === 'server' && <ServerUrlPanel />}
           {activeTab === 'receivers' && <ReceiversPanel />}

--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -57,7 +57,7 @@ import {
   useSignalEnhanceStore,
 } from '../dsp/signal-estimator';
 import { normalizeStitchedBins, stitchFloorShiftDb } from '../dsp/stitch-normalizer';
-import { getReceiverVfoHz, rxIndexOf, type ReceiverKey } from '../state/receiver-state';
+import { getReceiverVfoHz, KIWI_RECEIVER_INDEX, rxIndexOf, type ReceiverKey } from '../state/receiver-state';
 import { estimateRowFloorDb, forgetReceiverFloor, reportReceiverFloorDb } from '../dsp/floor-normalization';
 import { effectiveRxWfWindow, useRxDbWindowStore } from '../state/rx-db-window-store';
 import * as viewCenter from '../state/view-center';
@@ -280,12 +280,22 @@ export function Waterfall({
       const dbMin = popOn ? 0 : keyed ? wfTxDbMin : rxWin!.wfDbMin;
       const dbMax = popOn ? 1 : keyed ? wfTxDbMax : rxWin!.wfDbMax;
       renderer.setPopMode(popOn, popIntensity, reliefDepth, smoothness);
-      renderer.draw(
-        dbMin,
-        dbMax,
-        visualCenterHz(),
-        viewZoom.isInitialized() ? viewZoom.getDisplayedHzPerPixel() : null,
-      );
+      // Draw-time zoom span. Hardware DDCs follow the shared RX1-driven tween;
+      // the Kiwi slice receiver self-scales to its OWN current frame Hz/pixel so
+      // the renderer's viewScale (viewHzPerPixel / lastHzPerPixel) resolves to 1
+      // and its history fills the pane instead of being squished to the centre.
+      // Passing null keeps unit scale until a span is known. See
+      // displayedHzPerPixelFor.
+      const ownFrameHzPerPixel = selectDisplaySlice(useDisplayStore.getState(), receiver).hzPerPixel;
+      const viewHzPerPixel =
+        rxIndex === KIWI_RECEIVER_INDEX
+          ? ownFrameHzPerPixel > 0
+            ? viewZoom.displayedHzPerPixelFor(rxIndex, ownFrameHzPerPixel)
+            : null
+          : viewZoom.isInitialized()
+            ? viewZoom.getDisplayedHzPerPixel()
+            : null;
+      renderer.draw(dbMin, dbMax, visualCenterHz(), viewHzPerPixel);
     };
     const requestRedraw = () => {
       if (!isActive()) return;

--- a/zeus-web/src/components/WaterfallHeightfield.tsx
+++ b/zeus-web/src/components/WaterfallHeightfield.tsx
@@ -35,7 +35,7 @@ import { useDisplaySettingsStore } from '../state/display-settings-store';
 import { useConnectionStore } from '../state/connection-store';
 import { useTxStore } from '../state/tx-store';
 import { cancelDrawBusFrame, requestDrawBusFrame } from '../realtime/draw-bus';
-import { getReceiverVfoHz, rxIndexOf, type ReceiverKey } from '../state/receiver-state';
+import { getReceiverVfoHz, KIWI_RECEIVER_INDEX, rxIndexOf, type ReceiverKey } from '../state/receiver-state';
 import * as viewCenter from '../state/view-center';
 import * as viewZoom from '../state/view-zoom';
 import { usePanTuneGesture, type PanTuneGestureOptions } from '../util/use-pan-tune-gesture';
@@ -219,10 +219,20 @@ export function WaterfallHeightfield({
       // View span: zoom is a single global setting (DspPipelineService applies the
       // same SetZoom to RX1 and RX2, and both frames carry the same hzPerPixel),
       // so BOTH halves follow the one shared zoom glide — RX2 scales as smoothly
-      // as RX1 instead of stepping off its own slice.
-      const viewHzPerPixel = viewZoom.isInitialized()
-        ? viewZoom.getDisplayedHzPerPixel()
-        : null;
+      // as RX1 instead of stepping off its own slice. The Kiwi slice receiver is
+      // the exception: it has an independent native span the shared tween knows
+      // nothing about, so it self-scales to its OWN current frame Hz/pixel
+      // (viewHzPerPixel == the renderer's anchor → scale 1, full width). See
+      // displayedHzPerPixelFor.
+      const ownFrameHzPerPixel = selectDisplaySlice(useDisplayStore.getState(), receiver).hzPerPixel;
+      const viewHzPerPixel =
+        rxIndex === KIWI_RECEIVER_INDEX
+          ? ownFrameHzPerPixel > 0
+            ? viewZoom.displayedHzPerPixelFor(rxIndex, ownFrameHzPerPixel)
+            : null
+          : viewZoom.isInitialized()
+            ? viewZoom.getDisplayedHzPerPixel()
+            : null;
       const t0 = performance.now();
       renderer.draw(dbMin, dbMax, visualCenterHz(), viewHzPerPixel);
       const dt = performance.now() - t0;

--- a/zeus-web/src/state/receiver-state.ts
+++ b/zeus-web/src/state/receiver-state.ts
@@ -58,6 +58,18 @@ import {
  *  RX3+); `'A'`/`'B'` are legacy aliases for 0/1. */
 export type ReceiverKey = 'A' | 'B' | number;
 
+/** Reserved high index for the KiwiSDR slice receiver (mirrors
+ *  WireContract.KiwiReceiverIndex = MaxReceivers-1 = 7). It is a software
+ *  receiver, not a hardware DDC — it never counts toward the multi-RX count
+ *  stepper or the ADC-source list. */
+export const KIWI_RECEIVER_INDEX = 7;
+
+/** Operator-facing label for a receiver. Hardware DDCs carry no name and fall
+ *  back to "RX{n}" (1-based); the Kiwi slice receiver carries "Kiwi". */
+export function receiverLabel(r: { index: number; name?: string | null }): string {
+  return r.name ?? `RX${r.index + 1}`;
+}
+
 /** 0-based receiver index for a key. A → 0, B → 1, number → itself. */
 export function rxIndexOf(key: ReceiverKey): number {
   if (key === 'A') return 0;

--- a/zeus-web/src/state/view-zoom.ts
+++ b/zeus-web/src/state/view-zoom.ts
@@ -41,6 +41,8 @@
 // Kill switch: VIEW_ZOOM_TWEEN_ENABLED = false (or TAU_MS = 0) snaps to the
 // target every tick, restoring the pre-animation stepping feel.
 
+import { KIWI_RECEIVER_INDEX } from './receiver-state';
+
 export const VIEW_ZOOM_TWEEN_ENABLED = true;
 
 // Tween time-constant. A touch slower than the pan glide (view-center, 70 ms)
@@ -136,6 +138,25 @@ export function setTarget(hzPerPixel: number): void {
 
 /** The animated hzPerPixel the surfaces should render against. */
 export function getDisplayedHzPerPixel(): number {
+  return displayedHzPerPixel;
+}
+
+/** The displayed hzPerPixel a given receiver's spectrum surfaces should scale
+ *  their trace/history against.
+ *
+ *  Hardware DDCs (RX1..RX6) share the radio's one Hz/pixel scale and follow the
+ *  global zoom tween, so they get `getDisplayedHzPerPixel()`. The Kiwi slice
+ *  receiver (KIWI_RECEIVER_INDEX) is a remote KiwiSDR with its OWN independent
+ *  Hz/pixel (its native ~29 kHz span over its own bin count), which the shared
+ *  RX1-driven tween knows nothing about. Scaling the Kiwi trace by the RX1 ratio
+ *  squished it into the centre of the pane. Self-scale the Kiwi to its own
+ *  current frame Hz/pixel so the draw-time scaleX resolves to 1 (full width) and
+ *  the trace, waterfall, axis, and overlays all agree.
+ *
+ *  `ownFrameHzPerPixel` is the receiver's latest frame Hz/pixel (<= 0 when none
+ *  yet); a non-positive value falls back to the global displayed span. */
+export function displayedHzPerPixelFor(rxIndex: number, ownFrameHzPerPixel: number): number {
+  if (rxIndex === KIWI_RECEIVER_INDEX && ownFrameHzPerPixel > 0) return ownFrameHzPerPixel;
   return displayedHzPerPixel;
 }
 


### PR DESCRIPTION
Adds a remote KiwiSDR as a 7th **"Kiwi"** receiver alongside RX1-6.

## What it does
- **Dual-WebSocket client** (SND + WF streams) with **server-side demodulation**. Scheme-aware endpoint port parsing so proxy receivers connect on `:80`.
- **Shared audio bus**: the demodulated audio mixes onto the same RX audio bus as the hardware receivers via `IKiwiAudioBus`, so the Kiwi blends with the local RX rather than being a second device stream.
- **Receiver projection**: `KiwiSdrService` projects the Kiwi entry into `RadioService`'s receiver list via `IKiwiReceiverProvider` at the reserved index `WireContract.KiwiReceiverIndex`. The frontend routes its frames through the same per-RX render path as a hardware DDC and labels it "Kiwi". Because the Kiwi has its own native span, the panadapter/waterfall self-scale to its own frame Hz/pixel (`displayedHzPerPixelFor`) instead of following the RX1-driven zoom tween.
- **Settings -> KIWI panel** with a Leaflet map picker sourced from the public `kiwisdr.com` directory, proxied server-side at `/api/kiwi/directory` (the source is plain HTTP, so it can't be fetched directly from the browser).

## API surface
- `GET/POST /api/kiwi` - config (enable/url/password; password never returned, only `hasPassword`).
- `GET /api/kiwi/directory` - cached public KiwiSDR directory for the picker.
- Tuning / mute / lo / zoom for the Kiwi index route through the Kiwi service.

## Verification
- `dotnet build Zeus.slnx` - 0 errors.
- `dotnet test --filter "FullyQualifiedName~KiwiSdr"` - 50 passed, 0 failed.
- `npm run build` (tsc + vite) - 0 errors.