### PR TITLE
fix(qrz): only report XML subscription active when QRZ confirms it

### DIFF
--- a/Zeus.Server.Hosting/QrzService.cs
+++ b/Zeus.Server.Hosting/QrzService.cs
@@ -129,14 +129,15 @@ public sealed class QrzService
                 return new QrzStatus(false, false, null, "QRZ login failed");
             }
 
-            // Look up the user's own callsign to populate home station info. Success here
-            // is also proof the account has an active XML subscription (the session key
-            // alone doesn't guarantee lookup rights).
+            // _hasXmlSubscription was set authoritatively from the Session <SubExp>
+            // field during AcquireSessionKeyAsync — that is the only reliable signal
+            // of an active XML subscription. QRZ returns basic callsign data to
+            // non-subscribers as well, so lookup success does NOT prove a subscription.
+            // Look up the user's own callsign only to populate home station info.
             try
             {
                 var home = await LookupInternalAsync(username, ct);
                 _home = home;
-                _hasXmlSubscription = home != null;
 
                 // Persist credentials on successful login
                 await _credStore.SetAsync(ServiceName, username, password, ct);
@@ -319,7 +320,48 @@ public sealed class QrzService
 
         _sessionKey = Get(session, "Key");
         _sessionExpiry = DateTime.UtcNow.AddHours(1);
+
+        // <SubExp> is QRZ's authoritative subscription signal: the literal
+        // "non-subscriber" for accounts without an active XML subscription, an
+        // expiration date string (e.g. "Wed Dec 31 23:59:59 2025") otherwise.
+        _hasXmlSubscription = IsActiveSubscription(Get(session, "SubExp"));
+
         return _sessionKey;
+    }
+
+    // QRZ stamps <SubExp> in Unix asctime form, e.g. "Wed Dec 31 23:59:59 2025"
+    // (single-digit days are space-padded → "Wed Dec  1 ..."). Whitespace is
+    // collapsed before matching so both paddings parse with one format. A plain
+    // DateTime.TryParse does NOT recognise this layout — use TryParseExact.
+    private static readonly string[] QrzSubExpFormats =
+    {
+        "ddd MMM d HH:mm:ss yyyy",
+        "ddd MMM d yyyy",
+    };
+
+    // Determines whether QRZ's <SubExp> field reflects an active XML subscription.
+    // "non-subscriber" (or an expiration date in the past) → false; a future
+    // expiration date → true. Internal for unit testing.
+    internal static bool IsActiveSubscription(string? subExp)
+    {
+        if (string.IsNullOrWhiteSpace(subExp)) return false;
+
+        // Collapse runs of whitespace so asctime's space-padded day matches a
+        // single-space format.
+        var t = System.Text.RegularExpressions.Regex.Replace(subExp.Trim(), @"\s+", " ");
+        if (t.Contains("non-subscriber", StringComparison.OrdinalIgnoreCase)) return false;
+
+        const System.Globalization.DateTimeStyles styles =
+            System.Globalization.DateTimeStyles.AssumeUniversal | System.Globalization.DateTimeStyles.AdjustToUniversal;
+        if (DateTime.TryParseExact(t, QrzSubExpFormats, System.Globalization.CultureInfo.InvariantCulture, styles, out var expiry) ||
+            DateTime.TryParse(t, System.Globalization.CultureInfo.InvariantCulture, styles, out expiry))
+        {
+            return expiry > DateTime.UtcNow;
+        }
+
+        // QRZ returned a non-empty SubExp that isn't "non-subscriber" yet doesn't
+        // parse as a date — treat as subscribed rather than locking out a paying user.
+        return true;
     }
 
     private static string? Get(XElement? parent, string name)

--- a/tests/Zeus.Server.Tests/QrzSubscriptionTests.cs
+++ b/tests/Zeus.Server.Tests/QrzSubscriptionTests.cs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF), Christian Suarez (N9WAR), and contributors.
+//
+// Pins QrzService.IsActiveSubscription: HasXmlSubscription must reflect QRZ's
+// authoritative <SubExp> Session field, NOT lookup success. QRZ returns basic
+// callsign data to non-subscribers as well, so the old "self-lookup returned a
+// record → subscribed" heuristic falsely reported active subscriptions. Only an
+// explicit, unexpired SubExp date counts as active; "non-subscriber" does not.
+
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class QrzSubscriptionTests
+{
+    [Fact]
+    public void NonSubscriber_IsNotActive()
+    {
+        Assert.False(QrzService.IsActiveSubscription("non-subscriber"));
+        Assert.False(QrzService.IsActiveSubscription("Non-Subscriber"));
+        Assert.False(QrzService.IsActiveSubscription("  non-subscriber  "));
+    }
+
+    [Fact]
+    public void MissingOrEmpty_IsNotActive()
+    {
+        Assert.False(QrzService.IsActiveSubscription(null));
+        Assert.False(QrzService.IsActiveSubscription(""));
+        Assert.False(QrzService.IsActiveSubscription("   "));
+    }
+
+    [Fact]
+    public void FutureExpiryDate_IsActive()
+    {
+        // QRZ's documented SubExp format for active subscribers (weekday must
+        // match the date or .NET's parser rejects it — Dec 31 2099 is a Thursday).
+        Assert.True(QrzService.IsActiveSubscription("Thu Dec 31 23:59:59 2099"));
+    }
+
+    [Fact]
+    public void SpacePaddedDay_IsParsed()
+    {
+        // asctime space-pads single-digit days: "Mon Jan  1 ...". Jan 1 2099 is a Thursday.
+        Assert.True(QrzService.IsActiveSubscription("Thu Jan  1 00:00:00 2099"));
+    }
+
+    [Fact]
+    public void PastExpiryDate_IsNotActive()
+    {
+        // Dec 31 2000 was a Sunday.
+        Assert.False(QrzService.IsActiveSubscription("Sun Dec 31 23:59:59 2000"));
+    }
+}


### PR DESCRIPTION
## Problem

`QrzStatus.HasXmlSubscription` was inferred from whether the post-login self-lookup returned a record (`home != null`). But QRZ returns basic callsign data to **non-subscribers** as well, so the flag was reported **active for accounts without a paid XML subscription**.

## Fix

Derive the flag from QRZ's authoritative `<SubExp>` field in the `<Session>` element, captured during `AcquireSessionKeyAsync`:

- `"non-subscriber"` (or an expiry date in the past) → `false`
- a future expiry date → `true`

`<SubExp>` is emitted in Unix asctime form (`Wed Dec 31 23:59:59 2025`, with space-padded single-digit days). It is parsed with `TryParseExact` against that layout — a plain `DateTime.TryParse` does **not** recognise the asctime format, which previously left any date-based expiry check dead. The self-lookup is now used only to populate home-station info.

## Tests

New `QrzSubscriptionTests` cover: `non-subscriber`, null/empty, future date, past date, and the space-padded-day variant. All pass; hosting library compiles clean on the worktree.

## Scope / safety

Server-side QRZ status logic only. No operator-facing defaults change, PureSignal untouched.