### PR TITLE
fix(relay): resolve Attachment type collision from #994 (relay now typechecks)

### DIFF
--- a/cloud/zeuschat-relay/src/chat-room.ts
+++ b/cloud/zeuschat-relay/src/chat-room.ts
@@ -7,7 +7,11 @@ import {
   type RoomInfo,
   type RoomKind,
   type Msg,
-  type Attachment,
+  // Imported under an alias: this module already has a local `Attachment`
+  // interface (the per-connection hibernation state serialized onto each
+  // WebSocket). The photo attachment from the wire protocol is a different
+  // shape, so keep the names distinct to avoid the collision.
+  type Attachment as MsgAttachment,
   type PresenceStatus,
   MAX_MESSAGE_LEN,
   MAX_ATTACHMENT_DATAURL_LEN,
@@ -370,7 +374,7 @@ export class ChatRoom extends DurableObject<Env> {
     room: string,
     from: string,
     text: string,
-    attachment?: Attachment,
+    attachment?: MsgAttachment,
   ): Promise<void> {
     const msg: Msg = { id: crypto.randomUUID(), from, text, ts: Date.now(), room };
     if (attachment) msg.attachment = attachment;
@@ -731,14 +735,14 @@ export class ChatRoom extends DurableObject<Env> {
  * send anything, and the result is persisted + broadcast to the whole room, so
  * enforce the image-only + size invariants here regardless of the C# guard.
  */
-function sanitizeAttachment(a: Attachment | undefined): Attachment | undefined {
+function sanitizeAttachment(a: MsgAttachment | undefined): MsgAttachment | undefined {
   if (!a || typeof a !== 'object') return undefined;
   const mime = typeof a.mime === 'string' ? a.mime : '';
   const dataUrl = typeof a.dataUrl === 'string' ? a.dataUrl : '';
   if (!mime.startsWith('image/')) return undefined;
   if (!dataUrl.startsWith('data:image/')) return undefined;
   if (dataUrl.length > MAX_ATTACHMENT_DATAURL_LEN) return undefined;
-  const clean: Attachment = { kind: 'image', mime, dataUrl };
+  const clean: MsgAttachment = { kind: 'image', mime, dataUrl };
   if (typeof a.name === 'string' && a.name) clean.name = a.name.slice(0, 200);
   if (typeof a.width === 'number' && Number.isFinite(a.width)) clean.width = a.width;
   if (typeof a.height === 'number' && Number.isFinite(a.height)) clean.height = a.height;


### PR DESCRIPTION
## Follow-up to #994 — relay TypeScript no longer compiles cleanly

PR #994 added inline photo sharing. It exported a new `Attachment` photo type from `cloud/zeuschat-relay/src/protocol.ts` and imported it into `chat-room.ts` — where it **collided with the pre-existing local `interface Attachment`** (the per-connection WebSocket hibernation state: `callsign`, `since`, rate-limit counters, etc.). The local declaration shadowed the import, so `sanitizeAttachment` and `postMessage` resolved `Attachment` to the wrong shape.

`cd cloud/zeuschat-relay && npm run typecheck` failed with ~25 errors (TS2440 import/local conflict, TS2345, TS2339, TS2353). The PR's own runbook listed `npm run typecheck` as "optional", so this slipped through — and because `wrangler deploy` bundles via esbuild (type-stripping, no type-check), the worker would still deploy and run; this was purely a broken compile gate.

### Fix
Import the wire-protocol photo type under an alias (`Attachment as MsgAttachment`) and use it at the three photo-attachment sites (`postMessage` param, `sanitizeAttachment` signature, `clean` literal). The local connection-state `Attachment` is left untouched (it's used pervasively for hibernation serialize/deserialize).

**Type-annotation-only change — no runtime behavior change.**

### Verification
- `npm run typecheck` → **0 errors** (was ~25).
- `npx wrangler deploy --dry-run` → bundle builds, bindings intact (CHAT_ROOM, RATE_DO, QRZ_VERIFY).
- Relay **deployed** to `chat.openhpsdrzeus.com` (version `2cac251b-f057-4337-af8c-06cf8e7c1b8a`) and verified responding (HTTP 200). This completes the #994 relay-redeploy prerequisite so inline photos actually relay to peers.