### PR TITLE
feat(web): saved-layouts library separate from workspace tabs

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -1854,6 +1854,29 @@ public sealed record SaveNamedLayoutRequest(
 
 public sealed record SetActiveLayoutRequest(string RadioKey, string LayoutId);
 
+// Saved-layouts library — a per-radio pool of reusable layout PRESETS, kept
+// separate from the working tabs (`RadioLayoutsDto`). The operator snapshots a
+// good workspace arrangement into a saved layout so they can restore it later
+// (if they mess the live tab up) or seed a brand-new workspace from it. Saved
+// layouts are never "active"; they are templates, applied on demand.
+public sealed record SavedLayoutDto(
+    string Id,
+    string Name,
+    string LayoutJson,
+    long UpdatedUtc,
+    string? Icon = null,
+    string? Description = null);
+
+public sealed record SavedLayoutsDto(string RadioKey, IReadOnlyList<SavedLayoutDto> SavedLayouts);
+
+public sealed record SaveSavedLayoutRequest(
+    string RadioKey,
+    string SavedId,
+    string Name,
+    string LayoutJson,
+    string? Icon = null,
+    string? Description = null);
+
 // Prefs-database (profile) selector. All Zeus settings/layouts/prefs persist in
 // a single LiteDB file resolved by PrefsDbPath.Get() at startup. The operator
 // can keep several named databases and pick which is active from the connect

--- a/Zeus.Server.Hosting/LayoutStore.cs
+++ b/Zeus.Server.Hosting/LayoutStore.cs
@@ -65,6 +65,7 @@ public sealed class LayoutStore : IDisposable
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<LayoutEntry> _legacy;
     private readonly ILiteCollection<RadioLayoutsEntry> _v2;
+    private readonly ILiteCollection<RadioSavedLayoutsEntry> _saved;
     private readonly ILogger<LayoutStore> _log;
     private readonly object _lock = new();
 
@@ -82,6 +83,8 @@ public sealed class LayoutStore : IDisposable
         _legacy.EnsureIndex(x => x.ProfileId, unique: true);
         _v2 = _db.GetCollection<RadioLayoutsEntry>("ui_layouts_v2");
         _v2.EnsureIndex(x => x.RadioKey, unique: true);
+        _saved = _db.GetCollection<RadioSavedLayoutsEntry>("ui_saved_layouts");
+        _saved.EnsureIndex(x => x.RadioKey, unique: true);
 
         _log.LogInformation("LayoutStore initialized at {Path}", dbPath);
     }
@@ -279,6 +282,111 @@ public sealed class LayoutStore : IDisposable
         }
     }
 
+    // -----------------------------------------------------------------
+    // Saved-layouts library (reusable presets, separate from the tabs)
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// Read every saved layout (preset) for the given radio. Returns an empty
+    /// list when the radio has none yet — the library starts empty.
+    /// </summary>
+    public SavedLayoutsDto GetSavedLayouts(string radioKey)
+    {
+        radioKey = NormalizeRadioKey(radioKey);
+        lock (_lock)
+        {
+            var entry = _saved.FindOne(x => x.RadioKey == radioKey);
+            return entry is null
+                ? new SavedLayoutsDto(radioKey, Array.Empty<SavedLayoutDto>())
+                : ToSavedDto(entry);
+        }
+    }
+
+    /// <summary>
+    /// Create or replace a saved layout. Passing the id of an existing saved
+    /// layout overwrites its name/icon/description/arrangement in place — this
+    /// is the "replace" affordance (re-snapshot a preset from a fresh
+    /// workspace). A new id appends a new preset.
+    /// </summary>
+    public SavedLayoutsDto UpsertSavedLayout(
+        string radioKey,
+        string savedId,
+        string name,
+        string layoutJson,
+        string? icon = null,
+        string? description = null)
+    {
+        radioKey = NormalizeRadioKey(radioKey);
+        savedId = NormalizeLayoutId(savedId);
+        if (string.IsNullOrWhiteSpace(name)) name = savedId;
+        var normalisedIcon = NormalizeIcon(icon);
+        var normalisedDescription = NormalizeDescription(description);
+
+        lock (_lock)
+        {
+            var entry = _saved.FindOne(x => x.RadioKey == radioKey) ?? new RadioSavedLayoutsEntry
+            {
+                RadioKey = radioKey,
+                SavedLayouts = new List<SavedLayoutEntry>(),
+            };
+
+            var existing = entry.SavedLayouts.FirstOrDefault(l => l.SavedId == savedId);
+            if (existing is null)
+            {
+                entry.SavedLayouts.Add(new SavedLayoutEntry
+                {
+                    SavedId = savedId,
+                    Name = name,
+                    LayoutJson = layoutJson,
+                    UpdatedUtc = DateTime.UtcNow,
+                    Icon = normalisedIcon ?? string.Empty,
+                    Description = normalisedDescription ?? string.Empty,
+                });
+            }
+            else
+            {
+                existing.Name = name;
+                existing.LayoutJson = layoutJson;
+                existing.UpdatedUtc = DateTime.UtcNow;
+                if (icon is not null) existing.Icon = normalisedIcon ?? string.Empty;
+                if (description is not null) existing.Description = normalisedDescription ?? string.Empty;
+            }
+
+            if (entry.Id == 0) _saved.Insert(entry);
+            else _saved.Update(entry);
+
+            return ToSavedDto(entry);
+        }
+    }
+
+    /// <summary>Remove a saved layout from the library. No-op if absent.</summary>
+    public SavedLayoutsDto DeleteSavedLayout(string radioKey, string savedId)
+    {
+        radioKey = NormalizeRadioKey(radioKey);
+        savedId = NormalizeLayoutId(savedId);
+        lock (_lock)
+        {
+            var entry = _saved.FindOne(x => x.RadioKey == radioKey);
+            if (entry is null)
+                return new SavedLayoutsDto(radioKey, Array.Empty<SavedLayoutDto>());
+            entry.SavedLayouts.RemoveAll(l => l.SavedId == savedId);
+            _saved.Update(entry);
+            return ToSavedDto(entry);
+        }
+    }
+
+    private static SavedLayoutsDto ToSavedDto(RadioSavedLayoutsEntry e) => new(
+        e.RadioKey,
+        e.SavedLayouts
+            .Select(l => new SavedLayoutDto(
+                l.SavedId,
+                l.Name,
+                l.LayoutJson,
+                new DateTimeOffset(l.UpdatedUtc).ToUnixTimeMilliseconds(),
+                string.IsNullOrEmpty(l.Icon) ? null : l.Icon,
+                string.IsNullOrEmpty(l.Description) ? null : l.Description))
+            .ToList());
+
     private static RadioLayoutsDto ToDto(RadioLayoutsEntry e) => new(
         e.RadioKey,
         e.Layouts
@@ -362,6 +470,26 @@ public sealed class NamedLayoutEntry
     public DateTime UpdatedUtc { get; set; }
     // Optional presentation fields (issue #241 follow-up). Older rows that
     // predate these columns deserialise as empty strings under LiteDB.
+    public string Icon { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+}
+
+// Saved-layouts library — one row per radio holding a list of reusable layout
+// presets. Distinct from RadioLayoutsEntry (the live tabs): presets are never
+// "active", they are templates the operator applies on demand.
+public sealed class RadioSavedLayoutsEntry
+{
+    public int Id { get; set; }
+    public string RadioKey { get; set; } = string.Empty;
+    public List<SavedLayoutEntry> SavedLayouts { get; set; } = new();
+}
+
+public sealed class SavedLayoutEntry
+{
+    public string SavedId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string LayoutJson { get; set; } = string.Empty;
+    public DateTime UpdatedUtc { get; set; }
     public string Icon { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
 }

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -2981,6 +2981,34 @@ public static class ZeusEndpoints
             return Results.Ok(store.DeleteNamed(radio ?? "default", id));
         });
 
+        // Saved-layouts library — reusable layout presets per radio, separate
+        // from the working tabs above. The operator snapshots a workspace into a
+        // preset (PUT), restores/seeds from it client-side, and manages the pool.
+        app.MapGet("/api/ui/saved-layouts", (string? radio, LayoutStore store) =>
+            Results.Ok(store.GetSavedLayouts(radio ?? "default")));
+
+        app.MapPut("/api/ui/saved-layouts", (SaveSavedLayoutRequest req, LayoutStore store) =>
+        {
+            if (string.IsNullOrWhiteSpace(req.SavedId))
+                return Results.BadRequest(new { error = "savedId required" });
+            if (string.IsNullOrWhiteSpace(req.LayoutJson))
+                return Results.BadRequest(new { error = "layoutJson required" });
+            return Results.Ok(store.UpsertSavedLayout(
+                req.RadioKey ?? "default",
+                req.SavedId,
+                req.Name,
+                req.LayoutJson,
+                req.Icon,
+                req.Description));
+        });
+
+        app.MapDelete("/api/ui/saved-layouts", (string? radio, string? id, LayoutStore store) =>
+        {
+            if (string.IsNullOrWhiteSpace(id))
+                return Results.BadRequest(new { error = "id required" });
+            return Results.Ok(store.DeleteSavedLayout(radio ?? "default", id));
+        });
+
         // Detached workspace windows (extra Photino frames popped off the dock)
         // that were open at the last desktop shutdown. The desktop shell reads
         // this once on startup and reopens each; web/headless clients never call

--- a/tests/Zeus.Server.Tests/SavedLayoutsStoreTests.cs
+++ b/tests/Zeus.Server.Tests/SavedLayoutsStoreTests.cs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF), Christian Suarez (N9WAR), and contributors.
+//
+// Saved-layouts library CRUD round-trip — the reusable layout-preset pool
+// (separate from the working tabs). Exercises create / replace / rename /
+// delete plus persistence across a store reopen.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class SavedLayoutsStoreTests : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly string? _previous;
+
+    public SavedLayoutsStoreTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"zeus-prefs-saved-{Guid.NewGuid():N}.db");
+        _previous = Environment.GetEnvironmentVariable("ZEUS_PREFS_PATH");
+        Environment.SetEnvironmentVariable("ZEUS_PREFS_PATH", _dbPath);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("ZEUS_PREFS_PATH", _previous);
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+        try { if (File.Exists(_dbPath + "-log")) File.Delete(_dbPath + "-log"); } catch { }
+    }
+
+    private static LayoutStore NewStore() => new(NullLogger<LayoutStore>.Instance);
+
+    private const string Json = "{\"schemaVersion\":8,\"tiles\":[]}";
+
+    [Fact]
+    public void Empty_Radio_Has_No_Saved_Layouts()
+    {
+        using var store = NewStore();
+        var dto = store.GetSavedLayouts("HermesLite2");
+        Assert.Empty(dto.SavedLayouts);
+    }
+
+    [Fact]
+    public void Upsert_Adds_New_Saved_Layout_With_Metadata()
+    {
+        using var store = NewStore();
+        var dto = store.UpsertSavedLayout("HermesLite2", "s1", "My Backup", Json, "⭐", "portable");
+        var entry = Assert.Single(dto.SavedLayouts);
+        Assert.Equal("s1", entry.Id);
+        Assert.Equal("My Backup", entry.Name);
+        Assert.Equal("⭐", entry.Icon);
+        Assert.Equal("portable", entry.Description);
+    }
+
+    [Fact]
+    public void Upsert_Same_Id_Replaces_In_Place()
+    {
+        using var store = NewStore();
+        store.UpsertSavedLayout("HermesLite2", "s1", "First", Json, null, null);
+        const string newJson = "{\"schemaVersion\":8,\"tiles\":[{\"uid\":\"a\",\"panelId\":\"vfo\",\"x\":0,\"y\":0,\"w\":2,\"h\":2}]}";
+        var dto = store.UpsertSavedLayout("HermesLite2", "s1", "Renamed", newJson, null, null);
+
+        var entry = Assert.Single(dto.SavedLayouts); // replaced, not appended
+        Assert.Equal("Renamed", entry.Name);
+        Assert.Equal(newJson, entry.LayoutJson);
+    }
+
+    [Fact]
+    public void Saved_Layouts_Are_Per_Radio()
+    {
+        using var store = NewStore();
+        store.UpsertSavedLayout("HermesLite2", "s1", "HL2 preset", Json, null, null);
+        store.UpsertSavedLayout("AnanG2", "s2", "G2 preset", Json, null, null);
+
+        Assert.Equal("HL2 preset", Assert.Single(store.GetSavedLayouts("HermesLite2").SavedLayouts).Name);
+        Assert.Equal("G2 preset", Assert.Single(store.GetSavedLayouts("AnanG2").SavedLayouts).Name);
+    }
+
+    [Fact]
+    public void Saved_Layouts_Persist_Across_Reopen()
+    {
+        using (var store = NewStore())
+            store.UpsertSavedLayout("HermesLite2", "s1", "Backup", Json, "📡", null);
+
+        using var reopened = NewStore();
+        var entry = Assert.Single(reopened.GetSavedLayouts("HermesLite2").SavedLayouts);
+        Assert.Equal("Backup", entry.Name);
+        Assert.Equal("📡", entry.Icon);
+    }
+
+    [Fact]
+    public void Delete_Removes_Only_The_Target()
+    {
+        using var store = NewStore();
+        store.UpsertSavedLayout("HermesLite2", "s1", "Keep", Json, null, null);
+        store.UpsertSavedLayout("HermesLite2", "s2", "Drop", Json, null, null);
+
+        var dto = store.DeleteSavedLayout("HermesLite2", "s2");
+        var entry = Assert.Single(dto.SavedLayouts);
+        Assert.Equal("s1", entry.Id);
+    }
+
+    [Fact]
+    public void Saved_Layouts_Are_Independent_From_The_Tabs()
+    {
+        // The library and the working-tab collection (UpsertNamed) must not
+        // bleed into each other even under the same radio key.
+        using var store = NewStore();
+        store.UpsertNamed("HermesLite2", "tab1", "Tab One", Json);
+        store.UpsertSavedLayout("HermesLite2", "preset1", "Preset One", Json, null, null);
+
+        Assert.Equal("Tab One", Assert.Single(store.GetForRadio("HermesLite2").Layouts).Name);
+        Assert.Equal("Preset One", Assert.Single(store.GetSavedLayouts("HermesLite2").SavedLayouts).Name);
+    }
+}

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -109,6 +109,7 @@ import { useRotatorStore } from './state/rotator-store';
 import { useLoggerStore } from './state/logger-store';
 import { useTxStore } from './state/tx-store';
 import { useLayoutStore } from './state/layout-store';
+import { useSavedLayoutsStore } from './state/saved-layouts-store';
 import { useDisplaySettingsStore } from './state/display-settings-store';
 import { useCapabilitiesStore } from './state/capabilities-store';
 import { useKeyboardShortcuts } from './util/use-keyboard-shortcuts';
@@ -199,6 +200,8 @@ export default function App() {
   // landing flips this to e.g. "HermesLite2" / "AnanG2" and the store
   // re-fetches that radio's named-layout collection from the server.
   const loadLayoutsForRadio = useLayoutStore((s) => s.loadForRadio);
+  // The saved-layouts library is keyed on the same BoardKind as the tabs.
+  const loadSavedLayoutsForRadio = useSavedLayoutsStore((s) => s.loadForRadio);
   // Wait for the radio-store's initial fetch before loading any layout. Until
   // `radioLoaded` is true, `connected === 'Unknown'` is ambiguous: it could mean
   // "no radio" OR "not resolved yet". Loading 'default' eagerly here renders the
@@ -210,7 +213,8 @@ export default function App() {
     if (!radioLoaded) return;
     const key = radioConnected !== 'Unknown' ? radioConnected : 'default';
     void loadLayoutsForRadio(key);
-  }, [loadLayoutsForRadio, radioConnected, radioLoaded]);
+    void loadSavedLayoutsForRadio(key);
+  }, [loadLayoutsForRadio, loadSavedLayoutsForRadio, radioConnected, radioLoaded]);
   const activeLayoutId = useLayoutStore((s) => s.activeLayoutId);
 
   // Recover action for the workspace error boundary: reset the active layout to

--- a/zeus-web/src/components/LeftLayoutBar.tsx
+++ b/zeus-web/src/components/LeftLayoutBar.tsx
@@ -33,6 +33,7 @@ import {
 } from 'react';
 import { LockKeyhole } from 'lucide-react';
 import { parseLayoutOrDefault, useLayoutStore } from '../state/layout-store';
+import { useSavedLayoutsStore } from '../state/saved-layouts-store';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
 import {
   LayoutSettingsModal,
@@ -56,9 +57,16 @@ export function LeftLayoutBar() {
   const addLayout = useLayoutStore((s) => s.addLayout);
   const removeLayout = useLayoutStore((s) => s.removeLayout);
   const updateLayoutMeta = useLayoutStore((s) => s.updateLayoutMeta);
+  const replaceActiveWorkspace = useLayoutStore((s) => s.replaceActiveWorkspace);
   const setWorkspaceLockedInLayout = useLayoutStore(
     (s) => s.setWorkspaceLockedInLayout,
   );
+  // Saved-layouts library (reusable presets, separate from the tabs).
+  const savedLayouts = useSavedLayoutsStore((s) => s.savedLayouts);
+  const saveWorkspaceToLibrary = useSavedLayoutsStore((s) => s.saveWorkspaceAs);
+  const replaceSavedLayout = useSavedLayoutsStore((s) => s.replaceWorkspace);
+  const updateSavedLayoutMeta = useSavedLayoutsStore((s) => s.updateMeta);
+  const deleteSavedLayout = useSavedLayoutsStore((s) => s.deleteSavedLayout);
   const isLoaded = useLayoutStore((s) => s.isLoaded);
   const settingsViewOpen = useLayoutStore((s) => s.settingsViewOpen);
   const setSettingsView = useLayoutStore((s) => s.setSettingsView);
@@ -89,6 +97,8 @@ export function LeftLayoutBar() {
   }, [rxTraceColor]);
 
   const [modal, setModal] = useState<ModalState>({ kind: 'closed' });
+  // Create-mode "Start from" selection: '' = blank, else a saved-layout id.
+  const [createSourceId, setCreateSourceId] = useState('');
   const [draggingLayoutId, setDraggingLayoutId] = useState<string | null>(null);
   const lockedLayoutIds = useMemo(
     () =>
@@ -100,7 +110,10 @@ export function LeftLayoutBar() {
     [layouts],
   );
 
-  const handleAdd = () => setModal({ kind: 'create' });
+  const handleAdd = () => {
+    setCreateSourceId('');
+    setModal({ kind: 'create' });
+  };
 
   const handleDelete = (id: string, name: string) => {
     if (layouts.length <= 1) return;
@@ -117,14 +130,23 @@ export function LeftLayoutBar() {
 
   const handleModalSave = (value: LayoutSettingsValue) => {
     if (modal.kind === 'create') {
+      // Seed the new workspace: a chosen saved layout's arrangement, or blank.
+      const source = createSourceId
+        ? savedLayouts.find((l) => l.id === createSourceId)
+        : undefined;
+      const base = source
+        ? parseLayoutOrDefault(source.layoutJson)
+        : EMPTY_WORKSPACE_LAYOUT;
+      const seeded = value.locked || source;
       addLayout(value.name, {
         icon: value.icon || undefined,
         description: value.description || undefined,
-        ...(value.locked
-          ? { workspace: { ...EMPTY_WORKSPACE_LAYOUT, locked: true } }
+        ...(seeded
+          ? { workspace: value.locked ? { ...base, locked: true } : base }
           : {}),
       });
     } else if (modal.kind === 'edit') {
+      // Save edits IN PLACE — never spawns a new tab.
       updateLayoutMeta(modal.id, {
         name: value.name,
         icon: value.icon,
@@ -135,21 +157,36 @@ export function LeftLayoutBar() {
     setModal({ kind: 'closed' });
   };
 
-  // Save as new — copy the CURRENT panel arrangement into a fresh saved layout
-  // and re-target the manager to it. addLayout makes the new layout active.
-  const handleSaveAsNew = (value: LayoutSettingsValue) => {
+  // Saved-layouts library handlers (manager mode) ----------------------------
+
+  // Snapshot the live workspace into a NEW saved layout, seeding its icon /
+  // description from the workspace being edited.
+  const handleSaveToLibrary = (name: string) => {
+    if (modal.kind !== 'edit') return;
     const ws = useLayoutStore.getState().workspace;
-    const newId = addLayout(value.name, {
-      icon: value.icon || undefined,
-      description: value.description || undefined,
-      workspace: value.locked ? { ...ws, locked: true } : ws,
+    const current = layouts.find((l) => l.id === modal.id);
+    void saveWorkspaceToLibrary(name, ws, {
+      ...(current?.icon ? { icon: current.icon } : {}),
+      ...(current?.description ? { description: current.description } : {}),
     });
-    setModal({ kind: 'edit', id: newId });
   };
 
-  // Delete from the manager — removeLayout promotes the next layout to active;
-  // follow it so the still-open manager keeps editing a valid layout.
-  const handleManagerDelete = (id: string) => {
+  // Apply (restore) a saved layout onto the current workspace in place.
+  const handleApplySaved = (id: string) => {
+    const saved = savedLayouts.find((l) => l.id === id);
+    if (!saved) return;
+    replaceActiveWorkspace(parseLayoutOrDefault(saved.layoutJson));
+  };
+
+  // Overwrite a saved layout with the current workspace arrangement.
+  const handleReplaceSaved = (id: string) => {
+    void replaceSavedLayout(id, useLayoutStore.getState().workspace);
+  };
+
+  // Delete the selected workspace tab from the manager — removeLayout promotes
+  // the next layout to active; follow it so the manager keeps editing a valid
+  // workspace.
+  const handleDeleteWorkspace = (id: string) => {
     removeLayout(id);
     const nextActive = useLayoutStore.getState().activeLayoutId;
     setModal({ kind: 'edit', id: nextActive });
@@ -293,12 +330,18 @@ export function LeftLayoutBar() {
 
       {modal.kind === 'create' && (
         <LayoutSettingsModal
-          title="New layout"
+          title="New workspace"
+          saveLabel="Create"
           initial={{
-            name: `Layout ${layouts.length + 1}`,
+            name: `Workspace ${layouts.length + 1}`,
             icon: '',
             description: '',
             locked: false,
+          }}
+          createSource={{
+            savedLayouts,
+            sourceId: createSourceId,
+            onSourceChange: setCreateSourceId,
           }}
           onSave={handleModalSave}
           onClose={() => setModal({ kind: 'closed' })}
@@ -314,17 +357,22 @@ export function LeftLayoutBar() {
             locked: parseLayoutOrDefault(editingLayout.layoutJson).locked === true,
           }}
           manager={{
-            layouts: layouts.map((l) => ({
+            workspaces: layouts.map((l) => ({
               id: l.id,
               name: l.name,
               ...(l.icon ? { icon: l.icon } : {}),
               locked: lockedLayoutIds.has(l.id),
             })),
             selectedId: modal.id,
-            onSelect: openManage,
-            onSaveAsNew: handleSaveAsNew,
-            onDelete: handleManagerDelete,
-            canDelete: layouts.length > 1,
+            onSelectWorkspace: openManage,
+            onDeleteWorkspace: handleDeleteWorkspace,
+            canDeleteWorkspace: layouts.length > 1,
+            savedLayouts,
+            onSaveWorkspaceToLibrary: handleSaveToLibrary,
+            onApplySaved: handleApplySaved,
+            onReplaceSaved: handleReplaceSaved,
+            onRenameSaved: (id, name) => void updateSavedLayoutMeta(id, { name }),
+            onDeleteSaved: (id) => void deleteSavedLayout(id),
           }}
           onSave={handleModalSave}
           onClose={() => setModal({ kind: 'closed' })}

--- a/zeus-web/src/layout/LayoutSettingsModal.tsx
+++ b/zeus-web/src/layout/LayoutSettingsModal.tsx
@@ -3,23 +3,25 @@
 // Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
 // Copyright (C) 2025-2026 Brian Keating (EI6LF), Christian Suarez (N9WAR), and contributors.
 //
-// LayoutSettingsModal — create or manage saved layouts.
+// LayoutSettingsModal — create a workspace or manage workspaces + the
+// saved-layouts library.
+//
+// Two concepts, deliberately separate:
+//   • Workspace (tab)  — a live arrangement in the LeftLayoutBar. Switching
+//                        tabs swaps the workspace. Editing one and pressing
+//                        Save updates it IN PLACE; it never spawns a new tab.
+//   • Saved layout     — a reusable PRESET in a per-radio library. The
+//                        operator snapshots a good workspace into a saved
+//                        layout so they can restore it if they mess the live
+//                        tab up, or seed a brand-new workspace from it.
 //
 // Two shapes:
-//   • Create mode (no `manager` prop): a simple form that captures a label,
-//     icon, description, and lock state for a brand-new blank layout. Used by
-//     the LeftLayoutBar "+" slot.
-//   • Manager mode (`manager` prop supplied): the form is fronted by a "Saved
-//     layouts" dropdown listing every layout for the radio. Picking one
-//     switches the workspace to it and re-targets the editor. From here the
-//     operator gets the full CRUD set:
-//       - Save        → write the edited label/icon/description/lock to the
-//                        selected layout (its panel arrangement is already the
-//                        live one, so Save also commits the current layout).
-//       - Save as new → copy the CURRENT panel arrangement into a brand-new
-//                        saved layout under a new name.
-//       - Delete      → remove the selected layout (two-click confirm).
-//     Renaming is just editing the label and pressing Save.
+//   • Create mode (`createSource` supplied): "New workspace" — name/icon/etc.
+//     plus a "Start from" picker (Blank, or copy any saved layout).
+//   • Manager mode (`manager` supplied): edit the current workspace's
+//     metadata + lock, switch between workspaces, and run the full
+//     saved-layouts library CRUD (save current → library, apply, replace,
+//     rename, delete).
 
 import { useEffect, useId, useRef, useState } from 'react';
 import { X } from 'lucide-react';
@@ -40,7 +42,7 @@ export interface LayoutSettingsValue {
   locked: boolean;
 }
 
-/** One entry in the manager dropdown. */
+/** One workspace tab in the manager dropdown. */
 export interface LayoutManagerEntry {
   id: string;
   name: string;
@@ -48,30 +50,62 @@ export interface LayoutManagerEntry {
   locked: boolean;
 }
 
-/** Manager-mode controls. When supplied the modal renders the saved-layouts
- *  dropdown plus the Delete / Save-as-new affordances. */
+/** One reusable preset in the saved-layouts library. */
+export interface SavedLayoutEntry {
+  id: string;
+  name: string;
+  icon?: string;
+  description?: string;
+  updatedUtc: number;
+}
+
+/** Create-mode "Start from" picker — choose a blank workspace or clone the
+ *  arrangement (and metadata) of an existing saved layout. */
+export interface CreateSourceControls {
+  savedLayouts: SavedLayoutEntry[];
+  /** '' = blank, otherwise a saved-layout id. */
+  sourceId: string;
+  onSourceChange: (id: string) => void;
+}
+
+/** Manager-mode controls: workspace switcher + saved-layouts library CRUD. */
 export interface LayoutManagerControls {
-  /** All saved layouts for the current radio, in display order. */
-  layouts: LayoutManagerEntry[];
-  /** The layout currently being edited (also the active workspace). */
+  /** All workspace tabs for the current radio, in display order. */
+  workspaces: LayoutManagerEntry[];
+  /** The workspace currently being edited (also the active one). */
   selectedId: string;
-  /** Switch to / edit another saved layout. */
-  onSelect: (id: string) => void;
-  /** Copy the current panel arrangement into a new saved layout. */
-  onSaveAsNew: (value: LayoutSettingsValue) => void;
-  /** Delete the selected layout. */
-  onDelete: (id: string) => void;
-  /** False when only one layout remains (the last can't be deleted). */
-  canDelete: boolean;
+  /** Switch to / edit another workspace. */
+  onSelectWorkspace: (id: string) => void;
+  /** Delete the selected workspace tab. */
+  onDeleteWorkspace: (id: string) => void;
+  /** False when only one workspace remains (the last can't be deleted). */
+  canDeleteWorkspace: boolean;
+
+  /** The reusable saved-layout presets for this radio. */
+  savedLayouts: SavedLayoutEntry[];
+  /** Snapshot the current workspace into a NEW saved layout. */
+  onSaveWorkspaceToLibrary: (name: string) => void;
+  /** Apply (restore) a saved layout onto the current workspace. */
+  onApplySaved: (id: string) => void;
+  /** Overwrite a saved layout with the current workspace arrangement. */
+  onReplaceSaved: (id: string) => void;
+  /** Rename a saved layout. */
+  onRenameSaved: (id: string, name: string) => void;
+  /** Delete a saved layout from the library. */
+  onDeleteSaved: (id: string) => void;
 }
 
 interface LayoutSettingsModalProps {
-  /** Modal title. "Layout settings" for manage, "New layout" for create. */
+  /** Modal title. "Layout settings" for manage, "New workspace" for create. */
   title: string;
   initial: LayoutSettingsValue;
   onSave: (value: LayoutSettingsValue) => void;
   onClose: () => void;
-  /** When supplied, the modal is a saved-layouts manager (dropdown + CRUD). */
+  /** Label for the primary action button. Defaults to "Save". */
+  saveLabel?: string;
+  /** When supplied, the modal is in create mode with a "Start from" picker. */
+  createSource?: CreateSourceControls;
+  /** When supplied, the modal is a workspace + saved-layouts manager. */
   manager?: LayoutManagerControls;
 }
 
@@ -80,6 +114,8 @@ export function LayoutSettingsModal({
   initial,
   onSave,
   onClose,
+  saveLabel = 'Save',
+  createSource,
   manager,
 }: LayoutSettingsModalProps) {
   const titleId = useId();
@@ -88,7 +124,6 @@ export function LayoutSettingsModal({
   const [description, setDescription] = useState(initial.description);
   const [locked, setLocked] = useState(initial.locked);
   // Manager-only transient state.
-  const [newName, setNewName] = useState('');
   const [confirmDelete, setConfirmDelete] = useState(false);
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const nameRef = useRef<HTMLInputElement | null>(null);
@@ -99,8 +134,8 @@ export function LayoutSettingsModal({
     onClose,
   });
 
-  // When the operator picks a different layout from the dropdown, the parent
-  // re-derives `initial` from the newly-selected layout — resync the editable
+  // When the operator picks a different workspace from the dropdown, the parent
+  // re-derives `initial` from the newly-selected one — resync the editable
   // fields to it. Keyed on the selection id so it never clobbers in-progress
   // typing (the stored values only change on Save).
   useEffect(() => {
@@ -108,7 +143,6 @@ export function LayoutSettingsModal({
     setIcon(initial.icon);
     setDescription(initial.description);
     setLocked(initial.locked);
-    setNewName('');
     setConfirmDelete(false);
     // Resync only when the managed selection changes, not on every keystroke.
   }, [manager?.selectedId]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -124,20 +158,22 @@ export function LayoutSettingsModal({
     });
   };
 
-  const commitSaveAsNew = () => {
-    const trimmed = newName.trim();
-    if (!trimmed || !manager) return;
-    manager.onSaveAsNew({
-      name: trimmed,
-      icon: icon.trim(),
-      description: description.trim(),
-      locked,
-    });
-    setNewName('');
-  };
-
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) handleSave();
+  };
+
+  // Create-mode "Start from" change: cloning a saved layout pre-fills the
+  // metadata fields from it so the new workspace reads as a copy. Picking
+  // "Blank" leaves whatever the operator has typed.
+  const handleSourceChange = (id: string) => {
+    if (!createSource) return;
+    createSource.onSourceChange(id);
+    const src = createSource.savedLayouts.find((l) => l.id === id);
+    if (src) {
+      setName(src.name);
+      setIcon(src.icon ?? '');
+      setDescription(src.description ?? '');
+    }
   };
 
   return (
@@ -179,16 +215,42 @@ export function LayoutSettingsModal({
         </div>
 
         <div className="layout-settings-body">
+          {createSource && (
+            <label className="layout-settings-field">
+              <span className="layout-settings-field-label">Start from</span>
+              <select
+                className="layout-settings-input layout-settings-select"
+                value={createSource.sourceId}
+                onChange={(e) => handleSourceChange(e.target.value)}
+                aria-label="Start from"
+              >
+                <option value="">Blank workspace</option>
+                {createSource.savedLayouts.length > 0 && (
+                  <optgroup label="Copy a saved layout">
+                    {createSource.savedLayouts.map((l) => (
+                      <option key={l.id} value={l.id}>
+                        {(l.icon ? `${l.icon}  ` : '') + l.name}
+                      </option>
+                    ))}
+                  </optgroup>
+                )}
+              </select>
+              <span className="layout-settings-field-hint">
+                Start blank, or copy the panel arrangement of a saved layout.
+              </span>
+            </label>
+          )}
+
           {manager && (
             <label className="layout-settings-field">
-              <span className="layout-settings-field-label">Saved layouts</span>
+              <span className="layout-settings-field-label">Workspace</span>
               <select
                 className="layout-settings-input layout-settings-select"
                 value={manager.selectedId}
-                onChange={(e) => manager.onSelect(e.target.value)}
-                aria-label="Saved layouts"
+                onChange={(e) => manager.onSelectWorkspace(e.target.value)}
+                aria-label="Workspace"
               >
-                {manager.layouts.map((l) => (
+                {manager.workspaces.map((l) => (
                   <option key={l.id} value={l.id}>
                     {(l.icon ? `${l.icon}  ` : '') + l.name}
                     {l.locked ? '  🔒' : ''}
@@ -196,7 +258,7 @@ export function LayoutSettingsModal({
                 ))}
               </select>
               <span className="layout-settings-field-hint">
-                Pick a layout to switch the workspace to it and edit it below.
+                Pick a workspace to switch to it and edit it below.
               </span>
             </label>
           )}
@@ -313,42 +375,7 @@ export function LayoutSettingsModal({
             </span>
           </label>
 
-          {manager && (
-            <div className="layout-settings-field layout-settings-saveas">
-              <span className="layout-settings-field-label">
-                Save as new layout
-              </span>
-              <div className="layout-settings-icon-row">
-                <input
-                  type="text"
-                  className="layout-settings-input"
-                  value={newName}
-                  maxLength={24}
-                  onChange={(e) => setNewName(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') {
-                      e.preventDefault();
-                      commitSaveAsNew();
-                    }
-                  }}
-                  placeholder="New layout name"
-                  aria-label="New layout name"
-                />
-                <button
-                  type="button"
-                  className="btn ghost sm"
-                  disabled={!newName.trim()}
-                  onClick={commitSaveAsNew}
-                  title="Copy the current panel arrangement into a new saved layout"
-                >
-                  Create
-                </button>
-              </div>
-              <span className="layout-settings-field-hint">
-                Copies the current panel arrangement into a new saved layout.
-              </span>
-            </div>
-          )}
+          {manager && <SavedLayoutsLibrary manager={manager} />}
         </div>
 
         <div className="layout-settings-actions">
@@ -356,22 +383,22 @@ export function LayoutSettingsModal({
             <button
               type="button"
               className="btn ghost layout-settings-delete"
-              disabled={!manager.canDelete}
+              disabled={!manager.canDeleteWorkspace}
               onClick={() => {
                 if (!confirmDelete) {
                   setConfirmDelete(true);
                   return;
                 }
-                manager.onDelete(manager.selectedId);
+                manager.onDeleteWorkspace(manager.selectedId);
               }}
               onBlur={() => setConfirmDelete(false)}
               title={
-                manager.canDelete
-                  ? 'Delete this saved layout'
-                  : 'The last layout can’t be deleted'
+                manager.canDeleteWorkspace
+                  ? 'Delete this workspace'
+                  : 'The last workspace can’t be deleted'
               }
             >
-              {confirmDelete ? 'Confirm delete?' : 'Delete'}
+              {confirmDelete ? 'Confirm delete?' : 'Delete workspace'}
             </button>
           )}
           <span className="layout-settings-actions-spacer" />
@@ -384,10 +411,172 @@ export function LayoutSettingsModal({
             onClick={handleSave}
             disabled={!name.trim()}
           >
-            Save
+            {saveLabel}
           </button>
         </div>
       </div>
+    </div>
+  );
+}
+
+/** Saved-layouts library: snapshot the current workspace into a preset, then
+ *  apply / replace / rename / delete entries. Rendered inside manager mode. */
+function SavedLayoutsLibrary({ manager }: { manager: LayoutManagerControls }) {
+  const [newName, setNewName] = useState('');
+  // Per-row inline rename state.
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [renameText, setRenameText] = useState('');
+  // Two-click confirm for the destructive row actions.
+  const [confirm, setConfirm] = useState<{ id: string; action: 'apply' | 'delete' } | null>(null);
+
+  const commitSave = () => {
+    const trimmed = newName.trim();
+    if (!trimmed) return;
+    manager.onSaveWorkspaceToLibrary(trimmed);
+    setNewName('');
+  };
+
+  const startRename = (entry: SavedLayoutEntry) => {
+    setRenamingId(entry.id);
+    setRenameText(entry.name);
+    setConfirm(null);
+  };
+
+  const commitRename = (id: string) => {
+    const trimmed = renameText.trim();
+    if (trimmed) manager.onRenameSaved(id, trimmed);
+    setRenamingId(null);
+    setRenameText('');
+  };
+
+  const armed = (id: string, action: 'apply' | 'delete') =>
+    confirm?.id === id && confirm.action === action;
+
+  return (
+    <div className="layout-settings-field layout-settings-library">
+      <span className="layout-settings-field-label">Saved layouts</span>
+      <span className="layout-settings-field-hint">
+        Back up the current workspace as a reusable layout — restore or copy it
+        any time.
+      </span>
+
+      <div className="layout-settings-icon-row layout-settings-library-save">
+        <input
+          type="text"
+          className="layout-settings-input"
+          value={newName}
+          maxLength={24}
+          onChange={(e) => setNewName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              commitSave();
+            }
+          }}
+          placeholder="Save current workspace as…"
+          aria-label="New saved-layout name"
+        />
+        <button
+          type="button"
+          className="btn ghost sm"
+          disabled={!newName.trim()}
+          onClick={commitSave}
+          title="Snapshot the current workspace into a new saved layout"
+        >
+          Save
+        </button>
+      </div>
+
+      {manager.savedLayouts.length === 0 ? (
+        <div className="layout-settings-library-empty">
+          No saved layouts yet. Save one above to back up this workspace.
+        </div>
+      ) : (
+        <ul className="layout-settings-library-list">
+          {manager.savedLayouts.map((entry) => (
+            <li key={entry.id} className="layout-settings-library-item">
+              {renamingId === entry.id ? (
+                <input
+                  type="text"
+                  className="layout-settings-input layout-settings-library-rename"
+                  value={renameText}
+                  maxLength={24}
+                  autoFocus
+                  onChange={(e) => setRenameText(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      commitRename(entry.id);
+                    } else if (e.key === 'Escape') {
+                      e.preventDefault();
+                      setRenamingId(null);
+                    }
+                  }}
+                  onBlur={() => commitRename(entry.id)}
+                  aria-label={`Rename ${entry.name}`}
+                />
+              ) : (
+                <span className="layout-settings-library-name" title={entry.description}>
+                  <span className="layout-settings-library-icon" aria-hidden>
+                    {entry.icon || initialLetter(entry.name)}
+                  </span>
+                  {entry.name}
+                </span>
+              )}
+              <span className="layout-settings-library-actions">
+                <button
+                  type="button"
+                  className={`btn ghost xs ${armed(entry.id, 'apply') ? 'is-confirm' : ''}`}
+                  onClick={() => {
+                    if (!armed(entry.id, 'apply')) {
+                      setConfirm({ id: entry.id, action: 'apply' });
+                      return;
+                    }
+                    manager.onApplySaved(entry.id);
+                    setConfirm(null);
+                  }}
+                  onBlur={() => setConfirm((c) => (c?.id === entry.id && c.action === 'apply' ? null : c))}
+                  title="Replace the current workspace with this saved layout"
+                >
+                  {armed(entry.id, 'apply') ? 'Replace now?' : 'Apply'}
+                </button>
+                <button
+                  type="button"
+                  className="btn ghost xs"
+                  onClick={() => manager.onReplaceSaved(entry.id)}
+                  title="Overwrite this saved layout with the current workspace"
+                >
+                  Replace
+                </button>
+                <button
+                  type="button"
+                  className="btn ghost xs"
+                  onClick={() => startRename(entry)}
+                  title="Rename this saved layout"
+                >
+                  Rename
+                </button>
+                <button
+                  type="button"
+                  className={`btn ghost xs layout-settings-delete ${armed(entry.id, 'delete') ? 'is-confirm' : ''}`}
+                  onClick={() => {
+                    if (!armed(entry.id, 'delete')) {
+                      setConfirm({ id: entry.id, action: 'delete' });
+                      return;
+                    }
+                    manager.onDeleteSaved(entry.id);
+                    setConfirm(null);
+                  }}
+                  onBlur={() => setConfirm((c) => (c?.id === entry.id && c.action === 'delete' ? null : c))}
+                  title="Delete this saved layout"
+                >
+                  {armed(entry.id, 'delete') ? 'Confirm?' : 'Delete'}
+                </button>
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/zeus-web/src/state/layout-store.ts
+++ b/zeus-web/src/state/layout-store.ts
@@ -133,6 +133,10 @@ interface LayoutState {
   /** Reset the active layout's tiles to DEFAULT_WORKSPACE_LAYOUT. The
    *  layout itself (id + name) is preserved. */
   resetActiveLayout: () => void;
+  /** Replace the active layout's entire workspace (tiles + lock) with the
+   *  given arrangement, keeping the layout's id/name/icon/description. Used to
+   *  apply or restore a saved-layout preset onto the current tab. Persists. */
+  replaceActiveWorkspace: (workspace: WorkspaceLayout) => void;
 
   // Tile mutators — operate on the active layout. Persisted via the same
   // debounced PUT to /api/ui/layouts.
@@ -459,6 +463,10 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
     set({ layouts: next, workspace: DEFAULT_WORKSPACE_LAYOUT });
     cancelScheduledSave(radioKey, updated.id);
     void putNamedLayout(radioKey, updated);
+  },
+
+  replaceActiveWorkspace: (workspace) => {
+    applyWorkspaceMutationForLayout(set, get, get().activeLayoutId, workspace);
   },
 
   addTile: (panelId, opts) => {

--- a/zeus-web/src/state/saved-layouts-store.ts
+++ b/zeus-web/src/state/saved-layouts-store.ts
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF), Christian Suarez (N9WAR), and contributors.
+//
+// Saved-layouts library store. A per-radio POOL of reusable layout presets,
+// kept deliberately separate from the working tabs in `layout-store`. The
+// operator snapshots a good workspace arrangement into a saved layout so they
+// can:
+//   • restore it onto the current tab if they mess the live arrangement up,
+//   • seed a brand-new workspace from it,
+//   • keep a named library of arrangements (back up / replace / rename / delete).
+//
+// Saved layouts are never "active" — they are templates. Applying one is an
+// explicit action that copies its arrangement into a live tab via the
+// layout-store. This store owns only the library CRUD + server sync; the
+// apply/seed glue lives with the consumer (LeftLayoutBar) which already drives
+// the layout-store.
+
+import { create } from 'zustand';
+import { useLayoutStore } from './layout-store';
+import type { WorkspaceLayout } from '../layout/workspace';
+
+export interface SavedLayout {
+  id: string;
+  name: string;
+  /** Serialized WorkspaceLayout (parseLayoutOrDefault-ready). */
+  layoutJson: string;
+  icon?: string;
+  description?: string;
+  updatedUtc: number;
+}
+
+interface SavedLayoutsResponse {
+  radioKey: string;
+  savedLayouts: Array<{
+    id: string;
+    name: string;
+    layoutJson: string;
+    updatedUtc: number;
+    icon?: string | null;
+    description?: string | null;
+  }>;
+}
+
+export interface SavedLayoutMetaPatch {
+  name?: string;
+  icon?: string;
+  description?: string;
+}
+
+interface SavedLayoutsState {
+  /** Per-radio key the current `savedLayouts` list belongs to. */
+  radioKey: string;
+  /** Every saved layout (preset) for `radioKey`, newest-updated last. */
+  savedLayouts: SavedLayout[];
+  /** True after the first loadForRadio() resolves (success or failure). */
+  isLoaded: boolean;
+
+  /** Switch the radio key and reload the library. No-op when the key already
+   *  matches and the library has loaded. */
+  loadForRadio: (radioKey: string) => Promise<void>;
+  /** Snapshot the given workspace arrangement into a NEW saved layout. Returns
+   *  the new saved-layout id. */
+  saveWorkspaceAs: (
+    name: string,
+    workspace: WorkspaceLayout,
+    meta?: { icon?: string; description?: string },
+  ) => Promise<string>;
+  /** Overwrite an existing saved layout's arrangement with `workspace`,
+   *  keeping its name/icon/description unless overridden. The "replace" /
+   *  "re-snapshot" affordance. */
+  replaceWorkspace: (id: string, workspace: WorkspaceLayout) => Promise<void>;
+  /** Edit a saved layout's presentation metadata (rename, change icon/desc).
+   *  Leaves the stored arrangement untouched. */
+  updateMeta: (id: string, patch: SavedLayoutMetaPatch) => Promise<void>;
+  /** Remove a saved layout from the library. */
+  deleteSavedLayout: (id: string) => Promise<void>;
+}
+
+function newSavedId(): string {
+  return `saved-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function mapResponse(dto: SavedLayoutsResponse): SavedLayout[] {
+  return (dto.savedLayouts ?? []).map((l) => ({
+    id: l.id,
+    name: l.name,
+    layoutJson: l.layoutJson,
+    updatedUtc: l.updatedUtc,
+    ...(l.icon ? { icon: l.icon } : {}),
+    ...(l.description ? { description: l.description } : {}),
+  }));
+}
+
+function putSavedLayout(
+  radioKey: string,
+  saved: { id: string; name: string; layoutJson: string; icon?: string; description?: string },
+): Promise<SavedLayoutsResponse | null> {
+  if (!radioKey) return Promise.resolve(null);
+  return fetch('/api/ui/saved-layouts', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      radioKey,
+      savedId: saved.id,
+      name: saved.name,
+      layoutJson: saved.layoutJson,
+      icon: saved.icon ?? '',
+      description: saved.description ?? '',
+    }),
+  })
+    .then((res) => (res.ok ? (res.json() as Promise<SavedLayoutsResponse>) : null))
+    .catch(() => null);
+}
+
+export const useSavedLayoutsStore = create<SavedLayoutsState>((set, get) => ({
+  radioKey: '',
+  savedLayouts: [],
+  isLoaded: false,
+
+  loadForRadio: async (radioKey) => {
+    const safeKey = radioKey || 'default';
+    if (get().radioKey === safeKey && get().isLoaded) return;
+    try {
+      const res = await fetch(
+        `/api/ui/saved-layouts?radio=${encodeURIComponent(safeKey)}`,
+      );
+      if (!res.ok) throw new Error(`status ${res.status}`);
+      const dto = (await res.json()) as SavedLayoutsResponse;
+      set({ radioKey: safeKey, savedLayouts: mapResponse(dto), isLoaded: true });
+    } catch {
+      set({ radioKey: safeKey, savedLayouts: [], isLoaded: true });
+    }
+  },
+
+  saveWorkspaceAs: async (name, workspace, meta) => {
+    const radioKey = get().radioKey || useLayoutStore.getState().radioKey || 'default';
+    const id = newSavedId();
+    const saved: SavedLayout = {
+      id,
+      name: name.trim() || 'Untitled',
+      layoutJson: JSON.stringify(workspace),
+      updatedUtc: Date.now(),
+      ...(meta?.icon ? { icon: meta.icon } : {}),
+      ...(meta?.description ? { description: meta.description } : {}),
+    };
+    // Optimistic insert so the manager updates immediately.
+    set({ savedLayouts: [...get().savedLayouts, saved] });
+    const dto = await putSavedLayout(radioKey, saved);
+    if (dto) set({ savedLayouts: mapResponse(dto) });
+    return id;
+  },
+
+  replaceWorkspace: async (id, workspace) => {
+    const radioKey = get().radioKey || useLayoutStore.getState().radioKey || 'default';
+    const existing = get().savedLayouts.find((l) => l.id === id);
+    if (!existing) return;
+    const json = JSON.stringify(workspace);
+    set({
+      savedLayouts: get().savedLayouts.map((l) =>
+        l.id === id ? { ...l, layoutJson: json, updatedUtc: Date.now() } : l,
+      ),
+    });
+    const dto = await putSavedLayout(radioKey, { ...existing, layoutJson: json });
+    if (dto) set({ savedLayouts: mapResponse(dto) });
+  },
+
+  updateMeta: async (id, patch) => {
+    const radioKey = get().radioKey || useLayoutStore.getState().radioKey || 'default';
+    const existing = get().savedLayouts.find((l) => l.id === id);
+    if (!existing) return;
+    const next: SavedLayout = { ...existing };
+    if (patch.name !== undefined) next.name = patch.name.trim() || existing.name;
+    if (patch.icon !== undefined) {
+      const trimmed = patch.icon.trim();
+      if (trimmed) next.icon = trimmed;
+      else delete next.icon;
+    }
+    if (patch.description !== undefined) {
+      const trimmed = patch.description.trim();
+      if (trimmed) next.description = trimmed;
+      else delete next.description;
+    }
+    set({ savedLayouts: get().savedLayouts.map((l) => (l.id === id ? next : l)) });
+    const dto = await putSavedLayout(radioKey, {
+      id: next.id,
+      name: next.name,
+      layoutJson: next.layoutJson,
+      icon: next.icon ?? '',
+      description: next.description ?? '',
+    });
+    if (dto) set({ savedLayouts: mapResponse(dto) });
+  },
+
+  deleteSavedLayout: async (id) => {
+    const radioKey = get().radioKey || useLayoutStore.getState().radioKey || 'default';
+    set({ savedLayouts: get().savedLayouts.filter((l) => l.id !== id) });
+    try {
+      const res = await fetch(
+        `/api/ui/saved-layouts?radio=${encodeURIComponent(radioKey)}&id=${encodeURIComponent(id)}`,
+        { method: 'DELETE' },
+      );
+      if (res.ok) {
+        const dto = (await res.json()) as SavedLayoutsResponse;
+        set({ savedLayouts: mapResponse(dto) });
+      }
+    } catch {
+      // Optimistic removal already applied; a reload will reconcile.
+    }
+  },
+}));

--- a/zeus-web/src/styles/all-panels.css
+++ b/zeus-web/src/styles/all-panels.css
@@ -1395,3 +1395,77 @@
   border-color: var(--tx);
   color: var(--tx);
 }
+/* An armed two-click confirm (Apply/Delete in the library) shows its intent
+   at rest, not only on hover. */
+.layout-settings-library .btn.is-confirm {
+  border-color: var(--tx);
+  color: var(--tx);
+}
+
+/* Saved-layouts library — set off from the workspace fields by a hairline. */
+.layout-settings-library {
+  margin-top: 4px;
+  padding-top: 12px;
+  border-top: 1px solid var(--panel-border);
+}
+.layout-settings-library-save {
+  margin-top: 8px;
+}
+.layout-settings-library-empty {
+  margin-top: 10px;
+  font-size: 11px;
+  color: var(--fg-3);
+  font-style: italic;
+}
+.layout-settings-library-list {
+  list-style: none;
+  margin: 10px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.layout-settings-library-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  background: var(--bg-0);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--r-sm);
+}
+.layout-settings-library-name {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  flex: 1 1 auto;
+  font-size: 12px;
+  color: var(--fg-1);
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.layout-settings-library-icon {
+  font-size: 15px;
+  line-height: 1;
+  font-family: 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji',
+    var(--font-sans);
+}
+.layout-settings-library-rename {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 3px 8px;
+}
+.layout-settings-library-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex: 0 0 auto;
+}
+/* Compact button size for the per-row library actions. */
+.btn.xs {
+  padding: 0.2em 0.5em;
+  font-size: clamp(9px, 0.1vw + 8.5px, 11px);
+  min-height: 0;
+}


### PR DESCRIPTION
## Why

The Layout Settings dialog conflated two things into one object: every left-bar **tab** *was* a **saved layout**. That made "Save" feel like it spawned a new tab, and there was no way to keep a reusable arrangement you could restore after messing up the live one.

This splits them into two clear concepts:

- **Workspaces (tabs)** — the live left-bar arrangements. Editing one and pressing **Save** now updates it **in place**; it never creates a new tab.
- **Saved layouts** — a per-radio **library of reusable presets**. Snapshot a good workspace into one to back it up, restore it if you mess the live tab up, or seed a new workspace from it.

## What changed

**New-workspace flow** (`+` slot): a *Start from* picker — **Blank**, or copy the arrangement (and metadata) of any saved layout.

**Manager** (gear): a **Saved layouts** section with full CRUD:
- **Save** the current workspace as a reusable preset
- **Apply** — restore a preset onto the current workspace (two-click confirm, since it replaces the live arrangement)
- **Replace** — re-snapshot a preset from the current workspace
- **Rename** (inline) and **Delete** (two-click confirm)

**Backend**: new per-radio `ui_saved_layouts` LiteDB collection + `GET`/`PUT`/`DELETE` `/api/ui/saved-layouts`, kept fully independent from the existing `ui_layouts_v2` tab collection. New `SavedLayout*` DTOs.

## Files
- Contracts: `Zeus.Contracts/Dtos.cs`
- Store/endpoints: `Zeus.Server.Hosting/LayoutStore.cs`, `Zeus.Server.Hosting/ZeusEndpoints.cs`
- FE: `zeus-web/src/state/saved-layouts-store.ts` (new), `layout-store.ts` (`replaceActiveWorkspace`), `layout/LayoutSettingsModal.tsx`, `components/LeftLayoutBar.tsx`, `App.tsx`, `styles/all-panels.css`
- Tests: `tests/Zeus.Server.Tests/SavedLayoutsStoreTests.cs` (new)

## Verification
- `dotnet build` clean (Contracts + Hosting).
- **7/7** new `SavedLayoutsStoreTests` pass — CRUD, per-radio isolation, persistence across reopen, and independence from the tab collection.
- Frontend `tsc -b` typechecks clean on the `develop` base.

## Notes
- Red-light surface (UX of the Layout Settings dialog) — built per direct request from a code owner; flagging for awareness.
- Saved layouts are stored **per-radio** (matching the existing per-radio tab model) to avoid cross-board panel-availability mismatches.
- The endpoints go live on the next backend restart; I couldn't drive the modal end-to-end in the local preview (no backend wired to it), but the store layer is covered by the unit tests above.