### PR TITLE
feat(cat): serial COM ports for CAT control (Thetis CAT1–4 parity)

### DIFF
--- a/Zeus.Contracts/CatDtos.cs
+++ b/Zeus.Contracts/CatDtos.cs
@@ -36,3 +36,74 @@ public sealed record CatTestRequest(string BindAddress, int Port);
 
 /// <summary>CAT port test result. Mirrors <see cref="TciTestResult"/>.</summary>
 public sealed record CatTestResult(bool Ok, string? Error);
+
+// ---- Serial CAT ports (Thetis CAT1–4 parity) ------------------------------
+//
+// Thetis exposes four general-purpose serial CAT ports, each a functional
+// clone of the primary (TCP) CAT port speaking the identical Kenwood TS-2000
+// command set. Zeus mirrors that: each configured port feeds the SAME
+// CatCommandHandler, so a logger/digimode app can drive Zeus over a virtual
+// serial pair (com0com / socat) exactly as it would a real rig. There are
+// always <see cref="CatSerialDefaults.PortCount"/> slots; an unconfigured slot
+// is simply disabled. Parity / StopBits are carried as the System.IO.Ports
+// enum names ("None"/"Odd"/…, "One"/"OnePointFive"/"Two") so the wire DTO has
+// no platform type dependency.
+
+/// <summary>Shared constants for the serial CAT feature.</summary>
+public static class CatSerialDefaults
+{
+    /// <summary>Number of serial CAT port slots (Thetis CAT1–4).</summary>
+    public const int PortCount = 4;
+    /// <summary>Default baud — matches Thetis's effective CAT default (115200).</summary>
+    public const int BaudRate = 115200;
+    /// <summary>Baud rates offered in the UI (Thetis's combo list).</summary>
+    public static readonly int[] BaudRates =
+        { 300, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200 };
+}
+
+/// <summary>Persisted config for one serial CAT port. Defaults mirror Thetis:
+/// disabled, 115200 8-N-1. <paramref name="PortName"/> is a free-form device
+/// path (COM5, /dev/cu.usbserial-1, /dev/ttys013) — virtual pty/com0com pairs
+/// are not enumerable, so the UI never gates on a dropdown.</summary>
+public sealed record CatSerialPortConfig(
+    bool Enabled = false,
+    string PortName = "",
+    int BaudRate = CatSerialDefaults.BaudRate,
+    string Parity = "None",
+    int DataBits = 8,
+    string StopBits = "One");
+
+/// <summary>Full serial-CAT config: exactly <see cref="CatSerialDefaults.PortCount"/>
+/// ports, index 0 = CAT 1.</summary>
+public sealed record CatSerialConfig(IReadOnlyList<CatSerialPortConfig> Ports);
+
+/// <summary>Live status for one serial CAT port: its stored config plus whether
+/// it is currently open and the last open error (busy / not found / permission).</summary>
+public sealed record CatSerialPortStatus(
+    int Index,
+    bool Enabled,
+    string PortName,
+    int BaudRate,
+    string Parity,
+    int DataBits,
+    string StopBits,
+    bool Open,
+    int ClientActivity,
+    string? Error);
+
+/// <summary>Serial-CAT status response: per-port status plus the host's
+/// enumerable serial devices (suggestions only — see <see cref="CatSerialPortConfig"/>).</summary>
+public sealed record CatSerialStatus(
+    IReadOnlyList<CatSerialPortStatus> Ports,
+    IReadOnlyList<string> AvailablePorts);
+
+/// <summary>Probe-open request for one serial CAT port.</summary>
+public sealed record CatSerialTestRequest(
+    string PortName,
+    int BaudRate = CatSerialDefaults.BaudRate,
+    string Parity = "None",
+    int DataBits = 8,
+    string StopBits = "One");
+
+/// <summary>Probe-open result. Mirrors <see cref="CatTestResult"/>.</summary>
+public sealed record CatSerialTestResult(bool Ok, string? Error);

--- a/Zeus.Server.Hosting/Cat/CatSerialPort.cs
+++ b/Zeus.Server.Hosting/Cat/CatSerialPort.cs
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using System.IO.Ports;
+using System.Text;
+using Zeus.Server.Tci; // reuse TciRateLimiter (DRY — generic key/interval coalescer)
+
+namespace Zeus.Server.Cat;
+
+/// <summary>
+/// One live serial CAT connection (a Thetis CAT1–4 port). The serial analogue
+/// of <see cref="CatSession"/>: it owns ONLY the serial I/O and the ';' framing;
+/// every command goes to a <see cref="CatCommandHandler"/>, so the safety
+/// contract (no auto-key, per-source MOX ownership) and the full Tier-1 command
+/// surface are shared byte-for-byte with the TCP path — no protocol is
+/// duplicated here.
+///
+/// <para>Deliberately constructible standalone (device path + serial params)
+/// so an integration test can drive it over a socat pty pair with no
+/// <see cref="CatSerialService"/> / DI in the way.</para>
+///
+/// <para>Read loop: blocking-free <c>BaseStream.ReadAsync</c> under the caller's
+/// cancellation token, exactly as <see cref="CatSession"/> and the shipped
+/// <c>G2FrontPanelService</c> do. Because <c>SerialPort.BaseStream.ReadAsync</c>
+/// has historically been unreliable about honouring its cancellation token,
+/// <see cref="Dispose"/> also closes the port, which force-unblocks any
+/// in-flight read — so a settings change or shutdown always tears the loop down
+/// promptly.</para>
+/// </summary>
+internal sealed class CatSerialPort : IDisposable
+{
+    // Longest legal Kenwood command is well under this; a token that grows past
+    // it without a ';' is a misbehaving client → its buffer is dropped.
+    private const int MaxPendingChars = 256;
+
+    private readonly string _path;
+    private readonly int _baud;
+    private readonly Parity _parity;
+    private readonly int _dataBits;
+    private readonly StopBits _stopBits;
+    private readonly ILogger _log;
+
+    private readonly TciRateLimiter _rateLimiter;
+    private readonly CatCommandHandler _handler;
+    private readonly object _writeLock = new();
+
+    private SerialPort? _port;
+    private int _disposed;
+    private int _activity;
+
+    public CatSerialPort(
+        string path, int baud, Parity parity, int dataBits, StopBits stopBits,
+        RadioService radio, TxService tx, CatOptions options,
+        Func<double> latestRxDbm, ILogger log)
+    {
+        _path = path;
+        _baud = baud;
+        _parity = parity;
+        _dataBits = dataBits;
+        _stopBits = stopBits;
+        _log = log;
+        _rateLimiter = new TciRateLimiter(options.RateLimitMs, Send);
+        _handler = new CatCommandHandler(radio, tx, options, latestRxDbm, Send);
+    }
+
+    /// <summary>True once the connected client issued AI1/AI2 — gates the
+    /// unsolicited state-change pushes <see cref="CatSerialService"/> fans out.</summary>
+    public bool AutoInfoEnabled => _handler.AutoInfoEnabled;
+
+    /// <summary>Count of commands dispatched on this port (a cheap "is something
+    /// talking to me" signal for the status panel).</summary>
+    public int Activity => Volatile.Read(ref _activity);
+
+    public bool IsOpen => _port?.IsOpen ?? false;
+
+    /// <summary>Open the serial device. Throws on failure (port busy, missing,
+    /// permission) — the caller logs and schedules a reconnect.</summary>
+    public void Open()
+    {
+        var port = new SerialPort(_path, _baud, _parity, _dataBits, _stopBits)
+        {
+            Handshake = Handshake.None,
+            // Finite timeouts: a stuck line must never wedge the read/write path.
+            ReadTimeout = 500,
+            WriteTimeout = 500,
+            Encoding = Encoding.ASCII,
+        };
+        port.Open();
+        // Assert RTS/DTR after open (Thetis's "soft rock ptt" hack — some
+        // level-shifter interfaces need a line high). Best-effort: a virtual
+        // pty that doesn't model line control must not fail the open.
+        try { port.RtsEnable = true; } catch { /* line control unsupported */ }
+        try { port.DtrEnable = true; } catch { /* line control unsupported */ }
+        _port = port;
+    }
+
+    /// <summary>Read loop until cancelled or the port goes away. Frames on ';'
+    /// via <see cref="CatProtocol.ExtractCommands"/> and dispatches each command
+    /// through the shared handler.</summary>
+    public async Task RunAsync(CancellationToken ct)
+    {
+        var port = _port ?? throw new InvalidOperationException("Open() must precede RunAsync()");
+        // SerialPort.BaseStream.ReadAsync has historically ignored its
+        // cancellation token, which would wedge a settings-change/shutdown
+        // teardown (the read never returns, so the caller's finally that would
+        // dispose the port never runs). Closing the port force-unblocks the
+        // in-flight read regardless. This callback is the load-bearing teardown
+        // path; do not remove it.
+        //
+        // Offload the Close to the thread pool: CancellationTokenSource.Cancel()
+        // runs registrations SYNCHRONOUSLY on the canceller's thread (the HTTP
+        // PUT thread, or the host-shutdown thread), and SerialPort.Close() can
+        // block on a surprise-removed USB adapter. Queuing it keeps the canceller
+        // responsive while still unblocking the read promptly.
+        await using var reg = ct.Register(() =>
+            ThreadPool.QueueUserWorkItem(_ => { try { port.Close(); } catch { /* already torn down */ } }));
+        var stream = port.BaseStream;
+        var buf = new byte[2048];
+        var acc = new StringBuilder();
+        while (!ct.IsCancellationRequested)
+        {
+            int n;
+            try
+            {
+                n = await stream.ReadAsync(buf.AsMemory(0, buf.Length), ct);
+            }
+            catch (TimeoutException) { continue; }
+
+            if (n <= 0) { await Task.Delay(20, ct); continue; }
+
+            acc.Append(Encoding.ASCII.GetString(buf, 0, n));
+            var (commands, remainder) = CatProtocol.ExtractCommands(acc.ToString());
+            acc.Clear();
+            // Bound an un-terminated command so a client that never sends ';'
+            // can't grow the buffer without limit.
+            acc.Append(remainder.Length > MaxPendingChars ? string.Empty : remainder);
+
+            foreach (var token in commands)
+            {
+                Interlocked.Increment(ref _activity);
+                try { _handler.Dispatch(token); }
+                catch (Exception ex) { _log.LogDebug(ex, "cat.serial dispatch error port={Port} token={Token}", _path, token); }
+            }
+        }
+    }
+
+    /// <summary>Write a terminated CAT response to the port. Synchronous under a
+    /// lock (responses are tiny); mirrors G2FrontPanelService.Send. Called from
+    /// the read loop (command replies) and the rate-limiter timer (AI pushes).</summary>
+    public void Send(string line)
+    {
+        if (Volatile.Read(ref _disposed) != 0) return;
+        var port = _port;
+        if (port is null || !port.IsOpen) return;
+        try
+        {
+            lock (_writeLock)
+            {
+                if (port.IsOpen) port.Write(line);
+            }
+        }
+        catch (Exception ex)
+        {
+            _log.LogDebug(ex, "cat.serial write failed port={Port}", _path);
+        }
+    }
+
+    /// <summary>Enqueue a rate-limited (coalesced-by-key) push, e.g. FA during a
+    /// VFO spin. Bursts collapse to one send per RateLimitMs.</summary>
+    public void SendRateLimited(string key, string line) => _rateLimiter.Enqueue(key, line);
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+        _rateLimiter.Dispose();
+        var port = _port;
+        _port = null;
+        if (port is null) return;
+        // Closing force-unblocks an in-flight BaseStream.ReadAsync (belt-and-
+        // suspenders for the unreliable serial cancellation token).
+        try { if (port.IsOpen) port.Close(); } catch { /* already torn down */ }
+        port.Dispose();
+    }
+}

--- a/Zeus.Server.Hosting/Cat/CatSerialService.cs
+++ b/Zeus.Server.Hosting/Cat/CatSerialService.cs
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using System.IO.Ports;
+using Microsoft.Extensions.Options;
+using Zeus.Contracts;
+
+namespace Zeus.Server.Cat;
+
+/// <summary>
+/// Hosts the four serial CAT ports (Thetis CAT1–4). The serial sibling of
+/// <see cref="CatServer"/>: where CatServer accepts TCP clients, this opens up
+/// to <see cref="CatSerialDefaults.PortCount"/> configured serial devices and
+/// runs a <see cref="CatSerialPort"/> on each, all feeding the SAME
+/// <see cref="CatCommandHandler"/> command set. One subscription to the radio /
+/// TX / RX-meter events fans Auto-Information pushes out to every open port
+/// whose client enabled AI — identical to CatServer's broadcast, just over
+/// serial.
+///
+/// <para>Lifecycle mirrors the shipped <c>G2FrontPanelService</c>: a settings
+/// change (<see cref="CatSerialConfigStore.Changed"/>) cancels the per-pass
+/// wake token, tears the ports down, and re-resolves from disk — no server
+/// restart. Each port self-reconnects on a backoff if its device is busy or
+/// unplugged, so a port that comes back (com0com / socat re-created) re-opens
+/// on its own.</para>
+/// </summary>
+public sealed class CatSerialService : BackgroundService
+{
+    private sealed class Slot
+    {
+        public volatile bool Open;
+        public volatile string? Error;
+        // Read from the AI-broadcast event threads while RunPortAsync writes it;
+        // volatile so a fan-out always sees the current open port (or null).
+        public volatile CatSerialPort? Live;
+    }
+
+    private readonly ILogger<CatSerialService> _log;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly CatOptions _options;
+    private readonly CatSerialConfigStore _store;
+    private readonly RadioService _radio;
+    private readonly TxService _tx;
+    private readonly DspPipelineService _pipeline;
+
+    private readonly Slot[] _slots;
+
+    // Per-pass linked CTS so a settings change (RequestReconnect) breaks the
+    // current port set and forces a re-resolve, without stopping the service.
+    private volatile CancellationTokenSource? _wakeCts;
+    private bool _subscribed;
+
+    // Latest RX1 level (dBm) for the SM poll, stored as long bits + Interlocked
+    // so a 32-bit runtime (Pi) can't read a torn double. Mirrors CatServer.
+    private long _latestRxDbmBits = BitConverter.DoubleToInt64Bits(-130.0);
+
+    public CatSerialService(
+        ILogger<CatSerialService> log,
+        ILoggerFactory loggerFactory,
+        IOptions<CatOptions> options,
+        CatSerialConfigStore store,
+        RadioService radio,
+        TxService tx,
+        DspPipelineService pipeline)
+    {
+        _log = log;
+        _loggerFactory = loggerFactory;
+        _options = options.Value;
+        _store = store;
+        _radio = radio;
+        _tx = tx;
+        _pipeline = pipeline;
+        _slots = new Slot[CatSerialDefaults.PortCount];
+        for (int i = 0; i < _slots.Length; i++) _slots[i] = new Slot();
+        _store.Changed += OnSettingsChanged;
+    }
+
+    public double LatestRxDbm => BitConverter.Int64BitsToDouble(Interlocked.Read(ref _latestRxDbmBits));
+
+    private void OnSettingsChanged() => RequestReconnect();
+
+    /// <summary>Break the current port set so the run loop re-reads settings and
+    /// re-opens. Safe to call from the settings endpoint thread.</summary>
+    public void RequestReconnect()
+    {
+        try { _wakeCts?.Cancel(); }
+        catch (ObjectDisposedException) { /* loop already advanced */ }
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Subscribe once for the lifetime of the service; AI fan-out checks each
+        // open port's client-driven AI state, so a quiet port costs nothing.
+        _radio.StateChanged += OnRadioStateChanged;
+        _radio.MoxChanged += OnMoxChanged;
+        _pipeline.RxMeterUpdated += OnRxMeterUpdated;
+        _subscribed = true;
+        try
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                using var wake = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+                _wakeCts = wake;
+                var ct = wake.Token;
+
+                var configs = _store.Get();
+                var active = new List<Task>();
+                var claimed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                for (int i = 0; i < _slots.Length; i++)
+                {
+                    var cfg = configs[i];
+                    if (!cfg.Enabled || string.IsNullOrWhiteSpace(cfg.PortName))
+                    {
+                        _slots[i].Error = null;
+                        continue;
+                    }
+                    // A serial device is exclusive-open: two enabled slots on the
+                    // same path would have the loser fail-and-retry every 5 s
+                    // forever. Open it once; flag the duplicate clearly instead.
+                    if (!claimed.Add(cfg.PortName.Trim()))
+                    {
+                        _slots[i].Open = false;
+                        _slots[i].Error = $"Duplicate device {cfg.PortName} (already used by another CAT port)";
+                        continue;
+                    }
+                    active.Add(RunPortAsync(i, cfg, ct));
+                }
+
+                if (active.Count == 0)
+                {
+                    // No ports enabled — idle until a settings change or shutdown.
+                    await DelaySafe(Timeout.InfiniteTimeSpan, ct);
+                    continue;
+                }
+
+                try { await Task.WhenAll(active); }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) { break; }
+                catch (OperationCanceledException) { /* settings change — re-resolve */ }
+                catch (Exception ex) { _log.LogDebug(ex, "cat.serial.runset ended"); }
+            }
+        }
+        finally
+        {
+            if (_subscribed)
+            {
+                _radio.StateChanged -= OnRadioStateChanged;
+                _radio.MoxChanged -= OnMoxChanged;
+                _pipeline.RxMeterUpdated -= OnRxMeterUpdated;
+                _subscribed = false;
+            }
+        }
+    }
+
+    // One port's open → read → reconnect loop. Catches its own faults and backs
+    // off, so it only returns when the wake/stop token cancels.
+    private async Task RunPortAsync(int index, CatSerialPortConfig cfg, CancellationToken ct)
+    {
+        var slot = _slots[index];
+        var portLog = _loggerFactory.CreateLogger<CatSerialPort>();
+        while (!ct.IsCancellationRequested)
+        {
+            CatSerialPort? port = null;
+            try
+            {
+                port = new CatSerialPort(
+                    cfg.PortName, cfg.BaudRate, ParseParity(cfg.Parity), cfg.DataBits, ParseStopBits(cfg.StopBits),
+                    _radio, _tx, _options, () => LatestRxDbm, portLog);
+                port.Open();
+                slot.Live = port;
+                slot.Open = true;
+                slot.Error = null;
+                _log.LogInformation("cat.serial.open index={Idx} port={Port} baud={Baud} {Data}{Parity}{Stop}",
+                    index + 1, cfg.PortName, cfg.BaudRate, cfg.DataBits, cfg.Parity[..1], StopBitsDigit(cfg.StopBits));
+                await port.RunAsync(ct);
+            }
+            // A requested cancellation (settings change / shutdown) force-closes
+            // the port, which unblocks the read as OCE on some platforms and
+            // IOException/ObjectDisposedException on others. Either way it's a
+            // clean teardown — never a fault to surface in status or log as an error.
+            catch (Exception) when (ct.IsCancellationRequested) { break; }
+            catch (Exception ex)
+            {
+                slot.Error = Describe(ex);
+                _log.LogWarning(ex, "cat.serial.error index={Idx} port={Port}; retrying", index + 1, cfg.PortName);
+            }
+            finally
+            {
+                slot.Open = false;
+                slot.Live = null;
+                port?.Dispose();
+            }
+
+            // Backoff before reconnect (busy / unplugged). Cancellable so a
+            // settings change or shutdown doesn't wait it out.
+            if (!ct.IsCancellationRequested)
+                await DelaySafe(TimeSpan.FromSeconds(5), ct);
+        }
+    }
+
+    // --- Auto-Information pushes (open ports whose client enabled AI1/AI2) ---
+
+    private void OnRadioStateChanged(StateDto state)
+    {
+        if (!AnyOpen) return;
+        BroadcastRateLimited("FA", CatProtocol.Response("FA", CatProtocol.FormatFreq(state.VfoHz)));
+        Broadcast(CatProtocol.Response("MD", CatProtocol.ModeDigit(state.Mode)));
+        BroadcastRateLimited("IF",
+            CatProtocol.Response("IF", CatProtocol.BuildIfBody(state.VfoHz, state.Mode, _tx.IsMoxOn, split: false)));
+    }
+
+    private void OnMoxChanged(bool moxOn)
+    {
+        if (!AnyOpen) return;
+        var state = _radio.Snapshot();
+        Broadcast(CatProtocol.Response("IF", CatProtocol.BuildIfBody(state.VfoHz, state.Mode, moxOn, split: false)));
+    }
+
+    private void OnRxMeterUpdated(int channelId, double dbm)
+    {
+        if (channelId == 0)
+            Interlocked.Exchange(ref _latestRxDbmBits, BitConverter.DoubleToInt64Bits(dbm));
+    }
+
+    private bool AnyOpen
+    {
+        get
+        {
+            foreach (var s in _slots) if (s.Live is not null) return true;
+            return false;
+        }
+    }
+
+    private void Broadcast(string line)
+    {
+        foreach (var s in _slots)
+        {
+            var p = s.Live;
+            if (p is not null && p.AutoInfoEnabled) p.Send(line);
+        }
+    }
+
+    private void BroadcastRateLimited(string key, string line)
+    {
+        foreach (var s in _slots)
+        {
+            var p = s.Live;
+            if (p is not null && p.AutoInfoEnabled) p.SendRateLimited(key, line);
+        }
+    }
+
+    /// <summary>Per-port status (config from disk + live open/error/activity)
+    /// plus the host's enumerable serial devices for the UI's suggestions.</summary>
+    public CatSerialStatus Snapshot()
+    {
+        var configs = _store.Get();
+        var ports = new List<CatSerialPortStatus>(CatSerialDefaults.PortCount);
+        for (int i = 0; i < CatSerialDefaults.PortCount; i++)
+        {
+            var c = configs[i];
+            var s = _slots[i];
+            ports.Add(new CatSerialPortStatus(
+                Index: i,
+                Enabled: c.Enabled,
+                PortName: c.PortName,
+                BaudRate: c.BaudRate,
+                Parity: c.Parity,
+                DataBits: c.DataBits,
+                StopBits: c.StopBits,
+                Open: s.Open,
+                ClientActivity: s.Live?.Activity ?? 0,
+                Error: s.Error));
+        }
+        return new CatSerialStatus(ports, AvailablePorts());
+    }
+
+    /// <summary>Probe-open a port with the given params to verify it can be used,
+    /// then close it. Used by the Settings "Test" button.</summary>
+    public CatSerialTestResult TestPort(CatSerialTestRequest req)
+    {
+        if (string.IsNullOrWhiteSpace(req.PortName))
+            return new CatSerialTestResult(false, "Port name required");
+        try
+        {
+            using var p = new SerialPort(req.PortName.Trim(), req.BaudRate,
+                ParseParity(req.Parity), req.DataBits, ParseStopBits(req.StopBits))
+            {
+                Handshake = Handshake.None,
+                ReadTimeout = 300,
+                WriteTimeout = 300,
+            };
+            p.Open();
+            p.Close();
+            return new CatSerialTestResult(true, null);
+        }
+        catch (Exception ex)
+        {
+            return new CatSerialTestResult(false, Describe(ex));
+        }
+    }
+
+    private static IReadOnlyList<string> AvailablePorts()
+    {
+        try
+        {
+            return SerialPort.GetPortNames()
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+        catch
+        {
+            // GetPortNames can throw on some platforms; suggestions are optional.
+            return Array.Empty<string>();
+        }
+    }
+
+    internal static Parity ParseParity(string? s) =>
+        Enum.TryParse<Parity>(s, ignoreCase: true, out var p) ? p : Parity.None;
+
+    internal static StopBits ParseStopBits(string? s) =>
+        Enum.TryParse<StopBits>(s, ignoreCase: true, out var sb) && sb != StopBits.None ? sb : StopBits.One;
+
+    private static string StopBitsDigit(string? s) => s switch
+    {
+        "Two" => "2",
+        "OnePointFive" => "1.5",
+        _ => "1",
+    };
+
+    // Friendly, actionable message for the common serial-open failures.
+    private static string Describe(Exception ex) => ex switch
+    {
+        UnauthorizedAccessException => "Port is in use or access denied (another app may hold it; on Linux the user must be in the dialout group)",
+        FileNotFoundException => "Port not found",
+        ArgumentException => "Invalid port name",
+        IOException io => io.Message,
+        _ => ex.Message,
+    };
+
+    private static async Task DelaySafe(TimeSpan delay, CancellationToken ct)
+    {
+        try { await Task.Delay(delay, ct); } catch (OperationCanceledException) { }
+    }
+
+    public override void Dispose()
+    {
+        _store.Changed -= OnSettingsChanged;
+        foreach (var s in _slots)
+        {
+            s.Live?.Dispose();
+            s.Live = null;
+        }
+        base.Dispose();
+    }
+}

--- a/Zeus.Server.Hosting/CatSerialConfigStore.cs
+++ b/Zeus.Server.Hosting/CatSerialConfigStore.cs
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+//
+// Persisted config for the four serial CAT ports (Thetis CAT1–4 parity).
+// Single-row LiteDB collection ("cat_serial_config") sharing zeus-prefs.db,
+// mirroring G2PanelSettingsStore: a Changed event lets CatSerialService
+// re-resolve and reconnect without a server restart, and Insert-then-Update
+// (NOT Upsert with Id=0) avoids the LiteDB Id=0-always-inserts bug (PR #387).
+//
+// Serial CAT is host-specific (a COM port / device path is meaningful only on
+// the machine it is wired to), so — like the G2 panel — it is store-only with
+// NO appsettings section: you would never bake a COM port into config.
+
+using LiteDB;
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+public sealed class CatSerialConfigStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<CatSerialConfigEntry> _rows;
+    private readonly ILogger<CatSerialConfigStore> _log;
+    private readonly object _sync = new();
+
+    // Fired on any write so CatSerialService re-resolves + reconnects its ports.
+    public event Action? Changed;
+
+    public CatSerialConfigStore(ILogger<CatSerialConfigStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _rows = _db.GetCollection<CatSerialConfigEntry>("cat_serial_config");
+
+        _log.LogInformation("CatSerialConfigStore initialized at {Path}", dbPath);
+    }
+
+    /// <summary>The four port configs, always exactly
+    /// <see cref="CatSerialDefaults.PortCount"/> entries. A missing/short/long
+    /// stored row is normalised to that count (pad with disabled defaults,
+    /// truncate extras), so callers never index out of range.</summary>
+    public IReadOnlyList<CatSerialPortConfig> Get()
+    {
+        lock (_sync)
+        {
+            var entry = _rows.FindAll().FirstOrDefault();
+            var stored = entry?.Ports ?? new List<CatSerialPortEntry>();
+            // Sanitize on READ as well as write: a hand-edited or legacy DB row
+            // must never feed an empty/invalid Parity/baud downstream (e.g. the
+            // CatSerialService status log indexes Parity[..1]).
+            return Normalize(stored.Select(e => Sanitize(ToConfig(e))));
+        }
+    }
+
+    /// <summary>Replace all stored port configs. The incoming list is normalised
+    /// to exactly <see cref="CatSerialDefaults.PortCount"/> ports before saving,
+    /// and each port's fields are sanitised. Fires <see cref="Changed"/>.</summary>
+    public void Set(IEnumerable<CatSerialPortConfig> ports)
+    {
+        var normalized = Normalize(ports.Select(Sanitize));
+        lock (_sync)
+        {
+            var existing = _rows.FindAll().FirstOrDefault();
+            var nowUtc = DateTime.UtcNow;
+            var rows = normalized.Select(ToEntry).ToList();
+            if (existing is null)
+            {
+                _rows.Insert(new CatSerialConfigEntry { Ports = rows, UpdatedUtc = nowUtc });
+            }
+            else
+            {
+                existing.Ports = rows;
+                existing.UpdatedUtc = nowUtc;
+                _rows.Update(existing);
+            }
+        }
+        Changed?.Invoke();
+    }
+
+    // Pad/truncate to exactly PortCount. Each port keeps its own settings — in
+    // particular its own baud (Thetis has a real bug where CAT4 reports CAT1's
+    // baud; we deliberately give every slot an independent round-trip).
+    private static IReadOnlyList<CatSerialPortConfig> Normalize(IEnumerable<CatSerialPortConfig> ports)
+    {
+        var list = ports.Take(CatSerialDefaults.PortCount).ToList();
+        while (list.Count < CatSerialDefaults.PortCount)
+            list.Add(new CatSerialPortConfig());
+        return list;
+    }
+
+    // Clamp/whitelist user-supplied values so a bad PUT can't persist a config
+    // that throws on SerialPort construction.
+    private static CatSerialPortConfig Sanitize(CatSerialPortConfig c)
+    {
+        int baud = CatSerialDefaults.BaudRates.Contains(c.BaudRate)
+            ? c.BaudRate : CatSerialDefaults.BaudRate;
+        int data = c.DataBits is 8 or 7 or 6 ? c.DataBits : 8;
+        string parity = NormalizeParity(c.Parity);
+        string stop = NormalizeStopBits(c.StopBits);
+        return c with
+        {
+            PortName = (c.PortName ?? string.Empty).Trim(),
+            BaudRate = baud,
+            DataBits = data,
+            Parity = parity,
+            StopBits = stop,
+        };
+    }
+
+    private static string NormalizeParity(string? p) =>
+        p is "None" or "Odd" or "Even" or "Mark" or "Space" ? p : "None";
+
+    private static string NormalizeStopBits(string? s) =>
+        s is "One" or "OnePointFive" or "Two" ? s : "One";
+
+    private static CatSerialPortConfig ToConfig(CatSerialPortEntry e) => new(
+        Enabled: e.Enabled,
+        PortName: e.PortName ?? string.Empty,
+        BaudRate: e.BaudRate,
+        Parity: e.Parity ?? "None",
+        DataBits: e.DataBits,
+        StopBits: e.StopBits ?? "One");
+
+    private static CatSerialPortEntry ToEntry(CatSerialPortConfig c) => new()
+    {
+        Enabled = c.Enabled,
+        PortName = c.PortName,
+        BaudRate = c.BaudRate,
+        Parity = c.Parity,
+        DataBits = c.DataBits,
+        StopBits = c.StopBits,
+    };
+
+    public void Dispose() => _db.Dispose();
+}
+
+public sealed class CatSerialConfigEntry
+{
+    public int Id { get; set; }
+    public List<CatSerialPortEntry> Ports { get; set; } = new();
+    public DateTime UpdatedUtc { get; set; }
+}
+
+public sealed class CatSerialPortEntry
+{
+    public bool Enabled { get; set; }
+    public string PortName { get; set; } = "";
+    public int BaudRate { get; set; } = CatSerialDefaults.BaudRate;
+    public string Parity { get; set; } = "None";
+    public int DataBits { get; set; } = 8;
+    public string StopBits { get; set; } = "One";
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -3455,6 +3455,32 @@ public static class ZeusEndpoints
             return Results.Ok(result);
         });
 
+        // Serial CAT ports (Thetis CAT1–4). GET returns per-port config + live
+        // open/error status plus the host's enumerable serial devices (UI
+        // suggestions; pty/com0com pairs aren't enumerable so the field is
+        // free-form). PUT replaces all four port configs and hot-reconnects (no
+        // restart). POST /test probe-opens one port to verify it's usable.
+        app.MapGet("/api/cat/serial/status",
+            (Zeus.Server.Cat.CatSerialService svc) => Results.Ok(svc.Snapshot()));
+
+        app.MapPut("/api/cat/serial/config",
+            (CatSerialConfig req, CatSerialConfigStore store, Zeus.Server.Cat.CatSerialService svc) =>
+        {
+            var ports = req?.Ports ?? Array.Empty<CatSerialPortConfig>();
+            log.LogInformation("api.cat.serial.config ports=[{Ports}]",
+                string.Join(", ", ports.Select((p, i) => $"#{i + 1} {(p.Enabled ? $"{p.PortName}@{p.BaudRate}" : "off")}")));
+            store.Set(ports);
+            return Results.Ok(svc.Snapshot());
+        });
+
+        app.MapPost("/api/cat/serial/test",
+            (CatSerialTestRequest req, Zeus.Server.Cat.CatSerialService svc) =>
+        {
+            if (string.IsNullOrWhiteSpace(req?.PortName))
+                return Results.BadRequest(new { error = "portName required" });
+            return Results.Ok(svc.TestPort(req));
+        });
+
         app.Map("/ws", async (HttpContext ctx, StreamingHub hub) =>
         {
             if (!ctx.WebSockets.IsWebSocketRequest)

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -890,6 +890,14 @@ public static class ZeusHost
         builder.Services.AddHostedService(sp => sp.GetRequiredService<Cat.CatServer>());
         builder.Services.AddSingleton<CatManagementService>();
 
+        // Serial CAT ports (Thetis CAT1–4 parity) — the same Kenwood handler over
+        // up to four host serial devices for loggers/digimode apps wired through a
+        // virtual COM pair (com0com / socat). Store-only + hot-reconnect (no
+        // restart), mirroring the G2 front-panel bridge; all ports default off.
+        builder.Services.AddSingleton<CatSerialConfigStore>();
+        builder.Services.AddSingleton<Cat.CatSerialService>();
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<Cat.CatSerialService>());
+
         // ZeusChat — operator-to-operator chat over the Cloudflare relay.
         // Singleton (API surface) + hosted service (relay connection lifecycle),
         // same shape as SpotBroadcastService above. Opt-in persisted via

--- a/tests/Zeus.Server.Tests/Cat/CatSerialConfigStoreTests.cs
+++ b/tests/Zeus.Server.Tests/Cat/CatSerialConfigStoreTests.cs
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests.Cat;
+
+// Round-trip + normalisation tests for the serial-CAT config store. The key
+// invariant beyond persistence: every one of the four ports keeps its OWN baud
+// (Thetis has a real bug where CAT4 reports CAT1's baud — we must not repeat it).
+public sealed class CatSerialConfigStoreTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-cat-serial-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+    }
+
+    private CatSerialConfigStore NewStore() =>
+        new(NullLogger<CatSerialConfigStore>.Instance, _dbPath);
+
+    [Fact]
+    public void Get_OnFreshDb_ReturnsFourDisabledDefaults()
+    {
+        using var store = NewStore();
+        var ports = store.Get();
+        Assert.Equal(CatSerialDefaults.PortCount, ports.Count);
+        Assert.All(ports, p =>
+        {
+            Assert.False(p.Enabled);
+            Assert.Equal(string.Empty, p.PortName);
+            Assert.Equal(115200, p.BaudRate);
+            Assert.Equal("None", p.Parity);
+            Assert.Equal(8, p.DataBits);
+            Assert.Equal("One", p.StopBits);
+        });
+    }
+
+    [Fact]
+    public void Set_Then_Get_RoundTripsEachPortIndependently()
+    {
+        using (var store = NewStore())
+        {
+            store.Set(new[]
+            {
+                new CatSerialPortConfig(true,  "/dev/ttys001", 9600,   "None",  8, "One"),
+                new CatSerialPortConfig(true,  "COM3",         19200,  "Even",  7, "Two"),
+                new CatSerialPortConfig(false, "/dev/ttys002", 38400,  "Odd",   8, "OnePointFive"),
+                new CatSerialPortConfig(true,  "/dev/ttys003", 115200, "None",  8, "One"),
+            });
+        }
+
+        // New store instance → proves it persisted to disk, not just memory.
+        using var reopened = NewStore();
+        var ports = reopened.Get();
+        Assert.Equal(4, ports.Count);
+
+        Assert.Equal(9600, ports[0].BaudRate);
+        Assert.Equal(19200, ports[1].BaudRate);
+        Assert.Equal(115200, ports[3].BaudRate);
+        // The Thetis CAT4-baud bug guard: port 4 must NOT echo port 1's baud.
+        Assert.NotEqual(ports[0].BaudRate, ports[3].BaudRate);
+
+        Assert.Equal("COM3", ports[1].PortName);
+        Assert.Equal("Even", ports[1].Parity);
+        Assert.Equal(7, ports[1].DataBits);
+        Assert.Equal("Two", ports[1].StopBits);
+        Assert.True(ports[0].Enabled);
+        Assert.False(ports[2].Enabled);
+    }
+
+    [Fact]
+    public void Set_FewerThanFour_PadsToFour()
+    {
+        using var store = NewStore();
+        store.Set(new[] { new CatSerialPortConfig(true, "COM1", 9600, "None", 8, "One") });
+        var ports = store.Get();
+        Assert.Equal(4, ports.Count);
+        Assert.True(ports[0].Enabled);
+        Assert.False(ports[3].Enabled);
+    }
+
+    [Fact]
+    public void Set_MoreThanFour_TruncatesToFour()
+    {
+        using var store = NewStore();
+        store.Set(Enumerable.Range(0, 7)
+            .Select(i => new CatSerialPortConfig(true, $"COM{i}", 9600, "None", 8, "One")));
+        Assert.Equal(4, store.Get().Count);
+    }
+
+    [Fact]
+    public void Set_InvalidValues_AreSanitised()
+    {
+        using var store = NewStore();
+        store.Set(new[]
+        {
+            new CatSerialPortConfig(true, "  COM5  ", 12345 /*illegal*/, "Bogus", 5 /*illegal*/, "Three"),
+        });
+        var p = store.Get()[0];
+        Assert.Equal("COM5", p.PortName);          // trimmed
+        Assert.Equal(115200, p.BaudRate);          // illegal baud → default
+        Assert.Equal("None", p.Parity);            // unknown parity → None
+        Assert.Equal(8, p.DataBits);               // illegal data bits → 8
+        Assert.Equal("One", p.StopBits);           // unknown stop bits → One
+    }
+
+    [Fact]
+    public void Set_FiresChanged()
+    {
+        using var store = NewStore();
+        int fired = 0;
+        store.Changed += () => fired++;
+        store.Set(new[] { new CatSerialPortConfig(true, "COM1") });
+        Assert.Equal(1, fired);
+    }
+}

--- a/tests/Zeus.Server.Tests/Cat/CatSerialPortIntegrationTests.cs
+++ b/tests/Zeus.Server.Tests/Cat/CatSerialPortIntegrationTests.cs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.IO.Ports;
+using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Server.Cat;
+
+namespace Zeus.Server.Tests.Cat;
+
+// End-to-end proof that a CatSerialPort, opened on a REAL serial device, speaks
+// the Kenwood protocol: a virtual pty PAIR (socat) gives one end to
+// CatSerialPort and the test drives the other end exactly as N1MM/WSJT-X would.
+// Gated to Unix-with-socat; the protocol itself is also covered transport-
+// agnostically by CatCommandHandlerTests.
+public sealed class CatSerialPortIntegrationTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-cat-serial-int-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+        try { if (File.Exists(_dbPath + ".pa")) File.Delete(_dbPath + ".pa"); } catch { }
+    }
+
+    [SkippableFact]
+    public async Task RealSerialPair_RoundTripsKenwoodCommands()
+    {
+        Skip.IfNot(CatSerialTestSupport.PtyHarnessAvailable, "socat pty pair unavailable (POSIX + socat only)");
+        using var pair = await SocatPtyPair.CreateAsync(CatSerialTestSupport.ResolveSocat()!);
+
+        var (radio, tx, _pipeline, dispose) = CatSerialTestSupport.BuildRadio(_dbPath);
+        using var _ = dispose;
+        double latestDbm = -73.0;
+
+        // Zeus side: open pty A, run the read loop.
+        using var catPort = new CatSerialPort(
+            pair.DeviceA, 115200, Parity.None, 8, StopBits.One,
+            radio, tx, new CatOptions(), () => latestDbm, NullLogger<CatSerialPort>.Instance);
+        catPort.Open();
+        using var loopCts = new CancellationTokenSource();
+        var loop = catPort.RunAsync(loopCts.Token);
+
+        // Test (client) side: open pty B as a plain serial port.
+        using var client = OpenClient(pair.DeviceB);
+
+        // 1) ID; → the TS-2000 identity. Hamlib requires this first.
+        client.Write("ID;");
+        Assert.Equal("ID019;", await ReadResponseAsync(client));
+
+        // 2) FA<freq>; is a set with no reply — assert the radio actually tuned.
+        client.Write("FA00007074000;");
+        await WaitForAsync(() => radio.Snapshot().VfoHz == 7_074_000);
+        Assert.Equal(7_074_000, radio.Snapshot().VfoHz);
+
+        // 3) FA; query → reads the freq back over the wire.
+        client.Write("FA;");
+        Assert.Equal("FA00007074000;", await ReadResponseAsync(client));
+
+        loopCts.Cancel();
+        try { await loop.WaitAsync(TimeSpan.FromSeconds(2)); } catch { /* torn down */ }
+    }
+
+    internal static SerialPort OpenClient(string device)
+    {
+        var client = new SerialPort(device, 115200, Parity.None, 8, StopBits.One)
+        {
+            Handshake = Handshake.None,
+            ReadTimeout = 2000,
+            WriteTimeout = 2000,
+            Encoding = Encoding.ASCII,
+        };
+        client.Open();
+        return client;
+    }
+
+    // Read until a ';' terminator (or timeout). The pty is raw, so bytes arrive
+    // as written; accumulate until the Kenwood frame completes.
+    internal static async Task<string> ReadResponseAsync(SerialPort port)
+    {
+        var sb = new StringBuilder();
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(3);
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                int b = port.ReadByte();
+                if (b < 0) continue;
+                sb.Append((char)b);
+                if (b == ';') return sb.ToString();
+            }
+            catch (TimeoutException)
+            {
+                await Task.Delay(10);
+            }
+        }
+        throw new TimeoutException($"No terminated CAT response (got '{sb}')");
+    }
+
+    internal static async Task WaitForAsync(Func<bool> condition)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(3);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition()) return;
+            await Task.Delay(20);
+        }
+    }
+}

--- a/tests/Zeus.Server.Tests/Cat/CatSerialServiceIntegrationTests.cs
+++ b/tests/Zeus.Server.Tests/Cat/CatSerialServiceIntegrationTests.cs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Zeus.Contracts;
+using Zeus.Server;
+using Zeus.Server.Cat;
+
+namespace Zeus.Server.Tests.Cat;
+
+// Service-level proof of the FULL serial-CAT chain: CatSerialConfigStore (on
+// disk) → CatSerialService opens the configured device → live status reports
+// Open → a serial client talks to it through the real handler. This covers the
+// wiring the port-level test bypasses (config store, the BackgroundService
+// run/reconnect loop, Snapshot status, and clean teardown via StopAsync).
+public sealed class CatSerialServiceIntegrationTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-cat-serial-svc-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+        try { if (File.Exists(_dbPath + ".pa")) File.Delete(_dbPath + ".pa"); } catch { }
+        try { if (File.Exists(_dbPath + ".cfg")) File.Delete(_dbPath + ".cfg"); } catch { }
+    }
+
+    [SkippableFact]
+    public async Task Service_OpensConfiguredPort_AndServesAClient()
+    {
+        Skip.IfNot(CatSerialTestSupport.PtyHarnessAvailable, "socat pty pair unavailable (POSIX + socat only)");
+        using var pair = await SocatPtyPair.CreateAsync(CatSerialTestSupport.ResolveSocat()!);
+
+        var (radio, tx, pipeline, dispose) = CatSerialTestSupport.BuildRadio(_dbPath);
+        using var _ = dispose;
+
+        // Persist a config that enables CAT 1 on Zeus's end of the pty pair.
+        using var store = new CatSerialConfigStore(NullLogger<CatSerialConfigStore>.Instance, _dbPath + ".cfg");
+        store.Set(new[]
+        {
+            new CatSerialPortConfig(true, pair.DeviceA, 115200, "None", 8, "One"),
+            new CatSerialPortConfig(),
+            new CatSerialPortConfig(),
+            new CatSerialPortConfig(),
+        });
+
+        var svc = new CatSerialService(
+            NullLogger<CatSerialService>.Instance, NullLoggerFactory.Instance,
+            Options.Create(new CatOptions()), store, radio, tx, pipeline);
+
+        await ((IHostedService)svc).StartAsync(CancellationToken.None);
+        try
+        {
+            // Service should open the configured port within a moment.
+            await CatSerialPortIntegrationTests.WaitForAsync(() => svc.Snapshot().Ports[0].Open);
+            var snap = svc.Snapshot();
+            Assert.True(snap.Ports[0].Open, "CAT 1 should be open");
+            Assert.Null(snap.Ports[0].Error);
+            Assert.False(snap.Ports[1].Open, "CAT 2 (unconfigured) should be closed");
+
+            // A client on the other end gets a valid TS-2000 identity, proving
+            // the store→service→port→handler path is fully wired.
+            using var client = CatSerialPortIntegrationTests.OpenClient(pair.DeviceB);
+            client.Write("ID;");
+            Assert.Equal("ID019;", await CatSerialPortIntegrationTests.ReadResponseAsync(client));
+
+            // Setting the frequency over serial drives the real RadioService.
+            client.Write("FA00014250000;");
+            await CatSerialPortIntegrationTests.WaitForAsync(() => radio.Snapshot().VfoHz == 14_250_000);
+            Assert.Equal(14_250_000, radio.Snapshot().VfoHz);
+
+            // Activity counter reflects the two dispatched commands.
+            Assert.True(svc.Snapshot().Ports[0].ClientActivity >= 2);
+        }
+        finally
+        {
+            await ((IHostedService)svc).StopAsync(CancellationToken.None);
+        }
+
+        // After stop, the port is released (a fresh open from the test succeeds).
+        using var reopen = CatSerialPortIntegrationTests.OpenClient(pair.DeviceA);
+        Assert.True(reopen.IsOpen);
+    }
+
+    [SkippableFact]
+    public async Task Service_HotReconnects_OnSettingsChange()
+    {
+        Skip.IfNot(CatSerialTestSupport.PtyHarnessAvailable, "socat pty pair unavailable (POSIX + socat only)");
+        using var pair = await SocatPtyPair.CreateAsync(CatSerialTestSupport.ResolveSocat()!);
+
+        var (radio, tx, pipeline, dispose) = CatSerialTestSupport.BuildRadio(_dbPath);
+        using var _ = dispose;
+
+        using var store = new CatSerialConfigStore(NullLogger<CatSerialConfigStore>.Instance, _dbPath + ".cfg");
+        // Start with everything disabled.
+        store.Set(new[] { new CatSerialPortConfig(), new CatSerialPortConfig(), new CatSerialPortConfig(), new CatSerialPortConfig() });
+
+        var svc = new CatSerialService(
+            NullLogger<CatSerialService>.Instance, NullLoggerFactory.Instance,
+            Options.Create(new CatOptions()), store, radio, tx, pipeline);
+
+        await ((IHostedService)svc).StartAsync(CancellationToken.None);
+        try
+        {
+            Assert.False(svc.Snapshot().Ports[0].Open);
+
+            // Enabling a port via the store fires Changed → the service should
+            // re-resolve and open it with NO restart.
+            store.Set(new[]
+            {
+                new CatSerialPortConfig(true, pair.DeviceA, 9600, "None", 8, "One"),
+                new CatSerialPortConfig(), new CatSerialPortConfig(), new CatSerialPortConfig(),
+            });
+            await CatSerialPortIntegrationTests.WaitForAsync(() => svc.Snapshot().Ports[0].Open);
+            Assert.True(svc.Snapshot().Ports[0].Open, "port should hot-open after settings change");
+
+            // Disabling it again should close it, also with no restart.
+            store.Set(new[] { new CatSerialPortConfig(), new CatSerialPortConfig(), new CatSerialPortConfig(), new CatSerialPortConfig() });
+            await CatSerialPortIntegrationTests.WaitForAsync(() => !svc.Snapshot().Ports[0].Open);
+            Assert.False(svc.Snapshot().Ports[0].Open, "port should hot-close after settings change");
+        }
+        finally
+        {
+            await ((IHostedService)svc).StopAsync(CancellationToken.None);
+        }
+    }
+}

--- a/tests/Zeus.Server.Tests/Cat/CatSerialTestSupport.cs
+++ b/tests/Zeus.Server.Tests/Cat/CatSerialTestSupport.cs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests.Cat;
+
+// Shared harness for the serial-CAT integration tests: a socat-backed virtual
+// pty pair and a minimal connected RadioService/TxService. Gated to POSIX hosts
+// with socat installed (the macOS dev box; CI Linux if socat is present).
+internal static class CatSerialTestSupport
+{
+    public static string? ResolveSocat()
+    {
+        foreach (var p in new[] { "/opt/homebrew/bin/socat", "/usr/local/bin/socat", "/usr/bin/socat" })
+            if (File.Exists(p)) return p;
+        return null;
+    }
+
+    public static bool PtyHarnessAvailable =>
+        (OperatingSystem.IsMacOS() || OperatingSystem.IsLinux()) && ResolveSocat() is not null;
+
+    // A connected RadioService + TxService + DspPipelineService backed by a temp
+    // prefs DB, matching CatCommandHandlerTests.Build so the serial path drives
+    // the real seams.
+    public static (RadioService Radio, TxService Tx, DspPipelineService Pipeline, IDisposable Dispose) BuildRadio(string dbPath)
+    {
+        var lf = NullLoggerFactory.Instance;
+        var dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance, dbPath);
+        var paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance, dbPath + ".pa");
+        var radio = new RadioService(lf, dspStore, paStore);
+        radio.MarkProtocol2Connected("127.0.0.1:1024", 48_000);
+        var hub = new StreamingHub(new NullLogger<StreamingHub>());
+        var pipeline = new DspPipelineService(radio, hub, Array.Empty<IRxAudioSink>(), lf);
+        var tx = new TxService(radio, pipeline, hub, NullBandPlanService.Instance, new NullLogger<TxService>());
+        return (radio, tx, pipeline, new DisposableBag(dspStore, paStore));
+    }
+
+    private sealed class DisposableBag(params IDisposable[] items) : IDisposable
+    {
+        public void Dispose() { foreach (var i in items) { try { i.Dispose(); } catch { } } }
+    }
+}
+
+// Spawns `socat -d -d pty,raw,echo=0 pty,raw,echo=0`, parses the two device
+// paths it prints on stderr, and keeps the process alive for the test.
+internal sealed class SocatPtyPair : IDisposable
+{
+    private readonly Process _proc;
+    public string DeviceA { get; }
+    public string DeviceB { get; }
+
+    private SocatPtyPair(Process proc, string a, string b)
+    {
+        _proc = proc;
+        DeviceA = a;
+        DeviceB = b;
+    }
+
+    public static async Task<SocatPtyPair> CreateAsync(string socatPath)
+    {
+        var psi = new ProcessStartInfo(socatPath)
+        {
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        psi.ArgumentList.Add("-d");
+        psi.ArgumentList.Add("-d");
+        psi.ArgumentList.Add("pty,raw,echo=0");
+        psi.ArgumentList.Add("pty,raw,echo=0");
+
+        var proc = Process.Start(psi) ?? throw new InvalidOperationException("failed to start socat");
+
+        var devices = new List<string>();
+        var rx = new Regex(@"PTY is (\S+)");
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (devices.Count < 2 && DateTime.UtcNow < deadline)
+        {
+            var line = await proc.StandardError.ReadLineAsync();
+            if (line is null) break;
+            var m = rx.Match(line);
+            if (m.Success) devices.Add(m.Groups[1].Value);
+        }
+
+        if (devices.Count < 2)
+        {
+            try { proc.Kill(); } catch { }
+            throw new InvalidOperationException("socat did not report two pty devices");
+        }
+
+        // socat needs a beat to finish wiring the pair before we open them.
+        await Task.Delay(200);
+        return new SocatPtyPair(proc, devices[0], devices[1]);
+    }
+
+    public void Dispose()
+    {
+        try { if (!_proc.HasExited) _proc.Kill(); } catch { }
+        try { _proc.Dispose(); } catch { }
+    }
+}

--- a/zeus-web/src/api/catSerial.ts
+++ b/zeus-web/src/api/catSerial.ts
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+// REST client for the serial CAT ports (Thetis CAT1–4). Sibling of api/cat.ts;
+// the same Kenwood handler, just over host serial devices instead of TCP.
+
+import { ApiError } from './client';
+
+export const CAT_SERIAL_PORT_COUNT = 4;
+export const CAT_SERIAL_DEFAULT_BAUD = 115200;
+export const CAT_SERIAL_BAUD_RATES = [300, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200];
+export const CAT_SERIAL_PARITIES = ['None', 'Odd', 'Even', 'Mark', 'Space'];
+export const CAT_SERIAL_DATA_BITS = [8, 7, 6];
+// Value = System.IO.Ports.StopBits name; label = the human "1 / 1.5 / 2".
+export const CAT_SERIAL_STOP_BITS: { value: string; label: string }[] = [
+  { value: 'One', label: '1' },
+  { value: 'OnePointFive', label: '1.5' },
+  { value: 'Two', label: '2' },
+];
+
+export type CatSerialPortConfig = {
+  enabled: boolean;
+  portName: string;
+  baudRate: number;
+  parity: string;
+  dataBits: number;
+  stopBits: string;
+};
+
+export type CatSerialPortStatus = CatSerialPortConfig & {
+  index: number;
+  open: boolean;
+  clientActivity: number;
+  error: string | null;
+};
+
+export type CatSerialStatus = {
+  ports: CatSerialPortStatus[];
+  availablePorts: string[];
+};
+
+export type CatSerialTestResult = { ok: boolean; error: string | null };
+
+export function defaultPortConfig(): CatSerialPortConfig {
+  return {
+    enabled: false,
+    portName: '',
+    baudRate: CAT_SERIAL_DEFAULT_BAUD,
+    parity: 'None',
+    dataBits: 8,
+    stopBits: 'One',
+  };
+}
+
+function normalizePort(raw: unknown, index: number): CatSerialPortStatus {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  return {
+    index: typeof r.index === 'number' ? r.index : index,
+    enabled: Boolean(r.enabled),
+    portName: typeof r.portName === 'string' ? r.portName : '',
+    baudRate: typeof r.baudRate === 'number' ? r.baudRate : CAT_SERIAL_DEFAULT_BAUD,
+    parity: typeof r.parity === 'string' ? r.parity : 'None',
+    dataBits: typeof r.dataBits === 'number' ? r.dataBits : 8,
+    stopBits: typeof r.stopBits === 'string' ? r.stopBits : 'One',
+    open: Boolean(r.open),
+    clientActivity: typeof r.clientActivity === 'number' ? r.clientActivity : 0,
+    error: typeof r.error === 'string' && r.error.length > 0 ? r.error : null,
+  };
+}
+
+function normalizeStatus(raw: unknown): CatSerialStatus {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  const portsRaw = Array.isArray(r.ports) ? r.ports : [];
+  const ports: CatSerialPortStatus[] = [];
+  for (let i = 0; i < CAT_SERIAL_PORT_COUNT; i++) ports.push(normalizePort(portsRaw[i], i));
+  const availablePorts = Array.isArray(r.availablePorts)
+    ? r.availablePorts.filter((p): p is string => typeof p === 'string')
+    : [];
+  return { ports, availablePorts };
+}
+
+async function jsonFetch<T>(
+  input: RequestInfo,
+  init: RequestInit | undefined,
+  parse: (raw: unknown) => T,
+): Promise<T> {
+  const res = await fetch(input, init);
+  if (!res.ok) {
+    let message = `${res.status} ${res.statusText}`;
+    try {
+      const body = (await res.json()) as unknown;
+      if (body && typeof body === 'object' && 'error' in body && typeof (body as { error: unknown }).error === 'string') {
+        message = (body as { error: string }).error;
+      }
+    } catch {
+      /* non-JSON */
+    }
+    throw new ApiError(res.status, message);
+  }
+  return parse((await res.json()) as unknown);
+}
+
+export function getCatSerialStatus(signal?: AbortSignal): Promise<CatSerialStatus> {
+  return jsonFetch('/api/cat/serial/status', { signal }, normalizeStatus);
+}
+
+export function putCatSerialConfig(ports: CatSerialPortConfig[], signal?: AbortSignal): Promise<CatSerialStatus> {
+  return jsonFetch(
+    '/api/cat/serial/config',
+    {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ports }),
+      signal,
+    },
+    normalizeStatus,
+  );
+}
+
+export function testCatSerialPort(port: CatSerialPortConfig, signal?: AbortSignal): Promise<CatSerialTestResult> {
+  return jsonFetch(
+    '/api/cat/serial/test',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        portName: port.portName,
+        baudRate: port.baudRate,
+        parity: port.parity,
+        dataBits: port.dataBits,
+        stopBits: port.stopBits,
+      }),
+      signal,
+    },
+    (raw) => {
+      const r = (raw ?? {}) as Record<string, unknown>;
+      return { ok: Boolean(r.ok), error: typeof r.error === 'string' && r.error ? r.error : null };
+    },
+  );
+}

--- a/zeus-web/src/components/CatSerialPortsPanel.tsx
+++ b/zeus-web/src/components/CatSerialPortsPanel.tsx
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+import { useEffect, useState } from 'react';
+import { useCatSerialStore } from '../state/cat-serial-store';
+import {
+  CAT_SERIAL_BAUD_RATES,
+  CAT_SERIAL_PARITIES,
+  CAT_SERIAL_DATA_BITS,
+  CAT_SERIAL_STOP_BITS,
+  type CatSerialPortConfig,
+  type CatSerialPortStatus,
+} from '../api/catSerial';
+
+const fieldStyle: React.CSSProperties = {
+  padding: '5px 7px',
+  fontSize: 12,
+  fontFamily: 'monospace',
+  background: 'var(--bg-0)',
+  border: '1px solid var(--panel-border)',
+  borderRadius: 'var(--r-sm)',
+  color: 'var(--fg-0)',
+};
+
+const labelStyle: React.CSSProperties = {
+  fontSize: 10,
+  fontWeight: 600,
+  letterSpacing: '0.04em',
+  color: 'var(--fg-2)',
+};
+
+function StatusDot({ live }: { live: CatSerialPortStatus | undefined }) {
+  const color = live?.error ? 'var(--tx)' : live?.open ? 'var(--accent)' : 'var(--fg-3)';
+  const text = live?.error ? 'Error' : live?.open ? 'Open' : 'Closed';
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+      <span style={{ width: 8, height: 8, borderRadius: '50%', background: color, flexShrink: 0 }} />
+      <span style={{ fontSize: 11, color: 'var(--fg-2)' }}>{text}</span>
+    </span>
+  );
+}
+
+export function CatSerialPortsPanel() {
+  const config = useCatSerialStore((s) => s.config);
+  const status = useCatSerialStore((s) => s.status);
+  const testingIndex = useCatSerialStore((s) => s.testingIndex);
+  const lastTest = useCatSerialStore((s) => s.lastTest);
+  const saveConfig = useCatSerialStore((s) => s.saveConfig);
+  const test = useCatSerialStore((s) => s.test);
+
+  const [ports, setPorts] = useState<CatSerialPortConfig[]>(config);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setPorts(config);
+  }, [config]);
+
+  const availablePorts = status?.availablePorts ?? [];
+
+  function updatePort(i: number, patch: Partial<CatSerialPortConfig>) {
+    setPorts((prev) => prev.map((p, idx) => (idx === i ? { ...p, ...patch } : p)));
+  }
+
+  async function onSave(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await saveConfig(ports);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div style={{ maxWidth: 700 }}>
+      <h3
+        style={{
+          margin: '0 0 14px',
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: '0.12em',
+          textTransform: 'uppercase',
+          color: 'var(--fg-2)',
+        }}
+      >
+        CAT SERIAL PORTS
+      </h3>
+
+      <div
+        style={{
+          padding: 12,
+          marginBottom: 16,
+          fontSize: 11,
+          lineHeight: 1.5,
+          color: 'var(--fg-2)',
+          background: 'var(--bg-0)',
+          border: '1px solid var(--panel-border)',
+          borderRadius: 'var(--r-sm)',
+        }}
+      >
+        Four serial CAT ports (Kenwood TS-2000), the same command set as CAT-over-TCP above. Point
+        a logger or digimode app at a virtual serial pair — <strong>com0com</strong> on Windows,{' '}
+        <strong>socat</strong> on macOS/Linux — and enter Zeus's end of the pair below. The port
+        name is free-form (<span style={{ fontFamily: 'monospace' }}>COM5</span>,{' '}
+        <span style={{ fontFamily: 'monospace' }}>/dev/cu.usbserial-1</span>); virtual pairs aren't
+        auto-listed. Changes apply immediately — no restart.
+      </div>
+
+      <form onSubmit={onSave} style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+        {ports.map((port, i) => {
+          const live = status?.ports[i];
+          const isTesting = testingIndex === i;
+          const testResult = lastTest && lastTest.index === i ? lastTest.result : null;
+          return (
+            <fieldset
+              key={i}
+              style={{
+                margin: 0,
+                padding: 12,
+                border: '1px solid var(--panel-border)',
+                borderRadius: 'var(--r-sm)',
+                background: 'var(--bg-1)',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 10,
+              }}
+            >
+              <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                <label style={{ display: 'flex', alignItems: 'center', gap: 8, flex: 1 }}>
+                  <input
+                    type="checkbox"
+                    checked={port.enabled}
+                    onChange={(e) => updatePort(i, { enabled: e.target.checked })}
+                    style={{ accentColor: 'var(--accent)' }}
+                  />
+                  <span style={{ fontSize: 12, fontWeight: 700, color: 'var(--fg-1)' }}>
+                    CAT {i + 1}
+                  </span>
+                </label>
+                {port.enabled && <StatusDot live={live} />}
+              </div>
+
+              <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                <span style={labelStyle}>PORT / DEVICE</span>
+                <input
+                  type="text"
+                  list={`cat-serial-ports-${i}`}
+                  value={port.portName}
+                  onChange={(e) => updatePort(i, { portName: e.target.value })}
+                  spellCheck={false}
+                  placeholder="COM5  ·  /dev/cu.usbserial-1  ·  /dev/ttys013"
+                  style={fieldStyle}
+                />
+                {availablePorts.length > 0 && (
+                  <datalist id={`cat-serial-ports-${i}`}>
+                    {availablePorts.map((p) => (
+                      <option key={p} value={p} />
+                    ))}
+                  </datalist>
+                )}
+              </label>
+
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10 }}>
+                <label style={{ display: 'flex', flexDirection: 'column', gap: 4, flex: '1 1 120px' }}>
+                  <span style={labelStyle}>BAUD</span>
+                  <select
+                    value={port.baudRate}
+                    onChange={(e) => updatePort(i, { baudRate: Number(e.target.value) })}
+                    style={fieldStyle}
+                  >
+                    {CAT_SERIAL_BAUD_RATES.map((b) => (
+                      <option key={b} value={b}>
+                        {b}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label style={{ display: 'flex', flexDirection: 'column', gap: 4, flex: '1 1 90px' }}>
+                  <span style={labelStyle}>PARITY</span>
+                  <select
+                    value={port.parity}
+                    onChange={(e) => updatePort(i, { parity: e.target.value })}
+                    style={fieldStyle}
+                  >
+                    {CAT_SERIAL_PARITIES.map((p) => (
+                      <option key={p} value={p}>
+                        {p}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label style={{ display: 'flex', flexDirection: 'column', gap: 4, flex: '1 1 70px' }}>
+                  <span style={labelStyle}>DATA</span>
+                  <select
+                    value={port.dataBits}
+                    onChange={(e) => updatePort(i, { dataBits: Number(e.target.value) })}
+                    style={fieldStyle}
+                  >
+                    {CAT_SERIAL_DATA_BITS.map((d) => (
+                      <option key={d} value={d}>
+                        {d}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label style={{ display: 'flex', flexDirection: 'column', gap: 4, flex: '1 1 70px' }}>
+                  <span style={labelStyle}>STOP</span>
+                  <select
+                    value={port.stopBits}
+                    onChange={(e) => updatePort(i, { stopBits: e.target.value })}
+                    style={fieldStyle}
+                  >
+                    {CAT_SERIAL_STOP_BITS.map((s) => (
+                      <option key={s.value} value={s.value}>
+                        {s.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+
+              {live?.error && port.enabled && (
+                <div style={{ fontSize: 11, color: 'var(--tx)' }}>{live.error}</div>
+              )}
+
+              {testResult && (
+                <div style={{ fontSize: 11, color: testResult.ok ? 'var(--accent)' : 'var(--tx)' }}>
+                  {testResult.ok
+                    ? `✓ ${port.portName || 'port'} opened OK`
+                    : `✗ ${testResult.error ?? 'test failed'}`}
+                </div>
+              )}
+
+              <div>
+                <button
+                  type="button"
+                  className="btn sm"
+                  disabled={isTesting || !port.portName.trim()}
+                  onClick={() => test(i, port)}
+                >
+                  {isTesting ? 'TESTING…' : 'TEST PORT'}
+                </button>
+              </div>
+            </fieldset>
+          );
+        })}
+
+        {saveError && (
+          <div
+            style={{
+              padding: 10,
+              fontSize: 12,
+              color: 'var(--tx)',
+              background: 'rgba(230, 58, 43, 0.1)',
+              border: '1px solid var(--tx)',
+              borderRadius: 'var(--r-sm)',
+            }}
+          >
+            ✗ Save failed: {saveError}
+          </div>
+        )}
+
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          <span style={{ flex: 1, fontSize: 10, color: 'var(--fg-3)' }}>
+            CAT grants full TX control with no authentication — only expose serial ports to software
+            you trust.
+          </span>
+          <button type="submit" disabled={saving} className="btn sm active">
+            {saving ? 'SAVING…' : 'SAVE'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/zeus-web/src/components/NetworkSettingsPanel.tsx
+++ b/zeus-web/src/components/NetworkSettingsPanel.tsx
@@ -9,19 +9,23 @@
 // License for details.
 
 import { CatSettingsPanel } from './CatSettingsPanel';
+import { CatSerialPortsPanel } from './CatSerialPortsPanel';
 import { TciSettingsPanel } from './TciSettingsPanel';
 
 // The Network tab hosts Zeus's external network-control servers. TCI (the
 // existing ExpertSDR3 WebSocket interface) and CAT (the Kenwood TS-2000 TCP
-// interface) are independent servers configured side by side. Each child panel
-// owns its own store, polling, and persistence — this container only stacks
-// them with a separating rule.
+// interface) are independent servers configured side by side. CAT additionally
+// exposes four serial ports (Thetis CAT1–4) for clients that talk to a virtual
+// COM pair rather than TCP. Each child panel owns its own store, polling, and
+// persistence — this container only stacks them with separating rules.
 export function NetworkSettingsPanel() {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
       <TciSettingsPanel />
       <div style={{ borderTop: '1px solid var(--panel-border)' }} />
       <CatSettingsPanel />
+      <div style={{ borderTop: '1px solid var(--panel-border)' }} />
+      <CatSerialPortsPanel />
     </div>
   );
 }

--- a/zeus-web/src/state/cat-serial-store.test.ts
+++ b/zeus-web/src/state/cat-serial-store.test.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CatSerialPortConfig, CatSerialStatus } from '../api/catSerial';
+
+vi.mock('../api/catSerial', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/catSerial')>();
+  return {
+    ...actual, // keep the real constants/defaultPortConfig
+    getCatSerialStatus: vi.fn(),
+    putCatSerialConfig: vi.fn(),
+    testCatSerialPort: vi.fn(),
+  };
+});
+
+import {
+  getCatSerialStatus,
+  putCatSerialConfig,
+  testCatSerialPort,
+  defaultPortConfig,
+} from '../api/catSerial';
+import { useCatSerialStore } from './cat-serial-store';
+
+const mockGet = vi.mocked(getCatSerialStatus);
+const mockPut = vi.mocked(putCatSerialConfig);
+const mockTest = vi.mocked(testCatSerialPort);
+
+function statusFrom(ports: CatSerialPortConfig[], availablePorts: string[] = []): CatSerialStatus {
+  return {
+    ports: ports.map((p, index) => ({ ...p, index, open: p.enabled, clientActivity: 0, error: null })),
+    availablePorts,
+  };
+}
+
+function fourDefaults(): CatSerialPortConfig[] {
+  return [0, 1, 2, 3].map(defaultPortConfig);
+}
+
+describe('cat-serial-store', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useCatSerialStore.setState({
+      config: fourDefaults(),
+      status: null,
+      testingIndex: null,
+      lastTest: null,
+    });
+  });
+
+  it('adopts server config when it differs from the in-hand config', async () => {
+    const serverPorts = fourDefaults();
+    serverPorts[0] = { enabled: true, portName: '/dev/ttys9', baudRate: 9600, parity: 'Even', dataBits: 7, stopBits: 'Two' };
+    mockGet.mockResolvedValueOnce(statusFrom(serverPorts));
+
+    await useCatSerialStore.getState().refreshStatus();
+
+    const cfg = useCatSerialStore.getState().config;
+    expect(cfg[0]).toMatchObject({ enabled: true, portName: '/dev/ttys9', baudRate: 9600, parity: 'Even', dataBits: 7, stopBits: 'Two' });
+    expect(useCatSerialStore.getState().status?.availablePorts).toEqual([]);
+  });
+
+  it('keeps the in-hand config by reference when the server matches (no clobber of edits)', async () => {
+    const current = useCatSerialStore.getState().config;
+    mockGet.mockResolvedValueOnce(statusFrom(current, ['/dev/cu.usbserial-1']));
+
+    await useCatSerialStore.getState().refreshStatus();
+
+    // Same reference → the panel's useEffect([config]) won't refire and reset the form.
+    expect(useCatSerialStore.getState().config).toBe(current);
+    // Live status (availablePorts) still updates.
+    expect(useCatSerialStore.getState().status?.availablePorts).toEqual(['/dev/cu.usbserial-1']);
+  });
+
+  it('saveConfig adopts the posted config and the returned status', async () => {
+    const ports = fourDefaults();
+    ports[1] = { enabled: true, portName: 'COM3', baudRate: 115200, parity: 'None', dataBits: 8, stopBits: 'One' };
+    mockPut.mockResolvedValueOnce(statusFrom(ports));
+
+    await useCatSerialStore.getState().saveConfig(ports);
+
+    expect(mockPut).toHaveBeenCalledWith(ports);
+    expect(useCatSerialStore.getState().config).toBe(ports);
+    expect(useCatSerialStore.getState().status?.ports[1]?.portName).toBe('COM3');
+  });
+
+  it('test() records the per-index result and clears the in-flight flag', async () => {
+    mockTest.mockResolvedValueOnce({ ok: false, error: 'Port is in use' });
+
+    const result = await useCatSerialStore.getState().test(2, defaultPortConfig());
+
+    expect(result).toEqual({ ok: false, error: 'Port is in use' });
+    expect(useCatSerialStore.getState().testingIndex).toBeNull();
+    expect(useCatSerialStore.getState().lastTest).toEqual({ index: 2, result: { ok: false, error: 'Port is in use' } });
+  });
+
+  it('test() surfaces a thrown error as a failed result instead of rejecting', async () => {
+    mockTest.mockRejectedValueOnce(new Error('network down'));
+
+    const result = await useCatSerialStore.getState().test(0, defaultPortConfig());
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('network down');
+    expect(useCatSerialStore.getState().testingIndex).toBeNull();
+  });
+});

--- a/zeus-web/src/state/cat-serial-store.ts
+++ b/zeus-web/src/state/cat-serial-store.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+import { create } from 'zustand';
+import {
+  getCatSerialStatus,
+  putCatSerialConfig,
+  testCatSerialPort,
+  defaultPortConfig,
+  CAT_SERIAL_PORT_COUNT,
+  type CatSerialPortConfig,
+  type CatSerialStatus,
+  type CatSerialPortStatus,
+  type CatSerialTestResult,
+} from '../api/catSerial';
+
+// The backend (CatSerialConfigStore on disk) is the source of truth. The form
+// hydrates from /api/cat/serial/status once it arrives. As in cat-store, do NOT
+// seed from localStorage and do NOT auto-POST on load.
+function defaultConfigs(): CatSerialPortConfig[] {
+  return Array.from({ length: CAT_SERIAL_PORT_COUNT }, defaultPortConfig);
+}
+
+function stripConfig(p: CatSerialPortStatus): CatSerialPortConfig {
+  return {
+    enabled: p.enabled,
+    portName: p.portName,
+    baudRate: p.baudRate,
+    parity: p.parity,
+    dataBits: p.dataBits,
+    stopBits: p.stopBits,
+  };
+}
+
+function sameConfig(a: CatSerialPortConfig, b: CatSerialPortConfig): boolean {
+  return a.enabled === b.enabled
+    && a.portName === b.portName
+    && a.baudRate === b.baudRate
+    && a.parity === b.parity
+    && a.dataBits === b.dataBits
+    && a.stopBits === b.stopBits;
+}
+
+export type CatSerialTestState = { index: number; result: CatSerialTestResult };
+
+export type CatSerialStoreState = {
+  config: CatSerialPortConfig[];
+  status: CatSerialStatus | null;
+  testingIndex: number | null;
+  lastTest: CatSerialTestState | null;
+
+  refreshStatus: () => Promise<void>;
+  saveConfig: (ports: CatSerialPortConfig[]) => Promise<CatSerialStatus>;
+  test: (index: number, port: CatSerialPortConfig) => Promise<CatSerialTestResult>;
+};
+
+export const useCatSerialStore = create<CatSerialStoreState>((set, get) => ({
+  config: defaultConfigs(),
+  status: null,
+  testingIndex: null,
+  lastTest: null,
+
+  refreshStatus: async () => {
+    try {
+      const status = await getCatSerialStatus();
+      const current = get().config;
+      const serverConfig = status.ports.map(stripConfig);
+      // Form edits live in the panel's component-local state, NOT here — store
+      // `config` only ever holds defaults / last-saved / adopted server truth.
+      // So keep the SAME reference when the server already matches (the panel's
+      // useEffect([config]) then won't refire and reset the form); only adopt a
+      // new array when disk genuinely differs (external change / post-save truth).
+      const synced = serverConfig.length === current.length
+        && serverConfig.every((c, i) => current[i] !== undefined && sameConfig(c, current[i]!));
+      set({ status, config: synced ? current : serverConfig });
+    } catch {
+      /* transient — next poll recovers */
+    }
+  },
+
+  saveConfig: async (ports) => {
+    const status = await putCatSerialConfig(ports);
+    set({ config: ports, status });
+    return status;
+  },
+
+  test: async (index, port) => {
+    set({ testingIndex: index, lastTest: null });
+    try {
+      const result = await testCatSerialPort(port);
+      set({ testingIndex: null, lastTest: { index, result } });
+      return result;
+    } catch (e) {
+      const result: CatSerialTestResult = { ok: false, error: e instanceof Error ? e.message : 'test failed' };
+      set({ testingIndex: null, lastTest: { index, result } });
+      return result;
+    }
+  },
+}));
+
+// Initial probe + 2 s polling while the page is alive AND at least one serial
+// port is enabled (nothing to poll otherwise).
+if (typeof window !== 'undefined') {
+  void useCatSerialStore.getState().refreshStatus();
+  window.setInterval(() => {
+    if (!useCatSerialStore.getState().config.some((p) => p.enabled)) return;
+    void useCatSerialStore.getState().refreshStatus();
+  }, 2000);
+}


### PR DESCRIPTION
## What & why

We added CAT control (Kenwood TS-2000) yesterday as a **TCP** server, but Thetis also exposes **four serial COM ports** for the same CAT command set. Many loggers and digimode apps connect through a **virtual serial pair** (com0com on Windows, socat on macOS/Linux) rather than TCP. This PR adds those four serial ports, completing parity with Thetis's CAT1–4, and wires them into the **Network** settings tab directly under the existing CAT (TCP) panel.

Each serial port feeds the **same** `CatCommandHandler` the TCP path uses — so there's **no duplicated protocol logic**, and the safety contract is inherited unchanged.

## How it works

- **`CatSerialPort`** — one live serial connection: a `;`-framed read loop (`CatProtocol.ExtractCommands`) handing each command to a per-port `CatCommandHandler`. Built on the same cross-platform serial idiom already shipped in `G2FrontPanelService`.
- **`CatSerialService`** (`BackgroundService`) — hosts up to 4 ports, with one subscription fanning **Auto-Information** pushes out to ports whose client armed AI (mirrors `CatServer`). Per-port reconnect on a backoff; settings changes **hot-reconnect with no restart**.
- **`CatSerialConfigStore`** — single-row LiteDB persistence (collection `cat_serial_config`), always exactly 4 ports, `Insert`-then-`Update` (avoids the #387 `Id=0` upsert bug), sanitises on read **and** write.
- **Endpoints** — `GET/PUT /api/cat/serial/config|status`, `POST /api/cat/serial/test`.
- **UI** — `CatSerialPortsPanel`: 4 ports, each with enable / **free-form device path** (+ `GetPortNames()` datalist suggestions) / baud / parity / data / stop bits, a per-port **Test** button, and a live **open/error** status dot.

## Parity notes

- 4 ports; baud `300…115200`; parity none/odd/even/mark/space; data 8/7/6; stop 1/1.5/2; **default 115200 8-N-1** — all matching Thetis.
- Every port round-trips its **own** baud — deliberately **not** reproducing Thetis's real bug where CAT4 reports CAT1's baud.
- Thetis's SIO5/6/7 (Andromeda/Aries/Ganymede accessory channels, fixed 9600) are intentionally **out of scope**.

## Safety (unchanged)

The serial path constructs the identical `CatCommandHandler(radio, tx, options, …)` as TCP. Keying happens **only** on an explicit `TX;` → `TrySetMox(true, MoxSource.Cat)`. AI/state pushes never key; **PureSignal is never touched**. No serial path can key TX without an explicit command.

## Cross-platform

- `System.IO.Ports` was **already** referenced (G2 front-panel bridge) — **no new dependency**.
- Free-form device path (virtual pty/com0com pairs aren't enumerable, so the field is never gated on a dropdown); `GetPortNames()` guarded; finite Read/Write timeouts; RTS/DTR best-effort so a virtual pty that doesn't model line control still opens.
- Teardown of a possibly-unreliable `SerialPort.ReadAsync` is force-unblocked by closing the port, offloaded to the thread pool so a hung adapter can't block the HTTP request or host shutdown.

## Testing

- **Config store** — round-trip incl. independent per-port baud, normalise-to-4, sanitise of malicious values, `Changed` event.
- **socat pty-pair integration** (gated to POSIX + socat; `SkippableFact`):
  - port-level: real serial `ID;`→`ID019;`, `FA` set tunes the radio, `FA;` reads it back over the wire;
  - service-level: config store → service opens the device → status reports `Open` → client talks through the handler; plus enable/disable **hot-reconnect**.
- **Frontend** — vitest for the store no-clobber reconciliation (keeps reference when server matches, adopts on diff).
- Full backend suite green (**1917 passed**); frontend typecheck / eslint / SPA build clean. Verified locally on macOS with a socat virtual pair.

## Reviewer flags (per repo conventions — need Doug/Brian sign-off)

- **Network settings tab** placement + the new panel (red-light: UX/visual).
- **Zeus.Contracts wire format** additions (red-light: architecture).
- New `BackgroundService` + endpoints (red-light: architecture).
- **Known limitation:** ports speak the existing **Tier-1 TS-2000 subset** (same as TCP CAT), not the full TS-2000/ZZ vocabulary — exotic ZZ commands return `?;`, identical to the TCP path. Full command-set expansion is a separate follow-up.
- **Not bench-tested on hardware** — proven over virtual serial pairs only. Worth a quick N1MM/WSJT-X-over-com0com check before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)