### PR TITLE
fix(hamclock): run npm via node + npm-cli.js so the install dir can't shadow npm

### DIFF
--- a/Zeus.Server.Hosting/HamClockService.cs
+++ b/Zeus.Server.Hosting/HamClockService.cs
@@ -682,8 +682,10 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
 
     /// <summary>
     /// Build a ProcessStartInfo that resolves PATH-installed tools on every
-    /// OS. npm is a .cmd shim on Windows (not a PATH-resolvable .exe), so it
-    /// must be invoked through cmd.exe; node.exe resolves directly.
+    /// OS. npm/npx are run by invoking their JS entrypoint with node directly
+    /// (node "…/npm-cli.js" …) rather than through the npm/npm.cmd shim, so the
+    /// working directory can never hijack which npm runs; node.exe resolves
+    /// directly. See <see cref="CreateToolProcessStartInfo"/>.
     /// </summary>
     private ProcessStartInfo MakePsi(string tool, string args, string cwd)
     {
@@ -700,6 +702,34 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
             UseShellExecute = false,
             CreateNoWindow = true,
         };
+
+        // For npm/npx, run their JS entrypoint with node directly
+        // (node "<…>/npm-cli.js" <args>) instead of going through the
+        // npm / npm.cmd shim. cmd.exe resolves a bare `npm` against the working
+        // directory *before* PATH, so a stray or half-written node_modules\npm
+        // in the install dir (e.g. left by an interrupted `npm ci`) can shadow
+        // the real npm and fail with "Cannot find module npm-cli.js". Calling
+        // node with an absolute entrypoint removes every shim / PATH / CWD
+        // ambiguity, and is identical on Windows, macOS and Linux.
+        if (tool is "npm" or "npx")
+        {
+            var nodeExe = ResolveNodeExe(nodeDir);
+            var cliJs = nodeExe is null ? null : ResolveNpmCliJs(nodeExe, tool);
+            if (nodeExe is not null && cliJs is not null)
+            {
+                psi.FileName = nodeExe;
+                var quotedCli = $"\"{cliJs}\"";
+                psi.Arguments = args.Length == 0 ? quotedCli : $"{quotedCli} {args}";
+                if (nodeDir is not null)
+                    PrependPath(psi, nodeDir);
+                return psi;
+            }
+        }
+
+        // Fallback (and the normal path for node/tar/etc.): the npm/npx CLI
+        // entrypoint couldn't be located, so fall back to the shim. npm is a
+        // .cmd shim on Windows (not a PATH-resolvable .exe), so it must be
+        // invoked through cmd.exe; node.exe and tar resolve directly.
         var bundledTool = nodeDir is null ? null : ResolveBundledToolPath(tool, nodeDir);
         if (OperatingSystem.IsWindows() && (tool is "npm" or "npx"))
         {
@@ -720,6 +750,56 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
         if (nodeDir is not null)
             PrependPath(psi, nodeDir);
         return psi;
+    }
+
+    /// <summary>
+    /// Resolve the absolute path to the node executable to run: the bundled copy
+    /// when <paramref name="nodeDir"/> is set, otherwise the first <c>node</c>
+    /// found on PATH. Returns null if none is found.
+    /// </summary>
+    private static string? ResolveNodeExe(string? nodeDir)
+    {
+        var exeName = OperatingSystem.IsWindows() ? "node.exe" : "node";
+        if (nodeDir is not null)
+        {
+            var bundled = Path.Combine(nodeDir, exeName);
+            return File.Exists(bundled) ? bundled : null;
+        }
+        var path = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrEmpty(path)) return null;
+        foreach (var dir in path.Split(Path.PathSeparator))
+        {
+            if (string.IsNullOrWhiteSpace(dir)) continue;
+            string candidate;
+            try { candidate = Path.Combine(dir.Trim(), exeName); }
+            catch { continue; } // malformed PATH entry — skip
+            if (File.Exists(candidate)) return candidate;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Resolve the absolute path to npm-cli.js / npx-cli.js for the given node
+    /// executable. Checks the Windows / portable-archive layout (npm beside
+    /// node) and the Unix system layout (node in <c>&lt;prefix&gt;/bin</c>, npm
+    /// under <c>&lt;prefix&gt;/lib</c>). Returns null if not found.
+    /// </summary>
+    private static string? ResolveNpmCliJs(string nodeExe, string tool)
+    {
+        var cliName = tool == "npx" ? "npx-cli.js" : "npm-cli.js";
+        var dir = Path.GetDirectoryName(nodeExe);
+        if (string.IsNullOrEmpty(dir)) return null;
+        string[] candidates =
+        [
+            Path.Combine(dir, "node_modules", "npm", "bin", cliName),              // Windows install / portable archive
+            Path.Combine(dir, "..", "lib", "node_modules", "npm", "bin", cliName), // Unix system (node in <prefix>/bin)
+        ];
+        foreach (var c in candidates)
+        {
+            try { if (File.Exists(c)) return Path.GetFullPath(c); }
+            catch { /* malformed candidate — try the next */ }
+        }
+        return null;
     }
 
     private static string? ResolveBundledToolPath(string tool, string nodeDir)

--- a/tests/Zeus.Server.Tests/HamClockServiceTests.cs
+++ b/tests/Zeus.Server.Tests/HamClockServiceTests.cs
@@ -28,6 +28,86 @@ public sealed class HamClockServiceTests
     }
 
     [Fact]
+    public void CreateToolProcessStartInfo_RunsNpmViaNodeWithCliEntrypoint()
+    {
+        // npm must be launched as `node "<…>/npm-cli.js" ci`, never through the
+        // npm/npm.cmd shim — otherwise a stray node_modules\npm in the working
+        // dir can shadow the real npm (regression: "Cannot find module npm-cli.js").
+        var root = Path.Combine(Path.GetTempPath(), "zeus-hamclock-npm-" + Guid.NewGuid().ToString("N"));
+        var npmBin = Path.Combine(root, "node_modules", "npm", "bin");
+        Directory.CreateDirectory(npmBin);
+        try
+        {
+            var nodePath = Path.Combine(root, OperatingSystem.IsWindows() ? "node.exe" : "node");
+            File.WriteAllText(nodePath, string.Empty);
+            var cliPath = Path.Combine(npmBin, "npm-cli.js");
+            File.WriteAllText(cliPath, string.Empty);
+
+            var psi = HamClockService.CreateToolProcessStartInfo("npm", "ci", Path.GetTempPath(), root);
+
+            Assert.Equal(nodePath, psi.FileName);
+            Assert.DoesNotContain("cmd.exe", psi.FileName, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal($"\"{cliPath}\" ci", psi.Arguments);
+            var path = psi.Environment.First(kv => string.Equals(kv.Key, "PATH", StringComparison.OrdinalIgnoreCase)).Value;
+            Assert.StartsWith(root + Path.PathSeparator, path);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CreateToolProcessStartInfo_ResolvesNpxCliEntrypoint()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "zeus-hamclock-npx-" + Guid.NewGuid().ToString("N"));
+        var npmBin = Path.Combine(root, "node_modules", "npm", "bin");
+        Directory.CreateDirectory(npmBin);
+        try
+        {
+            var nodePath = Path.Combine(root, OperatingSystem.IsWindows() ? "node.exe" : "node");
+            File.WriteAllText(nodePath, string.Empty);
+            var cliPath = Path.Combine(npmBin, "npx-cli.js");
+            File.WriteAllText(cliPath, string.Empty);
+
+            var psi = HamClockService.CreateToolProcessStartInfo("npx", "--version", Path.GetTempPath(), root);
+
+            Assert.Equal(nodePath, psi.FileName);
+            Assert.Equal($"\"{cliPath}\" --version", psi.Arguments);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CreateToolProcessStartInfo_FallsBackToCmdShim_WhenNpmCliEntrypointMissing()
+    {
+        // No npm-cli.js next to node → fall back to the cmd.exe shim path on
+        // Windows so installs still work on unusual Node layouts.
+        if (!OperatingSystem.IsWindows()) return;
+
+        var root = Path.Combine(Path.GetTempPath(), "zeus-hamclock-npmfb-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "node.exe"), string.Empty);
+            File.WriteAllText(Path.Combine(root, "npm.cmd"), string.Empty); // shim present, npm-cli.js absent
+
+            var psi = HamClockService.CreateToolProcessStartInfo("npm", "ci", Path.GetTempPath(), root);
+
+            Assert.Equal("cmd.exe", psi.FileName);
+            Assert.Contains("npm.cmd", psi.Arguments, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("ci", psi.Arguments, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void ReadEnvPortFromContent_UsesFirstUncommentedPort()
     {
         const string env = """


### PR DESCRIPTION
## Problem

A HamClock install failed on a healthy Windows machine (Node 24.17.0, npm 11.13.0) with:

```
Error: Cannot find module 'C:\Users\…\AppData\Local\Zeus\hamclock\node_modules\npm\bin\npm-prefix.js'
Error: Cannot find module 'C:\Users\…\AppData\Local\Zeus\hamclock\node_modules\npm\bin\npm-cli.js'
npm ci failed; retrying with npm install… (same error) → ERROR: npm install failed
```

### Root cause

`HamClockService` launched npm as `cmd.exe /d /s /c "npm ci"` with the **install dir as the working directory**. `cmd.exe` resolves a bare `npm` against the **current directory before PATH**. A stray or half-written `node_modules\npm` in the install dir (e.g. left by an interrupted `npm ci`) — combined with an old-style npm launcher — makes the shim compute its module path from the install dir and die with `Cannot find module npm-prefix.js / npm-cli.js`. The system npm is fine; the *resolution path* is what breaks.

## Fix

Resolve npm/npx to their JS entrypoint and invoke node directly:

```
node "<…>/npm-cli.js" <args>
```

This bypasses the `npm`/`npm.cmd` shim and all PATH/CWD ambiguity, and is identical across Windows, macOS, and Linux. `npm-cli.js` is located next to the resolved node (Windows / portable archive) or under `<prefix>/lib` (Unix system install). If it can't be located, it falls back to the prior shim path so unusual Node layouts still work.

Nothing about the radio / DSP / TX path is touched — this is entirely within the optional HamClock sidecar installer.

## Tests

Adds regression coverage to `HamClockServiceTests`:
- npm is launched as `node "<abs npm-cli.js>" ci` (never `cmd.exe`)
- npx resolves `npx-cli.js`
- Windows shim fallback when `npm-cli.js` is absent

All 19 `HamClockServiceTests` pass locally on Windows; the resolution logic is cross-platform and CI runs macOS/Windows/Linux.