### PR TITLE
feat(tx-audio): import TX audio profiles + mirror the catalog to a folder

### DIFF
--- a/Zeus.Server.Hosting/TxAudioProfileService.cs
+++ b/Zeus.Server.Hosting/TxAudioProfileService.cs
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+using System.Text;
+using System.Text.Json;
 using Microsoft.Extensions.Hosting;
 using Zeus.Contracts;
 using Zeus.Plugins.Host;
@@ -78,6 +80,72 @@ public sealed class TxAudioProfileService : IHostedService
         if (removed)
             _log.LogInformation("TX audio profile '{Id}' deleted", TxAudioProfileStore.NormalizeId(id));
         return removed;
+    }
+
+    /// <summary>The on-disk folder every profile is mirrored into as JSON.</summary>
+    public string ProfileFolder => _store.ProfileFolder;
+
+    // Indented camelCase export — matches the folder-mirror format so a
+    // downloaded file is byte-for-byte the same shape as the on-disk mirror.
+    private static readonly JsonSerializerOptions ExportJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+    };
+
+    /// <summary>
+    /// Import a profile from a JSON document (an uploaded/shared file). The
+    /// profile is ADDED to the collection — it is never auto-applied, and it
+    /// never clobbers an existing profile: if the derived slug is taken, the
+    /// display name is bumped (\"Voice\" -> \"Voice 2\") until the id is free.
+    /// Partial / hand-edited files are tolerated (missing collections default to
+    /// empty so the apply path can't dereference a null). Throws
+    /// <see cref="ArgumentException"/> on unparseable input.
+    /// </summary>
+    public TxAudioProfileDto ImportProfile(string json, string? fallbackName = null)
+    {
+        var parsed = TxAudioProfileStore.ParseJson(json)
+            ?? throw new ArgumentException("File is not a valid TX audio profile (could not parse JSON).");
+
+        // Harden nullable members so a sparse file can't produce nulls that the
+        // ApplyAsync path iterates/dereferences.
+        var clean = parsed with
+        {
+            TxLeveling = parsed.TxLeveling ?? new TxLevelingConfig(),
+            CfcConfig = parsed.CfcConfig ?? CfcConfig.Default,
+            ChainOrder = parsed.ChainOrder ?? new List<string>(),
+            ChainParked = parsed.ChainParked ?? new List<string>(),
+            VstPluginStates = parsed.VstPluginStates ?? new Dictionary<string, string>(),
+            NativePluginStates = parsed.NativePluginStates ?? new Dictionary<string, Dictionary<string, string>>(),
+        };
+
+        var baseName = !string.IsNullOrWhiteSpace(clean.Name) ? clean.Name!.Trim()
+            : !string.IsNullOrWhiteSpace(fallbackName) ? fallbackName!.Trim()
+            : "imported profile";
+
+        var name = baseName;
+        var id = Slugify(name);
+        for (int n = 2; _store.Get(id) is not null; n++)
+        {
+            name = $"{baseName} {n}";
+            id = Slugify(name);
+        }
+
+        var saved = _store.Upsert(clean with { Id = id, Name = name });
+        _log.LogInformation("TX audio profile imported as '{Name}' (id={Id})", saved.Name, saved.Id);
+        return saved;
+    }
+
+    /// <summary>
+    /// Serialize a saved profile to downloadable JSON bytes (indented). Returns
+    /// null when no such profile. The byte shape matches the folder mirror.
+    /// </summary>
+    public (byte[] Bytes, string FileName)? ExportProfile(string id)
+    {
+        var profile = _store.Get(id);
+        if (profile is null) return null;
+        var json = JsonSerializer.Serialize(profile, ExportJsonOptions);
+        return (Encoding.UTF8.GetBytes(json), profile.Id + ".json");
     }
 
     /// <summary>

--- a/Zeus.Server.Hosting/TxAudioProfileStore.cs
+++ b/Zeus.Server.Hosting/TxAudioProfileStore.cs
@@ -31,11 +31,26 @@ public sealed class TxAudioProfileStore : IDisposable
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
     };
 
+    // Folder-mirror output: human-readable, so a profile dropped in the folder
+    // (or shared between operators) is easy to eyeball and hand-edit.
+    private static readonly JsonSerializerOptions FileJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+    };
+
+    // Each profile is ALSO mirrored to <prefs-dir>/tx-audio-profiles/<id>.json so
+    // the whole catalog lives as plain files on disk (portable, shareable,
+    // importable). LiteDB stays the source of truth; the folder is a write-through
+    // mirror — best-effort, never allowed to break a DB write.
+    private const string ProfileDirName = "tx-audio-profiles";
+
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<TxAudioProfileEntry> _profiles;
     private readonly ILiteCollection<TxAudioProfileLastLoadedEntry> _lastLoaded;
     private readonly ILogger<TxAudioProfileStore> _log;
     private readonly object _sync = new();
+    private readonly string _profileDir;
 
     public TxAudioProfileStore(ILogger<TxAudioProfileStore> log, string? dbPathOverride = null)
     {
@@ -44,6 +59,11 @@ public sealed class TxAudioProfileStore : IDisposable
         var dir = Path.GetDirectoryName(dbPath);
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
+
+        // Mirror folder sits next to the active prefs DB, so a ZEUS_PREFS_PATH
+        // override (dev `/run fresh`, CI, tests) isolates the folder too.
+        var prefsDir = Path.GetDirectoryName(Path.GetFullPath(dbPath));
+        _profileDir = Path.Combine(string.IsNullOrEmpty(prefsDir) ? "." : prefsDir, ProfileDirName);
 
         _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
         _profiles = _db.GetCollection<TxAudioProfileEntry>("tx_audio_profiles");
@@ -54,8 +74,15 @@ public sealed class TxAudioProfileStore : IDisposable
         catch (LiteException ex) when (ex.Message.Contains("INDEX_DUPLICATE_KEY", StringComparison.OrdinalIgnoreCase)) { }
         _lastLoaded = _db.GetCollection<TxAudioProfileLastLoadedEntry>("tx_audio_profile_last_loaded");
 
-        _log.LogInformation("TxAudioProfileStore initialized at {Path}", dbPath);
+        // Make sure every profile already in the DB is present in the folder.
+        try { SyncFolder(); }
+        catch (Exception ex) { _log.LogWarning(ex, "TX audio profile folder sync at startup failed"); }
+
+        _log.LogInformation("TxAudioProfileStore initialized at {Path} (folder {Folder})", dbPath, _profileDir);
     }
+
+    /// <summary>The on-disk folder every profile is mirrored into as JSON.</summary>
+    public string ProfileFolder => _profileDir;
 
     public static string NormalizeId(string id) => (id ?? "").Trim().ToLowerInvariant();
 
@@ -123,6 +150,7 @@ public sealed class TxAudioProfileStore : IDisposable
                 existing.UpdatedUtc = nowUtc;
                 _profiles.Update(existing);
             }
+            MirrorToFolder(normalized);
             return normalized;
         }
     }
@@ -144,6 +172,7 @@ public sealed class TxAudioProfileStore : IDisposable
                     ptr.ProfileId = null;
                     _lastLoaded.Update(ptr);
                 }
+                RemoveFromFolder(id);
             }
             return removed;
         }
@@ -171,6 +200,52 @@ public sealed class TxAudioProfileStore : IDisposable
             if (ptr.Id == 0) _lastLoaded.Insert(ptr);
             else _lastLoaded.Update(ptr);
         }
+    }
+
+    /// <summary>Parse a profile from a JSON document (e.g. an imported file).
+    /// Returns null on blank/invalid input rather than throwing.</summary>
+    public static TxAudioProfileDto? ParseJson(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return null;
+        try { return JsonSerializer.Deserialize<TxAudioProfileDto>(json, JsonOptions); }
+        catch { return null; }
+    }
+
+    // Write-through mirror of one profile to <folder>/<id>.json. Best-effort:
+    // the DB row is authoritative, so a folder IO failure is logged, not thrown.
+    private void MirrorToFolder(TxAudioProfileDto profile)
+    {
+        try
+        {
+            Directory.CreateDirectory(_profileDir);
+            var path = Path.Combine(_profileDir, profile.Id + ".json");
+            File.WriteAllText(path, JsonSerializer.Serialize(profile, FileJsonOptions));
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "Mirroring TX audio profile '{Id}' to folder failed", profile.Id);
+        }
+    }
+
+    private void RemoveFromFolder(string profileId)
+    {
+        try
+        {
+            var path = Path.Combine(_profileDir, profileId + ".json");
+            if (File.Exists(path)) File.Delete(path);
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "Removing TX audio profile file '{Id}' failed", profileId);
+        }
+    }
+
+    // Ensure every profile in the DB has a file in the folder (idempotent).
+    private void SyncFolder()
+    {
+        Directory.CreateDirectory(_profileDir);
+        foreach (var profile in GetAll())
+            MirrorToFolder(profile);
     }
 
     private TxAudioProfileDto? TryDeserialize(TxAudioProfileEntry entry)

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -481,6 +481,51 @@ public static class ZeusEndpoints
             return Results.Ok(new LastLoadedTxAudioProfileDto(svc.LastLoadedId));
         });
 
+        // Import a TX audio profile from an uploaded .json file (multipart). The
+        // webview can't hand the server a filesystem path, so the chosen file's
+        // bytes are uploaded here, parsed, and ADDED to the collection (never
+        // applied). The import is non-destructive — a slug collision bumps the
+        // name rather than overwriting. Every profile is also mirrored to the
+        // on-disk tx-audio-profiles folder. Antiforgery disabled — this is a
+        // loopback / LAN-token API, not a cookie-auth form post.
+        app.MapPost("/api/tx-audio-profiles/import", async (HttpRequest req, TxAudioProfileService svc) =>
+        {
+            try
+            {
+                if (!req.HasFormContentType)
+                    return Results.BadRequest(new { error = "Expected a multipart file upload." });
+                var form = await req.ReadFormAsync();
+                var file = form.Files.GetFile("file") ?? form.Files.FirstOrDefault();
+                if (file is null || file.Length == 0)
+                    return Results.BadRequest(new { error = "No file uploaded." });
+
+                var nameField = form.TryGetValue("name", out var n) ? n.ToString() : null;
+                var fallback = string.IsNullOrWhiteSpace(nameField)
+                    ? Path.GetFileNameWithoutExtension(file.FileName)
+                    : nameField;
+
+                using var reader = new StreamReader(file.OpenReadStream());
+                var json = await reader.ReadToEndAsync();
+                var imported = svc.ImportProfile(json, fallback);
+                return Results.Ok(imported);
+            }
+            catch (Exception ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+        }).DisableAntiforgery();
+
+        // Download a saved TX audio profile as a .json file so the operator can
+        // back it up or share it (the same bytes are mirrored in the
+        // tx-audio-profiles folder on disk).
+        app.MapGet("/api/tx-audio-profiles/{id}/export", (string id, TxAudioProfileService svc) =>
+        {
+            var export = svc.ExportProfile(id);
+            return export is null
+                ? Results.NotFound(new { error = $"no TX audio profile '{id}'" })
+                : Results.File(export.Value.Bytes, "application/json", export.Value.FileName);
+        });
+
         app.MapGet("/api/rx-audio-suite/profiles", (RxAudioProfileService profiles) =>
         {
             var list = profiles.List().Select(p => new

--- a/tests/Zeus.Server.Tests/TxAudioProfileServiceTests.cs
+++ b/tests/Zeus.Server.Tests/TxAudioProfileServiceTests.cs
@@ -197,6 +197,66 @@ public sealed class TxAudioProfileServiceTests : IDisposable
         Assert.Null(_service.Get("temp"));
     }
 
+    [Fact]
+    public async Task ExportImport_RoundTrips_FromJsonBytes()
+    {
+        await _mode.StartAsync(CancellationToken.None);
+        _radio.SetTxMicGain(-6);
+        var saved = await _service.SaveCurrentAsync("Roundtrip Voice");
+
+        var export = _service.ExportProfile(saved.Id);
+        Assert.NotNull(export);
+        var json = System.Text.Encoding.UTF8.GetString(export!.Value.Bytes);
+        Assert.Equal("roundtrip-voice.json", export.Value.FileName);
+
+        // Delete then re-import from the exported bytes — must restore the profile.
+        Assert.True(_service.Delete(saved.Id));
+        var imported = _service.ImportProfile(json, "ignored-fallback");
+        Assert.Equal("roundtrip-voice", imported.Id);
+        Assert.Equal("Roundtrip Voice", imported.Name);
+        Assert.Equal(-6, imported.MicGainDb);
+        Assert.NotNull(_service.Get("roundtrip-voice"));
+    }
+
+    [Fact]
+    public async Task Import_IsNonDestructive_UniquifiesNameOnSlugCollision()
+    {
+        await _mode.StartAsync(CancellationToken.None);
+        var saved = await _service.SaveCurrentAsync("Voice");
+        var json = System.Text.Encoding.UTF8.GetString(_service.ExportProfile(saved.Id)!.Value.Bytes);
+
+        // Re-import WITHOUT deleting: the existing profile must survive and the
+        // import lands under a bumped id/name.
+        var imported = _service.ImportProfile(json, null);
+        Assert.Equal("voice-2", imported.Id);
+        Assert.Equal("Voice 2", imported.Name);
+        Assert.NotNull(_service.Get("voice"));     // original intact
+        Assert.NotNull(_service.Get("voice-2"));   // import added
+    }
+
+    [Fact]
+    public void Import_RejectsUnparseableJson()
+    {
+        Assert.Throws<ArgumentException>(() => _service.ImportProfile("not a profile", null));
+    }
+
+    [Fact]
+    public void Import_ToleratesSparseFile_UsesFallbackName()
+    {
+        // A minimal hand-authored file: only a couple of fields, no name, no
+        // collections. Import must default the nullable members and name it from
+        // the fallback rather than throwing.
+        const string json = "{\"micGainDb\": -2, \"targetSpectralDensity\": 40}";
+        var imported = _service.ImportProfile(json, "My Import");
+
+        Assert.Equal("my-import", imported.Id);
+        Assert.Equal("My Import", imported.Name);
+        Assert.Equal(-2, imported.MicGainDb);
+        Assert.NotNull(imported.ChainOrder);
+        Assert.NotNull(imported.CfcConfig);
+        Assert.NotNull(imported.TxLeveling);
+    }
+
     public void Dispose()
     {
         _engine.DisposeAsync().AsTask().GetAwaiter().GetResult();

--- a/tests/Zeus.Server.Tests/TxAudioProfileStoreTests.cs
+++ b/tests/Zeus.Server.Tests/TxAudioProfileStoreTests.cs
@@ -7,16 +7,21 @@ namespace Zeus.Server.Tests;
 
 public class TxAudioProfileStoreTests : IDisposable
 {
+    private readonly string _root;
     private readonly string _dbPath;
 
     public TxAudioProfileStoreTests()
     {
-        _dbPath = Path.Combine(Path.GetTempPath(), $"zeus-prefs-txaudioprofiles-{Guid.NewGuid():N}.db");
+        // Per-test directory so the on-disk profile mirror folder
+        // (<dir>/tx-audio-profiles) is isolated and cleaned with the test.
+        _root = Path.Combine(Path.GetTempPath(), $"zeus-txaudioprofiles-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_root);
+        _dbPath = Path.Combine(_root, "zeus-prefs.db");
     }
 
     public void Dispose()
     {
-        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+        try { Directory.Delete(_root, recursive: true); } catch { }
     }
 
     private TxAudioProfileStore NewStore() =>
@@ -124,5 +129,59 @@ public class TxAudioProfileStoreTests : IDisposable
         store.SetLastLoadedId("studio-ssb");
         store.SetLastLoadedId(null);
         Assert.Null(store.GetLastLoadedId());
+    }
+
+    [Fact]
+    public void Upsert_MirrorsProfileToFolder()
+    {
+        using var store = NewStore();
+        store.Upsert(Sample("studio-ssb", "Studio SSB"));
+
+        var file = Path.Combine(store.ProfileFolder, "studio-ssb.json");
+        Assert.True(File.Exists(file));
+        Assert.Contains("Studio SSB", File.ReadAllText(file));
+    }
+
+    [Fact]
+    public void Delete_RemovesProfileFile()
+    {
+        using var store = NewStore();
+        store.Upsert(Sample("dx-punch", "DX Punch"));
+        var file = Path.Combine(store.ProfileFolder, "dx-punch.json");
+        Assert.True(File.Exists(file));
+
+        Assert.True(store.Delete("dx-punch"));
+        Assert.False(File.Exists(file));
+    }
+
+    [Fact]
+    public void NewStore_SyncsExistingProfilesToFolder()
+    {
+        using (var first = NewStore())
+            first.Upsert(Sample("essb-wide", "eSSB Wide"));
+
+        // Wipe the mirror folder, then re-open: the ctor must re-materialize it
+        // from the DB rows.
+        var folder = Path.Combine(_root, "tx-audio-profiles");
+        if (Directory.Exists(folder)) Directory.Delete(folder, recursive: true);
+
+        using var second = NewStore();
+        Assert.True(File.Exists(Path.Combine(second.ProfileFolder, "essb-wide.json")));
+    }
+
+    [Fact]
+    public void ParseJson_RoundTripsAndRejectsGarbage()
+    {
+        using var store = NewStore();
+        var saved = store.Upsert(Sample("studio-ssb", "Studio SSB", mic: -4));
+        var json = File.ReadAllText(Path.Combine(store.ProfileFolder, "studio-ssb.json"));
+
+        var parsed = TxAudioProfileStore.ParseJson(json);
+        Assert.NotNull(parsed);
+        Assert.Equal("studio-ssb", parsed!.Id);
+        Assert.Equal(-4, parsed.MicGainDb);
+
+        Assert.Null(TxAudioProfileStore.ParseJson("not json"));
+        Assert.Null(TxAudioProfileStore.ParseJson(""));
     }
 }

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -6756,6 +6756,69 @@ export function setLastLoadedTxAudioProfile(
   );
 }
 
+// Import a TX audio profile from a user-picked .json file (uploaded as
+// multipart — the webview can't hand the server a filesystem path). The profile
+// is ADDED to the collection (never applied); the server uniquifies the name if
+// the slug is already taken. Returns the stored profile.
+export function importTxAudioProfile(
+  file: File,
+  name?: string,
+  signal?: AbortSignal,
+): Promise<TxAudioProfileDto> {
+  const form = new FormData();
+  form.append('file', file, file.name);
+  if (name && name.trim().length > 0) form.append('name', name.trim());
+  // No explicit content-type — the browser sets the multipart boundary.
+  return jsonFetch(
+    '/api/tx-audio-profiles/import',
+    { method: 'POST', body: form, signal },
+    (raw) => {
+      const p = normalizeTxAudioProfile(raw);
+      if (!p) throw new ApiError(500, 'Malformed imported TX audio profile response');
+      return p;
+    },
+  );
+}
+
+// Download a saved TX audio profile as a .json file. Fetches the bytes and saves
+// them via a temporary object URL (so server-side errors surface as exceptions
+// the caller can show, rather than opening a JSON error blob in a new tab) —
+// mirrors exportPrefsDatabase.
+export async function exportTxAudioProfile(
+  id: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  const url = `/api/tx-audio-profiles/${encodeURIComponent(id)}/export`;
+  const res = await fetch(url, { signal });
+  if (!res.ok) {
+    let message = `${res.status} ${res.statusText}`;
+    try {
+      const body = (await res.json()) as { error?: unknown };
+      if (typeof body?.error === 'string') message = body.error;
+    } catch {
+      /* non-JSON body — keep status text */
+    }
+    throw new ApiError(res.status, message);
+  }
+
+  const blob = await res.blob();
+  const cd = res.headers.get('content-disposition') ?? '';
+  const match = /filename\*?=(?:UTF-8'')?"?([^";]+)"?/i.exec(cd);
+  const fileName = match?.[1] ? decodeURIComponent(match[1]) : `${id}.json`;
+
+  const objectUrl = URL.createObjectURL(blob);
+  try {
+    const a = document.createElement('a');
+    a.href = objectUrl;
+    a.download = fileName;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}
+
 export function fetchTxFidelityPolicy(
   signal?: AbortSignal,
 ): Promise<TxFidelityPolicyDto> {

--- a/zeus-web/src/components/TxAudioProfileBar.tsx
+++ b/zeus-web/src/components/TxAudioProfileBar.tsx
@@ -17,8 +17,8 @@
 // Token-only styling (var(--*) — never raw hex). The Save body is captured
 // server-side from live state; this component never assembles a profile body.
 
-import { useEffect, useId, useRef, useState, type CSSProperties } from 'react';
-import { ChevronDown, Plus } from 'lucide-react';
+import { useEffect, useId, useRef, useState, type ChangeEvent, type CSSProperties } from 'react';
+import { ChevronDown, Download, Plus, Upload } from 'lucide-react';
 
 import { ConfirmDialog } from '../layout/ConfirmDialog';
 import { TextInputDialog } from '../layout/TextInputDialog';
@@ -65,6 +65,8 @@ export function TxAudioProfileBar({ compact = false }: TxAudioProfileBarProps) {
   const save = useTxAudioProfileStore((s) => s.save);
   const apply = useTxAudioProfileStore((s) => s.apply);
   const remove = useTxAudioProfileStore((s) => s.remove);
+  const importProfile = useTxAudioProfileStore((s) => s.importProfile);
+  const exportProfile = useTxAudioProfileStore((s) => s.exportProfile);
 
   const [saveOpen, setSaveOpen] = useState(false);
   const [deletePending, setDeletePending] = useState<string | null>(null);
@@ -72,6 +74,7 @@ export function TxAudioProfileBar({ compact = false }: TxAudioProfileBarProps) {
   const [menuOpen, setMenuOpen] = useState(false);
   const pickerRef = useRef<HTMLDivElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const menuId = useId();
 
   // Load the list + last-loaded pointer once. Mounting in two places is fine —
@@ -149,6 +152,37 @@ export function TxAudioProfileBar({ compact = false }: TxAudioProfileBarProps) {
     const result = await remove(id);
     if (!result.ok) {
       setNotice({ tone: 'error', text: result.error ?? 'Profile delete failed.' });
+    }
+  };
+
+  // Import: open the OS file picker; the chosen .json is uploaded and ADDED to
+  // the catalog (never auto-applied).
+  const onImportPick = () => {
+    setNotice(null);
+    fileInputRef.current?.click();
+  };
+
+  const onImportFile = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    // Reset so re-picking the same file fires `change` again.
+    event.target.value = '';
+    if (!file) return;
+    setNotice(null);
+    const result = await importProfile(file);
+    if (!result.ok) {
+      setNotice({ tone: 'error', text: result.error ?? 'Profile import failed.' });
+      return;
+    }
+    setNotice({ tone: 'ok', text: `Imported "${file.name}".` });
+  };
+
+  // Export: download the selected profile as a .json file.
+  const onExport = async () => {
+    if (!selectedProfile) return;
+    setNotice(null);
+    const result = await exportProfile(selectedProfile.id);
+    if (!result.ok) {
+      setNotice({ tone: 'error', text: result.error ?? 'Profile export failed.' });
     }
   };
 
@@ -296,6 +330,33 @@ export function TxAudioProfileBar({ compact = false }: TxAudioProfileBarProps) {
         >
           Delete
         </button>
+        <button
+          type="button"
+          aria-label="Import TX audio profile"
+          title="Import a TX audio profile from a .json file"
+          disabled={busy}
+          onClick={onImportPick}
+          style={{ ...buttonStyle(busy), display: 'inline-flex', alignItems: 'center', justifyContent: 'center', padding: '0 7px' }}
+        >
+          <Upload size={14} aria-hidden />
+        </button>
+        <button
+          type="button"
+          aria-label="Export TX audio profile"
+          title="Download the selected TX audio profile as a .json file"
+          disabled={busy || !selectedProfile}
+          onClick={() => void onExport()}
+          style={{ ...buttonStyle(busy || !selectedProfile), display: 'inline-flex', alignItems: 'center', justifyContent: 'center', padding: '0 7px' }}
+        >
+          <Download size={14} aria-hidden />
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".json,application/json"
+          style={{ display: 'none' }}
+          onChange={(event) => void onImportFile(event)}
+        />
       </div>
 
       {notice && (

--- a/zeus-web/src/state/tx-audio-profile-store.ts
+++ b/zeus-web/src/state/tx-audio-profile-store.ts
@@ -23,8 +23,10 @@ import { create } from 'zustand';
 import {
   applyTxAudioProfile,
   deleteTxAudioProfile,
+  exportTxAudioProfile,
   fetchLastLoadedTxAudioProfile,
   fetchTxAudioProfiles,
+  importTxAudioProfile,
   saveTxAudioProfile,
   type TxAudioProfileDto,
 } from '../api/client';
@@ -92,6 +94,10 @@ interface TxAudioProfileState {
   apply(id: string): Promise<TxAudioProfileMutationResult>;
   /** Delete a profile by id. */
   remove(id: string): Promise<TxAudioProfileMutationResult>;
+  /** Import a profile from a user-picked .json file; ADDS it (never applies it). */
+  importProfile(file: File, name?: string): Promise<TxAudioProfileMutationResult>;
+  /** Download a saved profile by id as a .json file. */
+  exportProfile(id: string): Promise<TxAudioProfileMutationResult>;
 }
 
 function errorText(err: unknown): string {
@@ -212,6 +218,38 @@ export const useTxAudioProfileStore = create<TxAudioProfileState>((set, get) => 
       return { ok: true };
     } catch (err) {
       set({ busy: false });
+      return { ok: false, error: errorText(err) };
+    }
+  },
+
+  importProfile: async (file, name) => {
+    if (get().busy) return { ok: false, error: 'Busy.' };
+    set({ busy: true });
+    try {
+      const imported = await importTxAudioProfile(file, name);
+      // Import only ADDS to the catalog (it doesn't apply or change the
+      // selection). Refresh the list so the new row appears in the dropdown.
+      await get().load();
+      set({ busy: false });
+      // Defensive: ensure the imported row is present even if the reload raced.
+      if (!get().profiles.some((p) => p.id === imported.id)) {
+        set((s) => ({ profiles: [...s.profiles, imported].sort((a, b) => a.id.localeCompare(b.id)) }));
+      }
+      return { ok: true };
+    } catch (err) {
+      set({ busy: false });
+      return { ok: false, error: errorText(err) };
+    }
+  },
+
+  exportProfile: async (id) => {
+    const trimmed = id.trim().toLowerCase();
+    if (!trimmed) return { ok: false, error: 'Profile id is required.' };
+    try {
+      // A pure download side-effect — no store state changes, so no busy gate.
+      await exportTxAudioProfile(trimmed);
+      return { ok: true };
+    } catch (err) {
       return { ok: false, error: errorText(err) };
     }
   },


### PR DESCRIPTION
## What & why

Adds the ability to **import a TX audio profile from a file** in the TX suite, and ensures **every profile is saved as a plain file in a folder** on disk (portable, shareable, backup-able).

Previously TX audio profiles lived only inside `zeus-prefs.db` (LiteDB). They now also live as human-readable JSON on disk, and can be brought in from a file.

## Changes

**Folder mirror ("all saved to a folder")**
- Every profile is written through to `<prefs-dir>/tx-audio-profiles/<id>.json` — seeded starters, saved, and imported alike.
- Synced from the DB on startup, updated on save, removed on delete.
- The mirror follows `ZEUS_PREFS_PATH`, so dev (`/run fresh`), CI, and tests stay isolated.
- Best-effort: LiteDB remains the source of truth; a folder IO failure is logged, never allowed to break a DB write.

**Import**
- `POST /api/tx-audio-profiles/import` (multipart) — the chosen `.json` is uploaded, parsed, and **added** to the catalog. It is **never auto-applied**.
- Non-destructive: a slug collision bumps the display name (`Voice` → `Voice 2`) instead of overwriting.
- Tolerates sparse / hand-edited files (nullable members are defaulted so the apply path can't dereference a null).

**Export** (the natural companion to import + folder)
- `GET /api/tx-audio-profiles/{id}/export` — download a profile as JSON (byte-for-byte the folder-mirror shape).

**Frontend**
- Import (↑) and Export (↓) controls added to the shared `TxAudioProfileBar`, so they appear in both the **TX Fidelity panel** and the **TX Audio Suite** window.
- Client (`importTxAudioProfile` / `exportTxAudioProfile`) + store wiring; import refreshes the list without applying or changing the selection.

## Conventions followed
- Mirrors the existing prefs-database import/export pattern (`PrefsDbPath` + `/api/prefs/databases/*`): multipart upload, blob download, antiforgery disabled on the loopback/LAN-token upload.
- **No `Zeus.Contracts` wire-format changes** (import is multipart, export is a file download).
- **PureSignal untouched** — import/export never read or write any PS field, and import never applies.
- Token-only styling in the UI (no raw hex).

## Tests
- Store: folder mirror on upsert, file removal on delete, startup folder re-sync, `ParseJson` round-trip + garbage rejection.
- Service: export→delete→import round-trip, non-destructive uniquify on slug collision, unparseable-JSON rejection, sparse-file tolerance.
- All 21 `TxAudioProfile*` tests pass; Hosting compiles and the frontend typechecks.

## Notes for reviewers
- UI placement of the two new buttons is a small visual addition to an existing bar — flagging in case Brian/Doug want a different affordance, but it reuses the existing token styling and button pattern.