### PR TITLE
feat(web): persistent workspace zoom that scales the panel grid

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -972,6 +972,14 @@ public sealed record StateDto(
     int AttenDb = 0,
     NrConfig? Nr = null,
     int ZoomLevel = 1,
+    // Workspace UI zoom as a whole-percent scale of the panel-grid cell pitch
+    // (column width + row height). 100 = authored size; below 100 shrinks the
+    // cells so more grid fits the monitor (more usable panel space), above 100
+    // enlarges them. Purely a frontend display scale — NOT the spectral
+    // ZoomLevel above and NOT wired to the DSP. Persisted server-side so the
+    // operator's choice follows any client connecting to this radio. Defaulted
+    // so legacy state frames (no field) deserialize unchanged.
+    int WorkspaceZoomPct = 100,
     // Auto-attenuator control loop. When on (default), the server raises
     // AttOffsetDb by 1 per ~100 ms window in which any ADC-overload bit was
     // seen, and decays it by 1 per clean window. Ported from Thetis
@@ -1699,6 +1707,11 @@ public sealed record Nr2CoreConfigSetRequest(
 // on. The span-centering math lives in the engine; this contract just carries
 // the discrete factor on the wire.
 public sealed record ZoomSetRequest(int Level);
+
+// Workspace UI zoom — a whole-percent scale of the panel-grid cell pitch (see
+// StateDto.WorkspaceZoomPct). Distinct from ZoomSetRequest, which sets the
+// spectral analyzer zoom. The server clamps Pct into its allowed range.
+public sealed record WorkspaceZoomSetRequest(int Pct);
 
 public sealed record AutoAttSetRequest(bool Enabled);
 

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -574,6 +574,7 @@ public sealed class RadioService : IDisposable
             WdspNr3RnnrAvailable: Zeus.Dsp.Wdsp.WdspDspEngine.Nr3RnnrAvailable,
             Nr3ModelName: _nr3ModelStore?.GetActiveModelName(),
             ZoomLevel: rsSnap?.ZoomLevel ?? 1,
+            WorkspaceZoomPct: ClampWorkspaceZoomPct(rsSnap?.WorkspaceZoomPct ?? DefaultWorkspaceZoomPct),
             AutoAttEnabled: _adcProtection.Enabled,
             AttOffsetDb: 0,         // always reset — control-loop accumulator
             AdcOverloadWarning: false,
@@ -3666,6 +3667,22 @@ public sealed class RadioService : IDisposable
         return Snapshot();
     }
 
+    // Workspace UI zoom (cell-pitch scale, see StateDto.WorkspaceZoomPct). Pure
+    // frontend display value — persisted + rebroadcast here, no DSP side effect.
+    public const int MinWorkspaceZoomPct = 50;
+    public const int MaxWorkspaceZoomPct = 200;
+    public const int DefaultWorkspaceZoomPct = 100;
+
+    private static int ClampWorkspaceZoomPct(int pct) =>
+        Math.Clamp(pct, MinWorkspaceZoomPct, MaxWorkspaceZoomPct);
+
+    public StateDto SetWorkspaceZoom(int pct)
+    {
+        var clamped = ClampWorkspaceZoomPct(pct);
+        Mutate(s => s with { WorkspaceZoomPct = clamped });
+        return Snapshot();
+    }
+
     public void Dispose()
     {
         _paStore.Changed -= RecomputePaAndPush;
@@ -3831,6 +3848,7 @@ public sealed class RadioService : IDisposable
                 MicGainDb = snap.MicGainDb,
                 LevelerMaxGainDb = snap.LevelerMaxGainDb,
                 ZoomLevel = snap.ZoomLevel,
+                WorkspaceZoomPct = snap.WorkspaceZoomPct,
                 SsbFilterLoAbs = ssb.LoAbs,   SsbFilterHiAbs = ssb.HiAbs,
                 AmFilterLoAbs = am.LoAbs,     AmFilterHiAbs = am.HiAbs,
                 FmFilterLoAbs = fm.LoAbs,     FmFilterHiAbs = fm.HiAbs,

--- a/Zeus.Server.Hosting/RadioStateStore.cs
+++ b/Zeus.Server.Hosting/RadioStateStore.cs
@@ -173,6 +173,11 @@ public sealed class RadioStateEntry
     // restart.
     public double LevelerMaxGainDb { get; set; } = 8.0;
     public int ZoomLevel { get; set; } = 1;
+    // Workspace UI zoom (whole-percent cell-pitch scale; see
+    // StateDto.WorkspaceZoomPct). Default 100 = authored size; legacy rows
+    // missing the field hydrate to that. Persisted so the operator's panel
+    // scale survives a restart, same as the other UI-facing snapshot fields.
+    public int WorkspaceZoomPct { get; set; } = 100;
     // Drive slider % (0..100). Default 0 mirrors RadioService._drivePct seed.
     public int DrivePct { get; set; }
     // TUN drive slider % (0..100). Default 10 mirrors RadioService._tunePct seed —

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -2152,6 +2152,17 @@ public static class ZeusEndpoints
             return Results.Ok(r.SetZoom(req.Level));
         });
 
+        // Workspace UI zoom — scales the panel-grid cell pitch (see
+        // StateDto.WorkspaceZoomPct). Distinct from /api/rx/zoom (spectral). The
+        // server clamps Pct into range rather than 400-ing, so a slider step can
+        // never get stuck on an out-of-range value; the echoed state carries the
+        // accepted percent back for the optimistic-send reconcile.
+        app.MapPost("/api/ui/workspace-zoom", (WorkspaceZoomSetRequest req, RadioService r) =>
+        {
+            log.LogInformation("api.ui.workspaceZoom pct={Pct}", req.Pct);
+            return Results.Ok(r.SetWorkspaceZoom(req.Pct));
+        });
+
         // Band memory: last-used (hz, mode) per HF band. GET returns the full map so
         // the BandButtons UI can restore on load with one round-trip. PUT upserts one
         // entry — the web debounces writes so tuning doesn't hammer LiteDB.

--- a/tests/Zeus.Server.Tests/RadioStateStoreTests.cs
+++ b/tests/Zeus.Server.Tests/RadioStateStoreTests.cs
@@ -65,6 +65,7 @@ public class RadioStateStoreTests : IDisposable
                 MicGainDb = -7,
                 LevelerMaxGainDb = 12.5,
                 ZoomLevel = 4,
+                WorkspaceZoomPct = 130,
                 SsbFilterLoAbs = 300, SsbFilterHiAbs = 2400,
                 CwFilterLoAbs = 400, CwFilterHiAbs = 800,
                 SsbTxFilterLoAbs = 300, SsbTxFilterHiAbs = 2400,
@@ -104,6 +105,7 @@ public class RadioStateStoreTests : IDisposable
         Assert.Equal(-7, got.MicGainDb);
         Assert.Equal(12.5, got.LevelerMaxGainDb);
         Assert.Equal(4, got.ZoomLevel);
+        Assert.Equal(130, got.WorkspaceZoomPct);
         Assert.Equal(300, got.SsbFilterLoAbs);
         Assert.Equal(2400, got.SsbFilterHiAbs);
         Assert.Equal(400, got.CwFilterLoAbs);

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -239,6 +239,14 @@ export type ZoomLevel = number;
 export const ZOOM_MIN: ZoomLevel = 1;
 export const ZOOM_MAX: ZoomLevel = 32;
 
+// Workspace UI zoom as a whole-percent scale of the panel-grid cell pitch.
+// 100 = authored size. Distinct from the spectral ZoomLevel above. Range +
+// step mirror the backend clamp (RadioService.Min/MaxWorkspaceZoomPct).
+export const WORKSPACE_ZOOM_MIN = 50;
+export const WORKSPACE_ZOOM_MAX = 200;
+export const WORKSPACE_ZOOM_STEP = 10;
+export const WORKSPACE_ZOOM_DEFAULT = 100;
+
 export type AdcProtectionConfigDto = {
   enabled: boolean;
   attackMs: number;
@@ -337,6 +345,9 @@ export type RadioStateDto = {
   wdspNr3RnnrAvailable: boolean;
   nr3ModelName: string | null;
   zoomLevel: ZoomLevel;
+  // Workspace UI zoom (whole-percent cell-pitch scale; 100 = authored size).
+  // Server-persisted so it follows the radio across clients.
+  workspaceZoomPct: number;
   // PureSignal persisted settings — server is the source of truth, hydrated
   // into tx-store on connect so a fresh browser (no localStorage) sees the
   // operator's last dial-in. PsEnabled is the persisted standing arm
@@ -2430,6 +2441,7 @@ export function normalizeState(raw: unknown): RadioStateDto {
     wdspNr3RnnrAvailable: Boolean(r.wdspNr3RnnrAvailable),
     nr3ModelName: typeof r.nr3ModelName === 'string' ? r.nr3ModelName : null,
     zoomLevel: normalizeZoomLevel(r.zoomLevel),
+    workspaceZoomPct: normalizeWorkspaceZoomPct(r.workspaceZoomPct),
     // PureSignal persisted settings. Defaults match RadioService.cs init and
     // PsSettingsEntry — older servers without the fields fall back cleanly.
     psEnabled: typeof r.psEnabled === 'boolean' ? r.psEnabled : false,
@@ -2641,6 +2653,16 @@ function normalizeZoomLevel(v: unknown): ZoomLevel {
     return v;
   }
   return ZOOM_MIN;
+}
+
+// Clamp the server's workspace zoom percent into range, falling back to 100
+// for a missing/garbage field so a v1 server (no field) renders at authored
+// size rather than collapsing the grid.
+function normalizeWorkspaceZoomPct(v: unknown): number {
+  if (typeof v === 'number' && Number.isFinite(v)) {
+    return Math.min(WORKSPACE_ZOOM_MAX, Math.max(WORKSPACE_ZOOM_MIN, Math.round(v)));
+  }
+  return WORKSPACE_ZOOM_DEFAULT;
 }
 
 function normalizeRadios(raw: unknown): RadioInfoDto[] {
@@ -6087,6 +6109,25 @@ export function setZoom(
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ level }),
+      signal,
+    },
+    normalizeState,
+  );
+}
+
+// Workspace UI zoom — POSTs the new percent; the server clamps and echoes the
+// full state back for the optimistic-send + applyState reconcile. Distinct from
+// setZoom (spectral analyzer zoom).
+export function setWorkspaceZoom(
+  pct: number,
+  signal?: AbortSignal,
+): Promise<RadioStateDto> {
+  return jsonFetch(
+    '/api/ui/workspace-zoom',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ pct }),
       signal,
     },
     normalizeState,

--- a/zeus-web/src/components/SmartNrController.test.tsx
+++ b/zeus-web/src/components/SmartNrController.test.tsx
@@ -105,6 +105,7 @@ function mockState(nr: NrConfigDto): RadioStateDto {
     wdspNr3RnnrAvailable: false,
     nr3ModelName: null,
     zoomLevel: 1,
+    workspaceZoomPct: 100,
     psEnabled: false,
     psAuto: true,
     psPtol: false,

--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -33,9 +33,17 @@ import {
   type LayoutItem,
 } from 'react-grid-layout';
 import { absoluteStrategy } from 'react-grid-layout/core';
-import { Plus, Puzzle, Settings } from 'lucide-react';
+import { Minus, Plus, Puzzle, Settings } from 'lucide-react';
 import { useWorkspace } from './WorkspaceContext';
 import { parseLayoutOrDefault, useLayoutStore } from '../state/layout-store';
+import { useConnectionStore } from '../state/connection-store';
+import {
+  setWorkspaceZoom,
+  WORKSPACE_ZOOM_DEFAULT,
+  WORKSPACE_ZOOM_MAX,
+  WORKSPACE_ZOOM_MIN,
+  WORKSPACE_ZOOM_STEP,
+} from '../api/client';
 import { getPanelDef } from './panels';
 import {
   WORKSPACE_RESIZE_COMPACTOR,
@@ -186,16 +194,19 @@ export function FlexWorkspace({
       />
       <TerminatorLines active={terminatorActive} />
       {showAddPanelModal && !addPanelOpen && (
-        <button
-          type="button"
-          className="workspace-add-panel-btn"
-          onClick={() => setAddPanelOpen(true)}
-          disabled={!isLoaded}
-          title="Add a panel to this workspace"
-          aria-label="Add panel"
-        >
-          <Plus size={18} strokeWidth={2.2} aria-hidden />
-        </button>
+        <>
+          <WorkspaceZoomControls />
+          <button
+            type="button"
+            className="workspace-add-panel-btn"
+            onClick={() => setAddPanelOpen(true)}
+            disabled={!isLoaded}
+            title="Add a panel to this workspace"
+            aria-label="Add panel"
+          >
+            <Plus size={18} strokeWidth={2.2} aria-hidden />
+          </button>
+        </>
       )}
       {showAddPanelModal && addPanelOpen && (
         <AddPanelModal
@@ -222,6 +233,78 @@ export function FlexWorkspace({
           </p>
         </ConfirmDialog>
       )}
+    </div>
+  );
+}
+
+// Floating workspace-zoom cluster (− | nn% | +) that sits beside the Add Panel
+// button. Steps the server-persisted WorkspaceZoomPct; the percent readout
+// doubles as a reset-to-100% button. Optimistic store write + POST + applyState
+// reconcile, mirroring how the spectral-zoom controls talk to the server.
+function WorkspaceZoomControls() {
+  const pct = useConnectionStore((s) => s.workspaceZoomPct);
+  const setWorkspaceZoomPct = useConnectionStore((s) => s.setWorkspaceZoomPct);
+  const abortRef = useRef<AbortController | null>(null);
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const apply = useCallback(
+    (next: number) => {
+      const clamped = Math.min(
+        WORKSPACE_ZOOM_MAX,
+        Math.max(WORKSPACE_ZOOM_MIN, Math.round(next)),
+      );
+      if (clamped === useConnectionStore.getState().workspaceZoomPct) return;
+      setWorkspaceZoomPct(clamped); // optimistic — grid rescales immediately
+      abortRef.current?.abort();
+      const ctrl = new AbortController();
+      abortRef.current = ctrl;
+      setWorkspaceZoom(clamped, ctrl.signal)
+        .then((s) => {
+          if (!ctrl.signal.aborted) useConnectionStore.getState().applyState(s);
+        })
+        .catch(() => {
+          // Network/abort error: keep the optimistic value; the 1 Hz state
+          // poll reconciles to server truth on the next tick.
+        });
+    },
+    [setWorkspaceZoomPct],
+  );
+
+  return (
+    <div
+      className="workspace-zoom-controls"
+      role="group"
+      aria-label="Workspace zoom"
+    >
+      <button
+        type="button"
+        className="workspace-zoom-btn"
+        onClick={() => apply(pct - WORKSPACE_ZOOM_STEP)}
+        disabled={pct <= WORKSPACE_ZOOM_MIN}
+        title="Zoom workspace out"
+        aria-label="Zoom workspace out"
+      >
+        <Minus size={14} strokeWidth={2.4} aria-hidden />
+      </button>
+      <button
+        type="button"
+        className="workspace-zoom-readout"
+        onClick={() => apply(WORKSPACE_ZOOM_DEFAULT)}
+        title="Reset workspace zoom to 100%"
+        aria-label={`Workspace zoom ${pct}% — click to reset to 100%`}
+      >
+        {pct}%
+      </button>
+      <button
+        type="button"
+        className="workspace-zoom-btn"
+        onClick={() => apply(pct + WORKSPACE_ZOOM_STEP)}
+        disabled={pct >= WORKSPACE_ZOOM_MAX}
+        title="Zoom workspace in"
+        aria-label="Zoom workspace in"
+      >
+        <Plus size={14} strokeWidth={2.4} aria-hidden />
+      </button>
     </div>
   );
 }
@@ -338,10 +421,19 @@ function WorkspaceCanvas({
     const id = window.setTimeout(() => setFrozenWidth(width), 150);
     return () => window.clearTimeout(id);
   }, [frozenWidth, mounted, width]);
+  // Workspace UI zoom (operator-set, server-persisted). A multiplier on the
+  // CELL PITCH — not a CSS transform — so RGL keeps doing its drag/resize math
+  // in real pixels and hit-testing stays correct at any zoom. zoom < 1 shrinks
+  // the cells, so monitorCols/monitorRows/visibleRows below all grow and the
+  // operator gets MORE grid to spread panels across; zoom > 1 enlarges the
+  // cells (fewer fit; the canvas scrolls when a layout outgrows the monitor).
+  const workspaceZoomPct = useConnectionStore((s) => s.workspaceZoomPct);
+  const zoomFactor = (workspaceZoomPct > 0 ? workspaceZoomPct : 100) / 100;
   const baseColWidth =
     frozenWidth > 0
-      ? (frozenWidth - WORKSPACE_GRID_MARGIN_PX * (WORKSPACE_GRID_COLS - 1)) /
-        WORKSPACE_GRID_COLS
+      ? ((frozenWidth - WORKSPACE_GRID_MARGIN_PX * (WORKSPACE_GRID_COLS - 1)) /
+          WORKSPACE_GRID_COLS) *
+        zoomFactor
       : 0;
   // The MONITOR's capacity in grid cells — the MAXIMUM field. The workspace
   // canvas is bounded to this (not to the live window), so a panel can never be
@@ -367,7 +459,7 @@ function WorkspaceCanvas({
           1,
           Math.floor(
             (screenAvailH + WORKSPACE_GRID_MARGIN_PX) /
-              (WORKSPACE_ROW_HEIGHT_PX + WORKSPACE_GRID_MARGIN_PX),
+              (WORKSPACE_ROW_HEIGHT_PX * zoomFactor + WORKSPACE_GRID_MARGIN_PX),
           ),
         )
       : 0;
@@ -419,7 +511,9 @@ function WorkspaceCanvas({
   // (h rows × a constant rowHeight), so the old shrink-to-fit solver and its
   // per-tile pixel compensation are gone: the render layout is simply the stored
   // geometry, clamped to each panel's maxW/maxH.
-  const rowHeight = WORKSPACE_ROW_HEIGHT_PX;
+  // Row pitch scales with the same zoom factor so cells grow/shrink uniformly
+  // (square-ish aspect preserved). RGL accepts a fractional rowHeight.
+  const rowHeight = WORKSPACE_ROW_HEIGHT_PX * zoomFactor;
   const rowMargin = WORKSPACE_GRID_MARGIN_PX;
 
   // Per-tile render placement = stored geometry clamped to the panel's caps. A

--- a/zeus-web/src/state/connection-store.ts
+++ b/zeus-web/src/state/connection-store.ts
@@ -147,6 +147,9 @@ export type ConnectionState = {
   wdspNr3RnnrAvailable: boolean;
   nr3ModelName: string | null;
   zoomLevel: ZoomLevel;
+  // Workspace UI zoom (whole-percent cell-pitch scale; 100 = authored size).
+  // Server-persisted; FlexWorkspace reads this to scale the panel grid.
+  workspaceZoomPct: number;
   inflight: boolean;
   // Endpoint of the most recently successful /api/connect. Survives a
   // disconnect so ConnectPanel can float it to the top of the next scan.
@@ -178,6 +181,7 @@ export type ConnectionState = {
   setSelectedRxIndices: (indices: number[]) => void;
   toggleRxSelection: (index: number) => void;
   setZoomLevel: (level: ZoomLevel) => void;
+  setWorkspaceZoomPct: (pct: number) => void;
   setLastConnectedEndpoint: (ep: string | null) => void;
   setWisdomPhase: (phase: WisdomPhase) => void;
   setWisdomStatus: (status: string) => void;
@@ -246,6 +250,7 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
   wdspNr3RnnrAvailable: false,
   nr3ModelName: null,
   zoomLevel: 1,
+  workspaceZoomPct: 100,
   inflight: false,
   lastConnectedEndpoint: null,
   // Default to 'ready' so a page-load before the WS attach doesn't show the
@@ -305,6 +310,7 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
         wdspNr3RnnrAvailable: s.wdspNr3RnnrAvailable,
         nr3ModelName: s.nr3ModelName,
         zoomLevel: s.zoomLevel,
+        workspaceZoomPct: s.workspaceZoomPct,
       };
     }),
   setInflight: (inflight) => set({ inflight }),
@@ -356,6 +362,7 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
         : { selectedRxIndices, focusedRxIndex };
     }),
   setZoomLevel: (zoomLevel) => set({ zoomLevel }),
+  setWorkspaceZoomPct: (workspaceZoomPct) => set({ workspaceZoomPct }),
   setLastConnectedEndpoint: (lastConnectedEndpoint) =>
     set({ lastConnectedEndpoint }),
   setWisdomPhase: (wisdomPhase) => set({ wisdomPhase }),

--- a/zeus-web/src/styles/all-panels.css
+++ b/zeus-web/src/styles/all-panels.css
@@ -725,6 +725,78 @@
   opacity: 1;
 }
 
+/* Workspace zoom cluster (− | nn% | +) — a floating pill sitting to the LEFT
+ * of the round Add Panel button. Same chrome vocabulary so the two read as a
+ * matched pair of workspace-level affordances. */
+.workspace-zoom-controls {
+  position: absolute;
+  right: 54px;
+  bottom: 12px;
+  z-index: 5;
+  display: inline-flex;
+  align-items: center;
+  height: 34px;
+  padding: 0 2px;
+  border-radius: 999px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.015)),
+    rgba(12, 13, 15, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  box-shadow:
+    0 8px 20px rgba(0, 0, 0, 0.28),
+    inset 0 1px 0 rgba(255, 255, 255, 0.09);
+  opacity: 0.68;
+  transition:
+    opacity var(--dur-fast),
+    border-color var(--dur-fast);
+}
+.workspace-zoom-controls:hover,
+.workspace-zoom-controls:focus-within {
+  opacity: 1;
+  border-color: rgba(255, 255, 255, 0.24);
+}
+.workspace-zoom-btn,
+.workspace-zoom-readout {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 28px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--fg-1);
+  font-family: var(--font-sans);
+  cursor: pointer;
+  border-radius: 999px;
+  transition:
+    background var(--dur-fast),
+    color var(--dur-fast);
+}
+.workspace-zoom-btn {
+  width: 28px;
+}
+.workspace-zoom-readout {
+  min-width: 44px;
+  padding: 0 6px;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.01em;
+}
+.workspace-zoom-btn:hover:not(:disabled),
+.workspace-zoom-readout:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--fg-0);
+}
+.workspace-zoom-btn:disabled {
+  cursor: default;
+  opacity: 0.32;
+}
+.workspace-zoom-btn:focus-visible,
+.workspace-zoom-readout:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 1px;
+}
+
 
 /* Categorized AddPanel modal — left rail of category chips, right pane of
  * panel cards. Stacks the rail vertically so all categories are reachable


### PR DESCRIPTION
## What

Adds an operator-set **workspace zoom** that scales the fixed-cell panel grid and **persists** server-side, so the chosen scale sticks until changed and follows any client connecting to the radio.

## Why

Requested: the workspace should remember the zoom % and persist until changed, and zooming should govern all the space available for panels.

## How it works

Zoom is a multiplier on the grid **cell pitch** (column width + 15px row height) — **not** a CSS transform — so react-grid-layout keeps doing drag/resize hit-testing in real pixels and stays correct at any zoom.

- **Zoom out** → smaller cells → `monitorCols`/`monitorRows`/`visibleRows` all grow → **more grid for panels to spread into**.
- **Zoom in** → bigger cells → panels physically larger; the canvas scrolls when a layout outgrows the monitor.

## Persistence

Mirrors the existing spectral-zoom plumbing (`StateDto` → `RadioStateStore` → debounced flush → rebroadcast) but carries **no DSP wiring** — `WorkspaceZoomPct` is a pure UI value, distinct from the spectral `ZoomLevel`.

- New `POST /api/ui/workspace-zoom` clamps to **50..200%** and echoes full state for the optimistic-send reconcile.
- A floating `− nn% +` pill beside **Add Panel** steps the zoom (10% steps); the percent readout doubles as a reset-to-100% button.

## Control model decisions

Chosen by the maintainer up front: **scale the grid cells** (not CSS transform), persist to the **server prefs DB** (syncs per-radio, like spectral zoom).

## Files

| Layer | File |
|---|---|
| Wire | `Zeus.Contracts/Dtos.cs` — `StateDto.WorkspaceZoomPct=100`, `WorkspaceZoomSetRequest` |
| Persist | `Zeus.Server.Hosting/RadioStateStore.cs` |
| Service | `Zeus.Server.Hosting/RadioService.cs` — hydrate + flush + `SetWorkspaceZoom` (clamp) |
| API | `Zeus.Server.Hosting/ZeusEndpoints.cs` — `POST /api/ui/workspace-zoom` |
| Client | `zeus-web/src/api/client.ts` |
| Store | `zeus-web/src/state/connection-store.ts` |
| UI | `zeus-web/src/layout/FlexWorkspace.tsx` |
| Style | `zeus-web/src/styles/all-panels.css` |
| Test | `tests/Zeus.Server.Tests/RadioStateStoreTests.cs` |

## Verification

- `Zeus.Contracts` + `Zeus.Server.Hosting` build clean (0 warnings) against `develop`.
- `zeus-web` `tsc --noEmit` passes.
- `RadioStateStoreTests` 10/10 pass, including a new `WorkspaceZoomPct` persistence round-trip.

## Notes

- Backward-compatible: legacy state frames / DB rows without the field hydrate to 100%.
- Not browser-verified live (the headless preview can't render the WebGL workspace and needs a connected radio); the geometry is pure arithmetic over the existing fixed-cell derivations.