### PR TITLE
feat(web): link to QRZ API-key docs in QRZ settings

### DIFF
--- a/zeus-web/src/components/QrzSettingsPanel.tsx
+++ b/zeus-web/src/components/QrzSettingsPanel.tsx
@@ -166,7 +166,15 @@ export function QrzSettingsPanel() {
                 color: 'var(--fg-3)',
               }}
             >
-              Required for publishing QSOs to QRZ logbook
+              Required for publishing QSOs to QRZ logbook.{' '}
+              <a
+                href="https://www.qrz.com/docs/logbook30/api"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ color: 'var(--accent)' }}
+              >
+                Find your API key
+              </a>
             </div>
           </div>
 


### PR DESCRIPTION
## What

Adds a **Find your API key** link under the QRZ API Key field in the QRZ settings panel, pointing to https://www.qrz.com/docs/logbook30/api.

## Why

Operators need a QRZ Logbook API key to publish QSOs to their QRZ logbook, but the panel gave no guidance on where to obtain it. The link opens QRZ's Logbook API documentation in a new tab so users can quickly locate their key.

## Notes

- Single-line UI copy change in `zeus-web/src/components/QrzSettingsPanel.tsx`; link styled with the existing `--accent` token (no new palette).
- Opens in a new tab with `rel="noopener noreferrer"`.
- `tsc --noEmit` passes.