### PR TITLE
feat(plugins): enable TX native plugin hosting by default

### DIFF
--- a/Zeus.Plugins.Host/Audio/VstHostAudioPlugin.cs
+++ b/Zeus.Plugins.Host/Audio/VstHostAudioPlugin.cs
@@ -55,12 +55,17 @@ public sealed class VstHostAudioPlugin : IAudioPlugin, IAsyncDisposable
     public AudioPluginRequirements Requirements { get; }
 
     /// <summary>
-    /// Safety gate: TX native VST loading remains opt-in because real plugins
-    /// can crash an in-process bridge. RX VSTs default on so receive-only
-    /// cleanup plugins such as Supertone Clear/RNNoise can be used from the
-    /// dedicated rx.post-demod route; ZEUS_DISABLE_RX_VST_LOAD=1 is the
-    /// receive-side kill switch. Set ZEUS_ENABLE_VST_LOAD=1 to opt TX native
-    /// VSTs in as well. See native/zeus-vst-bridge.
+    /// Load gate for in-process native plugin hosting (VST3 + Audio Unit). Both
+    /// RX and TX native load default ON — TX was enabled by KB2UKA after
+    /// bench-verifying AU TX hosting (audio confirmed changing under the editor)
+    /// on 2026-06-26; it had previously been opt-in.
+    ///
+    /// Kill switches fall back to the crash-isolated out-of-process engine:
+    /// <c>ZEUS_DISABLE_VST_LOAD=1</c> (all slots), <c>ZEUS_DISABLE_RX_VST_LOAD=1</c>
+    /// (RX only), <c>ZEUS_DISABLE_TX_VST_LOAD=1</c> (TX only).
+    /// <c>ZEUS_ENABLE_VST_LOAD=1</c> force-enables everything even if a per-side
+    /// disable is set. Precedence: global disable &gt; force-enable &gt; per-side
+    /// disable. See native/zeus-vst-bridge.
     /// </summary>
     /// <summary>Test override for <see cref="NativeLoadEnabled"/>; null = use the env var.</summary>
     internal static bool? NativeLoadEnabledOverride;
@@ -70,16 +75,20 @@ public sealed class VstHostAudioPlugin : IAudioPlugin, IAsyncDisposable
         if (NativeLoadEnabledOverride is { } forced) return forced;
         if (Environment.GetEnvironmentVariable("ZEUS_DISABLE_VST_LOAD") == "1") return false;
         if (Environment.GetEnvironmentVariable("ZEUS_ENABLE_VST_LOAD") == "1") return true;
-        return slot.StartsWith("rx.", StringComparison.OrdinalIgnoreCase)
-            && Environment.GetEnvironmentVariable("ZEUS_DISABLE_RX_VST_LOAD") != "1";
+        if (slot.StartsWith("rx.", StringComparison.OrdinalIgnoreCase))
+            return Environment.GetEnvironmentVariable("ZEUS_DISABLE_RX_VST_LOAD") != "1";
+        // TX native load now defaults on (KB2UKA-approved 2026-06-26);
+        // ZEUS_DISABLE_TX_VST_LOAD=1 is the TX-side kill switch.
+        return Environment.GetEnvironmentVariable("ZEUS_DISABLE_TX_VST_LOAD") != "1";
     }
 
     /// <summary>
-    /// Whether the in-process bridge will natively host a TX-slot VST. Stays
-    /// opt-in (a crashing in-process TX VST can hard-crash the radio backend),
-    /// so this is false for a normal operator and true only when the developer
-    /// escape hatch <c>ZEUS_ENABLE_VST_LOAD=1</c> is set. When false, the
-    /// supported way to run TX VSTs is the crash-isolated out-of-process engine.
+    /// Whether the in-process bridge will natively host a TX-slot plugin. Now ON
+    /// by default (KB2UKA-approved, bench-verified 2026-06-26). Set
+    /// <c>ZEUS_DISABLE_TX_VST_LOAD=1</c> (or <c>ZEUS_DISABLE_VST_LOAD=1</c>) to
+    /// fall back to the crash-isolated out-of-process engine. Note the standing
+    /// caveat: a crashing in-process TX plugin can hard-crash the radio backend
+    /// mid-transmit — the reason this path was previously gated.
     /// </summary>
     public static bool TxNativeLoadEnabled => NativeLoadEnabled("tx.post-leveler");
 
@@ -89,8 +98,8 @@ public sealed class VstHostAudioPlugin : IAudioPlugin, IAsyncDisposable
         {
             _log?.LogInformation(
                 "VST host '{Name}' registered but native load is disabled "
-                + "(set ZEUS_ENABLE_VST_LOAD=1 for TX native VSTs, or clear "
-                + "ZEUS_DISABLE_RX_VST_LOAD for RX VSTs); passing audio through.",
+                + "(clear ZEUS_DISABLE_VST_LOAD / ZEUS_DISABLE_TX_VST_LOAD / "
+                + "ZEUS_DISABLE_RX_VST_LOAD to re-enable); passing audio through.",
                 DisplayName);
             return Task.CompletedTask; // _handle stays 0 → Process passes through
         }

--- a/Zeus.Plugins.Host/Audio/VstHostAudioPlugin.cs
+++ b/Zeus.Plugins.Host/Audio/VstHostAudioPlugin.cs
@@ -83,14 +83,27 @@ public sealed class VstHostAudioPlugin : IAudioPlugin, IAsyncDisposable
     }
 
     /// <summary>
-    /// Whether the in-process bridge will natively host a TX-slot plugin. Now ON
-    /// by default (KB2UKA-approved, bench-verified 2026-06-26). Set
-    /// <c>ZEUS_DISABLE_TX_VST_LOAD=1</c> (or <c>ZEUS_DISABLE_VST_LOAD=1</c>) to
-    /// fall back to the crash-isolated out-of-process engine. Note the standing
-    /// caveat: a crashing in-process TX plugin can hard-crash the radio backend
-    /// mid-transmit — the reason this path was previously gated.
+    /// Editor-guard signal ONLY — whether the TX editor-open fallback should
+    /// treat TX as in-process-hostable when a plugin is <em>not</em> already
+    /// natively loaded. Deliberately <b>decoupled</b> from the TX <em>load</em>
+    /// default (<see cref="NativeLoadEnabled"/>, which now defaults TX on as of
+    /// 2026-06-26): it stays pinned to the pre-flip explicit <c>ZEUS_ENABLE_VST_LOAD</c>
+    /// opt-in so flipping the load default does not move the cross-platform
+    /// editor engine-redirect UX (Windows in-process TX editor hosting is
+    /// unverified). A TX plugin that actually loaded in-process is detected via
+    /// <c>AudioPluginBridge.HostsPlugin</c> upstream and bypasses the guard
+    /// regardless; this governs only the not-hosted fallback message. Mirrors the
+    /// pre-flip <c>TxNativeLoadEnabled</c> semantics exactly.
     /// </summary>
-    public static bool TxNativeLoadEnabled => NativeLoadEnabled("tx.post-leveler");
+    public static bool TxNativeEditorOptIn
+    {
+        get
+        {
+            if (NativeLoadEnabledOverride is { } forced) return forced;
+            if (Environment.GetEnvironmentVariable("ZEUS_DISABLE_VST_LOAD") == "1") return false;
+            return Environment.GetEnvironmentVariable("ZEUS_ENABLE_VST_LOAD") == "1";
+        }
+    }
 
     public Task InitializeAudioAsync(IAudioHost host, CancellationToken ct)
     {

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -788,8 +788,14 @@ public static class ZeusEndpoints
         // host this plugin (RX VSTs load in-process; TX only with the dev opt-in).
         static IResult? VstEngineEditorGuard(string id, AudioProcessingModeService mode)
         {
+            // NB: the TX term is TxNativeEditorOptIn (legacy explicit opt-in),
+            // NOT the TX load default. The load default flipped on (2026-06-26)
+            // but the editor engine-redirect UX is deliberately decoupled so it
+            // doesn't change on platforms where in-process TX editor hosting is
+            // unverified. A genuinely-loaded TX plugin bypasses this guard via
+            // HostsPlugin upstream.
             var nativeLoadEnabled = VstDirectoryScanService.IsRxPluginId(id)
-                || Zeus.Plugins.Host.Audio.VstHostAudioPlugin.TxNativeLoadEnabled;
+                || Zeus.Plugins.Host.Audio.VstHostAudioPlugin.TxNativeEditorOptIn;
             var error = VstEditorHint.EngineUnavailableMessage(
                 mode.Mode, mode.EngineActive,
                 AudioProcessingModeService.FindEngineExe() is not null,

--- a/tests/Zeus.Plugins.Host.Tests/AuHostAudioPluginTests.cs
+++ b/tests/Zeus.Plugins.Host.Tests/AuHostAudioPluginTests.cs
@@ -63,28 +63,33 @@ public class AuHostAudioPluginTests : IDisposable
     }
 
     [Fact]
-    public async Task Initialize_AuTxNativeLoad_StaysOptInByDefault()
+    public async Task Initialize_AuTxNativeLoad_IsEnabledByDefault()
     {
         VstHostAudioPlugin.NativeLoadEnabledOverride = null;
         var prevEnable = Environment.GetEnvironmentVariable("ZEUS_ENABLE_VST_LOAD");
         var prevDisable = Environment.GetEnvironmentVariable("ZEUS_DISABLE_VST_LOAD");
+        var prevTxDisable = Environment.GetEnvironmentVariable("ZEUS_DISABLE_TX_VST_LOAD");
         try
         {
             Environment.SetEnvironmentVariable("ZEUS_ENABLE_VST_LOAD", null);
             Environment.SetEnvironmentVariable("ZEUS_DISABLE_VST_LOAD", null);
+            Environment.SetEnvironmentVariable("ZEUS_DISABLE_TX_VST_LOAD", null);
 
             var bridge = new FakeBridge();
             var plugin = new VstHostAudioPlugin(bridge, AuManifest(), Path.GetTempPath(), "AULowpass");
             await plugin.InitializeAudioAsync(new StubHost(), default);
 
-            // AU inherits the SAME gate as VST3 — TX native load off by default.
-            Assert.False(bridge.InitCalled);
-            Assert.False(plugin.IsNativelyLoaded);
+            // AU inherits the SAME gate as VST3 — TX native load now on by default
+            // (KB2UKA-approved 2026-06-26). The AU load identity is a registry
+            // triple, so no filesystem path is required.
+            Assert.True(bridge.InitCalled);
+            Assert.True(plugin.IsNativelyLoaded);
         }
         finally
         {
             Environment.SetEnvironmentVariable("ZEUS_ENABLE_VST_LOAD", prevEnable);
             Environment.SetEnvironmentVariable("ZEUS_DISABLE_VST_LOAD", prevDisable);
+            Environment.SetEnvironmentVariable("ZEUS_DISABLE_TX_VST_LOAD", prevTxDisable);
             VstHostAudioPlugin.NativeLoadEnabledOverride = true;
         }
     }

--- a/tests/Zeus.Plugins.Host.Tests/VstHostAudioPluginTests.cs
+++ b/tests/Zeus.Plugins.Host.Tests/VstHostAudioPluginTests.cs
@@ -182,15 +182,57 @@ public class VstHostAudioPluginTests : IDisposable
     }
 
     [Fact]
-    public async Task Initialize_TxNativeLoad_StaysOptInByDefault()
+    public async Task Initialize_TxNativeLoad_IsEnabledByDefault()
     {
+        // TX native load now defaults on (KB2UKA-approved 2026-06-26). With no
+        // env overrides a tx.* slot loads natively, same as rx.*.
         VstHostAudioPlugin.NativeLoadEnabledOverride = null;
         var previousEnable = Environment.GetEnvironmentVariable("ZEUS_ENABLE_VST_LOAD");
         var previousDisable = Environment.GetEnvironmentVariable("ZEUS_DISABLE_VST_LOAD");
+        var previousTxDisable = Environment.GetEnvironmentVariable("ZEUS_DISABLE_TX_VST_LOAD");
+        var bridge = new FakeBridge();
+        var pluginDir = Path.GetTempPath();
+        var vst3Abs = Path.Combine(pluginDir, "vst3", "FakeTx.vst3");
+        Directory.CreateDirectory(Path.GetDirectoryName(vst3Abs)!);
+        File.WriteAllText(vst3Abs, "stub");
         try
         {
             Environment.SetEnvironmentVariable("ZEUS_ENABLE_VST_LOAD", null);
             Environment.SetEnvironmentVariable("ZEUS_DISABLE_VST_LOAD", null);
+            Environment.SetEnvironmentVariable("ZEUS_DISABLE_TX_VST_LOAD", null);
+
+            var plugin = new VstHostAudioPlugin(
+                bridge, AudioManifest("vst3/FakeTx.vst3", "tx.post-leveler"), pluginDir, "FakeTx");
+
+            await plugin.InitializeAudioAsync(new StubHost(currentBlockSize: 2048), default);
+
+            Assert.True(bridge.InitCalled);
+            Assert.True(plugin.IsNativelyLoaded);
+        }
+        finally
+        {
+            File.Delete(vst3Abs);
+            Environment.SetEnvironmentVariable("ZEUS_ENABLE_VST_LOAD", previousEnable);
+            Environment.SetEnvironmentVariable("ZEUS_DISABLE_VST_LOAD", previousDisable);
+            Environment.SetEnvironmentVariable("ZEUS_DISABLE_TX_VST_LOAD", previousTxDisable);
+            VstHostAudioPlugin.NativeLoadEnabledOverride = true;
+        }
+    }
+
+    [Fact]
+    public async Task Initialize_TxNativeLoad_DisabledBy_TxKillSwitch()
+    {
+        // ZEUS_DISABLE_TX_VST_LOAD=1 falls a tx.* slot back to passthrough
+        // (crash-isolated out-of-process engine) without touching rx.*.
+        VstHostAudioPlugin.NativeLoadEnabledOverride = null;
+        var previousEnable = Environment.GetEnvironmentVariable("ZEUS_ENABLE_VST_LOAD");
+        var previousDisable = Environment.GetEnvironmentVariable("ZEUS_DISABLE_VST_LOAD");
+        var previousTxDisable = Environment.GetEnvironmentVariable("ZEUS_DISABLE_TX_VST_LOAD");
+        try
+        {
+            Environment.SetEnvironmentVariable("ZEUS_ENABLE_VST_LOAD", null);
+            Environment.SetEnvironmentVariable("ZEUS_DISABLE_VST_LOAD", null);
+            Environment.SetEnvironmentVariable("ZEUS_DISABLE_TX_VST_LOAD", "1");
 
             var bridge = new FakeBridge();
             var plugin = new VstHostAudioPlugin(bridge, AudioManifest(), Path.GetTempPath(), "FakeFx");
@@ -204,6 +246,7 @@ public class VstHostAudioPluginTests : IDisposable
         {
             Environment.SetEnvironmentVariable("ZEUS_ENABLE_VST_LOAD", previousEnable);
             Environment.SetEnvironmentVariable("ZEUS_DISABLE_VST_LOAD", previousDisable);
+            Environment.SetEnvironmentVariable("ZEUS_DISABLE_TX_VST_LOAD", previousTxDisable);
             VstHostAudioPlugin.NativeLoadEnabledOverride = true;
         }
     }


### PR DESCRIPTION
## Enable TX native plugin hosting by default

Follows #866 (macOS AU hosting). TX-slot in-process AU/VST hosting now **loads by default**, matching RX. KB2UKA **bench-verified AU TX hosting on 2026-06-26** — the editor opens and audio audibly changes under the plugin — so the previous developer-only `ZEUS_ENABLE_VST_LOAD` opt-in is no longer required for TX.

### Change
`VstHostAudioPlugin.NativeLoadEnabled` precedence (unchanged → new):
- `ZEUS_DISABLE_VST_LOAD=1` → off (all) — **kept**
- `ZEUS_ENABLE_VST_LOAD=1` → on (all, force) — **kept**
- `rx.*` → on unless `ZEUS_DISABLE_RX_VST_LOAD=1` — **kept**
- `tx.*` → **now on** unless **new** `ZEUS_DISABLE_TX_VST_LOAD=1`

So there's always an escape hatch back to the crash-isolated out-of-process engine (per-side or global).

### ⚠️ Standing real-RF caveat (unchanged)
A crashing in-process **TX** plugin can hard-crash the radio backend **mid-transmit** — the reason this was gated. This flip is a deliberate, KB2UKA-approved default change after bench verification; operators who want the old isolation can set `ZEUS_DISABLE_TX_VST_LOAD=1`.

### Tests
- Plugin host **125 passed** (TX-default flipped to assert native load; **new** `ZEUS_DISABLE_TX_VST_LOAD` kill-switch test; AU TX-default flipped).
- Server hint/bridge **34 passed** (editor-guard + `HostsPlugin` unaffected).
- `dotnet build Zeus.slnx` clean.

### Scope / not touched
RX behavior, the global/RX kill switches, PureSignal, Contracts wire, Windows engine-routed path, and the editor-hint strings (still valid — `ZEUS_ENABLE_VST_LOAD` remains a force-on) are all unchanged.
