### PR TITLE
fix(remote): play RX audio in the browser for remote sessions

### DIFF
--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -336,7 +336,10 @@ export default function App() {
     // own Zustand subscription on the hot path.
     return useCapabilitiesStore.subscribe((state) => {
       const host = state.capabilities?.host;
-      if (host) setAudioHostMode(host === 'desktop' ? 'native' : 'browser');
+      // A remote (?remote=) session always plays RX audio in the browser even
+      // when the host is a desktop app — the host's native sink only feeds its
+      // own speakers, not the remote operator. See isNativeAudio().
+      if (host) setAudioHostMode(host === 'desktop' && !remoteMode ? 'native' : 'browser');
     });
   }, []);
 

--- a/zeus-web/src/audio/host-mode.test.ts
+++ b/zeus-web/src/audio/host-mode.test.ts
@@ -57,6 +57,19 @@ describe('audio host-mode flag', () => {
     expect(getAudioHostMode()).toBe('browser');
   });
 
+  it('forces browser audio for a remote session even on a desktop host', () => {
+    // A remote operator connecting to a desktop-mode radio must play RX audio
+    // in the browser — the host's native sink only drives its own speakers.
+    window.history.replaceState({}, '', '/?remote=N9WAR');
+    try {
+      setHost('desktop');
+      expect(isNativeAudio()).toBe(false);
+      expect(getAudioHostMode()).toBe('browser');
+    } finally {
+      window.history.replaceState({}, '', '/');
+    }
+  });
+
   it('setAudioHostMode("native") logs exactly once across repeated calls', () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     setAudioHostMode('native');

--- a/zeus-web/src/audio/host-mode.ts
+++ b/zeus-web/src/audio/host-mode.ts
@@ -35,8 +35,25 @@ export function getAudioHostMode(): AudioHostMode {
   return isNativeAudio() ? 'native' : 'browser';
 }
 
-/** True when the desktop host is rendering RX audio via its native sink. */
+/** True when the SPA is a remote (?remote=<CALLSIGN>) WebRTC session. Checked
+ *  inline (not via remote-client) to avoid an import cycle with ws-client. */
+function isRemoteSession(): boolean {
+  try {
+    return !!new URLSearchParams(window.location.search).get('remote')?.trim();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * True when the desktop host is rendering RX audio via its native sink and the
+ * browser should therefore NOT play it. Never true for a remote session: the
+ * host being in desktop mode means *its own* speakers get the native audio, but
+ * a remote operator's browser must play the streamed RX audio — so remote always
+ * runs in browser-audio mode regardless of the host's capabilities.
+ */
 export function isNativeAudio(): boolean {
+  if (isRemoteSession()) return false;
   return useCapabilitiesStore.getState().capabilities?.host === 'desktop';
 }
 


### PR DESCRIPTION
Follow-up to #988 from a live remote bench session, where the console showed `audio.host: native audio active (desktop mode)` and no RX audio.

**Root cause:** `isNativeAudio()` returns true whenever the host reports `host: 'desktop'`. A remote operator connects to a desktop-mode radio, so their browser concluded "the host plays audio natively" and opted out of browser playback entirely — but the host's native sink only drives the *host's own* speakers, so the remote session got silence.

**Fix:** a remote (`?remote=<CALLSIGN>`) session now always runs in browser-audio mode regardless of the host's capabilities, so streamed RX audio actually plays. Server-side already streams RX on request in desktop mode (`GatedWebSocketAudioSink`); this was purely the client opting out. One-line guard in `isNativeAudio()` plus the matching `setAudioHostMode` call; new unit test covers the remote-on-desktop case.

Verified: `tsc` clean, 6/6 host-mode tests pass. Bench-verify: a remote session against a desktop-mode host now plays RX audio.
