### PR TITLE
feat(freedv): end-of-over TX tail + wider speech-band resampler

### DIFF
--- a/Zeus.Dsp.FreeDv/FreeDvModem.cs
+++ b/Zeus.Dsp.FreeDv/FreeDvModem.cs
@@ -86,6 +86,16 @@ public sealed class FreeDvModem : IDisposable
     private int _speechRate = FreeDvResampler.FsLow;
     private int _modemRate = FreeDvResampler.FsLow;
 
+    // RX decoder-input instrumentation (hot-path accumulators, 1 Hz log). The
+    // level into freedv_rx is set by WDSP's FIXED RX AGC under FreeDV; if that
+    // level drives the float->int16 conversion into clipping the OFDM demod sees
+    // a distorted constellation and the decoded speech turns harsh/"nasal" on
+    // strong signals. Logging peak + clamp rate makes that level-dependent
+    // failure observable instead of a guess. See docs/lessons/.
+    private float _rxInPeakAccum;
+    private long _rxClampAccum;
+    private long _rxInstrLastMs;
+
     // Config (control thread writes; hot path applies squelch lazily)
     private bool _squelchEnabled = true;
     private float _snrSquelchThresh = DefaultSquelchThresh(FreeDvSubmode.Mode700D);
@@ -321,6 +331,71 @@ public sealed class FreeDvModem : IDisposable
         }
     }
 
+    /// <summary>
+    /// End-of-over flush: encode the residual sub-frame of mic speech so a
+    /// COMPLETE final OFDM frame exists in the output FIFO, then report how many
+    /// 48 kHz output samples are now pending. The TX tail drain (TxAudioIngest)
+    /// drives <see cref="DrainTo"/> to push those samples to the radio before PTT
+    /// drops, so the receiver gets whole frames instead of a mid-symbol cut — the
+    /// root cause of end-of-over garble. Control-thread only; gates the TX hot
+    /// path out for the encode, then republishes the handle. No-op (returns 0)
+    /// when native is missing or TX isn't open.
+    /// </summary>
+    public int FinishTx()
+    {
+        if (!_nativeAvailable) return 0;
+        lock (_reconfigGate)
+        {
+            IntPtr fd = Volatile.Read(ref _txFreedv);
+            if (fd == IntPtr.Zero) return 0;
+            int nspeech = _txNSpeech, nmodem = _txNNomModem;
+            if (nspeech <= 0 || nmodem <= 0) return 0;
+
+            // Gate the TX hot path out so we own _tx8In / _txOut48 / resamplers.
+            Volatile.Write(ref _txFreedv, IntPtr.Zero);
+            Thread.MemoryBarrier();
+            SpinUntilIdle(ref _txBusy);
+
+            // Pad the partial residual up to one whole speech frame with silence
+            // and encode it, so the final transmitted frame is well-formed. Any
+            // accidental whole-frame backlog is drained the same way.
+            while (_tx8In.Count > 0)
+            {
+                int have = Math.Min(_tx8In.Count, nspeech);
+                _tx8In.Read(_txSpeechFloat.AsSpan(0, have));
+                if (have < nspeech)
+                    Array.Clear(_txSpeechFloat, have, nspeech - have);
+                FloatToShort(_txSpeechFloat, _txSpeechShort, nspeech);
+                FreeDvNativeMethods.freedv_tx(fd, _txModemShort, _txSpeechShort);
+                ShortToFloat(_txModemShort, _txModemFloat, nmodem);
+                int up = _txUp.Process(_txModemFloat.AsSpan(0, nmodem), _txInterp);
+                WriteBounded(_txOut48, _txInterp.AsSpan(0, up));
+            }
+
+            Volatile.Write(ref _txFreedv, fd);
+            return _txOut48.Count;
+        }
+    }
+
+    /// <summary>48 kHz output samples awaiting transmit (the TX tail backlog).</summary>
+    public int TxPendingOutSamples() => _txOut48.Count;
+
+    /// <summary>
+    /// Drain queued modem output into <paramref name="block48k"/> WITHOUT encoding
+    /// any new speech — fills with pending TX output, silence-pads the remainder,
+    /// and returns the count of REAL (non-pad) samples. Used by the end-of-over
+    /// tail drain to clock the completed final frame out to the radio. Must only
+    /// be called while the TX hot path is quiesced (the tail drain owns TX
+    /// exclusively, mirroring the tune-driver handoff), so it touches _txOut48
+    /// directly without the seqlock. Returns 0 when nothing is pending.
+    /// </summary>
+    public int DrainTo(Span<float> block48k)
+    {
+        int filled = _txOut48.Read(block48k);
+        if (filled < block48k.Length) block48k.Slice(filled).Clear();
+        return filled;
+    }
+
     // -------- RX hot path (DSP tick thread; no lock, no alloc) --------
 
     public void ProcessRxInPlace(Span<float> block48k)
@@ -346,7 +421,7 @@ public sealed class FreeDvModem : IDisposable
             while (nin > 0 && _rx8In.Count >= nin)
             {
                 _rx8In.Read(_rxModemFloat.AsSpan(0, nin));
-                FloatToShort(_rxModemFloat, _rxModemShort, nin);
+                FloatToShortRxInstrumented(_rxModemFloat, _rxModemShort, nin);
 
                 int nout = FreeDvNativeMethods.freedv_rx(fd, _rxSpeechShort, _rxModemShort);
                 FreeDvNativeMethods.freedv_get_modem_stats(fd, out int sync, out float snr);
@@ -360,6 +435,22 @@ public sealed class FreeDvModem : IDisposable
                     WriteBounded(_rxOut48, _rxInterp.AsSpan(0, up));
                 }
                 nin = FreeDvNativeMethods.freedv_nin(fd);
+            }
+
+            // 1 Hz decoder-input health log: flags level-dependent clipping into
+            // freedv_rx (the "sometimes nasally on strong signals" symptom). Only
+            // emitted when synced and the input is actually clamping, so a quiet
+            // band stays silent in the log.
+            long nowMs = Environment.TickCount64;
+            if (nowMs - _rxInstrLastMs >= 1000)
+            {
+                _rxInstrLastMs = nowMs;
+                if (_synced && _rxClampAccum > 0)
+                    _log?.LogWarning(
+                        "freedv.rx.in clipping: peak={Peak:F3} clamps/s={Clamps} snr={Snr:F1}dB — FIXED RX AGC may be over-driving the decoder",
+                        _rxInPeakAccum, _rxClampAccum, Volatile.Read(ref _snrDb));
+                _rxInPeakAccum = 0f;
+                _rxClampAccum = 0;
             }
 
             int filled = _rxOut48.Read(block48k);
@@ -423,6 +514,27 @@ public sealed class FreeDvModem : IDisposable
     private static void ShortToFloat(short[] src, float[] dst, int n)
     {
         for (int i = 0; i < n; i++) dst[i] = src[i] * (1f / 32768f);
+    }
+
+    // RX modem-input conversion that also accumulates peak + clamp count for the
+    // 1 Hz decoder-input health log. Same math as FloatToShort; the only added
+    // cost is two comparisons per sample, off any allocation path.
+    private void FloatToShortRxInstrumented(float[] src, short[] dst, int n)
+    {
+        float peak = _rxInPeakAccum;
+        long clamps = 0;
+        for (int i = 0; i < n; i++)
+        {
+            float v = src[i];
+            float a = v < 0 ? -v : v;
+            if (a > peak) peak = a;
+            int s = (int)MathF.Round(v * 32767f);
+            if (s > short.MaxValue) { s = short.MaxValue; clamps++; }
+            else if (s < short.MinValue) { s = short.MinValue; clamps++; }
+            dst[i] = (short)s;
+        }
+        _rxInPeakAccum = peak;
+        _rxClampAccum += clamps;
     }
 
     // -------- reconfig helpers (control thread, under _reconfigGate) --------

--- a/Zeus.Dsp.FreeDv/FreeDvResampler.cs
+++ b/Zeus.Dsp.FreeDv/FreeDvResampler.cs
@@ -7,13 +7,25 @@
 //
 // Dependency-free streaming sample-rate conversion between the radio audio
 // rate (48 kHz) and the FreeDV modem rate (8 kHz). The ratio is exactly 6:1,
-// so a single Hamming-windowed-sinc prototype low-pass (cutoff ~3.4 kHz, well
-// above the FreeDV occupied bandwidth of ~2.4 kHz) drives both a decimator and
-// a polyphase interpolator. Both keep filter history across calls so block
+// so a single Hamming-windowed-sinc prototype low-pass drives both a decimator
+// and a polyphase interpolator. Both keep filter history across calls so block
 // boundaries are seamless, and both are pure span -> span with NO allocation
 // and NO locking — matching the realtime discipline of the Zeus audio bus
 // (AudioChain, FloatSpscRing). This replaces any external libsamplerate / soxr
 // dependency — important for the arm64 / Raspberry Pi targets.
+//
+// FIDELITY NOTE (voice clarity): this resampler is in BOTH speech paths — the
+// decoded-speech 8k->48k upsample the operator hears, and the mic-speech
+// 48k->8k downsample codec2 analyses. A short Hamming prototype has a wide
+// transition band, so a cutoff at 3.4 kHz left the passband flat only to
+// ~2.5 kHz — audibly dull/"nasal", because the 2.5–3.4 kHz speech presence band
+// rolled off. The prototype is now longer (40 taps/phase = 240-tap) with the
+// cutoff nudged to 3.5 kHz: the passband stays flat to ~3.2 kHz and the
+// stopband still lands below the 4 kHz (8 kHz-rate) Nyquist, so the speech band
+// survives without aliasing on decimation. The OFDM modem-in/out paths
+// (~2.4 kHz wide) are unaffected by the cutoff change. Cost is trivial
+// (~1.8M MACs/s) and group delay (~2.5 ms) is absorbed by the latency-bounded
+// rings.
 
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -26,8 +38,8 @@ internal static class FreeDvResampler
     internal const int Factor = 6;            // 48000 / 8000
     internal const int FsHigh = 48000;
     internal const int FsLow = 8000;
-    private const int TapsPerPhase = 16;      // -> 96-tap prototype, good stopband for voice
-    private const double CutoffHz = 3400.0;   // < 8 kHz Nyquist, above FreeDV ~2.4 kHz BW
+    private const int TapsPerPhase = 40;      // -> 240-tap prototype: flat to ~3.2 kHz, stopband < 4 kHz
+    private const double CutoffHz = 3500.0;   // < 4 kHz (8 kHz-rate) Nyquist, above FreeDV ~2.4 kHz BW
 
     // Prototype low-pass, normalized so DC gain == 1. Shared by both directions.
     private static readonly float[] Prototype = DesignLowpass(TapsPerPhase * Factor, CutoffHz, FsHigh);

--- a/Zeus.Dsp.FreeDv/RadeModem.cs
+++ b/Zeus.Dsp.FreeDv/RadeModem.cs
@@ -371,6 +371,76 @@ public sealed class RadeModem : IDisposable
         }
     }
 
+    /// <summary>
+    /// End-of-over flush: encode the residual sub-frame of mic speech so a
+    /// COMPLETE final RADE frame exists, then append the End-of-Over frame (which
+    /// carries the configured callsign via the FreeDV reliable-text LDPC), and
+    /// report the 48 kHz output samples now pending. The TX tail drain clocks
+    /// those out before PTT drops, so the over ends on a whole frame AND the EOO
+    /// callsign actually reaches the air (previously best-effort and never fired,
+    /// because there was no post-unkey drain — see ProcessTx note in
+    /// FreeDvService). Control-thread only; gates the TX hot path out. Returns 0
+    /// when native is missing or TX isn't open.
+    /// </summary>
+    public int FinishTx()
+    {
+        if (!_nativeAvailable) return 0;
+        lock (_reconfigGate)
+        {
+            IntPtr h = Volatile.Read(ref _txRade);
+            if (h == IntPtr.Zero) return 0;
+            int nspeech = _txNSpeech, ntx = _txNTxOut;
+            if (nspeech <= 0 || ntx <= 0) return 0;
+
+            Volatile.Write(ref _txRade, IntPtr.Zero);
+            Thread.MemoryBarrier();
+            SpinUntilIdle(ref _txBusy);
+
+            // Complete any residual speech into whole frame(s).
+            while (_tx16In.Count > 0)
+            {
+                int have = Math.Min(_tx16In.Count, nspeech);
+                _tx16In.Read(_tx16Float.AsSpan(0, have));
+                if (have < nspeech) Array.Clear(_tx16Float, have, nspeech - have);
+                FloatToShort(_tx16Float, _tx16Short, nspeech);
+                int n = RadeNativeMethods.zeus_rade_tx(h, _tx16Short, _txIqOut);
+                if (n > ntx) n = ntx;
+                for (int i = 0; i < n; i++) _txModemReal[i] = _txIqOut[2 * i];
+                int up = _txUp.Process(_txModemReal.AsSpan(0, n), _txInterp);
+                WriteBounded(_txOut48, _txInterp.AsSpan(0, up));
+            }
+
+            // Append the EOO (closing callsign) frame as the final modem audio.
+            if (_txNEooOut > 0)
+            {
+                int n = RadeNativeMethods.zeus_rade_tx_eoo(h, _txIqOut);
+                if (n > _txNEooOut) n = _txNEooOut;
+                for (int i = 0; i < n; i++) _txModemReal[i] = _txIqOut[2 * i];
+                int up = _txUp.Process(_txModemReal.AsSpan(0, n), _txInterp);
+                WriteBounded(_txOut48, _txInterp.AsSpan(0, up));
+            }
+
+            Volatile.Write(ref _txRade, h);
+            return _txOut48.Count;
+        }
+    }
+
+    /// <summary>48 kHz output samples awaiting transmit (the TX tail backlog).</summary>
+    public int TxPendingOutSamples() => _txOut48.Count;
+
+    /// <summary>
+    /// Drain queued modem output into <paramref name="block48k"/> WITHOUT encoding
+    /// new speech; silence-pads the remainder and returns the real (non-pad)
+    /// count. Used by the end-of-over tail drain while the TX hot path is quiesced
+    /// (the drain owns TX exclusively). Returns 0 when nothing is pending.
+    /// </summary>
+    public int DrainTo(Span<float> block48k)
+    {
+        int filled = _txOut48.Read(block48k);
+        if (filled < block48k.Length) block48k.Slice(filled).Clear();
+        return filled;
+    }
+
     private static void WriteBounded(FreeDvSampleRing ring, ReadOnlySpan<float> src)
     {
         if (ring.Count > MaxOutFifo) ring.Drop(ring.Count - MaxOutFifo);

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -1297,6 +1297,15 @@ public class DspPipelineService : BackgroundService,
         return _txIngest;
     }
 
+    /// <summary>
+    /// FreeDV end-of-over TX tail: complete the final modem frame and clock it
+    /// out to the radio before PTT drops, so the receiver gets whole OFDM frames
+    /// (no end-of-over garble). Called by <see cref="TxService"/> on un-key,
+    /// before the wire MOX bit drops. No-op unless FreeDV is engaged. Blocks the
+    /// caller for the bounded tail duration.
+    /// </summary>
+    public void DrainFreeDvTxTail() => ResolveTxIngest()?.DrainFreeDvTxTail();
+
     // Persisted TX display analyzer config (live TX waterfall feature). Optional
     // so test constructions of DspPipelineService keep working; when null the
     // engine just runs at its built-in defaults. Display-only — never affects

--- a/Zeus.Server.Hosting/FreeDvService.cs
+++ b/Zeus.Server.Hosting/FreeDvService.cs
@@ -231,6 +231,29 @@ public sealed class FreeDvService : IDisposable
         else _modem.FlushTx();
     }
 
+    /// <summary>
+    /// End-of-over flush on the active modem: complete the final frame (and, for
+    /// RADE, append the EOO callsign) so a whole frame can be clocked out on the
+    /// TX tail. Returns the 48 kHz output samples now pending so the tail drain
+    /// knows how long to hold PTT. No-op (0) unless FreeDV is engaged.
+    /// </summary>
+    public int FinishTx()
+    {
+        if (!Active) return 0;
+        return _radeActive ? _rade.FinishTx() : _modem.FinishTx();
+    }
+
+    /// <summary>
+    /// Drain queued modem output (no new encoding) into the block for the TX tail
+    /// drain; returns the real (non-pad) sample count, 0 when empty. Must only be
+    /// called while the TX path is owned by the tail drain.
+    /// </summary>
+    public int DrainTx(Span<float> block48k)
+    {
+        if (!Active) { block48k.Clear(); return 0; }
+        return _radeActive ? _rade.DrainTo(block48k) : _modem.DrainTo(block48k);
+    }
+
     public FreeDvStatusDto Status()
     {
         bool rade = RadeSelected;

--- a/Zeus.Server.Hosting/TxAudioIngest.cs
+++ b/Zeus.Server.Hosting/TxAudioIngest.cs
@@ -119,6 +119,21 @@ public sealed class TxAudioIngest : IDisposable
     // mute by writing FROM this buffer, not by zeroing _scratchIq in place.
     private readonly float[] _muteIq = new float[4096];
 
+    // FreeDV end-of-over TX tail. Non-zero while the mic hot path must yield TX
+    // exclusively to DrainFreeDvTxTail (no double-feed into WDSP fexchange2),
+    // exactly as it defers to TxTuneDriver. Also the re-entrancy guard (CAS) so
+    // two rapid un-keys can't both drive ProcessTxBlock. Dedicated scratch so the
+    // drain (run on the un-key thread) never aliases _scratchMic/_scratchIq.
+    private int _tailDraining;
+    private readonly float[] _tailMic = new float[1024];
+    private readonly float[] _tailIq = new float[4096];
+    private const int TxRateHz = 48000;          // TX block / DAC rate
+    // Bench-tunable on the G2: hard ceiling on how long the un-key blocks while
+    // the final FreeDV frame clocks out, and the extra hold after the last block
+    // so the radio FIFO finishes transmitting before PTT drops.
+    private const int FreeDvTxTailMaxMs = 350;
+    private const int FreeDvTxTailGuardMs = 60;
+
     private long _totalMicSamples;
     private long _totalTxBlocks;
     private long _droppedFrames;
@@ -293,6 +308,102 @@ public sealed class TxAudioIngest : IDisposable
         _log = log;
         _handler = OnMicPcmBytesFromBrowserMic;
         _hub.MicPcmReceived += _handler;
+    }
+
+    /// <summary>
+    /// FreeDV end-of-over TX tail. Called by <see cref="TxService"/> on a genuine
+    /// un-key, BEFORE the wire MOX bit drops and while the WDSP TXA is still up.
+    /// Completes the final modem frame (RADE also appends its EOO callsign), then
+    /// clocks the queued modem audio out to the radio at the DAC rate so the
+    /// receiver gets WHOLE OFDM frames instead of a mid-symbol cut — the root
+    /// cause of end-of-over garble. Blocks the caller for the bounded tail
+    /// duration, then returns so PTT can drop. No-op unless FreeDV is engaged and
+    /// the engine is a real (TXA-capable) backend. Sets <see cref="_tailDraining"/>
+    /// so the mic hot path yields TX exclusively (no double-feed into fexchange2),
+    /// mirroring the tune-driver handoff. Runs on the un-key (API) thread; the
+    /// mic ingest runs on the audio thread — the _sync barrier below quiesces any
+    /// in-flight mic block before the drain feeds the ring.
+    /// </summary>
+    public void DrainFreeDvTxTail()
+    {
+        var freeDv = _freeDv;
+        if (freeDv is null || !freeDv.Active) return;
+        if (_txOwnedByTuneDriver()) return;        // TUN/two-tone owns TX
+        var engine = _engineProvider();
+        int blockSize = engine?.TxBlockSamples ?? 0;
+        int iqOut = engine?.TxOutputSamples ?? 0;
+        if (engine is null || blockSize <= 0 || iqOut <= 0
+            || blockSize > _tailMic.Length || 2 * iqOut > _tailIq.Length)
+            return;
+
+        // Claim TX exclusively (CAS — bail if another tail drain is already
+        // running). Then take _sync as a barrier so any mic critical section
+        // already in flight finishes before we feed the ring.
+        if (Interlocked.CompareExchange(ref _tailDraining, 1, 0) != 0) return;
+        lock (_sync) { _accumulatorFill = 0; }
+        try
+        {
+            // Complete the final frame so a well-formed last OFDM symbol exists.
+            freeDv.FinishTx();
+
+            long freq = System.Diagnostics.Stopwatch.Frequency;
+            long periodTicks = (long)(freq * (double)blockSize / TxRateHz);
+            long deadline = System.Diagnostics.Stopwatch.GetTimestamp();
+            long hardStop = deadline + (long)(freq * (FreeDvTxTailMaxMs / 1000.0));
+            int idle = 0;
+            while (System.Diagnostics.Stopwatch.GetTimestamp() < hardStop)
+            {
+                int real = freeDv.DrainTx(new Span<float>(_tailMic, 0, blockSize));
+                // DrainTx silence-pads a short block; once the queue is empty
+                // (two fully-silent blocks) stop so we don't key dead carrier.
+                if (real == 0) { if (++idle >= 2) break; }
+                else idle = 0;
+
+                int produced = engine.ProcessTxBlock(
+                    new ReadOnlySpan<float>(_tailMic, 0, blockSize),
+                    new Span<float>(_tailIq, 0, 2 * iqOut));
+                if (produced > 0)
+                {
+                    var iqSpan = new ReadOnlySpan<float>(_tailIq, 0, 2 * produced);
+                    _ring.Write(iqSpan);                                   // P1 EP2 packer
+                    _forwardP2?.Invoke(new ReadOnlyMemory<float>(_tailIq, 0, 2 * produced)); // P2 DUC
+                }
+
+                // Pace at the DAC rate so the radio FIFO transmits as we feed it.
+                deadline += periodTicks;
+                long remaining = deadline - System.Diagnostics.Stopwatch.GetTimestamp();
+                if (remaining > 0)
+                {
+                    int ms = (int)(remaining * 1000 / freq);
+                    if (ms > 0) Thread.Sleep(ms);
+                }
+                else deadline = System.Diagnostics.Stopwatch.GetTimestamp(); // re-anchor if behind
+            }
+
+            // Hold long enough for the radio FIFO to finish the last blocks before
+            // PTT drops (bench-tunable on the G2).
+            Thread.Sleep(FreeDvTxTailGuardMs);
+            _log.LogInformation("freedv.tx.tail drained, dropping PTT");
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "freedv.tx.tail drain threw");
+        }
+        finally
+        {
+            // Mirror the old MOX-falling-edge cleanup so the next over starts
+            // clean. The ring is already drained (we paced + guarded), so Clear
+            // only removes any safety remainder. _lastSeenMox=false stops the
+            // audio thread re-running the falling-edge clear after _moxOn flips.
+            lock (_sync)
+            {
+                _ring.Clear();
+                _accumulatorFill = 0;
+                _lastSeenMox = false;
+            }
+            freeDv.FlushTx();
+            Volatile.Write(ref _tailDraining, 0);
+        }
     }
 
     // FreeDV digital-voice modem coordinator. When FreeDV is the active mode,
@@ -528,6 +639,14 @@ public sealed class TxAudioIngest : IDisposable
 
         lock (_sync)
         {
+            // FreeDV end-of-over tail is clocking the final frame out on the
+            // un-key thread; yield TX exclusively (no second feeder on the WDSP
+            // TXA / radio IQ ring). Authoritative check under _sync — the drain
+            // sets _tailDraining then takes _sync as a barrier, so any frame that
+            // reaches here after that point bails. Drop the accumulator so no
+            // pre-tail remainder stitches onto the next over.
+            if (Volatile.Read(ref _tailDraining) != 0) { _accumulatorFill = 0; return; }
+
             // ATOMIC single-select gate (external-audio-jacks re-port, the
             // crux). This is the AUTHORITATIVE host/radio arbitration: it runs
             // in the SAME critical section as the accumulator append, so no flip

--- a/Zeus.Server.Hosting/TxService.cs
+++ b/Zeus.Server.Hosting/TxService.cs
@@ -222,6 +222,20 @@ public sealed class TxService
             ? (long)(preKeyMs / 1000.0 * System.Diagnostics.Stopwatch.Frequency)
             : 0;
 
+        // FreeDV end-of-over TX tail. On a genuine, accepted mic un-key, clock the
+        // final modem frame out to the radio while the wire MOX bit is STILL
+        // asserted and _moxOn is still true — done here, before the state lock, so
+        // the audio thread never runs its falling-edge ring-clear mid-tail and the
+        // receiver gets whole OFDM frames instead of a mid-symbol cut. No-op unless
+        // FreeDV is engaged; blocks briefly (bounded) for the tail to transmit.
+        // The acceptance test mirrors the lock below (only the owner / UI may
+        // drop), so we never transmit a tail for a drop that will be rejected.
+        if (!on && IsMoxOn
+            && (source == MoxSource.UI || MoxOwner is null || MoxOwner == source))
+        {
+            _pipeline.DrainFreeDvTxTail();
+        }
+
         bool wasTunOn;
         bool? txActiveCaptured;
         lock (_sync)

--- a/docs/designs/freedv-integration.md
+++ b/docs/designs/freedv-integration.md
@@ -81,6 +81,14 @@ one consumer of that library.
   RX sync) — the modem path compiles and is unit-testable but has not been keyed
   on real hardware.
 
+## Fidelity follow-up (end-of-over tail + speech-band resampling)
+
+End-of-over garble and dull/"nasal" audio were addressed by adding a FreeDV TX
+tail (complete + clock out the final OFDM frame before PTT drops; RADE's EOO
+callsign now rides it), widening the 48k⇄8k resampler passband, and instrumenting
+the RX decoder input for level-dependent clipping. Bench-tuning knobs and the G2
+validation checklist live in [`docs/lessons/freedv-fidelity.md`](../lessons/freedv-fidelity.md).
+
 ## Gotcha worth remembering
 
 `Zeus.Server.Hosting` types live in namespace **`Zeus.Server`**, not

--- a/docs/lessons/freedv-fidelity.md
+++ b/docs/lessons/freedv-fidelity.md
@@ -1,0 +1,81 @@
+# FreeDV fidelity — end-of-over tail + speech-band resampling
+
+Two operator-reported FreeDV problems and the changes made to fix them. Read
+this before touching `Zeus.Dsp.FreeDv` resamplers, the FreeDV TX un-key path, or
+the FreeDV RX gain staging.
+
+## Symptoms
+
+1. **Random garbled artifacts at the END of an over.** Receiving stations heard
+   noise/garbage on the last fraction of a second of every transmission.
+2. **Voices sometimes sound "nasally."** Dull/boxy decoded speech, worse on some
+   signals than others.
+
+## Root causes
+
+- **End-of-over garble = no TX tail.** The modem encodes whole OFDM frames. At
+  un-key the wire MOX bit dropped immediately, so the radio stopped RF mid-frame
+  and the buffered-but-untransmitted modem audio was discarded (`FlushTx`). The
+  receiver saw a truncated final OFDM symbol → garbage. Confirmed by the existing
+  code comment that RADE's EOO callsign "is not auto-fired" because "the TX tail
+  needs to drain" — there was no post-unkey drain at all.
+- **Nasal = the shared 48k⇄8k resampler ate the speech presence band.** The
+  prototype low-pass was a short (96-tap) Hamming sinc at 3.4 kHz cutoff, whose
+  wide transition band left the passband flat only to ~2.5 kHz. The 2.5–3.4 kHz
+  speech presence band rolled off in BOTH speech paths (mic→codec2 analysis and
+  decoded-speech→operator), so everyone sounded dull.
+- **Nasal "sometimes" = level-dependent decoder-input clipping (suspected).**
+  FreeDV forces WDSP RX AGC to **Fixed**; on strong signals that fixed level can
+  drive the float→int16 conversion into `freedv_rx` toward clipping → harsh
+  decode. Now *instrumented* (not yet auto-corrected) — see below.
+
+## Changes
+
+- **TX tail / PTT hang** (`TxService` → `DspPipelineService.DrainFreeDvTxTail` →
+  `TxAudioIngest.DrainFreeDvTxTail`). On a genuine FreeDV un-key, BEFORE the wire
+  MOX bit drops, the final modem frame is completed (`FinishTx`) and the queued
+  modem audio is clocked out to the radio at the DAC rate, then PTT drops. The
+  receiver now gets whole frames. The mic hot path yields TX exclusively during
+  the drain (CAS `_tailDraining` flag + `_sync` barrier) so there is never a
+  second feeder on WDSP `fexchange2`. **For RADE this also makes the EOO callsign
+  actually transmit** (it rides the tail).
+- **Resampler** (`FreeDvResampler`): 16→40 taps/phase (240-tap prototype), cutoff
+  3.4→3.5 kHz. Passband now flat to ~3.2 kHz; stopband still below the 4 kHz
+  (8 kHz-rate) Nyquist so decimation doesn't alias. Cost is trivial.
+- **RX decoder-input health log** (`FreeDvModem`): when synced and the input to
+  `freedv_rx` is clamping, a 1 Hz `freedv.rx.in clipping: peak=… clamps/s=…`
+  warning fires. This is the evidence to decide whether the Fixed RX AGC needs
+  headroom.
+
+## Bench-tuning on the G2 (the open knobs)
+
+The DSP changes are unit-tested (incl. against the real codec2/zeus_rade libs),
+but the TX-tail TIMING needs on-air confirmation. Knobs:
+
+- `TxAudioIngest.FreeDvTxTailMaxMs` (350) — hard ceiling on how long un-key blocks
+  while the final frame clocks out.
+- `TxAudioIngest.FreeDvTxTailGuardMs` (60) — extra hold after the last block so the
+  radio FIFO finishes before PTT drops. **Tune this first:** if the very end is
+  still clipped, raise it; if there is dead carrier at the end, lower it.
+- `FreeDvResampler.TapsPerPhase` / `CutoffHz` — raise the cutoff toward 3.6–3.8 kHz
+  if more brightness is wanted (keep stopband < 4 kHz).
+
+Validation steps:
+1. Key FreeDV (700D) on the G2 into a dummy load; have a second FreeDV RX decode.
+   Confirm the end of each over decodes cleanly (no tail garble).
+2. Watch the server log for `freedv.tx.tail drained, dropping PTT` per un-key.
+3. On RADE V1, confirm the decoding station shows the EOO callsign.
+4. Work some real stations; watch for `freedv.rx.in clipping` warnings. If they
+   appear on strong signals, add headroom to the Fixed RX AGC seed (red-light:
+   that's a level an operator feels — change with bench data, not blind).
+
+## Not yet changed (deliberately)
+
+- **Fixed RX AGC headroom** — instrumented, not auto-adjusted. Needs the clipping
+  log from a real on-air session first.
+- **TX leveler end-of-over transient** — the tail draining real frames largely
+  mitigates it; the residual is a WDSP-internal leveler ramp that can't be frozen
+  per-block without a WDSP API change.
+- **Auto-detect parking on a marginal submode** — possible secondary cause of
+  "sometimes nasal"; correlate the nasal episodes with submode/SNR telemetry
+  before changing the scanner.

--- a/tests/Zeus.Dsp.FreeDv.Tests/FreeDvModemTests.cs
+++ b/tests/Zeus.Dsp.FreeDv.Tests/FreeDvModemTests.cs
@@ -75,6 +75,44 @@ public class FreeDvModemTests
     }
 
     [Fact]
+    public void FinishTx_AndDrainTo_DoNotThrow_WhenIdleOrNativeMissing()
+    {
+        // Tail API must be safe to call regardless of native availability: when
+        // codec2 is absent FinishTx reports nothing pending and DrainTo clears
+        // the block. This is the contract the un-key path relies on.
+        using var modem = new FreeDvModem();
+        Assert.Equal(0, modem.FinishTx());
+        var block = new float[480];
+        Array.Fill(block, 0.5f);
+        Assert.Equal(0, modem.DrainTo(block));
+        Assert.All(block, s => Assert.Equal(0f, s)); // DrainTo silence-pads the empty queue
+    }
+
+    [SkippableFact]
+    public void FinishTx_CompletesResidualFrame_ThenDrainToEmpties()
+    {
+        using var modem = new FreeDvModem();
+        Skip.IfNot(modem.NativeAvailable, "codec2 native library absent — TX encode path not exercised.");
+
+        modem.Activate();
+        // Feed a sub-frame of mic speech (less than one codec2 frame) so a partial
+        // residual is left in the 8 kHz input ring — the end-of-over case.
+        var mic = new float[2400]; // 50 ms @ 48 kHz
+        for (int i = 0; i < mic.Length; i++) mic[i] = 0.2f * MathF.Sin(2f * MathF.PI * 800f * i / 48000f);
+        modem.ProcessTxInPlace((float[])mic.Clone());
+
+        int pending = modem.FinishTx();      // completes the final frame
+        Assert.True(pending > 0, "FinishTx should queue a completed final frame");
+        Assert.Equal(pending, modem.TxPendingOutSamples());
+
+        // Drain it out block by block; the queue must empty.
+        var blk = new float[480];
+        int guard = 0;
+        while (modem.DrainTo(blk) > 0 && guard++ < 10_000) { }
+        Assert.Equal(0, modem.TxPendingOutSamples());
+    }
+
+    [Fact]
     public void RxText_NullBeforeAnyDecode()
     {
         using var modem = new FreeDvModem();

--- a/tests/Zeus.Dsp.FreeDv.Tests/FreeDvResamplerTests.cs
+++ b/tests/Zeus.Dsp.FreeDv.Tests/FreeDvResamplerTests.cs
@@ -143,6 +143,53 @@ public class FreeDvResamplerTests
         Assert.Equal(600, interp.Process(new float[100], outp)); // 100 * 6
     }
 
+    [Fact]
+    public void PresenceBandTone_3kHz_IsPreserved()
+    {
+        // The fidelity fix: the prototype is long enough (and the cutoff high
+        // enough) that the 2.5–3.4 kHz speech presence band survives the
+        // 48k->8k->48k round trip. The old short/3.4 kHz design rolled 3 kHz off
+        // hard (the dull/"nasal" symptom); the new design keeps it near unity.
+        var dec = FreeDvResampler.NewDecimator();
+        var interp = FreeDvResampler.NewInterpolator();
+
+        int n = FsHigh;
+        var input = new float[n];
+        for (int i = 0; i < n; i++)
+            input[i] = MathF.Sin(2f * MathF.PI * 3000f * i / FsHigh);
+
+        var low = new float[FreeDvResampler.MaxDecimatedLength(n)];
+        int n8 = dec.Process(input, low);
+        var high = new float[FreeDvResampler.InterpolatedLength(n8)];
+        int n48 = interp.Process(low.AsSpan(0, n8), high);
+
+        double ratio = Rms(high, n48 / 4, n48 * 3 / 4) / Rms(input, n / 4, n * 3 / 4);
+        Assert.InRange(ratio, 0.70, 1.15);
+    }
+
+    [Fact]
+    public void ToneAboveNyquist_IsRejected_NoAliasing()
+    {
+        // A 5 kHz tone is above the 4 kHz (8 kHz-rate) Nyquist; the anti-alias
+        // low-pass must reject it before decimation so it cannot fold back into
+        // the voice band. Stopband sits below 4 kHz, so the round trip is ~silent.
+        var dec = FreeDvResampler.NewDecimator();
+        var interp = FreeDvResampler.NewInterpolator();
+
+        int n = FsHigh;
+        var input = new float[n];
+        for (int i = 0; i < n; i++)
+            input[i] = MathF.Sin(2f * MathF.PI * 5000f * i / FsHigh);
+
+        var low = new float[FreeDvResampler.MaxDecimatedLength(n)];
+        int n8 = dec.Process(input, low);
+        var high = new float[FreeDvResampler.InterpolatedLength(n8)];
+        int n48 = interp.Process(low.AsSpan(0, n8), high);
+
+        double ratio = Rms(high, n48 / 4, n48 * 3 / 4) / Rms(input, n / 4, n * 3 / 4);
+        Assert.True(ratio < 0.20, $"5 kHz leaked through at ratio {ratio:F3}");
+    }
+
     private static double Rms(float[] x, int lo, int hi)
     {
         double s = 0; int c = 0;

--- a/tests/Zeus.Dsp.FreeDv.Tests/RadeModemTests.cs
+++ b/tests/Zeus.Dsp.FreeDv.Tests/RadeModemTests.cs
@@ -50,6 +50,21 @@ public class RadeModemTests
         modem.FlushTx();
     }
 
+    [Fact]
+    public void FinishTx_AndDrainTo_DoNotThrow_WhenIdleOrNativeMissing()
+    {
+        using var modem = new RadeModem();
+        Assert.Equal(0, modem.FinishTx());
+        modem.Activate();
+        modem.SetTxText("N9WAR");
+        // FinishTx completes the over and appends the EOO callsign when native is
+        // present; reports 0 and stays safe when absent.
+        modem.FinishTx();
+        var block = new float[480];
+        modem.DrainTo(block);
+        Assert.True(modem.TxPendingOutSamples() >= 0);
+    }
+
     [SkippableFact]
     public void WhenNativeMissing_ActiveTx_Silences_AndRxPassesThrough()
     {


### PR DESCRIPTION
## Why

Two operator-reported FreeDV problems, plus a fidelity bump to make Zeus's FreeDV best-in-class:

1. **Random garbled artifacts at the END of every over** — receivers heard noise on the last fraction of a second.
2. **Voices sometimes sound "nasally"** — dull/boxy decoded speech, worse on some signals than others.

## Root causes

- **End-of-over garble = no TX tail.** The modem encodes whole OFDM frames, but at un-key the wire MOX bit dropped mid-frame and the buffered-but-untransmitted modem audio was discarded (`FlushTx`). The receiver saw a truncated final OFDM symbol → garbage. (The code even admitted it: RADE's EOO callsign "is not auto-fired" because "the TX tail needs to drain" — there was no drain.)
- **Nasal/dull = the shared 48k⇄8k resampler ate the speech presence band.** A short 96-tap Hamming sinc at 3.4 kHz cutoff is flat only to ~2.5 kHz, so the 2.5–3.4 kHz presence band rolled off in **both** speech paths (mic→codec2 analysis and decoded-speech→operator).
- **"Sometimes" nasal = suspected level-dependent clipping** into `freedv_rx` (FreeDV forces a Fixed RX AGC). Now *instrumented*, not blindly changed.

## Changes

**FreeDV TX tail (PTT hang).** On a genuine un-key, *before* the wire MOX bit drops and while TXA is still up, complete the final modem frame (`FinishTx`) and clock the queued modem audio to the radio at the DAC rate, then drop PTT. Receivers now get whole frames.
- New modem API: `FinishTx()` / `DrainTo()` / `TxPendingOutSamples()` on `FreeDvModem` and `RadeModem`.
- `FreeDvService.FinishTx`/`DrainTx` route to the active modem; `DspPipelineService.DrainFreeDvTxTail` → `TxAudioIngest.DrainFreeDvTxTail` owns the paced drain; `TxService.TrySetMox(false)` invokes it before the state lock.
- Mic hot path yields TX exclusively during the drain (CAS `_tailDraining` + `_sync` barrier) — no double-feed into WDSP `fexchange2`. Trip stays immediate.
- **RADE's End-of-Over callsign now actually transmits** — it rides the tail.

**Resampler fidelity** (`FreeDvResampler`): 96→240-tap prototype, 3.4→3.5 kHz cutoff. Passband flat to ~3.2 kHz; stopband still below the 4 kHz Nyquist (no aliasing). Cost is trivial.

**RX decoder-input health log** (`FreeDvModem`): 1 Hz `freedv.rx.in clipping:` warning when synced and the input to `freedv_rx` is clamping — the evidence to decide whether the Fixed RX AGC needs headroom. **AGC level deliberately not changed** (operator-felt default).

## Tests

- Resampler now asserts a 3 kHz tone is preserved and a 5 kHz tone is rejected (anti-alias).
- Modem tail API asserts final-frame completion and drain-to-empty (runs against the real codec2/zeus_rade libs when present).
- **56 DSP + 255 Tx/FreeDV server tests pass.** Branch builds clean on `develop`.

## ⚠ Needs G2 bench validation before merge

The DSP is unit-tested, but the **tail timing** must be confirmed on-air. Knobs in `TxAudioIngest`: `FreeDvTxTailGuardMs` (60) — raise if the end is still clipped, lower if there's dead carrier — and `FreeDvTxTailMaxMs` (350). Full checklist + the bench steps are in [`docs/lessons/freedv-fidelity.md`](docs/lessons/freedv-fidelity.md). This touches the TX/MOX keying path, so per project rules it wants a bench pass on the G2 first.