### PR TITLE
feat(recorder): rework tape deck into the "Digital Recorder" — folders, CRUD, level meters, one-click transmit

### DIFF
--- a/Zeus.Contracts/MoxSource.cs
+++ b/Zeus.Contracts/MoxSource.cs
@@ -51,4 +51,13 @@ public enum MoxSource : byte
     /// <see cref="UI"/> remains the master override. CAT keying never arms
     /// PureSignal and never auto-keys on connect.</summary>
     Cat = 5,
+    /// <summary>The WAV recorder / tape deck keying TX for over-the-air
+    /// playback of a recording. Same release rule as the others: only
+    /// <see cref="Wav"/> releases what <see cref="Wav"/> claimed, and
+    /// <see cref="UI"/> remains the master override. If the operator was
+    /// already transmitting when playback started, the recorder rides that key
+    /// and never drops it. WAV playback never arms PureSignal and never
+    /// auto-keys on connect — the operator (or an explicit Air playback)
+    /// initiates every transmission.</summary>
+    Wav = 6,
 }

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -624,6 +624,15 @@ public class DspPipelineService : BackgroundService,
     private long _monInjW;
     private long _monInjR;
 
+    // Output samples per Tick at the 30 Hz cadence (~1600 @ 48 kHz). When RX
+    // produces no audio this tick (RX1 muted / no band audio) but a local clip
+    // is mid-playback through the monitor-inject ring, we synthesize a silent RX
+    // block this size, mix the queued playback into it, and publish — otherwise
+    // local WAV playback is inaudible while RX is silent (FIX 4). Sized to drain
+    // the ring at ~real time so playback stays glitch-free.
+    private static readonly int MonitorInjectSilentBlockSamples =
+        Math.Min(AudioDrainCapacity, (int)Math.Round(AudioOutputRateHz * TickPeriod.TotalSeconds));
+
     /// <summary>
     /// Enqueue mono float32 samples to be mixed into the local RX audio output
     /// (the operator's monitor) on the next ticks. Realtime-safe, lock-free.
@@ -5867,6 +5876,34 @@ public class DspPipelineService : BackgroundService,
                 PublishAudio(in audioFrame);
                 RxAudioAvailable?.Invoke(0, AudioOutputRateHz, new ReadOnlyMemory<float>(audioBuf, 0, audioSampleCount));
             }
+        }
+        else if (!txMonitorOn && MonitorBacklog > 0)
+        {
+            // FIX 4: RX produced no audio this tick (RX1 muted, or no band audio)
+            // yet a local clip is playing back through the monitor-inject ring.
+            // The audioSampleCount>0 path above — which mixes and publishes the
+            // monitor inject — was skipped, so the clip would be silent even
+            // though status says "playing". Synthesize a full-size silent RX
+            // block, mix the queued playback into it, and publish so the operator
+            // hears it on EVERY sink. STRICT no-op when the ring is empty (the
+            // MonitorBacklog>0 guard is a single volatile read), so normal /
+            // muted-RX behaviour is byte-identical when nothing is playing.
+            // Deliberately does NOT fire RxAudioAvailable: that tap feeds RX
+            // capture, which must stay byte-identical (no synthetic silence).
+            int monBlock = Math.Min(audioBuf.Length, MonitorInjectSilentBlockSamples);
+            Array.Clear(audioBuf, 0, monBlock);
+            MixMonitorInject(audioBuf.AsSpan(0, monBlock));
+            LimitRxAudioBuffer(audioBuf.AsSpan(0, monBlock));
+
+            var injectFrame = new AudioFrame(
+                Seq: ++_audioSeq,
+                TsUnixMs: nowMs,
+                RxId: 0,
+                Channels: 1,
+                SampleRateHz: (uint)AudioOutputRateHz,
+                SampleCount: (ushort)monBlock,
+                Samples: new ReadOnlyMemory<float>(audioBuf, 0, monBlock));
+            PublishAudio(in injectFrame);
         }
         if (txMonitorOn)
         {

--- a/Zeus.Server.Hosting/Wav/WavFile.cs
+++ b/Zeus.Server.Hosting/Wav/WavFile.cs
@@ -84,6 +84,96 @@ public static class WavFile
         return (mono, sampleRate);
     }
 
+    /// <summary>Read just the format and length of a WAV without loading the
+    /// data chunk into memory. Parses the <c>fmt </c> chunk and the <c>data</c>
+    /// chunk's declared size, then returns the sample rate and the mono frame
+    /// count (<c>dataBytes / bytesPerSample / channels</c>) — the same length
+    /// <see cref="ReadAllSamples"/> would return. Cheap enough to call for every
+    /// file in a directory listing. Throws <see cref="InvalidDataException"/> on
+    /// a malformed or unsupported header.</summary>
+    public static (int SampleRate, long SampleCount) ReadInfo(string path)
+    {
+        using var fs = File.OpenRead(path);
+        using var br = new BinaryReader(fs);
+
+        Span<byte> tag = stackalloc byte[4];
+        ReadExactly(br, tag);
+        if (!tag.SequenceEqual("RIFF"u8)) throw new InvalidDataException("not a RIFF file");
+        br.ReadUInt32(); // riff size — ignored
+        ReadExactly(br, tag);
+        if (!tag.SequenceEqual("WAVE"u8)) throw new InvalidDataException("not a WAVE file");
+
+        ushort channels = 0, bitsPerSample = 0;
+        int sampleRate = 0;
+        long dataBytes = -1;
+
+        while (fs.Position + 8 <= fs.Length)
+        {
+            ReadExactly(br, tag);
+            uint chunkSize = br.ReadUInt32();
+            if (tag.SequenceEqual("fmt "u8))
+            {
+                br.ReadUInt16(); // format tag
+                channels = br.ReadUInt16();
+                sampleRate = (int)br.ReadUInt32();
+                br.ReadUInt32(); // byte rate
+                br.ReadUInt16(); // block align
+                bitsPerSample = br.ReadUInt16();
+                int consumed = 16;
+                if (chunkSize > consumed) fs.Seek(chunkSize - consumed, SeekOrigin.Current);
+            }
+            else if (tag.SequenceEqual("data"u8))
+            {
+                // Record the declared size; do NOT read the payload.
+                dataBytes = chunkSize;
+                fs.Seek(chunkSize, SeekOrigin.Current);
+            }
+            else
+            {
+                fs.Seek(chunkSize, SeekOrigin.Current);
+            }
+            if ((chunkSize & 1) == 1) fs.Seek(1, SeekOrigin.Current); // RIFF word-align
+        }
+
+        if (dataBytes < 0 || channels == 0 || sampleRate == 0 || bitsPerSample == 0)
+            throw new InvalidDataException("WAV missing fmt/data");
+
+        long bytesPerSample = bitsPerSample / 8;
+        long frames = dataBytes / Math.Max(1, bytesPerSample * channels);
+        return (sampleRate, frames);
+    }
+
+    /// <summary>Downsample mono samples into a peak envelope of
+    /// <paramref name="buckets"/> values, each the maximum |sample| over its
+    /// time slice (0..1). Used to draw the waveform overview for a clip. When
+    /// there are fewer samples than buckets, returns one |sample| per sample.</summary>
+    public static float[] Envelope(ReadOnlySpan<float> samples, int buckets)
+    {
+        buckets = Math.Clamp(buckets, 1, 4096);
+        if (samples.Length == 0) return new float[buckets];
+        if (samples.Length <= buckets)
+        {
+            var one = new float[samples.Length];
+            for (int i = 0; i < samples.Length; i++) one[i] = MathF.Abs(samples[i]);
+            return one;
+        }
+        var env = new float[buckets];
+        for (int b = 0; b < buckets; b++)
+        {
+            int start = (int)((long)b * samples.Length / buckets);
+            int end = (int)((long)(b + 1) * samples.Length / buckets);
+            if (end <= start) end = start + 1;
+            float peak = 0f;
+            for (int i = start; i < end && i < samples.Length; i++)
+            {
+                float a = MathF.Abs(samples[i]);
+                if (a > peak) peak = a;
+            }
+            env[b] = peak;
+        }
+        return env;
+    }
+
     private static float[] DecodeFloat32(byte[] data, int channels)
     {
         int totalSamples = data.Length / 4;

--- a/Zeus.Server.Hosting/Wav/WavLibrary.cs
+++ b/Zeus.Server.Hosting/Wav/WavLibrary.cs
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Zeus.Server.Wav;
+
+/// <summary>
+/// Owns the managed recordings tree on disk: the root folder, the one-time
+/// migration of loose legacy files, traversal-guarded path resolution, the
+/// directory listing, and folder/file CRUD. Deliberately free of any audio /
+/// DSP / radio dependency so it can be exercised directly against a temp root
+/// in unit tests; <see cref="WavRecorderService"/> composes it for the live
+/// host.
+///
+/// Every path that crosses the wire is root-relative with forward slashes;
+/// every path that comes in from the wire is resolved through
+/// <see cref="ResolveRel"/>, which rejects absolute paths and any "<c>..</c>"
+/// that would escape the root.
+/// </summary>
+public sealed class WavLibrary
+{
+    // Managed root folder name appended to the OS Downloads folder. The whole
+    // tree under this folder belongs to Zeus.
+    public const string ManagedFolderName = "Zeus Recordings";
+
+    // Files we create carry this prefix (zeus-rx-… / zeus-tx-…) so the source
+    // can be inferred from the name and the legacy migration knows what is ours.
+    public const string FilePrefix = "zeus-";
+
+    private readonly string _root;
+    private readonly ILogger _log;
+
+    public WavLibrary(string root, ILogger? log = null)
+    {
+        _root = root;
+        _log = log ?? NullLogger.Instance;
+        Directory.CreateDirectory(_root);
+        MigrateLooseDownloads();
+    }
+
+    public string Root => _root;
+
+    // Recordings save under the OS Downloads folder by default so they land
+    // where the operator expects. UserProfile/Downloads is the default on
+    // macOS, Windows, and Linux; fall back to the profile root, then the
+    // working dir, if Downloads can't be resolved.
+    public static string ResolveDownloadsDir()
+    {
+        string? home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrEmpty(home)) return Environment.CurrentDirectory;
+        string downloads = Path.Combine(home, "Downloads");
+        return Directory.Exists(downloads) ? downloads : home;
+    }
+
+    public static string DefaultRoot()
+        => Path.Combine(ResolveDownloadsDir(), ManagedFolderName);
+
+    // One-time migration: pull any loose zeus-*.wav files that older builds
+    // wrote directly into the parent (Downloads) folder up into the managed
+    // root. Best-effort and defensive — never throws.
+    private void MigrateLooseDownloads()
+    {
+        try
+        {
+            var parent = Directory.GetParent(_root);
+            if (parent is null || !parent.Exists) return;
+            foreach (var path in Directory.EnumerateFiles(parent.FullName, FilePrefix + "*.wav"))
+            {
+                try
+                {
+                    string dest = Path.Combine(_root, Path.GetFileName(path));
+                    if (File.Exists(dest))
+                    {
+                        _log.LogInformation("wav.migrate skip (exists) file={File}", path);
+                        continue;
+                    }
+                    File.Move(path, dest);
+                    _log.LogInformation("wav.migrate moved {From} -> {To}", path, dest);
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    _log.LogWarning(ex, "wav.migrate failed file={File}", path);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "wav.migrate scan failed");
+        }
+    }
+
+    // ---- Listing -----------------------------------------------------------
+
+    public IReadOnlyList<WavRecordingInfo> ListRecordings()
+    {
+        var list = new List<WavRecordingInfo>();
+        if (!Directory.Exists(_root)) return list;
+
+        foreach (var path in Directory.EnumerateFiles(_root, "*.wav", SearchOption.AllDirectories))
+        {
+            var fi = new FileInfo(path);
+            string rel = RelOf(path)!;
+            string folder = Path.GetDirectoryName(rel)?.Replace('\\', '/') ?? "";
+            double durationSec = 0;
+            try
+            {
+                var (rate, count) = WavFile.ReadInfo(path);
+                durationSec = Math.Round(count / (double)Math.Max(1, rate), 1);
+            }
+            catch (Exception ex) when (ex is IOException or InvalidDataException)
+            {
+                // Corrupt/locked file — list it with duration 0 rather than
+                // dropping the whole listing.
+                _log.LogDebug(ex, "wav.list info failed file={File}", path);
+            }
+
+            list.Add(new WavRecordingInfo(
+                Name: Path.GetFileNameWithoutExtension(fi.Name),
+                FileName: fi.Name,
+                RelPath: rel,
+                Folder: folder,
+                Bytes: fi.Length,
+                DurationSec: durationSec,
+                Source: DetectSource(fi.Name),
+                ModifiedUnixMs: new DateTimeOffset(fi.LastWriteTimeUtc).ToUnixTimeMilliseconds()));
+        }
+        list.Sort((a, b) => b.ModifiedUnixMs.CompareTo(a.ModifiedUnixMs));
+        return list;
+    }
+
+    public IReadOnlyList<string> ListFolders()
+    {
+        var list = new List<string>();
+        if (!Directory.Exists(_root)) return list;
+        foreach (var dir in Directory.EnumerateDirectories(_root, "*", SearchOption.AllDirectories))
+            list.Add(RelOf(dir)!.Replace('\\', '/'));
+        list.Sort(StringComparer.Ordinal);
+        return list;
+    }
+
+    public static string DetectSource(string fileName)
+    {
+        if (fileName.StartsWith(FilePrefix + "rx-", StringComparison.OrdinalIgnoreCase)) return "rx";
+        if (fileName.StartsWith(FilePrefix + "tx-", StringComparison.OrdinalIgnoreCase)) return "tx";
+        return "unknown";
+    }
+
+    // ---- New recording path ------------------------------------------------
+
+    /// <summary>Resolve (and create if needed) the absolute directory a new
+    /// recording in <paramref name="folder"/> should land in.</summary>
+    public string ResolveRecordDir(string? folder)
+    {
+        if (string.IsNullOrWhiteSpace(folder)) return _root;
+        string dir = ResolveRel(folder);
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    // ---- CRUD --------------------------------------------------------------
+
+    public bool DeleteRecording(string relPath)
+    {
+        string path = ResolveRel(relPath);
+        if (!File.Exists(path)) throw new FileNotFoundException("recording not found", relPath);
+        File.Delete(path);
+        _log.LogInformation("wav.delete file={File}", path);
+        return true;
+    }
+
+    /// <summary>Rename a recording within its current folder. The new name is
+    /// sanitised (path separators and illegal chars stripped) and always keeps
+    /// the <c>.wav</c> extension. Refuses to overwrite an existing file.
+    /// Returns the new root-relative path.</summary>
+    public string RenameRecording(string relFrom, string newDisplayName)
+    {
+        string from = ResolveRel(relFrom);
+        if (!File.Exists(from)) throw new FileNotFoundException("recording not found", relFrom);
+
+        string safe = SanitizeFileStem(newDisplayName);
+        string dir = Path.GetDirectoryName(from)!;
+        string to = Path.Combine(dir, safe + ".wav");
+        if (File.Exists(to) && !string.Equals(to, from, StringComparison.Ordinal))
+            throw new InvalidOperationException("a recording with that name already exists");
+
+        File.Move(from, to, overwrite: false);
+        _log.LogInformation("wav.rename {From} -> {To}", from, to);
+        return RelOf(to)!;
+    }
+
+    /// <summary>Move a recording into another folder under the root (created if
+    /// missing). Refuses to overwrite. Returns the new root-relative path.</summary>
+    public string MoveRecording(string relFrom, string destFolder)
+    {
+        string from = ResolveRel(relFrom);
+        if (!File.Exists(from)) throw new FileNotFoundException("recording not found", relFrom);
+
+        string destDir = string.IsNullOrWhiteSpace(destFolder) ? _root : ResolveRel(destFolder);
+        Directory.CreateDirectory(destDir);
+
+        string to = Path.Combine(destDir, Path.GetFileName(from));
+        if (File.Exists(to) && !string.Equals(to, from, StringComparison.Ordinal))
+            throw new InvalidOperationException("a recording with that name already exists in the destination");
+
+        File.Move(from, to, overwrite: false);
+        _log.LogInformation("wav.move {From} -> {To}", from, to);
+        return RelOf(to)!;
+    }
+
+    /// <summary>Create a folder under the root. Returns its root-relative path.</summary>
+    public string CreateFolder(string relPath)
+    {
+        string dir = ResolveRel(relPath);
+        Directory.CreateDirectory(dir);
+        _log.LogInformation("wav.folder.create {Dir}", dir);
+        return RelOf(dir)!.Replace('\\', '/');
+    }
+
+    /// <summary>Delete a folder under the root. Recursively deletes only if the
+    /// folder (and its subfolders) contain solely <c>.wav</c> files; refuses
+    /// otherwise. Returns the deleted root-relative path.</summary>
+    public string DeleteFolder(string relPath)
+    {
+        string dir = ResolveRel(relPath);
+        if (string.Equals(Path.GetFullPath(dir), Path.GetFullPath(_root), StringComparison.Ordinal))
+            throw new InvalidOperationException("cannot delete the recordings root");
+        if (!Directory.Exists(dir)) throw new FileNotFoundException("folder not found", relPath);
+
+        foreach (var file in Directory.EnumerateFiles(dir, "*", SearchOption.AllDirectories))
+        {
+            if (!file.EndsWith(".wav", StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException("folder contains non-recording files; refusing to delete");
+        }
+
+        Directory.Delete(dir, recursive: true);
+        _log.LogInformation("wav.folder.delete {Dir}", dir);
+        return RelOf(dir)!.Replace('\\', '/');
+    }
+
+    // ---- Path helpers ------------------------------------------------------
+
+    /// <summary>Resolve a root-relative path to an absolute path, rejecting
+    /// absolute inputs and anything that escapes the managed root via "<c>..</c>".
+    /// The single guarded entry point for every file/folder operation.</summary>
+    public string ResolveRel(string rel)
+    {
+        if (string.IsNullOrWhiteSpace(rel))
+            throw new ArgumentException("path is required", nameof(rel));
+
+        // Normalise separators. A rooted input — Unix "/etc", a leading slash,
+        // or a Windows drive/UNC path — is rejected outright; wire paths are
+        // root-relative with no leading slash.
+        string normalized = rel.Replace('\\', '/').Trim();
+        if (normalized.Length == 0)
+            throw new ArgumentException("path is required", nameof(rel));
+        if (normalized.StartsWith('/') || Path.IsPathRooted(normalized))
+            throw new ArgumentException("absolute paths are not allowed", nameof(rel));
+
+        string rootFull = Path.GetFullPath(_root);
+        string combined = Path.GetFullPath(Path.Combine(rootFull, normalized));
+
+        string rootWithSep = rootFull.EndsWith(Path.DirectorySeparatorChar)
+            ? rootFull
+            : rootFull + Path.DirectorySeparatorChar;
+        if (!string.Equals(combined, rootFull, StringComparison.Ordinal)
+            && !combined.StartsWith(rootWithSep, StringComparison.Ordinal))
+            throw new ArgumentException("path escapes the recordings root", nameof(rel));
+
+        return combined;
+    }
+
+    /// <summary>Absolute path → root-relative path with forward slashes, or null
+    /// if the input is null/empty.</summary>
+    public string? RelOf(string? absPath)
+    {
+        if (string.IsNullOrEmpty(absPath)) return null;
+        string rel = Path.GetRelativePath(_root, absPath);
+        return rel.Replace('\\', '/');
+    }
+
+    // Strip path separators and illegal filename characters, drop any trailing
+    // .wav the caller included, and reject an empty result.
+    public static string SanitizeFileStem(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("name is required", nameof(name));
+        string stem = name.Trim();
+        if (stem.EndsWith(".wav", StringComparison.OrdinalIgnoreCase))
+            stem = stem[..^4];
+        stem = Path.GetFileName(stem); // strips any directory separators
+        foreach (char c in Path.GetInvalidFileNameChars())
+            stem = stem.Replace(c.ToString(), "");
+        stem = stem.Trim().Trim('.');
+        if (stem.Length == 0)
+            throw new ArgumentException("name has no usable characters", nameof(name));
+        return stem;
+    }
+}

--- a/Zeus.Server.Hosting/Wav/WavLibrary.cs
+++ b/Zeus.Server.Hosting/Wav/WavLibrary.cs
@@ -33,18 +33,34 @@ public sealed class WavLibrary
     // can be inferred from the name and the legacy migration knows what is ours.
     public const string FilePrefix = "zeus-";
 
-    private readonly string _root;
+    private string _root;
     private readonly ILogger _log;
 
-    public WavLibrary(string root, ILogger? log = null)
+    /// <param name="migrate">When true (the default), run the one-time
+    /// loose-Downloads migration. This MUST be false for an operator-chosen
+    /// custom root: that root's parent is an arbitrary user directory and we
+    /// must never scan it for, or move, files.</param>
+    public WavLibrary(string root, ILogger? log = null, bool migrate = true)
     {
         _root = root;
         _log = log ?? NullLogger.Instance;
         Directory.CreateDirectory(_root);
-        MigrateLooseDownloads();
+        if (migrate) MigrateLooseDownloads();
     }
 
     public string Root => _root;
+
+    /// <summary>Point the library at a different root, creating it if needed.
+    /// NEVER migrates — relocating to a user-chosen directory must not touch its
+    /// parent. All path helpers use the new root immediately afterward.</summary>
+    public void SetRoot(string newRoot)
+    {
+        if (string.IsNullOrWhiteSpace(newRoot))
+            throw new ArgumentException("root is required", nameof(newRoot));
+        Directory.CreateDirectory(newRoot);
+        _root = newRoot;
+        _log.LogInformation("wav.root set {Root}", newRoot);
+    }
 
     // Recordings save under the OS Downloads folder by default so they land
     // where the operator expects. UserProfile/Downloads is the default on
@@ -223,8 +239,10 @@ public sealed class WavLibrary
     }
 
     /// <summary>Delete a folder under the root. Recursively deletes only if the
-    /// folder (and its subfolders) contain solely <c>.wav</c> files; refuses
-    /// otherwise. Returns the deleted root-relative path.</summary>
+    /// folder (and its subfolders) contain solely <c>.wav</c> files and
+    /// ignorable OS sidecars (<c>.DS_Store</c>, <c>Thumbs.db</c>, dot-files);
+    /// refuses on any genuine user content. Returns the deleted root-relative
+    /// path.</summary>
     public string DeleteFolder(string relPath)
     {
         string dir = ResolveRel(relPath);
@@ -234,10 +252,12 @@ public sealed class WavLibrary
 
         foreach (var file in Directory.EnumerateFiles(dir, "*", SearchOption.AllDirectories))
         {
-            if (!file.EndsWith(".wav", StringComparison.OrdinalIgnoreCase))
-                throw new InvalidOperationException("folder contains non-recording files; refusing to delete");
+            if (file.EndsWith(".wav", StringComparison.OrdinalIgnoreCase)) continue;
+            if (IsIgnorableSidecar(Path.GetFileName(file))) continue; // .DS_Store / Thumbs.db etc.
+            throw new InvalidOperationException("folder contains non-recording files; refusing to delete");
         }
 
+        // recursive: true sweeps the recordings AND any ignorable sidecars.
         Directory.Delete(dir, recursive: true);
         _log.LogInformation("wav.folder.delete {Dir}", dir);
         return RelOf(dir)!.Replace('\\', '/');
@@ -284,8 +304,86 @@ public sealed class WavLibrary
         return rel.Replace('\\', '/');
     }
 
+    // ---- Server-side directory browser -------------------------------------
+
+    /// <summary>List the immediate subdirectories of <paramref name="path"/> so a
+    /// remote web client can pick a folder on the machine the backend runs on.
+    /// This is a read-only filesystem browse, deliberately NOT confined to the
+    /// recordings root — the whole point is choosing a new root anywhere the
+    /// operator can write.
+    ///
+    /// <para>An empty/whitespace <paramref name="path"/> starts at the user's
+    /// home directory (falling back to the working directory). The path is
+    /// normalised with <see cref="Path.GetFullPath(string)"/>; a path that does
+    /// not exist or is not a directory throws
+    /// <see cref="DirectoryNotFoundException"/>. Entries that can't be read are
+    /// skipped (each is wrapped) rather than failing the whole listing. The
+    /// result is sorted by name, ordinal-ignore-case. <c>Parent</c> is null when
+    /// the resolved path is a filesystem/drive root.</para></summary>
+    public static WavDirListing BrowseDirectories(string? path)
+    {
+        string start;
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            start = string.IsNullOrEmpty(home) ? Environment.CurrentDirectory : home;
+        }
+        else
+        {
+            start = path;
+        }
+
+        string full = Path.GetFullPath(start);
+        if (!Directory.Exists(full))
+            throw new DirectoryNotFoundException($"not a directory: {full}");
+
+        var dirs = new List<WavDirEntry>();
+        foreach (var dir in Directory.EnumerateDirectories(full))
+        {
+            try
+            {
+                dirs.Add(new WavDirEntry(Path.GetFileName(dir), dir));
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // Skip entries we can't read rather than dropping the listing.
+            }
+        }
+        dirs.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
+
+        string? parent = Directory.GetParent(full)?.FullName;
+
+        return new WavDirListing(
+            Path: full,
+            Parent: parent,
+            Separator: Path.DirectorySeparatorChar.ToString(),
+            Dirs: dirs);
+    }
+
+    // A FIXED, portable invalid-filename set applied on every platform. Cannot
+    // use Path.GetInvalidFileNameChars(): on Unix that is only {'/','\0'}, so a
+    // backslash or a Windows-reserved char ( : * ? " < > | ) would survive into
+    // an on-disk name. The wire path is always forward-slash and root-relative,
+    // so any such char desyncs the on-disk name from RelOf's path and the
+    // recording becomes visible-but-unmanageable (Play/Delete/Move throw
+    // FileNotFoundException). Strip the same set everywhere, plus control chars.
+    private static readonly char[] PortableInvalidFileNameChars =
+        { '\\', '/', ':', '*', '?', '"', '<', '>', '|' };
+
+    // Windows reserved DEVICE names. A file whose stem (case-insensitive,
+    // extension ignored) is one of these is unopenable on Windows even though it
+    // is perfectly legal on macOS/Linux. Suffix an underscore on EVERY platform
+    // so a clip named on a Mac/Linux box stays portable to a Windows operator.
+    private static readonly HashSet<string> WindowsReservedNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "CON", "PRN", "AUX", "NUL",
+        "COM0", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+        "LPT0", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+    };
+
     // Strip path separators and illegal filename characters, drop any trailing
-    // .wav the caller included, and reject an empty result.
+    // .wav the caller included, and reject an empty result. Portable across all
+    // platforms Zeus runs on (see PortableInvalidFileNameChars).
     public static string SanitizeFileStem(string name)
     {
         if (string.IsNullOrWhiteSpace(name))
@@ -293,12 +391,44 @@ public sealed class WavLibrary
         string stem = name.Trim();
         if (stem.EndsWith(".wav", StringComparison.OrdinalIgnoreCase))
             stem = stem[..^4];
-        stem = Path.GetFileName(stem); // strips any directory separators
-        foreach (char c in Path.GetInvalidFileNameChars())
-            stem = stem.Replace(c.ToString(), "");
-        stem = stem.Trim().Trim('.');
+        stem = Path.GetFileName(stem); // strips OS-native directory separators
+
+        var sb = new System.Text.StringBuilder(stem.Length);
+        foreach (char c in stem)
+        {
+            if (c < 0x20) continue;                                   // control chars 0x00-0x1F
+            if (Array.IndexOf(PortableInvalidFileNameChars, c) >= 0) continue;
+            sb.Append(c);
+        }
+        stem = sb.ToString().Trim().Trim('.');
         if (stem.Length == 0)
             throw new ArgumentException("name has no usable characters", nameof(name));
+
+        // A Windows reserved device name (CON, NUL, COM1, …) is unopenable on
+        // Windows; disambiguate with a trailing underscore on all platforms.
+        if (WindowsReservedNames.Contains(stem))
+            stem += "_";
         return stem;
     }
+
+    // OS-generated sidecar / metadata files that must never block a folder
+    // delete: macOS Finder (.DS_Store), Windows Explorer (Thumbs.db /
+    // desktop.ini), and any dot-file. These get deleted alongside the .wavs.
+    private static bool IsIgnorableSidecar(string fileName)
+    {
+        if (string.IsNullOrEmpty(fileName)) return false;
+        if (fileName.StartsWith('.')) return true; // .DS_Store and any dot-file
+        return fileName.Equals("Thumbs.db", StringComparison.OrdinalIgnoreCase)
+            || fileName.Equals("desktop.ini", StringComparison.OrdinalIgnoreCase);
+    }
 }
+
+/// <summary>One subdirectory in a <see cref="WavLibrary.BrowseDirectories"/>
+/// listing: its display name and its absolute path.</summary>
+public sealed record WavDirEntry(string Name, string Path);
+
+/// <summary>Result of <see cref="WavLibrary.BrowseDirectories"/>: the resolved
+/// absolute <c>Path</c>, its <c>Parent</c> (null at a filesystem root), the OS
+/// directory <c>Separator</c> for display, and the immediate subdirectories.</summary>
+public sealed record WavDirListing(
+    string Path, string? Parent, string Separator, IReadOnlyList<WavDirEntry> Dirs);

--- a/Zeus.Server.Hosting/Wav/WavMeter.cs
+++ b/Zeus.Server.Hosting/Wav/WavMeter.cs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+
+namespace Zeus.Server.Wav;
+
+/// <summary>
+/// Lock-free peak-hold / RMS / clip meter for the tape deck. Folded one audio
+/// block at a time from the capture and playback threads and read from the
+/// status path. The fields are plain (not behind a lock): a torn read of a VU
+/// value is harmless, and the audio hot path must never block on a meter. Time
+/// drives the peak decay (≈20 dB/sec) so the result is correct regardless of
+/// how big each block is.
+/// </summary>
+public sealed class WavMeter
+{
+    // Sample magnitude at/above which we treat the block as clipped, and how
+    // long the clip latch stays lit after the last clipped block.
+    private const double ClipThreshold = 0.999;
+    private const long ClipHoldMs = 1000;
+
+    private double _peak;
+    private double _rms;
+    private long _clipUntilTick;
+    private long _lastTick;
+
+    public WavMeter() => Reset();
+
+    /// <summary>Linear peak, 0..1, with peak-hold + decay.</summary>
+    public double Peak => _peak;
+
+    /// <summary>Linear RMS of the most recent block, 0..1.</summary>
+    public double Rms => _rms;
+
+    /// <summary>Peak expressed in dBFS, floored at -100.</summary>
+    public double PeakDb => ToDb(_peak);
+
+    /// <summary>True while the clip latch is lit.</summary>
+    public bool Clip => Environment.TickCount64 < Volatile.Read(ref _clipUntilTick);
+
+    /// <summary>Reset to silence — called on record/play start and stop/finish.</summary>
+    public void Reset()
+    {
+        _peak = 0;
+        _rms = 0;
+        Volatile.Write(ref _clipUntilTick, 0);
+        Volatile.Write(ref _lastTick, Environment.TickCount64);
+    }
+
+    /// <summary>Fold one block of mono samples into the meter.</summary>
+    public void Update(ReadOnlySpan<float> block)
+    {
+        if (block.IsEmpty) return;
+        double blockPeak = 0, sumSq = 0;
+        bool clipped = false;
+        for (int i = 0; i < block.Length; i++)
+        {
+            double s = block[i];
+            double a = Math.Abs(s);
+            if (a > blockPeak) blockPeak = a;
+            sumSq += s * s;
+            if (a >= ClipThreshold) clipped = true;
+        }
+        double blockRms = Math.Sqrt(sumSq / block.Length);
+
+        long now = Environment.TickCount64;
+        long last = Volatile.Read(ref _lastTick);
+        Volatile.Write(ref _lastTick, now);
+        double dt = Math.Min(1.0, Math.Max(0, (now - last) / 1000.0));
+        // 20 dB/sec on the linear scale ⇒ factor = 10^(-dt).
+        double decayed = _peak * Math.Pow(10, -dt);
+
+        _peak = Math.Max(blockPeak, decayed);
+        _rms = blockRms;
+        if (clipped) Volatile.Write(ref _clipUntilTick, now + ClipHoldMs);
+    }
+
+    /// <summary>Linear amplitude → dBFS, floored at -100.</summary>
+    public static double ToDb(double linear)
+        => linear <= 0 ? -100 : Math.Max(-100, 20 * Math.Log10(linear));
+}

--- a/Zeus.Server.Hosting/Wav/WavMeter.cs
+++ b/Zeus.Server.Hosting/Wav/WavMeter.cs
@@ -27,7 +27,16 @@ public sealed class WavMeter
     private long _clipUntilTick;
     private long _lastTick;
 
-    public WavMeter() => Reset();
+    // Monotonic millisecond clock. Defaults to Environment.TickCount64; an
+    // injected provider lets tests drive decay / clip-latch expiry deterministically
+    // without flaky sleeps. WavRecorderService uses the default.
+    private readonly Func<long> _now;
+
+    public WavMeter(Func<long>? nowMsProvider = null)
+    {
+        _now = nowMsProvider ?? (() => Environment.TickCount64);
+        Reset();
+    }
 
     /// <summary>Linear peak, 0..1, with peak-hold + decay.</summary>
     public double Peak => _peak;
@@ -39,7 +48,7 @@ public sealed class WavMeter
     public double PeakDb => ToDb(_peak);
 
     /// <summary>True while the clip latch is lit.</summary>
-    public bool Clip => Environment.TickCount64 < Volatile.Read(ref _clipUntilTick);
+    public bool Clip => _now() < Volatile.Read(ref _clipUntilTick);
 
     /// <summary>Reset to silence — called on record/play start and stop/finish.</summary>
     public void Reset()
@@ -47,7 +56,7 @@ public sealed class WavMeter
         _peak = 0;
         _rms = 0;
         Volatile.Write(ref _clipUntilTick, 0);
-        Volatile.Write(ref _lastTick, Environment.TickCount64);
+        Volatile.Write(ref _lastTick, _now());
     }
 
     /// <summary>Fold one block of mono samples into the meter.</summary>
@@ -66,7 +75,7 @@ public sealed class WavMeter
         }
         double blockRms = Math.Sqrt(sumSq / block.Length);
 
-        long now = Environment.TickCount64;
+        long now = _now();
         long last = Volatile.Read(ref _lastTick);
         Volatile.Write(ref _lastTick, now);
         double dt = Math.Min(1.0, Math.Max(0, (now - last) / 1000.0));

--- a/Zeus.Server.Hosting/Wav/WavRecorderService.cs
+++ b/Zeus.Server.Hosting/Wav/WavRecorderService.cs
@@ -6,6 +6,7 @@
 //                         Christian Suarez (N9WAR), and contributors.
 
 using System.Buffers.Binary;
+using Zeus.Contracts;
 using Microsoft.Extensions.Logging;
 
 namespace Zeus.Server.Wav;
@@ -22,6 +23,18 @@ public enum WavRecordSource
     Tx = 1,
 }
 
+/// <summary>Where a recording is sent when played back.</summary>
+public enum WavPlayDest
+{
+    /// <summary>Mix into the local monitor via the preview sink regardless of
+    /// MOX. Never keys the transmitter. Heard by the operator only.</summary>
+    Local = 0,
+    /// <summary>Transmit the recording over the air. The recorder keys MOX
+    /// itself (<see cref="MoxSource.Wav"/>) when the rig is unkeyed, and
+    /// releases only what it keyed.</summary>
+    Air = 1,
+}
+
 /// <summary>Recorder state for the status DTO.</summary>
 public enum WavRecorderState
 {
@@ -34,18 +47,26 @@ public enum WavRecorderState
 /// Records RX or processed-TX audio to a float32 WAV and plays recordings back.
 ///
 /// <para><b>Capture</b> is non-destructive: it subscribes to
-/// <see cref="DspPipelineService.RxAudioAvailable"/> (RX) and
-/// <see cref="DspPipelineService.TxMonitorAudioAvailable"/> (processed TX) and
-/// copies whatever the pipeline already produced — it never pulls samples out
-/// of a ring another consumer depends on.</para>
+/// <see cref="DspPipelineService.RxAudioAvailable"/> (RX) and the
+/// <see cref="TxAudioIngest.MicPcmTapped"/> mic tap (processed TX) and copies
+/// whatever the pipeline already produced — it never pulls samples out of a
+/// ring another consumer depends on.</para>
 ///
-/// <para><b>Playback</b> streams a WAV to the local monitor via
-/// <see cref="IPreviewAudioSink"/> (mixed into the operator's RX output), or
-/// to the air via <see cref="TxAudioIngest"/> so the recording is processed by
-/// the normal TX chain like live speech.</para>
+/// <para><b>Files</b> live under a managed root (<c>&lt;Downloads&gt;/Zeus
+/// Recordings</c>) owned by <see cref="WavLibrary"/>: arbitrary nesting of
+/// folders, traversal-guarded paths, and a prefix-free recursive listing.</para>
+///
+/// <para><b>Playback</b> takes an explicit destination.
+/// <see cref="WavPlayDest.Local"/> streams a WAV to the operator's monitor via
+/// <see cref="IPreviewAudioSink"/> without keying. <see cref="WavPlayDest.Air"/>
+/// transmits the recording through <see cref="TxAudioIngest"/> so it is
+/// processed by the normal TX chain like live speech; the recorder keys MOX
+/// itself only when the rig is unkeyed and releases only what it keyed (see
+/// <see cref="MoxSource.Wav"/>).</para>
 ///
 /// Threading: capture callbacks arrive on the WDSP worker; playback runs on a
-/// dedicated pump thread. All state transitions take <see cref="_sync"/>.
+/// dedicated pump thread. All state transitions take <see cref="_sync"/>. The
+/// <see cref="WavMeter"/> is updated lock-free from the audio hot paths.
 /// </summary>
 public sealed class WavRecorderService : IDisposable
 {
@@ -57,8 +78,10 @@ public sealed class WavRecorderService : IDisposable
     private readonly IPreviewAudioSink _preview;
     private readonly TxAudioIngest _txIngest;
     private readonly TxService _tx;
+    private readonly RadioService _radio;
     private readonly ILogger<WavRecorderService> _log;
-    private readonly string _recordingsDir;
+    private readonly WavLibrary _library;
+    private readonly WavMeter _meter = new();
 
     private readonly object _sync = new();
     private WavRecorderState _state = WavRecorderState.Idle;
@@ -73,47 +96,35 @@ public sealed class WavRecorderService : IDisposable
     // Playback
     private Thread? _playThread;
     private CancellationTokenSource? _playCts;
-    private string? _playingFile;
+    private string? _playingFile;       // absolute path of the clip being played
     private bool _restorePreviewOff;
     private bool _playingOnAir;
+    private bool _weKeyedMox;            // true ⇒ we raised MOX and must drop it
+    private double _playingDurationSec;
 
     public WavRecorderService(
         DspPipelineService pipeline,
         IPreviewAudioSink preview,
         TxAudioIngest txIngest,
         TxService tx,
-        ILogger<WavRecorderService> log)
+        RadioService radio,
+        ILogger<WavRecorderService> log,
+        string? recordingsRootOverride = null)
     {
         _pipeline = pipeline;
         _preview = preview;
         _txIngest = txIngest;
         _tx = tx;
+        _radio = radio;
         _log = log;
 
-        _recordingsDir = ResolveDownloadsDir();
-        Directory.CreateDirectory(_recordingsDir);
+        _library = new WavLibrary(recordingsRootOverride ?? WavLibrary.DefaultRoot(), log);
 
         _pipeline.RxAudioAvailable += OnRxAudio;
         _txIngest.MicPcmTapped += OnMicPcm;
     }
 
-    public string RecordingsDir => _recordingsDir;
-
-    // Recordings save to the OS Downloads folder by default so they land
-    // where the operator expects to find files. UserProfile/Downloads is the
-    // default on macOS, Windows, and Linux; fall back to the profile root, then
-    // the working dir, if Downloads can't be resolved.
-    private static string ResolveDownloadsDir()
-    {
-        string? home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        if (string.IsNullOrEmpty(home)) return Environment.CurrentDirectory;
-        string downloads = Path.Combine(home, "Downloads");
-        return Directory.Exists(downloads) ? downloads : home;
-    }
-
-    // Files we own carry this prefix so listing/deleting never touches other
-    // WAVs the operator happens to keep in Downloads.
-    private const string FilePrefix = "zeus-";
+    public string RecordingsDir => _library.Root;
 
     public WavRecorderStatus GetStatus()
     {
@@ -122,46 +133,55 @@ public sealed class WavRecorderService : IDisposable
             return new WavRecorderStatus(
                 State: _state.ToString().ToLowerInvariant(),
                 Source: _recordSource.ToString().ToLowerInvariant(),
-                File: _state == WavRecorderState.Recording ? _writer?.Path
-                      : _state == WavRecorderState.Playing ? _playingFile
+                File: _state == WavRecorderState.Recording ? _library.RelOf(_writer?.Path)
+                      : _state == WavRecorderState.Playing ? _library.RelOf(_playingFile)
                       : null,
                 Seconds: _state == WavRecorderState.Recording && _writer is { } w
                     ? Math.Round(w.SampleCount / (double)Math.Max(1, w.SampleRate), 1)
                     : 0,
+                DurationSec: _state == WavRecorderState.Playing
+                    ? Math.Round(_playingDurationSec, 1)
+                    : 0,
                 Mox: _tx.IsMoxOn,
-                OnAir: _state == WavRecorderState.Playing && _playingOnAir);
+                OnAir: _state == WavRecorderState.Playing && _playingOnAir,
+                Peak: _meter.Peak,
+                Rms: _meter.Rms,
+                PeakDb: _meter.PeakDb,
+                Clip: _meter.Clip);
         }
     }
 
     // ---- Recording ---------------------------------------------------------
 
-    /// <summary>Begin capturing the chosen source to a new timestamped WAV.
-    /// Returns the file path. Throws if not idle.</summary>
-    public string StartRecording(WavRecordSource source)
+    /// <summary>Begin capturing the chosen source to a new timestamped WAV under
+    /// the managed root (optionally inside <paramref name="folder"/>). Returns
+    /// the new file's root-relative path. Throws if not idle.</summary>
+    public string StartRecording(WavRecordSource source, string? folder = null)
     {
         lock (_sync)
         {
             if (_state != WavRecorderState.Idle)
                 throw new InvalidOperationException($"recorder busy ({_state})");
 
+            string dir = _library.ResolveRecordDir(folder);
             int rate = DspPipelineService.AudioOutputRateHz;
-            string name = $"{FilePrefix}{source.ToString().ToLowerInvariant()}-"
+            string name = $"{WavLibrary.FilePrefix}{source.ToString().ToLowerInvariant()}-"
                         + $"{DateTime.Now:yyyyMMdd-HHmmss}.wav";
-            string path = Path.Combine(_recordingsDir, name);
+            string path = Path.Combine(dir, name);
             _writer = new WavWriter(path, rate);
             _recordSource = source;
             _state = WavRecorderState.Recording;
-            // RX taps demodulated receive audio; TX taps the mic feeding the TX
-            // chain — both non-destructive, both silent (no monitor playback).
+            _meter.Reset();
             _log.LogInformation("wav.record start source={Source} file={File} rate={Rate}",
                 source, path, rate);
-            return path;
+            return _library.RelOf(path)!;
         }
     }
 
     /// <summary>Stop the in-progress recording and finalise the file.
-    /// Returns the path and sample count, or null if not recording.</summary>
-    public (string Path, long Samples)? StopRecording()
+    /// Returns the root-relative path and sample count, or null if not
+    /// recording.</summary>
+    public (string RelPath, long Samples)? StopRecording()
     {
         lock (_sync)
         {
@@ -172,8 +192,9 @@ public sealed class WavRecorderService : IDisposable
             string path = w.Path;
             long samples = w.SampleCount;
             w.Dispose();
+            _meter.Reset();
             _log.LogInformation("wav.record stop file={File} samples={Samples}", path, samples);
-            return (path, samples);
+            return (_library.RelOf(path)!, samples);
         }
     }
 
@@ -186,6 +207,7 @@ public sealed class WavRecorderService : IDisposable
                 && _writer is { } w)
             {
                 w.Append(samples.Span);
+                _meter.Update(samples.Span);
             }
         }
     }
@@ -204,36 +226,60 @@ public sealed class WavRecorderService : IDisposable
             int n = Math.Min(_micDecode.Length, src.Length / 4);
             for (int i = 0; i < n; i++)
                 _micDecode[i] = BinaryPrimitives.ReadSingleLittleEndian(src.Slice(i * 4, 4));
-            w.Append(_micDecode.AsSpan(0, n));
+            var span = _micDecode.AsSpan(0, n);
+            w.Append(span);
+            _meter.Update(span);
         }
     }
 
-    // ---- Local playback ----------------------------------------------------
+    // ---- Playback ----------------------------------------------------------
 
-    /// <summary>Play a recording. MOX state at play time decides the
-    /// destination: <b>MOX on → over the air</b> (injected into the TX chain
-    /// and processed like live speech); <b>MOX off → local monitor</b> (mixed
-    /// into RX audio, no transmit). The operator owns MOX — this never keys or
-    /// unkeys. Throws if not idle or the file is missing.</summary>
-    public void Play(string fileName)
+    /// <summary>Play a recording to an explicit destination.
+    /// <list type="bullet">
+    ///   <item><see cref="WavPlayDest.Local"/> — mix into the monitor via the
+    ///   preview sink regardless of MOX; never keys.</item>
+    ///   <item><see cref="WavPlayDest.Air"/> — transmit. If MOX is already on we
+    ///   ride the existing key (and will NOT drop it at the end); if MOX is off
+    ///   we key <see cref="MoxSource.Wav"/> ourselves and drop only what we
+    ///   keyed.</item>
+    /// </list>
+    /// Throws <see cref="FileNotFoundException"/> if the file is missing,
+    /// <see cref="InvalidOperationException"/> if the recorder is busy or MOX
+    /// keying is refused, <see cref="ArgumentException"/> on a bad path.</summary>
+    public void Play(string relPath, WavPlayDest dest)
     {
-        string path = ResolveRecording(fileName);
+        string path = _library.ResolveRel(relPath);
+        if (!File.Exists(path)) throw new FileNotFoundException("recording not found", relPath);
         var (samples, rate) = WavFile.ReadAllSamples(path);
+
+        bool onAir = dest == WavPlayDest.Air;
+        bool weKeyed = false;
 
         lock (_sync)
         {
             if (_state != WavRecorderState.Idle)
                 throw new InvalidOperationException($"recorder busy ({_state})");
 
-            bool onAir = _tx.IsMoxOn;
+            if (onAir && !_tx.IsMoxOn)
+            {
+                if (!_tx.TrySetMox(true, MoxSource.Wav, out var err))
+                    throw new InvalidOperationException(err ?? "could not key MOX");
+                weKeyed = true;
+            }
+            // else over-air on an already-keyed rig: ride the operator's key and
+            // do not unkey at the end.
+
             _playingFile = path;
             _playingOnAir = onAir;
+            _weKeyedMox = weKeyed;
+            _playingDurationSec = samples.Length / (double)Math.Max(1, rate);
             _state = WavRecorderState.Playing;
             _playCts = new CancellationTokenSource();
+            _meter.Reset();
 
             // Local playback mixes into the speaker via the preview path; force
             // it on for the clip and restore after. Over-air playback does NOT
-            // touch the preview sink (the operator hears their own TX monitor /
+            // touch the preview sink (the operator hears their TX monitor /
             // sidetone as usual, not a local copy).
             _restorePreviewOff = false;
             if (!onAir)
@@ -243,14 +289,16 @@ public sealed class WavRecorderService : IDisposable
             }
 
             var ct = _playCts.Token;
-            _playThread = new Thread(() => PlaybackPump(samples, rate, onAir, ct))
+            bool keyedForSettle = weKeyed;
+            _playThread = new Thread(() => PlaybackPump(samples, rate, onAir, keyedForSettle, ct))
             {
                 IsBackground = true,
                 Name = "wav-playback",
             };
             _playThread.Start();
-            _log.LogInformation("wav.play start file={File} samples={Samples} rate={Rate} onAir={OnAir}",
-                path, samples.Length, rate, onAir);
+            _log.LogInformation(
+                "wav.play start file={File} samples={Samples} rate={Rate} onAir={OnAir} weKeyed={WeKeyed}",
+                path, samples.Length, rate, onAir, weKeyed);
         }
     }
 
@@ -268,7 +316,7 @@ public sealed class WavRecorderService : IDisposable
         FinishPlayback();
     }
 
-    private void PlaybackPump(float[] samples, int rate, bool onAir, CancellationToken ct)
+    private void PlaybackPump(float[] samples, int rate, bool onAir, bool weKeyed, CancellationToken ct)
     {
         // Playback is paced by the 48 kHz mic-block clock. Non-48 kHz files
         // are converted once here so both desktop preview and over-air TX see
@@ -280,6 +328,16 @@ public sealed class WavRecorderService : IDisposable
             {
                 _log.LogWarning("wav.play unsupported sampleRate={Rate}", rate);
                 return;
+            }
+
+            // When we keyed MOX ourselves, give the radio a brief settle before
+            // the first audio block so the relay/PA is up. Interruptible. Runs
+            // on the pump thread, never the request thread.
+            if (onAir && weKeyed)
+            {
+                int settleMs = Math.Clamp(_radio.TxMoxPreKeyDelayMs, 0, 250);
+                if (settleMs <= 0) settleMs = 50;
+                ct.WaitHandle.WaitOne(settleMs);
             }
 
             airBlock = onAir ? new byte[TxMicBlockResampler.OutputBlockBytes] : null;
@@ -303,6 +361,8 @@ public sealed class WavRecorderService : IDisposable
                     stop = true;
                     return;
                 }
+
+                _meter.Update(block);
 
                 if (onAir)
                 {
@@ -353,53 +413,58 @@ public sealed class WavRecorderService : IDisposable
 
     private void FinishPlayback()
     {
+        bool dropMox;
         lock (_sync)
         {
             if (_state != WavRecorderState.Playing) return;
             if (_restorePreviewOff) { _preview.SetEnabled(false); _restorePreviewOff = false; }
+            dropMox = _weKeyedMox;
+            _weKeyedMox = false;
             _playCts?.Dispose();
             _playCts = null;
             _playThread = null;
-            _log.LogInformation("wav.play stop file={File} onAir={OnAir}", _playingFile, _playingOnAir);
+            _log.LogInformation("wav.play stop file={File} onAir={OnAir} droppingMox={Drop}",
+                _playingFile, _playingOnAir, dropMox);
             _playingFile = null;
             _playingOnAir = false;
+            _playingDurationSec = 0;
             _state = WavRecorderState.Idle;
+            _meter.Reset();
         }
+
+        // Drop MOX only if we keyed it. Done outside _sync (TrySetMox reads
+        // RadioService under its own lock). A drop on an already-off rig is a
+        // harmless no-op/refusal — if the operator manually unkeyed mid-clip,
+        // Wav no longer owns MOX and the refusal is fine.
+        if (dropMox)
+            _tx.TrySetMox(false, MoxSource.Wav, out _);
     }
 
-    // ---- Listing -----------------------------------------------------------
+    // ---- Listing / CRUD (delegated to the library) -------------------------
 
-    public IReadOnlyList<WavRecordingInfo> ListRecordings()
+    public IReadOnlyList<WavRecordingInfo> ListRecordings() => _library.ListRecordings();
+    public IReadOnlyList<string> ListFolders() => _library.ListFolders();
+
+    /// <summary>Compute a peak-envelope overview of a recording for the waveform
+    /// display: <paramref name="buckets"/> values (clamped 16..2000), each the
+    /// max |sample| over its time slice (0..1). Throws
+    /// <see cref="FileNotFoundException"/> if the clip is missing,
+    /// <see cref="ArgumentException"/> on a bad path.</summary>
+    public IReadOnlyList<float> ComputeWaveform(string relPath, int buckets)
     {
-        var list = new List<WavRecordingInfo>();
-        foreach (var path in Directory.EnumerateFiles(_recordingsDir, FilePrefix + "*.wav"))
-        {
-            var fi = new FileInfo(path);
-            list.Add(new WavRecordingInfo(
-                Name: fi.Name,
-                Bytes: fi.Length,
-                ModifiedUnixMs: new DateTimeOffset(fi.LastWriteTimeUtc).ToUnixTimeMilliseconds()));
-        }
-        list.Sort((a, b) => b.ModifiedUnixMs.CompareTo(a.ModifiedUnixMs));
-        return list;
+        string path = _library.ResolveRel(relPath);
+        if (!File.Exists(path)) throw new FileNotFoundException("recording not found", relPath);
+        var (samples, _) = WavFile.ReadAllSamples(path);
+        return WavFile.Envelope(samples, Math.Clamp(buckets, 16, 2000));
     }
 
-    public bool DeleteRecording(string fileName)
-    {
-        string path = ResolveRecording(fileName);
-        File.Delete(path);
-        _log.LogInformation("wav.delete file={File}", path);
-        return true;
-    }
-
-    private string ResolveRecording(string fileName)
-    {
-        // Guard against path traversal — only bare names inside the dir.
-        string safe = Path.GetFileName(fileName);
-        string path = Path.Combine(_recordingsDir, safe);
-        if (!File.Exists(path)) throw new FileNotFoundException("recording not found", safe);
-        return path;
-    }
+    public bool DeleteRecording(string relPath) => _library.DeleteRecording(relPath);
+    public string RenameRecording(string relFrom, string newDisplayName)
+        => _library.RenameRecording(relFrom, newDisplayName);
+    public string MoveRecording(string relFrom, string destFolder)
+        => _library.MoveRecording(relFrom, destFolder);
+    public string CreateFolder(string relPath) => _library.CreateFolder(relPath);
+    public string DeleteFolder(string relPath) => _library.DeleteFolder(relPath);
 
     public void Dispose()
     {
@@ -412,7 +477,10 @@ public sealed class WavRecorderService : IDisposable
 
 /// <summary>Status DTO for <c>GET /api/wav/status</c>.</summary>
 public sealed record WavRecorderStatus(
-    string State, string Source, string? File, double Seconds, bool Mox, bool OnAir);
+    string State, string Source, string? File, double Seconds, double DurationSec,
+    bool Mox, bool OnAir, double Peak, double Rms, double PeakDb, bool Clip);
 
 /// <summary>One entry in the recordings list.</summary>
-public sealed record WavRecordingInfo(string Name, long Bytes, long ModifiedUnixMs);
+public sealed record WavRecordingInfo(
+    string Name, string FileName, string RelPath, string Folder,
+    long Bytes, double DurationSec, string Source, long ModifiedUnixMs);

--- a/Zeus.Server.Hosting/Wav/WavRecorderService.cs
+++ b/Zeus.Server.Hosting/Wav/WavRecorderService.cs
@@ -57,8 +57,10 @@ public enum WavRecorderState
 /// folders, traversal-guarded paths, and a prefix-free recursive listing.</para>
 ///
 /// <para><b>Playback</b> takes an explicit destination.
-/// <see cref="WavPlayDest.Local"/> streams a WAV to the operator's monitor via
-/// <see cref="IPreviewAudioSink"/> without keying. <see cref="WavPlayDest.Air"/>
+/// <see cref="WavPlayDest.Local"/> mixes the WAV into the RX audio block via
+/// <see cref="DspPipelineService.EnqueueMonitorAudio"/> (the universal monitor
+/// path that reaches every sink — browser WebSocket and desktop native — alike)
+/// without keying. <see cref="WavPlayDest.Air"/>
 /// transmits the recording through <see cref="TxAudioIngest"/> so it is
 /// processed by the normal TX chain like live speech; the recorder keys MOX
 /// itself only when the rig is unkeyed and releases only what it keyed (see
@@ -75,12 +77,12 @@ public sealed class WavRecorderService : IDisposable
     private const int PlaybackBlockMs = 20;
 
     private readonly DspPipelineService _pipeline;
-    private readonly IPreviewAudioSink _preview;
     private readonly TxAudioIngest _txIngest;
     private readonly TxService _tx;
     private readonly RadioService _radio;
     private readonly ILogger<WavRecorderService> _log;
     private readonly WavLibrary _library;
+    private readonly WavRecorderSettingsStore _settings;
     private readonly WavMeter _meter = new();
 
     private readonly object _sync = new();
@@ -97,34 +99,152 @@ public sealed class WavRecorderService : IDisposable
     private Thread? _playThread;
     private CancellationTokenSource? _playCts;
     private string? _playingFile;       // absolute path of the clip being played
-    private bool _restorePreviewOff;
     private bool _playingOnAir;
     private bool _weKeyedMox;            // true ⇒ we raised MOX and must drop it
     private double _playingDurationSec;
 
     public WavRecorderService(
         DspPipelineService pipeline,
-        IPreviewAudioSink preview,
         TxAudioIngest txIngest,
         TxService tx,
         RadioService radio,
         ILogger<WavRecorderService> log,
+        WavRecorderSettingsStore settings,
         string? recordingsRootOverride = null)
     {
         _pipeline = pipeline;
-        _preview = preview;
         _txIngest = txIngest;
         _tx = tx;
         _radio = radio;
         _log = log;
+        _settings = settings;
 
-        _library = new WavLibrary(recordingsRootOverride ?? WavLibrary.DefaultRoot(), log);
+        // Resolve the effective root: an explicit test override wins; otherwise
+        // the persisted custom root if it's set and usable; otherwise the
+        // platform default. Migrate loose legacy files ONLY when we land on the
+        // default root — never scan an operator-chosen parent directory.
+        string defaultRoot = WavLibrary.DefaultRoot();
+        string effectiveRoot;
+        bool migrate;
+        if (!string.IsNullOrWhiteSpace(recordingsRootOverride))
+        {
+            effectiveRoot = recordingsRootOverride;
+            migrate = PathsEqual(recordingsRootOverride, defaultRoot);
+        }
+        else
+        {
+            string? persisted = _settings.GetRoot();
+            if (!string.IsNullOrWhiteSpace(persisted) && IsUsableRoot(persisted))
+            {
+                effectiveRoot = persisted;
+                migrate = false;
+            }
+            else
+            {
+                effectiveRoot = defaultRoot;
+                migrate = true;
+            }
+        }
+
+        _library = new WavLibrary(effectiveRoot, log, migrate);
 
         _pipeline.RxAudioAvailable += OnRxAudio;
         _txIngest.MicPcmTapped += OnMicPcm;
     }
 
     public string RecordingsDir => _library.Root;
+
+    /// <summary>The current recordings root and whether it is the platform
+    /// default.</summary>
+    public (string Root, bool IsDefault) GetRecordingsRoot()
+    {
+        lock (_sync)
+        {
+            return (_library.Root, PathsEqual(_library.Root, WavLibrary.DefaultRoot()));
+        }
+    }
+
+    /// <summary>Change the recordings root, persisting the choice.
+    /// <para>Null/empty resets to the platform default (and clears the persisted
+    /// value). A non-empty value must be an ABSOLUTE, creatable, writable path.
+    /// Only allowed while idle.</para>
+    /// Throws <see cref="InvalidOperationException"/> if the recorder is busy and
+    /// <see cref="ArgumentException"/> on a path that is relative or cannot be
+    /// created/written.</summary>
+    public (string Root, bool IsDefault) SetRecordingsRoot(string? absPath)
+    {
+        lock (_sync)
+        {
+            if (_state != WavRecorderState.Idle)
+                throw new InvalidOperationException($"recorder busy ({_state})");
+
+            string defaultRoot = WavLibrary.DefaultRoot();
+            string resolved;
+
+            if (string.IsNullOrWhiteSpace(absPath))
+            {
+                resolved = defaultRoot;
+                _settings.SetRoot(null);
+            }
+            else
+            {
+                if (!Path.IsPathRooted(absPath))
+                    throw new ArgumentException("recordings path must be absolute", nameof(absPath));
+                resolved = Path.GetFullPath(absPath);
+                if (!TryProbeWritable(resolved, out string? err))
+                    throw new ArgumentException(err ?? "recordings path is not writable", nameof(absPath));
+                _settings.SetRoot(resolved);
+            }
+
+            _library.SetRoot(resolved);
+            return (_library.Root, PathsEqual(_library.Root, defaultRoot));
+        }
+    }
+
+    // A persisted root is usable if it already exists or can be created.
+    private static bool IsUsableRoot(string root)
+    {
+        try
+        {
+            Directory.CreateDirectory(root);
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    // Create the directory and prove we can write a file into it, then clean up
+    // the probe. Any failure means the path is unusable as a root.
+    private static bool TryProbeWritable(string root, out string? error)
+    {
+        error = null;
+        try
+        {
+            Directory.CreateDirectory(root);
+            string probe = Path.Combine(root, ".zeus-write-probe");
+            File.WriteAllText(probe, "");
+            File.Delete(probe);
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
+        {
+            error = $"recordings path is not writable: {ex.Message}";
+            return false;
+        }
+    }
+
+    // Case- and separator-tolerant absolute-path comparison.
+    private static bool PathsEqual(string a, string b)
+    {
+        string fa = Path.TrimEndingDirectorySeparator(Path.GetFullPath(a));
+        string fb = Path.TrimEndingDirectorySeparator(Path.GetFullPath(b));
+        var cmp = OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        return string.Equals(fa, fb, cmp);
+    }
 
     public WavRecorderStatus GetStatus()
     {
@@ -269,33 +389,52 @@ public sealed class WavRecorderService : IDisposable
             // else over-air on an already-keyed rig: ride the operator's key and
             // do not unkey at the end.
 
-            _playingFile = path;
-            _playingOnAir = onAir;
-            _weKeyedMox = weKeyed;
-            _playingDurationSec = samples.Length / (double)Math.Max(1, rate);
-            _state = WavRecorderState.Playing;
-            _playCts = new CancellationTokenSource();
-            _meter.Reset();
-
-            // Local playback mixes into the speaker via the preview path; force
-            // it on for the clip and restore after. Over-air playback does NOT
-            // touch the preview sink (the operator hears their TX monitor /
-            // sidetone as usual, not a local copy).
-            _restorePreviewOff = false;
-            if (!onAir)
+            // From here on a key may be raised. If ANYTHING below throws (e.g.
+            // thread/OOM exhaustion on a Pi when starting the pump), the pump's
+            // finally→FinishPlayback never runs, so we must unwind to Idle and —
+            // critically — drop any MOX we raised. Otherwise the rig is stranded
+            // keyed with no release path. RF-safety: only ever drop a key we
+            // raised ourselves; never touch an operator-held key.
+            try
             {
-                _restorePreviewOff = !_preview.IsEnabled;
-                if (_restorePreviewOff) _preview.SetEnabled(true);
+                _playingFile = path;
+                _playingOnAir = onAir;
+                _weKeyedMox = weKeyed;
+                _playingDurationSec = samples.Length / (double)Math.Max(1, rate);
+                _state = WavRecorderState.Playing;
+                _playCts = new CancellationTokenSource();
+                _meter.Reset();
+
+                // Local playback is mixed into the RX audio block on the pump thread
+                // (see EmitBlock → EnqueueMonitorAudio), so it reaches the operator's
+                // speakers in both web and desktop modes. Over-air playback feeds the
+                // TX chain instead. Nothing to arm here.
+                var ct = _playCts.Token;
+                bool keyedForSettle = weKeyed;
+                _playThread = new Thread(() => PlaybackPump(samples, rate, onAir, keyedForSettle, ct))
+                {
+                    IsBackground = true,
+                    Name = "wav-playback",
+                };
+                _playThread.Start();
+            }
+            catch
+            {
+                // Unwind: reset state, tear down the CTS/thread refs, and release
+                // any key we raised so we never leave the transmitter stranded.
+                _state = WavRecorderState.Idle;
+                _playingFile = null;
+                _playingOnAir = false;
+                _weKeyedMox = false;
+                _playingDurationSec = 0;
+                _playCts?.Dispose();
+                _playCts = null;
+                _playThread = null;
+                if (weKeyed)
+                    _tx.TrySetMox(false, MoxSource.Wav, out _);
+                throw;
             }
 
-            var ct = _playCts.Token;
-            bool keyedForSettle = weKeyed;
-            _playThread = new Thread(() => PlaybackPump(samples, rate, onAir, keyedForSettle, ct))
-            {
-                IsBackground = true,
-                Name = "wav-playback",
-            };
-            _playThread.Start();
             _log.LogInformation(
                 "wav.play start file={File} samples={Samples} rate={Rate} onAir={OnAir} weKeyed={WeKeyed}",
                 path, samples.Length, rate, onAir, weKeyed);
@@ -312,7 +451,14 @@ public sealed class WavRecorderService : IDisposable
             _playCts?.Cancel();
             thread = _playThread;
         }
-        thread?.Join(500);
+        // Only join a thread that actually started and is still running. A thread
+        // that was created but never Start()ed (Play threw mid-setup) throws
+        // ThreadStateException on Join — which would skip FinishPlayback and leave
+        // a keyed rig. IsAlive is false for both an unstarted and an
+        // already-finished thread, so guarding on it keeps FinishPlayback always
+        // reachable. FinishPlayback is idempotent (no-ops if already Idle).
+        if (thread is { IsAlive: true })
+            thread.Join(500);
         FinishPlayback();
     }
 
@@ -379,7 +525,13 @@ public sealed class WavRecorderService : IDisposable
                 }
                 else
                 {
-                    _preview.PublishPreview(block, TxMicBlockResampler.OutputSampleRate);
+                    // Local monitor: mix into the RX audio block so it reaches
+                    // every sink — browser (WebSocket) AND desktop (native) —
+                    // alike. The old preview-sink side-channel was desktop-only
+                    // and silent in web mode; EnqueueMonitorAudio is the
+                    // universal path PluginPlaybackSink already uses. A full ring
+                    // (returns false) just drops the block, same as that path.
+                    _pipeline.EnqueueMonitorAudio(block);
                 }
 
                 Pace();
@@ -417,7 +569,6 @@ public sealed class WavRecorderService : IDisposable
         lock (_sync)
         {
             if (_state != WavRecorderState.Playing) return;
-            if (_restorePreviewOff) { _preview.SetEnabled(false); _restorePreviewOff = false; }
             dropMox = _weKeyedMox;
             _weKeyedMox = false;
             _playCts?.Dispose();
@@ -458,13 +609,53 @@ public sealed class WavRecorderService : IDisposable
         return WavFile.Envelope(samples, Math.Clamp(buckets, 16, 2000));
     }
 
-    public bool DeleteRecording(string relPath) => _library.DeleteRecording(relPath);
+    public bool DeleteRecording(string relPath)
+    {
+        EnsureNotActiveTarget(_library.ResolveRel(relPath));
+        return _library.DeleteRecording(relPath);
+    }
     public string RenameRecording(string relFrom, string newDisplayName)
         => _library.RenameRecording(relFrom, newDisplayName);
     public string MoveRecording(string relFrom, string destFolder)
         => _library.MoveRecording(relFrom, destFolder);
     public string CreateFolder(string relPath) => _library.CreateFolder(relPath);
-    public string DeleteFolder(string relPath) => _library.DeleteFolder(relPath);
+    public string DeleteFolder(string relPath)
+    {
+        EnsureNotActiveTarget(_library.ResolveRel(relPath));
+        return _library.DeleteFolder(relPath);
+    }
+
+    // Refuse to delete the file currently being recorded or played, or a folder
+    // that contains it. On Unix the unlink succeeds and silently truncates the
+    // live capture (data loss); on Windows it throws a sharing violation (500).
+    // Stop both up front with a clear error the endpoint maps to 409 Conflict.
+    private void EnsureNotActiveTarget(string absPathOrDir)
+    {
+        lock (_sync)
+        {
+            if (_state == WavRecorderState.Idle) return;
+            string? active = _state == WavRecorderState.Recording ? _writer?.Path
+                           : _state == WavRecorderState.Playing ? _playingFile
+                           : null;
+            if (string.IsNullOrEmpty(active)) return;
+            if (IsSameOrUnder(absPathOrDir, active))
+                throw new InvalidOperationException(
+                    $"cannot delete a recording that is currently {_state.ToString().ToLowerInvariant()}");
+        }
+    }
+
+    // True when <paramref name="candidate"/> is the same file as
+    // <paramref name="target"/> or lives under it (when target is a directory).
+    private static bool IsSameOrUnder(string target, string candidate)
+    {
+        string t = Path.TrimEndingDirectorySeparator(Path.GetFullPath(target));
+        string c = Path.TrimEndingDirectorySeparator(Path.GetFullPath(candidate));
+        var cmp = OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        return string.Equals(t, c, cmp)
+            || c.StartsWith(t + Path.DirectorySeparatorChar, cmp);
+    }
 
     public void Dispose()
     {

--- a/Zeus.Server.Hosting/Wav/WavRecorderSettingsStore.cs
+++ b/Zeus.Server.Hosting/Wav/WavRecorderSettingsStore.cs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+using LiteDB;
+using Microsoft.Extensions.Logging;
+
+namespace Zeus.Server.Wav;
+
+/// <summary>
+/// Persists the single operator preference that the tape deck needs across
+/// restarts: the recordings root directory. Null/absent = "use the platform
+/// default" (<see cref="WavLibrary.DefaultRoot"/>).
+///
+/// Deliberately the smallest possible LiteDB store — one tiny single-row
+/// document, no concurrent writers — mirroring <see cref="PreferredRadioStore"/>
+/// exactly so it stays clear of the Linux LiteDB shared-mode crash (issue #682)
+/// that bit a heavier store. Lives in <c>zeus-prefs.db</c> alongside the other
+/// non-sensitive preferences.
+/// </summary>
+public sealed class WavRecorderSettingsStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<WavRecorderSettingsEntry> _entries;
+    private readonly ILogger<WavRecorderSettingsStore> _log;
+    private readonly object _sync = new();
+
+    public WavRecorderSettingsStore(ILogger<WavRecorderSettingsStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _entries = _db.GetCollection<WavRecorderSettingsEntry>("wav_recorder_settings");
+
+        _log.LogInformation("WavRecorderSettingsStore initialized at {Path}", dbPath);
+    }
+
+    /// <summary>The persisted recordings root, or null if the operator has not
+    /// chosen one (use the platform default). Empty/whitespace stored values are
+    /// treated as null.</summary>
+    public string? GetRoot()
+    {
+        lock (_sync)
+        {
+            var e = _entries.FindAll().FirstOrDefault();
+            return string.IsNullOrWhiteSpace(e?.RecordingsRoot) ? null : e!.RecordingsRoot;
+        }
+    }
+
+    /// <summary>Persist the chosen recordings root. Null/empty clears it back to
+    /// "use the platform default".</summary>
+    public void SetRoot(string? absPath)
+    {
+        string? value = string.IsNullOrWhiteSpace(absPath) ? null : absPath;
+        lock (_sync)
+        {
+            var existing = _entries.FindAll().FirstOrDefault();
+            if (existing is null)
+            {
+                _entries.Insert(new WavRecorderSettingsEntry
+                {
+                    RecordingsRoot = value,
+                    UpdatedUtc = DateTime.UtcNow,
+                });
+            }
+            else
+            {
+                existing.RecordingsRoot = value;
+                existing.UpdatedUtc = DateTime.UtcNow;
+                _entries.Update(existing);
+            }
+        }
+    }
+
+    public void Dispose() => _db.Dispose();
+}
+
+public sealed class WavRecorderSettingsEntry
+{
+    public int Id { get; set; }
+    /// <summary>Absolute path to the operator-chosen recordings root, or null
+    /// for "use the platform default". LiteDB hydrates as null for older rows
+    /// that pre-date this store.</summary>
+    public string? RecordingsRoot { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -920,36 +920,58 @@ public static class ZeusEndpoints
                 return MapEditorResult(result, open: false);
             });
 
-        // WAV recorder / player. Records RX or processed-TX audio to float32
-        // WAVs in the Downloads folder, and plays recordings back to the local
-        // monitor (no keying). Over-the-air playback is a later layer.
+        // WAV recorder / tape deck. Records RX or processed-TX audio to float32
+        // WAVs under the managed root (<Downloads>/Zeus Recordings), organises
+        // them into folders, and plays recordings back to the local monitor or
+        // over the air. All paths on the wire are root-relative with forward
+        // slashes; the service traversal-guards every one.
         app.MapGet("/api/wav/status", (Zeus.Server.Wav.WavRecorderService wav) =>
             Results.Ok(wav.GetStatus()));
         app.MapGet("/api/wav/list", (Zeus.Server.Wav.WavRecorderService wav) =>
-            Results.Ok(new { dir = wav.RecordingsDir, recordings = wav.ListRecordings() }));
+            Results.Ok(new
+            {
+                root = wav.RecordingsDir,
+                folders = wav.ListFolders(),
+                recordings = wav.ListRecordings(),
+            }));
+        app.MapGet("/api/wav/waveform",
+            (string? file, int? buckets, Zeus.Server.Wav.WavRecorderService wav) =>
+        {
+            if (string.IsNullOrWhiteSpace(file))
+                return Results.BadRequest(new { error = "file is required" });
+            try { return Results.Ok(new { file, buckets = wav.ComputeWaveform(file, buckets ?? 400) }); }
+            catch (FileNotFoundException) { return Results.NotFound(new { error = "recording not found" }); }
+            catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
+            catch (InvalidDataException ex) { return Results.BadRequest(new { error = ex.Message }); }
+        });
         app.MapPost("/api/wav/record/start",
             (WavRecordStartRequest body, Zeus.Server.Wav.WavRecorderService wav) =>
         {
             var source = string.Equals(body?.Source, "tx", StringComparison.OrdinalIgnoreCase)
                 ? Zeus.Server.Wav.WavRecordSource.Tx
                 : Zeus.Server.Wav.WavRecordSource.Rx;
-            try { return Results.Ok(new { file = wav.StartRecording(source) }); }
+            try { return Results.Ok(new { relPath = wav.StartRecording(source, body?.Folder) }); }
+            catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
             catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
         });
         app.MapPost("/api/wav/record/stop", (Zeus.Server.Wav.WavRecorderService wav) =>
         {
             var r = wav.StopRecording();
             return r is { } x
-                ? Results.Ok(new { file = Path.GetFileName(x.Path), samples = x.Samples })
-                : Results.Ok(new { file = (string?)null, samples = 0L });
+                ? Results.Ok(new { relPath = x.RelPath, samples = x.Samples })
+                : Results.Ok(new { relPath = (string?)null, samples = 0L });
         });
         app.MapPost("/api/wav/play",
             (WavPlayRequest body, Zeus.Server.Wav.WavRecorderService wav) =>
         {
             if (string.IsNullOrWhiteSpace(body?.File))
                 return Results.BadRequest(new { error = "file is required" });
-            try { wav.Play(body.File); return Results.Ok(wav.GetStatus()); }
+            var dest = string.Equals(body?.Dest, "air", StringComparison.OrdinalIgnoreCase)
+                ? Zeus.Server.Wav.WavPlayDest.Air
+                : Zeus.Server.Wav.WavPlayDest.Local;
+            try { wav.Play(body!.File!, dest); return Results.Ok(wav.GetStatus()); }
             catch (FileNotFoundException) { return Results.NotFound(new { error = "recording not found" }); }
+            catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
             catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
         });
         app.MapPost("/api/wav/stop", (Zeus.Server.Wav.WavRecorderService wav) =>
@@ -957,10 +979,53 @@ public static class ZeusEndpoints
             wav.StopPlayback();
             return Results.Ok(wav.GetStatus());
         });
-        app.MapDelete("/api/wav/{file}", (string file, Zeus.Server.Wav.WavRecorderService wav) =>
+        app.MapPost("/api/wav/rename",
+            (WavRenameRequest body, Zeus.Server.Wav.WavRecorderService wav) =>
         {
-            try { wav.DeleteRecording(file); return Results.Ok(new { deleted = file }); }
+            if (string.IsNullOrWhiteSpace(body?.From) || string.IsNullOrWhiteSpace(body?.Name))
+                return Results.BadRequest(new { error = "from and name are required" });
+            try { return Results.Ok(new { relPath = wav.RenameRecording(body.From, body.Name) }); }
             catch (FileNotFoundException) { return Results.NotFound(new { error = "recording not found" }); }
+            catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
+            catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
+        });
+        app.MapPost("/api/wav/move",
+            (WavMoveRequest body, Zeus.Server.Wav.WavRecorderService wav) =>
+        {
+            if (string.IsNullOrWhiteSpace(body?.From))
+                return Results.BadRequest(new { error = "from is required" });
+            try { return Results.Ok(new { relPath = wav.MoveRecording(body.From, body.Folder ?? "") }); }
+            catch (FileNotFoundException) { return Results.NotFound(new { error = "recording not found" }); }
+            catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
+            catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
+        });
+        app.MapPost("/api/wav/folder/create",
+            (WavFolderRequest body, Zeus.Server.Wav.WavRecorderService wav) =>
+        {
+            if (string.IsNullOrWhiteSpace(body?.Path))
+                return Results.BadRequest(new { error = "path is required" });
+            try { return Results.Ok(new { folder = wav.CreateFolder(body.Path) }); }
+            catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
+            catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
+        });
+        app.MapPost("/api/wav/folder/delete",
+            (WavFolderRequest body, Zeus.Server.Wav.WavRecorderService wav) =>
+        {
+            if (string.IsNullOrWhiteSpace(body?.Path))
+                return Results.BadRequest(new { error = "path is required" });
+            try { return Results.Ok(new { deleted = wav.DeleteFolder(body.Path) }); }
+            catch (FileNotFoundException) { return Results.NotFound(new { error = "folder not found" }); }
+            catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
+            catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
+        });
+        app.MapPost("/api/wav/delete",
+            (WavDeleteRequest body, Zeus.Server.Wav.WavRecorderService wav) =>
+        {
+            if (string.IsNullOrWhiteSpace(body?.File))
+                return Results.BadRequest(new { error = "file is required" });
+            try { wav.DeleteRecording(body.File); return Results.Ok(new { deleted = body.File }); }
+            catch (FileNotFoundException) { return Results.NotFound(new { error = "recording not found" }); }
+            catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
         });
 
         app.MapGet("/api/state", (RadioService r) => r.Snapshot());
@@ -4933,5 +4998,9 @@ internal sealed record TxDutyGuidanceDto(
 // "P1" or "P2" so the server sends the correct stop frame.
 internal sealed record ReclaimRadioRequest(string? Endpoint, string? Protocol);
 internal sealed record HardwareDiagnosticsMarkerRequest(string? Label, string? Notes);
-internal sealed record WavRecordStartRequest(string? Source);
-internal sealed record WavPlayRequest(string? File);
+internal sealed record WavRecordStartRequest(string? Source, string? Folder);
+internal sealed record WavPlayRequest(string? File, string? Dest);
+internal sealed record WavRenameRequest(string? From, string? Name);
+internal sealed record WavMoveRequest(string? From, string? Folder);
+internal sealed record WavFolderRequest(string? Path);
+internal sealed record WavDeleteRequest(string? File);

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -1062,6 +1062,8 @@ public static class ZeusEndpoints
             catch (FileNotFoundException) { return Results.NotFound(new { error = "folder not found" }); }
             catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
             catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
+            // Sharing violation (a file in the folder is open/in use) on Windows.
+            catch (IOException ex) { return Results.Conflict(new { error = ex.Message }); }
         });
         app.MapPost("/api/wav/delete",
             (WavDeleteRequest body, Zeus.Server.Wav.WavRecorderService wav) =>
@@ -1071,6 +1073,52 @@ public static class ZeusEndpoints
             try { wav.DeleteRecording(body.File); return Results.Ok(new { deleted = body.File }); }
             catch (FileNotFoundException) { return Results.NotFound(new { error = "recording not found" }); }
             catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
+            // Active recording/playback target — refused up front.
+            catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
+            // Sharing violation (file open/in use) on Windows.
+            catch (IOException ex) { return Results.Conflict(new { error = ex.Message }); }
+        });
+
+        // The recordings root: where new captures land and the listing reads
+        // from. Operator-selectable and persisted across restarts.
+        app.MapGet("/api/wav/root", (Zeus.Server.Wav.WavRecorderService wav) =>
+        {
+            var (root, isDefault) = wav.GetRecordingsRoot();
+            return Results.Ok(new { root, isDefault });
+        });
+        app.MapPost("/api/wav/root",
+            (WavRootRequest body, Zeus.Server.Wav.WavRecorderService wav) =>
+        {
+            try
+            {
+                // Null/empty/missing path resets to the platform default.
+                var (root, isDefault) = wav.SetRecordingsRoot(body?.Path);
+                return Results.Ok(new { root, isDefault });
+            }
+            catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
+            catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
+        });
+
+        // Read-only server-side directory browser so the web UI can pick a
+        // recordings root on the machine the backend runs on. Deliberately not
+        // confined to the recordings root.
+        app.MapGet("/api/wav/dirs", (string? path) =>
+        {
+            try
+            {
+                var listing = Zeus.Server.Wav.WavLibrary.BrowseDirectories(path);
+                return Results.Ok(new
+                {
+                    path = listing.Path,
+                    parent = listing.Parent,
+                    separator = listing.Separator,
+                    dirs = listing.Dirs.Select(d => new { name = d.Name, path = d.Path }),
+                });
+            }
+            catch (Exception ex) when (ex is DirectoryNotFoundException or ArgumentException or IOException)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
         });
 
         app.MapGet("/api/state", (RadioService r) => r.Snapshot());
@@ -5049,3 +5097,5 @@ internal sealed record WavRenameRequest(string? From, string? Name);
 internal sealed record WavMoveRequest(string? From, string? Folder);
 internal sealed record WavFolderRequest(string? Path);
 internal sealed record WavDeleteRequest(string? File);
+// Body for POST /api/wav/root. Null/empty Path resets to the platform default.
+internal sealed record WavRootRequest(string? Path);

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -514,10 +514,13 @@ public static class ZeusHost
         // seams remain in core: AudioTapBridge (RX tap), RadioStateReader,
         // PluginQrzLookup, and the voyeur-engines-v1 build workflow.
         // WAV recorder/player: taps DspPipelineService RX + TX-monitor audio to
-        // record float32 WAVs (default save folder = Downloads) and plays them
-        // back locally via the preview sink. Over-the-air playback is layered
-        // on later. Singleton resolved on first /api/wav call; its ctor wires
-        // the pipeline event subscriptions.
+        // record float32 WAVs under the managed root (<Downloads>/Zeus
+        // Recordings) and plays them back either locally via the preview sink
+        // or over the air (keying MoxSource.Wav when the rig is unkeyed).
+        // Singleton resolved on first /api/wav call; its ctor wires the
+        // pipeline event subscriptions and runs the one-time loose-file
+        // migration. The optional recordingsRootOverride ctor param defaults to
+        // null here (Downloads-based) — tests inject a temp root.
         builder.Services.AddSingleton<Zeus.Server.Wav.WavRecorderService>();
         // PS auto-attenuate timer2code-equivalent: ramps the radio's TX step
         // attenuator (Protocol2 only today) when calcc feedback level lands outside

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -521,6 +521,10 @@ public static class ZeusHost
         // pipeline event subscriptions and runs the one-time loose-file
         // migration. The optional recordingsRootOverride ctor param defaults to
         // null here (Downloads-based) — tests inject a temp root.
+        // Persists the operator-chosen recordings root (null = platform default).
+        // Tiny single-row LiteDB store, mirrors PreferredRadioStore to stay clear
+        // of the Linux shared-mode crash (#682).
+        builder.Services.AddSingleton<Zeus.Server.Wav.WavRecorderSettingsStore>();
         builder.Services.AddSingleton<Zeus.Server.Wav.WavRecorderService>();
         // PS auto-attenuate timer2code-equivalent: ramps the radio's TX step
         // attenuator (Protocol2 only today) when calcc feedback level lands outside

--- a/tests/Zeus.Server.Tests/WavRecorderServiceTests.cs
+++ b/tests/Zeus.Server.Tests/WavRecorderServiceTests.cs
@@ -5,6 +5,11 @@
 //                         Douglas J. Cerrato (KB2UKA),
 //                         Christian Suarez (N9WAR), and contributors.
 
+using System.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Protocol1;
+using Zeus.Server;
 using Zeus.Server.Wav;
 
 namespace Zeus.Server.Tests;
@@ -287,5 +292,435 @@ public sealed class WavRecorderServiceTests
             Assert.True(File.Exists(keep), "non-zeus parent file must be untouched");
         }
         finally { Directory.Delete(sandbox, true); }
+    }
+
+    [Fact]
+    public void Migration_Disabled_LeavesLooseZeusWavInParent()
+    {
+        var (sandbox, root) = NewSandbox();
+        try
+        {
+            // A loose legacy file sitting directly in the parent. With migration
+            // off (the contract for an operator-chosen custom root) it must NOT
+            // be scanned for or moved — we never touch an arbitrary user dir.
+            string loose = Path.Combine(sandbox, "zeus-rx-legacy.wav");
+            WriteWav(loose, 48_000, 100);
+
+            _ = new WavLibrary(root, log: null, migrate: false);
+
+            Assert.True(File.Exists(loose), "loose zeus file must stay put when migration is disabled");
+            Assert.False(File.Exists(Path.Combine(root, "zeus-rx-legacy.wav")),
+                "nothing should have been migrated into the root");
+        }
+        finally { Directory.Delete(sandbox, true); }
+    }
+
+    [Fact]
+    public void SetRoot_RelocatesEffectiveRoot_ListReadsFromNewRoot()
+    {
+        var (sandbox, root) = NewSandbox();
+        try
+        {
+            var lib = new WavLibrary(root, log: null, migrate: false);
+            WriteWav(Path.Combine(root, "zeus-rx-old.wav"), 48_000, 100);
+            Assert.Single(lib.ListRecordings());
+
+            // Point the library at a fresh root with different content.
+            string newRoot = Path.Combine(sandbox, "Relocated");
+            lib.SetRoot(newRoot);
+            Assert.Equal(newRoot, lib.Root);
+            Assert.True(Directory.Exists(newRoot), "SetRoot creates the directory");
+
+            // Listing now reads from the new root, not the old one.
+            Assert.Empty(lib.ListRecordings());
+            WriteWav(Path.Combine(newRoot, "zeus-rx-new.wav"), 48_000, 100);
+            var recs = lib.ListRecordings();
+            Assert.Single(recs);
+            Assert.Equal("zeus-rx-new.wav", recs[0].FileName);
+        }
+        finally { Directory.Delete(sandbox, true); }
+    }
+
+    [Fact]
+    public void SettingsStore_RoundTripsRoot_AndClearsToNull()
+    {
+        var (sandbox, _) = NewSandbox();
+        try
+        {
+            string dbPath = Path.Combine(sandbox, "wav-settings.db");
+
+            // Fresh store: nothing persisted yet.
+            using (var store = new WavRecorderSettingsStore(NullLogger<WavRecorderSettingsStore>.Instance, dbPath))
+            {
+                Assert.Null(store.GetRoot());
+
+                string chosen = Path.Combine(sandbox, "MyRecordings");
+                store.SetRoot(chosen);
+                Assert.Equal(chosen, store.GetRoot());
+            }
+
+            // Re-open: the value survives across store instances (LiteDB on disk).
+            using (var reopened = new WavRecorderSettingsStore(NullLogger<WavRecorderSettingsStore>.Instance, dbPath))
+            {
+                Assert.Equal(Path.Combine(sandbox, "MyRecordings"), reopened.GetRoot());
+
+                // Clearing with null resets to "use default".
+                reopened.SetRoot(null);
+                Assert.Null(reopened.GetRoot());
+
+                // Whitespace is treated as null too.
+                reopened.SetRoot("   ");
+                Assert.Null(reopened.GetRoot());
+            }
+        }
+        finally { Directory.Delete(sandbox, true); }
+    }
+
+    [Fact]
+    public void BrowseDirectories_ListsSubdirsAndParent_SortedOrdinalIgnoreCase()
+    {
+        var (sandbox, _) = NewSandbox();
+        try
+        {
+            // Build a small tree under the sandbox.
+            Directory.CreateDirectory(Path.Combine(sandbox, "Beta"));
+            Directory.CreateDirectory(Path.Combine(sandbox, "alpha"));
+            Directory.CreateDirectory(Path.Combine(sandbox, "Gamma"));
+            // A file at the top level must be ignored (dirs only).
+            File.WriteAllText(Path.Combine(sandbox, "note.txt"), "x");
+
+            var listing = WavLibrary.BrowseDirectories(sandbox);
+
+            Assert.Equal(Path.GetFullPath(sandbox), listing.Path);
+            Assert.Equal(Path.DirectorySeparatorChar.ToString(), listing.Separator);
+            Assert.Equal(Directory.GetParent(sandbox)!.FullName, listing.Parent);
+
+            // Subdirectories only, sorted ordinal-ignore-case (alpha, Beta, Gamma).
+            Assert.Equal(new[] { "alpha", "Beta", "Gamma" }, listing.Dirs.Select(d => d.Name).ToArray());
+            Assert.All(listing.Dirs, d => Assert.True(Directory.Exists(d.Path)));
+        }
+        finally { Directory.Delete(sandbox, true); }
+    }
+
+    [Fact]
+    public void BrowseDirectories_NonexistentPath_Throws()
+    {
+        var (sandbox, _) = NewSandbox();
+        try
+        {
+            string missing = Path.Combine(sandbox, "does-not-exist");
+            Assert.Throws<DirectoryNotFoundException>(() => WavLibrary.BrowseDirectories(missing));
+        }
+        finally { Directory.Delete(sandbox, true); }
+    }
+
+    // ---- H2: migration must never clobber an existing destination -----------
+
+    [Fact]
+    public void Migration_DestinationCollision_LeavesLooseFileAndDoesNotOverwrite()
+    {
+        var (sandbox, root) = NewSandbox();
+        try
+        {
+            // Pre-existing file already in the root, distinctive sample count.
+            WriteWav(Path.Combine(root, "zeus-rx-x.wav"), 48_000, 999);
+            // A loose legacy file of the SAME name sitting in the parent.
+            WriteWav(Path.Combine(sandbox, "zeus-rx-x.wav"), 48_000, 100);
+
+            _ = new WavLibrary(root); // ctor migration runs
+
+            // Collision → loose file untouched, root file NOT overwritten.
+            Assert.True(File.Exists(Path.Combine(sandbox, "zeus-rx-x.wav")),
+                "loose file must remain when the destination already exists");
+            Assert.Equal(100, WavFile.ReadInfo(Path.Combine(sandbox, "zeus-rx-x.wav")).SampleCount);
+            Assert.Equal(999, WavFile.ReadInfo(Path.Combine(root, "zeus-rx-x.wav")).SampleCount);
+        }
+        finally { Directory.Delete(sandbox, true); }
+    }
+
+    // ---- H3: DeleteFolder catastrophic-delete guard -------------------------
+
+    [Fact]
+    public void DeleteFolder_RefusesRootAndUserContent_LeavesTreeIntact()
+    {
+        var (sandbox, root) = NewSandbox();
+        try
+        {
+            var lib = new WavLibrary(root);
+            WriteWav(Path.Combine(root, "zeus-rx-keep.wav"), 48_000, 100);
+
+            // "." resolves to the root itself — must refuse; root survives.
+            Assert.Throws<InvalidOperationException>(() => lib.DeleteFolder("."));
+            Assert.True(Directory.Exists(root));
+            Assert.True(File.Exists(Path.Combine(root, "zeus-rx-keep.wav")));
+
+            // A subtree holding genuine user content is refused, left intact.
+            WriteWav(Path.Combine(root, "Mixed", "zeus-rx.wav"), 48_000, 100);
+            Directory.CreateDirectory(Path.Combine(root, "Mixed", "sub"));
+            File.WriteAllText(Path.Combine(root, "Mixed", "sub", "notes.txt"), "keep me");
+            Assert.Throws<InvalidOperationException>(() => lib.DeleteFolder("Mixed"));
+            Assert.True(File.Exists(Path.Combine(root, "Mixed", "zeus-rx.wav")));
+            Assert.True(File.Exists(Path.Combine(root, "Mixed", "sub", "notes.txt")));
+
+            // An empty folder deletes cleanly.
+            lib.CreateFolder("Empty");
+            Assert.Equal("Empty", lib.DeleteFolder("Empty"));
+            Assert.False(Directory.Exists(Path.Combine(root, "Empty")));
+        }
+        finally { Directory.Delete(sandbox, true); }
+    }
+
+    // ---- M2: OS sidecar files are ignorable, not blocking -------------------
+
+    [Fact]
+    public void DeleteFolder_IgnoresOsSidecars_StillRefusesRealContent()
+    {
+        var (sandbox, root) = NewSandbox();
+        try
+        {
+            var lib = new WavLibrary(root);
+
+            // wav + macOS/Windows sidecars → deletes successfully.
+            WriteWav(Path.Combine(root, "Sidecar", "zeus-rx.wav"), 48_000, 100);
+            File.WriteAllText(Path.Combine(root, "Sidecar", ".DS_Store"), "x");
+            File.WriteAllText(Path.Combine(root, "Sidecar", "Thumbs.db"), "x");
+            Assert.Equal("Sidecar", lib.DeleteFolder("Sidecar"));
+            Assert.False(Directory.Exists(Path.Combine(root, "Sidecar")));
+
+            // wav + a genuine user file → still refused.
+            WriteWav(Path.Combine(root, "Real", "zeus-rx.wav"), 48_000, 100);
+            File.WriteAllText(Path.Combine(root, "Real", "notes.txt"), "hello");
+            Assert.Throws<InvalidOperationException>(() => lib.DeleteFolder("Real"));
+            Assert.True(Directory.Exists(Path.Combine(root, "Real")));
+        }
+        finally { Directory.Delete(sandbox, true); }
+    }
+
+    // ---- M5: portable filename sanitization on every platform ---------------
+
+    [Fact]
+    public void Rename_StripsBackslashAndReservedChars_RoundTripsOnAllPlatforms()
+    {
+        var (sandbox, root) = NewSandbox();
+        try
+        {
+            var lib = new WavLibrary(root);
+            WriteWav(Path.Combine(root, "zeus-rx-a.wav"), 48_000, 100);
+
+            // A backslash must never survive into the on-disk name (it would
+            // desync from the forward-slash wire path). Result is a single
+            // segment that round-trips through the path resolver.
+            string rel = lib.RenameRecording("zeus-rx-a.wav", "a\\b");
+            Assert.DoesNotContain('\\', rel);
+            Assert.DoesNotContain('/', rel);
+            Assert.True(File.Exists(lib.ResolveRel(rel)), "renamed file must resolve");
+            // Round-trips through a subsequent Move resolve (no FileNotFound).
+            string moved = lib.MoveRecording(rel, "Dest");
+            Assert.True(File.Exists(lib.ResolveRel(moved)));
+
+            // Every Windows-reserved char is stripped, on any platform.
+            WriteWav(Path.Combine(root, "zeus-rx-b.wav"), 48_000, 100);
+            string rel2 = lib.RenameRecording("zeus-rx-b.wav", "keep:me*?\"<>|ok");
+            string name2 = Path.GetFileName(lib.ResolveRel(rel2));
+            foreach (char c in new[] { ':', '*', '?', '"', '<', '>', '|', '\\', '/' })
+                Assert.DoesNotContain(c, name2);
+            Assert.EndsWith(".wav", name2);
+            Assert.True(File.Exists(lib.ResolveRel(rel2)));
+        }
+        finally { Directory.Delete(sandbox, true); }
+    }
+
+    // ---- M5b: Windows reserved device names made portable on every platform -
+
+    [Theory]
+    [InlineData("NUL", "NUL_")]
+    [InlineData("com1", "com1_")]
+    public void Rename_WindowsReservedDeviceName_IsDisambiguatedAndRoundTrips(string input, string expectedStem)
+    {
+        var (sandbox, root) = NewSandbox();
+        try
+        {
+            var lib = new WavLibrary(root);
+            WriteWav(Path.Combine(root, "zeus-rx-a.wav"), 48_000, 100);
+
+            // A reserved device name (unopenable on Windows) gets an underscore
+            // suffix on ALL platforms so the on-disk name is portable.
+            string rel = lib.RenameRecording("zeus-rx-a.wav", input);
+            Assert.Equal(expectedStem + ".wav", Path.GetFileName(rel));
+            // Round-trips through the path resolver (no FileNotFoundException).
+            Assert.True(File.Exists(lib.ResolveRel(rel)));
+        }
+        finally { Directory.Delete(sandbox, true); }
+    }
+
+    // ---- M9: Move refuses to overwrite an existing destination --------------
+
+    [Fact]
+    public void Move_RefusesOverwrite_LeavesBothUnchanged()
+    {
+        var (sandbox, root) = NewSandbox();
+        try
+        {
+            var lib = new WavLibrary(root);
+            WriteWav(Path.Combine(root, "zeus-rx-x.wav"), 48_000, 100);
+            WriteWav(Path.Combine(root, "Dest", "zeus-rx-x.wav"), 48_000, 200);
+
+            Assert.Throws<InvalidOperationException>(
+                () => lib.MoveRecording("zeus-rx-x.wav", "Dest"));
+
+            Assert.Equal(100, WavFile.ReadInfo(Path.Combine(root, "zeus-rx-x.wav")).SampleCount);
+            Assert.Equal(200, WavFile.ReadInfo(Path.Combine(root, "Dest", "zeus-rx-x.wav")).SampleCount);
+        }
+        finally { Directory.Delete(sandbox, true); }
+    }
+
+    // ---- M10: traversal guard covers backslash + rooted inputs --------------
+
+    [Theory]
+    [InlineData("..\\..\\escape.wav")]
+    [InlineData("DX\\..\\..\\x.wav")]
+    public void ResolveRel_RejectsBackslashTraversal_OnAllPlatforms(string bad)
+    {
+        var (sandbox, root) = NewSandbox();
+        try
+        {
+            var lib = new WavLibrary(root);
+            Assert.Throws<ArgumentException>(() => lib.ResolveRel(bad));
+        }
+        finally { Directory.Delete(sandbox, true); }
+    }
+
+    [Fact]
+    public void ResolveRel_RejectsWindowsRootedPaths_OnWindows()
+    {
+        if (!OperatingSystem.IsWindows()) return; // drive/UNC roots are Windows-only
+        var (sandbox, root) = NewSandbox();
+        try
+        {
+            var lib = new WavLibrary(root);
+            Assert.Throws<ArgumentException>(() => lib.ResolveRel("C:\\Windows"));
+            Assert.Throws<ArgumentException>(() => lib.ResolveRel("\\\\server\\share\\x"));
+        }
+        finally { Directory.Delete(sandbox, true); }
+    }
+
+    // ---- L7: injectable clock drives decay + clip-latch deterministically ---
+
+    [Fact]
+    public void Meter_WithInjectedClock_DecaysAndClearsClipLatch()
+    {
+        long now = 1_000_000;
+        var m = new WavMeter(() => now);
+
+        var full = new float[480];
+        Array.Fill(full, 1.0f);
+        m.Update(full);                 // peak 1.0, clip latch lit until now+1000
+        Assert.True(m.Peak >= 0.999);
+        Assert.True(m.Clip);
+
+        // 20 dB/sec ⇒ after 500 ms the linear peak is 10^(-0.5) ≈ 0.316.
+        now += 500;
+        m.Update(new float[480]);       // silent block at +500 ms
+        Assert.InRange(m.Peak, 0.30, 0.33);
+
+        // ClipHoldMs = 1000: still lit at +500, clears past +1000 from the clip.
+        Assert.True(m.Clip);
+        now += 600;                     // +1100 ms from the clipped block
+        Assert.False(m.Clip);
+    }
+
+    // ---- L8: Envelope boundary conditions -----------------------------------
+
+    [Fact]
+    public void Envelope_EdgeCases()
+    {
+        // buckets clamps up to a minimum of 1.
+        Assert.Single(WavFile.Envelope(new float[4], 0));
+
+        // Empty input returns `buckets` zeros.
+        var z = WavFile.Envelope(Array.Empty<float>(), 8);
+        Assert.Equal(8, z.Length);
+        Assert.All(z, v => Assert.Equal(0f, v));
+
+        // Fewer samples than buckets ⇒ one |sample| per sample.
+        Assert.Equal(8, WavFile.Envelope(new float[8], 10000).Length);
+
+        // length == buckets ⇒ per-sample magnitudes.
+        var per = WavFile.Envelope(new float[] { -0.1f, 0.2f, -0.3f, 0.4f }, 4);
+        Assert.Equal(4, per.Length);
+        Assert.Equal(0.1f, per[0], 3);
+        Assert.Equal(0.3f, per[2], 3);
+    }
+
+    // ---- L10: a corrupt .wav is listed (duration 0), never drops the listing -
+
+    [Fact]
+    public void List_IncludesCorruptWav_WithZeroDuration()
+    {
+        var (sandbox, root) = NewSandbox();
+        try
+        {
+            var lib = new WavLibrary(root);
+            WriteWav(Path.Combine(root, "zeus-rx-good.wav"), 48_000, 48_000); // 1.0s
+            File.WriteAllText(Path.Combine(root, "broken.wav"), "not a wav");
+
+            var recs = lib.ListRecordings();
+            Assert.Equal(2, recs.Count);
+            Assert.Equal(1.0, recs.Single(r => r.FileName == "zeus-rx-good.wav").DurationSec, 1);
+            Assert.Equal(0, recs.Single(r => r.FileName == "broken.wav").DurationSec);
+        }
+        finally { Directory.Delete(sandbox, true); }
+    }
+
+    // ---- M4: over-air playback keys MOX, returns to Idle, releases the key ---
+    // Exercises the live WavRecorderService against a real TxService/RadioService
+    // (FIX 3's normal key/release lifecycle). A deterministic forced-failure after
+    // keying isn't unit-triggerable (Thread.Start can't be made to throw on cue),
+    // so the unwind catch is covered by review; this proves we always release a
+    // key we raised on the happy path and on clip end.
+
+    [Fact]
+    public void Play_OverAir_KeysMoxThenReleasesOnFinish()
+    {
+        var (sandbox, root) = NewSandbox();
+        string dbPath = Path.Combine(sandbox, $"prefs-{Guid.NewGuid():N}.db");
+        try
+        {
+            var loggerFactory = NullLoggerFactory.Instance;
+            var dspStore = new DspSettingsStore(NullLogger<DspSettingsStore>.Instance, dbPath);
+            var paStore = new PaSettingsStore(NullLogger<PaSettingsStore>.Instance, dbPath + ".pa");
+            var radio = new RadioService(loggerFactory, dspStore, paStore);
+            radio.MarkProtocol2Connected("127.0.0.1:1024", 48_000);
+            var hub = new StreamingHub(new NullLogger<StreamingHub>());
+            var pipeline = new DspPipelineService(radio, hub, Array.Empty<IRxAudioSink>(), loggerFactory);
+            var tx = new TxService(radio, pipeline, hub, NullBandPlanService.Instance, new NullLogger<TxService>());
+            var ring = new TxIqRing();
+            using var ingest = new TxAudioIngest(ring, pipeline, tx, hub, new NullLogger<TxAudioIngest>());
+            using var settings = new WavRecorderSettingsStore(
+                NullLogger<WavRecorderSettingsStore>.Instance, dbPath + ".wav");
+            using var wav = new WavRecorderService(
+                pipeline, ingest, tx, radio, NullLogger<WavRecorderService>.Instance, settings,
+                recordingsRootOverride: root);
+
+            // A short clip (0.1 s @ 48 kHz) so the pump finishes quickly.
+            string rel = "zeus-tx-air.wav";
+            WriteWav(Path.Combine(root, rel), 48_000, 4_800);
+
+            Assert.False(tx.IsMoxOn);
+            wav.Play(rel, WavPlayDest.Air);
+            Assert.True(tx.IsMoxOn, "over-air playback must key MOX when the rig is unkeyed");
+
+            // Pump runs on its own thread; wait for it to finish and drop the key.
+            var sw = Stopwatch.StartNew();
+            while (wav.GetStatus().State != "idle" && sw.ElapsedMilliseconds < 5_000)
+                Thread.Sleep(20);
+
+            Assert.Equal("idle", wav.GetStatus().State);
+            Assert.False(tx.IsMoxOn, "MOX must be released after over-air playback ends");
+        }
+        finally
+        {
+            try { Directory.Delete(sandbox, true); } catch { }
+        }
     }
 }

--- a/tests/Zeus.Server.Tests/WavRecorderServiceTests.cs
+++ b/tests/Zeus.Server.Tests/WavRecorderServiceTests.cs
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+
+using Zeus.Server.Wav;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Deterministic coverage for the tape-deck file management (<see cref="WavLibrary"/>),
+/// the level meter (<see cref="WavMeter"/>), and the header-only WAV info read
+/// (<see cref="WavFile.ReadInfo"/>). The audio / radio orchestration in
+/// <see cref="WavRecorderService"/> (MOX keying, the playback pump) is covered
+/// by review — it needs a live TxService / radio — but every file, listing,
+/// CRUD, traversal-guard, and meter behaviour is exercised here against an
+/// isolated temp root.
+/// </summary>
+public sealed class WavRecorderServiceTests
+{
+    // Each test gets a fresh, unique sandbox whose parent contains nothing of
+    // ours, so the ctor's loose-file migration is a no-op unless the test seeds
+    // it deliberately.
+    private static (string Sandbox, string Root) NewSandbox()
+    {
+        string sandbox = Path.Combine(Path.GetTempPath(), "zeus-wavtests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(sandbox);
+        return (sandbox, Path.Combine(sandbox, WavLibrary.ManagedFolderName));
+    }
+
+    private static void WriteWav(string path, int sampleRate, int samples)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        using var w = new WavWriter(path, sampleRate);
+        w.Append(new float[samples]);
+    }
+
+    [Fact]
+    public void List_ReturnsRelPathFolderDurationAndSourceAcrossTree()
+    {
+        var (sandbox, root) = NewSandbox();
+        try
+        {
+            var lib = new WavLibrary(root);
+            // One at the root, one in a subfolder.
+            WriteWav(Path.Combine(root, "zeus-rx-20260101-000000.wav"), 48_000, 48_000); // 1.0s
+            WriteWav(Path.Combine(root, "DX", "zeus-tx-20260101-000100.wav"), 48_000, 24_000); // 0.5s
+            // A non-prefixed wav must still be listed (root is wholly ours) and
+            // reported as source "unknown".
+            WriteWav(Path.Combine(root, "imported.wav"), 48_000, 96_000); // 2.0s
+
+            var recs = lib.ListRecordings();
+            Assert.Equal(3, recs.Count);
+
+            var rx = recs.Single(r => r.FileName == "zeus-rx-20260101-000000.wav");
+            Assert.Equal("zeus-rx-20260101-000000", rx.Name);
+            Assert.Equal("zeus-rx-20260101-000000.wav", rx.RelPath);
+            Assert.Equal("", rx.Folder);
+            Assert.Equal("rx", rx.Source);
+            Assert.Equal(1.0, rx.DurationSec, 1);
+
+            var tx = recs.Single(r => r.FileName == "zeus-tx-20260101-000100.wav");
+            Assert.Equal("DX/zeus-tx-20260101-000100.wav", tx.RelPath);
+            Assert.Equal("DX", tx.Folder);
+            Assert.Equal("tx", tx.Source);
+            Assert.Equal(0.5, tx.DurationSec, 1);
+
+            var other = recs.Single(r => r.FileName == "imported.wav");
+            Assert.Equal("unknown", other.Source);
+            Assert.Equal(2.0, other.DurationSec, 1);
+
+            // Folder listing includes the subfolder, forward-slashed.
+            Assert.Contains("DX", lib.ListFolders());
+        }
+        finally { Directory.Delete(sandbox, true); }
+    }
+
+    [Fact]
+    public void ReadInfo_MatchesRateAndSampleCountAndReadAllSamples()
+    {
+        var (sandbox, root) = NewSandbox();
+        try
+        {
+            string path = Path.Combine(root, "zeus-rx-info.wav");
+            const int rate = 48_000;
+            const int count = 12_345;
+            WriteWav(path, rate, count);
+
+            var (infoRate, infoCount) = WavFile.ReadInfo(path);
+            Assert.Equal(rate, infoRate);
+            Assert.Equal(count, infoCount);
+
+            var (samples, allRate) = WavFile.ReadAllSamples(path);
+            Assert.Equal(rate, allRate);
+            Assert.Equal(count, samples.Length);
+            Assert.Equal(samples.Length, infoCount);
+        }
+        finally { Directory.Delete(sandbox, true); }
+    }
+
+    [Fact]
+    public void Rename_PreservesExtension_SanitizesIllegalChars_RefusesCollision()
+    {
+        var (sandbox, root) = NewSandbox();
+        try
+        {
+            var lib = new WavLibrary(root);
+            WriteWav(Path.Combine(root, "zeus-rx-a.wav"), 48_000, 100);
+            WriteWav(Path.Combine(root, "zeus-rx-b.wav"), 48_000, 100);
+
+            // Sanitisation: a path separator and a NUL (illegal on every OS) are
+            // stripped; a caller-supplied ".wav" is not doubled.
+            string rel = lib.RenameRecording("zeus-rx-a.wav", "Sub/My Clip\0.wav");
+            Assert.Equal("My Clip.wav", rel);
+            Assert.True(File.Exists(Path.Combine(root, "My Clip.wav")));
+            Assert.False(File.Exists(Path.Combine(root, "zeus-rx-a.wav")));
+
+            // Collision: renaming b onto the existing "My Clip" is refused.
+            Assert.Throws<InvalidOperationException>(
+                () => lib.RenameRecording("zeus-rx-b.wav", "My Clip"));
+            Assert.True(File.Exists(Path.Combine(root, "zeus-rx-b.wav")));
+        }
+        finally { Directory.Delete(sandbox, true); }
+    }
+
+    [Fact]
+    public void Move_RelocatesBetweenFolders()
+    {
+        var (sandbox, root) = NewSandbox();
+        try
+        {
+            var lib = new WavLibrary(root);
+            WriteWav(Path.Combine(root, "zeus-rx-x.wav"), 48_000, 100);
+
+            string rel = lib.MoveRecording("zeus-rx-x.wav", "Contests/2026");
+            Assert.Equal("Contests/2026/zeus-rx-x.wav", rel);
+            Assert.True(File.Exists(Path.Combine(root, "Contests", "2026", "zeus-rx-x.wav")));
+            Assert.False(File.Exists(Path.Combine(root, "zeus-rx-x.wav")));
+        }
+        finally { Directory.Delete(sandbox, true); }
+    }
+
+    [Fact]
+    public void Folder_CreateAndDelete_DeleteRefusesNonWavContents()
+    {
+        var (sandbox, root) = NewSandbox();
+        try
+        {
+            var lib = new WavLibrary(root);
+
+            string folder = lib.CreateFolder("Nets/Weekly");
+            Assert.Equal("Nets/Weekly", folder);
+            Assert.True(Directory.Exists(Path.Combine(root, "Nets", "Weekly")));
+
+            // A folder holding only wavs deletes recursively.
+            WriteWav(Path.Combine(root, "Nets", "Weekly", "zeus-rx-net.wav"), 48_000, 100);
+            string deleted = lib.DeleteFolder("Nets/Weekly");
+            Assert.Equal("Nets/Weekly", deleted);
+            Assert.False(Directory.Exists(Path.Combine(root, "Nets", "Weekly")));
+
+            // A folder with a non-wav file is refused and left intact.
+            string keep = Path.Combine(root, "Mixed");
+            Directory.CreateDirectory(keep);
+            WriteWav(Path.Combine(keep, "zeus-rx-keep.wav"), 48_000, 100);
+            File.WriteAllText(Path.Combine(keep, "notes.txt"), "hello");
+            Assert.Throws<InvalidOperationException>(() => lib.DeleteFolder("Mixed"));
+            Assert.True(Directory.Exists(keep));
+        }
+        finally { Directory.Delete(sandbox, true); }
+    }
+
+    [Theory]
+    [InlineData("../escape.wav")]
+    [InlineData("DX/../../escape.wav")]
+    [InlineData("/etc/passwd")]
+    public void ResolveRel_RejectsTraversalAndAbsolute(string bad)
+    {
+        var (sandbox, root) = NewSandbox();
+        try
+        {
+            var lib = new WavLibrary(root);
+            Assert.Throws<ArgumentException>(() => lib.ResolveRel(bad));
+        }
+        finally { Directory.Delete(sandbox, true); }
+    }
+
+    [Fact]
+    public void ResolveRel_AcceptsNestedRelativePathInsideRoot()
+    {
+        var (sandbox, root) = NewSandbox();
+        try
+        {
+            var lib = new WavLibrary(root);
+            string resolved = lib.ResolveRel("DX/sub/clip.wav");
+            Assert.StartsWith(Path.GetFullPath(root), resolved);
+        }
+        finally { Directory.Delete(sandbox, true); }
+    }
+
+    [Fact]
+    public void Meter_FullScaleBlock_PeaksAtOneAndLatchesClip()
+    {
+        var m = new WavMeter();
+        var fullScale = new float[960];
+        Array.Fill(fullScale, 1.0f);
+        m.Update(fullScale);
+
+        Assert.True(m.Peak >= 0.999, $"peak was {m.Peak}");
+        Assert.True(m.Rms >= 0.999, $"rms was {m.Rms}");
+        Assert.True(m.Clip);
+        Assert.True(m.PeakDb >= -0.1, $"peakDb was {m.PeakDb}");
+    }
+
+    [Fact]
+    public void Meter_HalfScaleBlock_NoClip_RmsHalf()
+    {
+        var m = new WavMeter();
+        var half = new float[480];
+        Array.Fill(half, 0.5f);
+        m.Update(half);
+
+        Assert.InRange(m.Peak, 0.49, 0.51);
+        Assert.InRange(m.Rms, 0.49, 0.51);
+        Assert.False(m.Clip);
+    }
+
+    [Fact]
+    public void Meter_Reset_ReturnsToSilence()
+    {
+        var m = new WavMeter();
+        var fullScale = new float[100];
+        Array.Fill(fullScale, 1.0f);
+        m.Update(fullScale);
+        m.Reset();
+
+        Assert.Equal(0, m.Peak);
+        Assert.Equal(0, m.Rms);
+        Assert.False(m.Clip);
+        Assert.Equal(-100, m.PeakDb);
+    }
+
+    [Fact]
+    public void Envelope_ProducesRequestedBucketsWithPerSlicePeaks()
+    {
+        // 1000 samples: first half silent, second half at 0.5. With 2 buckets the
+        // first must be ~0 and the second ~0.5.
+        var samples = new float[1000];
+        for (int i = 500; i < 1000; i++) samples[i] = 0.5f;
+
+        var env = WavFile.Envelope(samples, 2);
+        Assert.Equal(2, env.Length);
+        Assert.Equal(0f, env[0], 3);
+        Assert.Equal(0.5f, env[1], 3);
+
+        // Every value is a 0..1 magnitude.
+        var many = WavFile.Envelope(samples, 400);
+        Assert.Equal(400, many.Length);
+        Assert.All(many, v => Assert.InRange(v, 0f, 1f));
+
+        // Fewer samples than buckets ⇒ one |sample| per sample.
+        var tiny = WavFile.Envelope(new float[] { -0.25f, 0.75f }, 400);
+        Assert.Equal(2, tiny.Length);
+        Assert.Equal(0.25f, tiny[0], 3);
+        Assert.Equal(0.75f, tiny[1], 3);
+    }
+
+    [Fact]
+    public void Migration_MovesLooseZeusWavFromParentIntoRoot()
+    {
+        var (sandbox, root) = NewSandbox();
+        try
+        {
+            // Loose legacy file sitting directly in the parent ("Downloads").
+            string loose = Path.Combine(sandbox, "zeus-rx-legacy.wav");
+            WriteWav(loose, 48_000, 100);
+            // A non-ours file in the parent must be left alone.
+            string keep = Path.Combine(sandbox, "vacation.wav");
+            WriteWav(keep, 48_000, 100);
+
+            // Ctor runs the migration.
+            _ = new WavLibrary(root);
+
+            Assert.False(File.Exists(loose), "loose zeus file should have moved out of parent");
+            Assert.True(File.Exists(Path.Combine(root, "zeus-rx-legacy.wav")), "should land in root");
+            Assert.True(File.Exists(keep), "non-zeus parent file must be untouched");
+        }
+        finally { Directory.Delete(sandbox, true); }
+    }
+}

--- a/zeus-web/src/layout/panels.ts
+++ b/zeus-web/src/layout/panels.ts
@@ -476,10 +476,12 @@ export const PANELS: Record<string, PanelDef> = {
   },
   wavrecorder: {
     id: 'wavrecorder',
-    name: 'Tape Deck · WAV Recorder',
+    name: 'Digital Recorder',
     category: 'tools',
-    tags: ['recorder', 'wav', 'tape', 'record', 'playback', 'audio', 'reel'],
+    tags: ['recorder', 'wav', 'tape', 'record', 'playback', 'audio', 'reel', 'meter', 'folder'],
     component: WavRecorderPanel,
+    minW: 4,
+    minH: 8,
   },
   analogmeter: {
     id: 'analogmeter',

--- a/zeus-web/src/layout/panels.ts
+++ b/zeus-web/src/layout/panels.ts
@@ -476,9 +476,9 @@ export const PANELS: Record<string, PanelDef> = {
   },
   wavrecorder: {
     id: 'wavrecorder',
-    name: 'Digital Recorder',
+    name: 'Wav Recorder',
     category: 'tools',
-    tags: ['recorder', 'wav', 'tape', 'record', 'playback', 'audio', 'reel', 'meter', 'folder'],
+    tags: ['recorder', 'wav', 'record', 'playback', 'audio', 'meter', 'folder'],
     component: WavRecorderPanel,
     minW: 4,
     minH: 8,

--- a/zeus-web/src/layout/panels/DirectoryPickerModal.tsx
+++ b/zeus-web/src/layout/panels/DirectoryPickerModal.tsx
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Server-side folder browser for the WAV Recorder. The recordings live on
+// the machine running the backend, so a native OS folder dialog can't pick
+// them — this walks the server filesystem via /api/wav/dirs and commits the
+// choice via POST /api/wav/root. Token-only theming, keyboard-accessible.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useDialogFocusTrap } from '../useDialogFocusTrap';
+
+type DirEntry = { name: string; path: string };
+
+type DirsResp = {
+  path: string;
+  parent: string | null;
+  separator: string;
+  dirs: DirEntry[];
+};
+
+type RootResp = { root: string; isDefault: boolean };
+
+interface DirectoryPickerModalProps {
+  /** Where to start browsing (typically the current recordings root). */
+  initialPath: string;
+  /** True when the current root is the built-in default (gates Reset). */
+  rootIsDefault: boolean;
+  onClose: () => void;
+  /** Called after the root is successfully changed (or reset). */
+  onChanged: (root: string, isDefault: boolean) => void;
+}
+
+export function DirectoryPickerModal({
+  initialPath,
+  rootIsDefault,
+  onClose,
+  onChanged,
+}: DirectoryPickerModalProps) {
+  const [path, setPath] = useState(initialPath);
+  const [parent, setParent] = useState<string | null>(null);
+  const [dirs, setDirs] = useState<DirEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const aliveRef = useRef(true);
+
+  useDialogFocusTrap({ dialogRef, onClose });
+
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => {
+      aliveRef.current = false;
+    };
+  }, []);
+
+  // Navigate to a folder. On the initial open, fall back to the user's home
+  // (empty path) if the requested folder can't be listed.
+  const browse = useCallback(async (target: string, allowHomeFallback = false) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/wav/dirs?path=${encodeURIComponent(target)}`);
+      if (!res.ok) throw new Error(`${res.status}`);
+      const d = (await res.json()) as DirsResp;
+      if (!aliveRef.current) return;
+      setPath(d.path ?? target);
+      setParent(d.parent ?? null);
+      setDirs(Array.isArray(d.dirs) ? d.dirs : []);
+      if (listRef.current) listRef.current.scrollTop = 0;
+    } catch {
+      if (!aliveRef.current) return;
+      if (allowHomeFallback && target !== '') {
+        void browse('', false);
+        return;
+      }
+      setError('Could not open that folder.');
+      setDirs([]);
+    } finally {
+      if (aliveRef.current) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void browse(initialPath, true);
+  }, [browse, initialPath]);
+
+  const commit = useCallback(
+    async (target: string | null) => {
+      setBusy(true);
+      setError(null);
+      try {
+        const res = await fetch('/api/wav/root', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ path: target }),
+        });
+        if (!res.ok) {
+          let msg =
+            res.status === 409
+              ? 'Recorder is busy — stop recording or playback first.'
+              : 'That folder can’t be used as the save location.';
+          if (res.status !== 409) {
+            try {
+              const t = (await res.text()).trim();
+              if (t) msg = t.slice(0, 160);
+            } catch {
+              /* keep default */
+            }
+          }
+          throw new Error(msg);
+        }
+        const j = (await res.json()) as RootResp;
+        if (!aliveRef.current) return;
+        onChanged(j.root, j.isDefault);
+        onClose();
+      } catch (e) {
+        if (!aliveRef.current) return;
+        setError(e instanceof Error ? e.message : 'Failed to set folder.');
+      } finally {
+        if (aliveRef.current) setBusy(false);
+      }
+    },
+    [onChanged, onClose],
+  );
+
+  return (
+    <div className="zdr-dirpick-backdrop" onMouseDown={onClose}>
+      <div
+        ref={dialogRef}
+        className="zdr-dirpick"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Choose recordings folder"
+        tabIndex={-1}
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <header className="zdr-dirpick__head">
+          <span className="zdr-dirpick__title">RECORDINGS FOLDER</span>
+          <button
+            type="button"
+            className="zdr-dirpick__close"
+            aria-label="Close folder picker"
+            title="Close (Esc)"
+            onClick={onClose}
+          >
+            ✕
+          </button>
+        </header>
+
+        <div className="zdr-dirpick__pathrow">
+          <button
+            type="button"
+            className="zdr-dirpick__up"
+            onClick={() => parent !== null && void browse(parent)}
+            disabled={parent === null || loading || busy}
+            aria-label="Up one folder"
+            title="Up one folder"
+          >
+            ↑
+          </button>
+          <span className="zdr-dirpick__path" title={path || 'Home'}>
+            {path || 'Home'}
+          </span>
+        </div>
+
+        <div ref={listRef} className="zdr-dirpick__list" aria-busy={loading}>
+          {loading ? (
+            <div className="zdr-dirpick__hint">Loading…</div>
+          ) : dirs.length === 0 ? (
+            <div className="zdr-dirpick__hint">No sub-folders here.</div>
+          ) : (
+            dirs.map((d) => (
+              <button
+                key={d.path}
+                type="button"
+                className="zdr-dirpick__dir"
+                onClick={() => void browse(d.path)}
+                disabled={busy}
+                title={d.path}
+              >
+                <span className="zdr-dirpick__diricon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
+                    <path
+                      d="M3 6.5A1.5 1.5 0 0 1 4.5 5h4l2 2.2H19.5A1.5 1.5 0 0 1 21 8.7v9.8a1.5 1.5 0 0 1-1.5 1.5h-15A1.5 1.5 0 0 1 3 18.5Z"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.4"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </span>
+                <span className="zdr-dirpick__dirname">{d.name}</span>
+                <span className="zdr-dirpick__chev" aria-hidden="true">
+                  ›
+                </span>
+              </button>
+            ))
+          )}
+        </div>
+
+        {error && (
+          <div className="zdr-dirpick__error" role="alert">
+            {error}
+          </div>
+        )}
+
+        <footer className="zdr-dirpick__actions">
+          <button
+            type="button"
+            className="zdr-dirpick__btn zdr-dirpick__btn--reset"
+            onClick={() => void commit(null)}
+            disabled={busy || rootIsDefault}
+            title={rootIsDefault ? 'Already using the default folder' : 'Reset to the default recordings folder'}
+          >
+            Reset to default
+          </button>
+          <span className="zdr-dirpick__spacer" />
+          <button type="button" className="zdr-dirpick__btn" onClick={onClose} disabled={busy}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="zdr-dirpick__btn zdr-dirpick__btn--use"
+            onClick={() => void commit(path)}
+            disabled={busy || loading || !path}
+          >
+            {busy ? 'Saving…' : 'Use this folder'}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/zeus-web/src/layout/panels/WavRecorderPanel.css
+++ b/zeus-web/src/layout/panels/WavRecorderPanel.css
@@ -1,134 +1,738 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later
  *
- * Zeus — reel-to-reel tape-deck skin for the WAV recorder panel.
- * Skeuomorphic deck styling. Material colours (tape/flange/hub) are local to
- * this deck, not global palette tokens; chrome borrows --panel-top/--panel-bot
- * and accents (--accent/--tx/--amber) so it sits in the Zeus look.
+ * Zeus — ZEUS Digital Recorder panel.
+ * Rack-mount digital-recorder skin: dark wells, lit segmented LED meter,
+ * round transport buttons, waveform strip, folder/file browser, info column.
+ * Token-only palette (zeus-web/src/styles/tokens.css). No raw hex except a few
+ * neutral shadow/overlay rgba()s that have no token equivalent.
  */
 
-.reel-deck {
-  --deck-face: linear-gradient(180deg, var(--panel-top, #2a2d31), var(--panel-bot, #161719));
-  --tape: #4a3b2f;          /* spooled tape */
-  --tape-edge: #6b5946;
-  --flange: #d9dde2;        /* bright metal reel flange */
-  --flange-shade: #9aa1a8;
-  --hub: #3a3f45;
-  padding: 10px;
-  width: 100%;
-  color: var(--text);
-  font-size: 13px;
-}
-
-.reel-deck__deck {
-  background: var(--deck-face);
-  border: 1px solid var(--line, #000);
-  border-radius: 8px;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 2px 6px rgba(0, 0, 0, 0.4);
-  padding: 14px 16px 12px;
-}
-
-/* Two reels with the tape spanning between them. */
-.reel-deck__reels {
+.zdr {
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  position: relative;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  width: 100%;
   gap: 8px;
+  padding: 8px;
+  color: var(--fg-1);
+  font-size: 12px;
+  overflow: auto;
 }
 
-.reel-deck__tape-path {
-  position: absolute;
-  left: 18%;
-  right: 18%;
-  top: 12px;
-  height: 3px;
-  background: linear-gradient(90deg, transparent, var(--tape-edge) 12%, var(--tape-edge) 88%, transparent);
-  opacity: 0.7;
+/* Three columns at width: file tree | center console | meter+info rail.
+ * Uses flex-wrap so the rail (then the tree) drops to its own row as the
+ * panel narrows, before the explicit narrow breakpoint forces a full stack. */
+.zdr__body {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: 8px;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
-.reel {
-  width: 84px;
-  height: 84px;
+/* Narrow: full vertical stack, meter/transport/waveform first. */
+.zdr--narrow .zdr__body {
+  flex-wrap: nowrap;
+  flex-direction: column;
+}
+.zdr--narrow .zdr__center {
+  order: 0;
+}
+.zdr--narrow .zdr__library {
+  order: 1;
+  max-height: 240px;
+}
+.zdr--narrow .zdr__rail {
+  order: 2;
+}
+
+/* ============================ Library (file system) ===================== */
+
+.zdr__library {
+  display: flex;
+  flex-direction: column;
+  min-width: 190px;
+  flex: 1 1 220px;
+  min-height: 120px;
+  background: var(--bg-inset);
+  border: 1px solid var(--line);
+  border-radius: var(--r-lg);
+  overflow: hidden;
+}
+
+.zdr__libhead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  padding: 5px 6px;
+  border-bottom: 1px solid var(--line);
+  background: var(--bg-1);
+}
+
+.zdr__crumbs {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  min-width: 0;
+  gap: 1px;
+  font-size: 11px;
+}
+.zdr__crumb-sep {
+  color: var(--fg-3);
+  margin: 0 2px;
+}
+.zdr__crumb {
+  color: var(--fg-2);
+  font-weight: 600;
+  padding: 1px 3px;
+  border-radius: var(--r-xs);
+  background: transparent;
+  letter-spacing: 0.02em;
+}
+.zdr__crumb:hover {
+  color: var(--fg-0);
+  background: var(--bg-3);
+}
+.zdr__crumb.is-current {
+  color: var(--accent-bright);
+  cursor: default;
+}
+
+.zdr__libactions {
+  display: flex;
+  gap: 3px;
   flex: 0 0 auto;
 }
 
-.reel__spin {
-  transform-origin: 50% 50%;
-}
-
-/* Recording spins forward; playback spins forward a touch faster; idle holds.
-   prefers-reduced-motion users get a still deck. */
-.reel__spin.is-rec {
-  animation: reel-turn 2.4s linear infinite;
-}
-.reel__spin.is-play {
-  animation: reel-turn 1.7s linear infinite;
-}
-
-@keyframes reel-turn {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .reel__spin.is-rec,
-  .reel__spin.is-play { animation: none; }
-}
-
-/* Mechanical seconds counter. */
-.reel-deck__counter {
-  font-variant-numeric: tabular-nums;
-  letter-spacing: 2px;
-  background: #0c0d0e;
-  color: var(--amber, #ffa028);
-  border: 1px solid #000;
-  border-radius: 3px;
-  padding: 2px 8px;
-  font-size: 14px;
-  box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.8);
-}
-.reel-deck__counter.is-rec { color: var(--tx, #e63a2b); }
-
-.reel-deck__transport {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-  margin-top: 12px;
-}
-
-.reel-btn {
-  background: var(--bg-2, #2c2f33);
-  color: var(--text);
-  border: 1px solid var(--line, #000);
-  border-radius: 4px;
-  padding: 5px 11px;
-  font-family: inherit;
-  font-size: 13px;
-  font-weight: 600;
-  cursor: pointer;
-}
-.reel-btn:disabled { opacity: 0.45; cursor: default; }
-.reel-btn.is-rec-active { background: var(--tx, #e63a2b); color: #fff; }
-.reel-btn.is-on { background: var(--accent, #4a9eff); color: #fff; }
-
-.reel-deck__list {
+.zdr__filelist {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 4px;
   display: flex;
   flex-direction: column;
-  gap: 3px;
-  margin-top: 10px;
+  gap: 2px;
 }
-.reel-deck__row {
+
+.zdr__folderrow,
+.zdr__filerow {
   display: flex;
-  gap: 6px;
   align-items: center;
-  padding: 3px 4px;
-  border-radius: 4px;
+  gap: 4px;
+  padding: 2px 4px;
+  border-radius: var(--r-sm);
+  border: 1px solid transparent;
 }
-.reel-deck__row.is-playing { background: var(--bg-2, #2c2f33); }
-.reel-deck__name {
-  flex: 1;
+.zdr__filerow.is-selected {
+  background: var(--accent-soft);
+  border-color: var(--accent-line);
+}
+.zdr__filerow.is-playing {
+  background: var(--ok-soft);
+  border-color: var(--green-soft);
+}
+
+.zdr__folderbtn,
+.zdr__filebtn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1 1 auto;
+  min-width: 0;
+  text-align: left;
+  color: var(--fg-1);
+  background: transparent;
+  font-size: 12px;
+}
+.zdr__folderbtn:hover,
+.zdr__filebtn:hover {
+  color: var(--fg-0);
+}
+
+.zdr__glyph {
+  flex: 0 0 auto;
+  font-size: 12px;
+  line-height: 1;
+}
+.zdr__folder-name,
+.zdr__file-name {
+  flex: 1 1 auto;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.reel-deck__hint { margin-top: 8px; font-size: 11px; opacity: 0.5; }
+.zdr__folder-name {
+  font-weight: 600;
+}
+
+.zdr__file-meta {
+  flex: 0 0 auto;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--fg-2);
+  font-variant-numeric: tabular-nums;
+}
+
+.zdr__src {
+  flex: 0 0 auto;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 1px 3px;
+  border-radius: var(--r-xs);
+  border: 1px solid var(--line-strong);
+  color: var(--fg-3);
+}
+.zdr__src--rx {
+  color: var(--accent-bright);
+  border-color: var(--accent-line);
+}
+.zdr__src--tx {
+  color: var(--tx);
+  border-color: var(--tx);
+}
+
+.zdr__rowmenu,
+.zdr__confirm {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex: 0 0 auto;
+}
+
+.zdr__iconbtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 20px;
+  padding: 0 4px;
+  border-radius: var(--r-sm);
+  border: 1px solid var(--line);
+  background: var(--bg-2);
+  color: var(--fg-2);
+  font-size: 11px;
+  line-height: 1;
+}
+.zdr__iconbtn:hover {
+  background: var(--bg-3);
+  color: var(--fg-0);
+}
+.zdr__iconbtn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.zdr__iconbtn.is-danger {
+  border-color: var(--tx);
+  color: var(--tx);
+}
+.zdr__rowdel:hover {
+  border-color: var(--tx);
+  color: var(--tx);
+}
+
+.zdr__renameinput,
+.zdr__moveselect {
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 22px;
+  padding: 0 6px;
+  font-family: inherit;
+  font-size: 12px;
+  color: var(--fg-0);
+  background: var(--bg-0);
+  border: 1px solid var(--accent-line);
+  border-radius: var(--r-sm);
+  outline: none;
+}
+.zdr__moveselect {
+  background: var(--bg-2);
+  border-color: var(--line-strong);
+}
+
+.zdr__empty {
+  padding: 10px 8px;
+  color: var(--fg-3);
+  font-size: 11px;
+  text-align: center;
+}
+
+/* ============================ Center console ============================ */
+
+.zdr__center {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 2 1 340px;
+  min-width: 280px;
+}
+
+/* ---- Level meter ---- */
+
+.zdr__meter {
+  background: var(--bg-inset);
+  border: 1px solid var(--line);
+  border-radius: var(--r-lg);
+  padding: 7px 9px 8px;
+}
+.zdr__meterhead {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+.zdr__meterlabel {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: var(--fg-2);
+  margin-right: auto;
+}
+.zdr__clip {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  padding: 1px 6px;
+  border-radius: var(--r-xs);
+  border: 1px solid var(--line-strong);
+  color: var(--fg-4);
+  background: var(--bg-meter);
+}
+.zdr__clip.is-clip {
+  color: #fff;
+  background: var(--tx);
+  border-color: var(--tx);
+  box-shadow: 0 0 10px var(--tx-soft);
+}
+
+.zdr__metercanvas {
+  display: block;
+  width: 100%;
+  height: 40px;
+  border-radius: var(--r-sm);
+}
+
+.zdr__lcd {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  background: var(--bg-meter);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-sm);
+  box-shadow: inset 0 0 8px rgba(0, 0, 0, 0.8);
+}
+.zdr__lcd small {
+  font-size: 0.62em;
+  font-weight: 600;
+  opacity: 0.7;
+  margin-left: 3px;
+}
+.zdr__lcd--peak,
+.zdr__lcd--hold {
+  font-size: 14px;
+  padding: 2px 7px;
+  color: var(--amber);
+}
+.zdr__lcd--hold {
+  color: var(--fg-2);
+}
+.zdr__lcd--big {
+  font-size: 22px;
+  padding: 3px 10px;
+  color: var(--amber);
+}
+
+/* ---- Transport ---- */
+
+.zdr__transport {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 8px 10px;
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: var(--r-lg);
+}
+
+.zdr__xport {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  width: 58px;
+  flex: 0 0 auto;
+}
+.zdr__xport-glyph {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 38% 32%, var(--bg-3), var(--bg-0) 78%);
+  border: 1px solid var(--line-strong);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 2px 5px rgba(0, 0, 0, 0.5);
+  color: var(--fg-2);
+  transition: transform var(--dur-fast) var(--ease-out);
+}
+.zdr__xport:hover:not(:disabled) .zdr__xport-glyph {
+  transform: translateY(-1px);
+}
+.zdr__xport:active:not(:disabled) .zdr__xport-glyph {
+  transform: translateY(1px);
+}
+.zdr__xport:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.zdr__xport-text {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--fg-2);
+  font-family: var(--font-mono);
+}
+.zdr__xport:focus-visible {
+  outline: none;
+}
+.zdr__xport:focus-visible .zdr__xport-glyph {
+  outline: 2px solid var(--accent-bright);
+  outline-offset: 2px;
+}
+
+/* RECORD — red dot */
+.zdr__glyph-rec {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+}
+.zdr__xport--rec .zdr__glyph-rec {
+  background: var(--tx);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.4) inset;
+}
+.zdr__xport--rec.is-on .zdr__xport-glyph {
+  border-color: var(--tx);
+  box-shadow:
+    0 0 14px var(--tx-soft),
+    inset 0 0 8px var(--tx-soft);
+}
+.zdr__xport--rec.is-on .zdr__xport-text {
+  color: var(--tx);
+}
+
+/* PLAY — blue triangle */
+.zdr__glyph-play {
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 9px 0 9px 15px;
+  border-color: transparent transparent transparent var(--accent-bright);
+  margin-left: 3px;
+}
+.zdr__xport--play.is-on .zdr__xport-glyph {
+  border-color: var(--accent-bright);
+  box-shadow:
+    0 0 14px var(--accent-soft),
+    inset 0 0 8px var(--accent-soft);
+}
+.zdr__xport--play.is-on .zdr__xport-text {
+  color: var(--accent-bright);
+}
+
+/* TRANSMIT — green antenna */
+.zdr__xport--air .zdr__xport-glyph {
+  color: var(--green-soft);
+}
+.zdr__xport--air.is-on .zdr__xport-glyph {
+  color: #fff;
+  background: radial-gradient(circle at 38% 32%, var(--green-soft), var(--bg-0) 92%);
+  border-color: var(--green-soft);
+  box-shadow:
+    0 0 16px var(--ok-soft),
+    inset 0 0 10px var(--ok-soft);
+}
+.zdr__xport--air.is-on .zdr__xport-text {
+  color: var(--ok);
+}
+
+/* STOP — square */
+.zdr__glyph-stop {
+  width: 15px;
+  height: 15px;
+  border-radius: 2px;
+  background: var(--fg-1);
+}
+
+.zdr__xport-side {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 5px;
+  margin-left: auto;
+  min-width: 96px;
+}
+.zdr__lcd--clock {
+  font-size: 17px;
+  text-align: center;
+  padding: 3px 10px;
+  color: var(--amber);
+  letter-spacing: 0.04em;
+}
+
+.zdr__srctoggle {
+  display: flex;
+  gap: 2px;
+  justify-content: center;
+}
+.zdr__srcbtn {
+  flex: 1 1 0;
+  padding: 3px 0;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--fg-2);
+  background: var(--bg-2);
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+}
+.zdr__srcbtn.is-on {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+.zdr__srcbtn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/* ---- Waveform ---- */
+
+.zdr__wavewrap {
+  position: relative;
+  flex: 1 1 70px;
+  min-height: 64px;
+  background: var(--bg-meter);
+  border: 1px solid var(--line);
+  border-radius: var(--r-lg);
+  overflow: hidden;
+}
+.zdr__wavecanvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+.zdr__waveempty {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--fg-3);
+  font-size: 11px;
+  pointer-events: none;
+}
+
+/* ---- File info ---- */
+
+.zdr__info {
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: var(--r-lg);
+  padding: 7px 9px;
+  flex: 0 0 auto;
+}
+.zdr__info-title {
+  font-weight: 700;
+  font-size: 12px;
+  color: var(--fg-0);
+  margin-bottom: 6px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.zdr__info-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px 12px;
+  margin: 0;
+}
+.zdr__info-grid div {
+  min-width: 0;
+}
+.zdr__info-wide {
+  grid-column: 1 / -1;
+}
+.zdr__info-grid dt {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+}
+.zdr__info-grid dd {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-1);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ============================ Right rail ================================ */
+
+.zdr__rail {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1 1 200px;
+  min-width: 180px;
+}
+
+.zdr__railhead {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  color: var(--fg-3);
+  margin-bottom: 6px;
+}
+
+.zdr__vmeters {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 150px;
+  background: var(--bg-inset);
+  border: 1px solid var(--line);
+  border-radius: var(--r-lg);
+  padding: 7px 9px 8px;
+}
+.zdr__vmeterbody {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 90px;
+  gap: 3px;
+}
+.zdr__vmetercanvas {
+  display: block;
+  width: 100%;
+  flex: 1 1 auto;
+  min-height: 80px;
+}
+.zdr__vmeterscale {
+  display: flex;
+  justify-content: space-around;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: var(--fg-3);
+}
+
+.zdr__railreadouts {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  margin-top: 7px;
+}
+
+.zdr__railchips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 7px;
+}
+.zdr__chip {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 2px 6px;
+  border-radius: var(--r-xs);
+  border: 1px solid var(--line-strong);
+  color: var(--fg-2);
+  background: var(--bg-2);
+}
+
+/* ============================ Status bar ================================ */
+
+.zdr__statusbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 0 0 auto;
+  padding: 4px 8px;
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  font-size: 11px;
+}
+.zdr__statepill {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  padding: 2px 8px;
+  border-radius: var(--r-xs);
+  border: 1px solid var(--line-strong);
+  color: var(--fg-2);
+}
+.zdr__statepill--recording {
+  color: var(--tx);
+  border-color: var(--tx);
+}
+.zdr__statepill--playing {
+  color: var(--accent-bright);
+  border-color: var(--accent-line);
+}
+
+.zdr__onair {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--fg-3);
+}
+.zdr__onair-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--fg-4);
+}
+.zdr__onair.is-on {
+  color: var(--ok);
+}
+.zdr__onair.is-on .zdr__onair-dot {
+  background: var(--green-soft);
+  box-shadow: 0 0 8px var(--ok-soft);
+}
+
+.zdr__errmsg {
+  margin-left: auto;
+  color: var(--tx);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ============================ Reduced motion ============================ */
+
+@media (prefers-reduced-motion: reduce) {
+  .zdr__xport-glyph {
+    transition: none;
+  }
+}

--- a/zeus-web/src/layout/panels/WavRecorderPanel.css
+++ b/zeus-web/src/layout/panels/WavRecorderPanel.css
@@ -57,10 +57,14 @@
   min-width: 190px;
   flex: 1 1 220px;
   min-height: 120px;
-  background: var(--bg-inset);
+  background: linear-gradient(180deg, var(--bg-1) 0%, var(--bg-inset) 14%);
   border: 1px solid var(--line);
   border-radius: var(--r-lg);
   overflow: hidden;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.04),
+    inset 0 0 0 1px rgba(0, 0, 0, 0.3),
+    0 2px 8px rgba(0, 0, 0, 0.4);
 }
 
 .zdr__libhead {
@@ -70,7 +74,10 @@
   gap: 6px;
   padding: 5px 6px;
   border-bottom: 1px solid var(--line);
-  background: var(--bg-1);
+  background: linear-gradient(180deg, var(--bg-2) 0%, var(--bg-1) 100%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 1px 0 rgba(0, 0, 0, 0.4);
 }
 
 .zdr__crumbs {
@@ -104,8 +111,56 @@
 
 .zdr__libactions {
   display: flex;
+  align-items: center;
   gap: 3px;
+  flex: 0 1 auto;
+  min-width: 0;
+}
+
+/* Save-location button — folder glyph + abbreviated path. */
+.zdr__dirbtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  max-width: 132px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: var(--r-sm);
+  border: 1px solid var(--line-strong);
+  background: linear-gradient(180deg, var(--bg-3) 0%, var(--bg-2) 100%);
+  color: var(--fg-2);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 1px 2px rgba(0, 0, 0, 0.4);
+}
+.zdr__dirbtn:hover {
+  color: var(--fg-0);
+  border-color: var(--accent-line);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    0 0 8px var(--accent-soft);
+}
+.zdr__dirbtn:focus-visible {
+  outline: 2px solid var(--accent-bright);
+  outline-offset: 1px;
+}
+.zdr__dirbtn-glyph {
   flex: 0 0 auto;
+  display: inline-flex;
+  color: var(--amber);
+  filter: drop-shadow(0 0 3px var(--amber-soft));
+}
+.zdr__dirbtn-path {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .zdr__filelist {
@@ -276,10 +331,13 @@
 /* ---- Level meter ---- */
 
 .zdr__meter {
-  background: var(--bg-inset);
+  background: linear-gradient(180deg, var(--bg-1) 0%, var(--bg-inset) 100%);
   border: 1px solid var(--line);
   border-radius: var(--r-lg);
   padding: 7px 9px 8px;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 2px 8px rgba(0, 0, 0, 0.4);
 }
 .zdr__meterhead {
   display: flex;
@@ -317,16 +375,23 @@
   width: 100%;
   height: 40px;
   border-radius: var(--r-sm);
+  background: var(--bg-meter);
+  box-shadow:
+    inset 0 0 0 1px rgba(0, 0, 0, 0.6),
+    inset 0 2px 6px rgba(0, 0, 0, 0.7);
 }
 
 .zdr__lcd {
   font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
   font-weight: 700;
-  background: var(--bg-meter);
+  background: linear-gradient(180deg, #000 0%, var(--bg-meter) 60%);
   border: 1px solid var(--line-strong);
   border-radius: var(--r-sm);
-  box-shadow: inset 0 0 8px rgba(0, 0, 0, 0.8);
+  box-shadow:
+    inset 0 1px 4px rgba(0, 0, 0, 0.9),
+    inset 0 0 0 1px rgba(0, 0, 0, 0.5),
+    0 1px 0 rgba(255, 255, 255, 0.04);
 }
 .zdr__lcd small {
   font-size: 0.62em;
@@ -339,14 +404,19 @@
   font-size: 14px;
   padding: 2px 7px;
   color: var(--amber);
+  text-shadow: 0 0 6px var(--amber-soft);
 }
 .zdr__lcd--hold {
   color: var(--fg-2);
+  text-shadow: none;
 }
 .zdr__lcd--big {
   font-size: 22px;
   padding: 3px 10px;
   color: var(--amber);
+  text-shadow:
+    0 0 8px var(--amber-soft),
+    0 0 2px var(--amber-soft);
 }
 
 /* ---- Transport ---- */
@@ -357,9 +427,12 @@
   gap: 10px;
   flex-wrap: wrap;
   padding: 8px 10px;
-  background: var(--bg-1);
+  background: linear-gradient(180deg, var(--bg-2) 0%, var(--bg-1) 100%);
   border: 1px solid var(--line);
   border-radius: var(--r-lg);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 2px 8px rgba(0, 0, 0, 0.4);
 }
 
 .zdr__xport {
@@ -377,19 +450,32 @@
   width: 46px;
   height: 46px;
   border-radius: 50%;
-  background: radial-gradient(circle at 38% 32%, var(--bg-3), var(--bg-0) 78%);
+  background:
+    radial-gradient(circle at 38% 30%, rgba(255, 255, 255, 0.08), transparent 46%),
+    radial-gradient(circle at 50% 120%, var(--bg-3), var(--bg-0) 72%);
   border: 1px solid var(--line-strong);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.05),
-    0 2px 5px rgba(0, 0, 0, 0.5);
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    inset 0 -2px 5px rgba(0, 0, 0, 0.6),
+    0 3px 7px rgba(0, 0, 0, 0.55);
   color: var(--fg-2);
-  transition: transform var(--dur-fast) var(--ease-out);
+  transition:
+    transform var(--dur-fast) var(--ease-out),
+    box-shadow var(--dur-fast) var(--ease-out),
+    border-color var(--dur-fast) var(--ease-out);
 }
 .zdr__xport:hover:not(:disabled) .zdr__xport-glyph {
   transform: translateY(-1px);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.1),
+    inset 0 -2px 5px rgba(0, 0, 0, 0.6),
+    0 5px 10px rgba(0, 0, 0, 0.55);
 }
 .zdr__xport:active:not(:disabled) .zdr__xport-glyph {
   transform: translateY(1px);
+  box-shadow:
+    inset 0 2px 5px rgba(0, 0, 0, 0.7),
+    0 1px 3px rgba(0, 0, 0, 0.5);
 }
 .zdr__xport:disabled {
   opacity: 0.4;
@@ -415,19 +501,30 @@
   width: 18px;
   height: 18px;
   border-radius: 50%;
-}
-.zdr__xport--rec .zdr__glyph-rec {
-  background: var(--tx);
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.4) inset;
+  background: radial-gradient(circle at 38% 32%, #ff8a93, var(--tx) 70%);
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.4) inset,
+    0 0 6px var(--tx-soft);
 }
 .zdr__xport--rec.is-on .zdr__xport-glyph {
   border-color: var(--tx);
+  background:
+    radial-gradient(circle at 38% 30%, rgba(255, 255, 255, 0.1), transparent 46%),
+    radial-gradient(circle at 50% 120%, var(--bg-2), var(--bg-0) 72%);
   box-shadow:
-    0 0 14px var(--tx-soft),
-    inset 0 0 8px var(--tx-soft);
+    0 0 16px var(--tx-soft),
+    0 0 4px var(--tx-soft),
+    inset 0 0 10px var(--tx-soft);
+}
+.zdr__xport--rec.is-on .zdr__glyph-rec {
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.4) inset,
+    0 0 12px var(--tx),
+    0 0 5px var(--tx);
 }
 .zdr__xport--rec.is-on .zdr__xport-text {
   color: var(--tx);
+  text-shadow: 0 0 6px var(--tx-soft);
 }
 
 /* PLAY — blue triangle */
@@ -438,31 +535,67 @@
   border-width: 9px 0 9px 15px;
   border-color: transparent transparent transparent var(--accent-bright);
   margin-left: 3px;
+  filter: drop-shadow(0 0 3px var(--accent-soft));
 }
 .zdr__xport--play.is-on .zdr__xport-glyph {
-  border-color: var(--accent-bright);
+  border-color: var(--accent-line);
+  background:
+    radial-gradient(circle at 38% 30%, rgba(255, 255, 255, 0.1), transparent 46%),
+    radial-gradient(circle at 50% 120%, var(--bg-2), var(--bg-0) 72%);
   box-shadow:
-    0 0 14px var(--accent-soft),
-    inset 0 0 8px var(--accent-soft);
+    0 0 16px var(--accent-soft),
+    0 0 4px var(--accent-soft),
+    inset 0 0 10px var(--accent-soft);
+}
+.zdr__xport--play.is-on .zdr__glyph-play {
+  filter: drop-shadow(0 0 6px var(--accent-bright));
 }
 .zdr__xport--play.is-on .zdr__xport-text {
   color: var(--accent-bright);
+  text-shadow: 0 0 6px var(--accent-soft);
 }
 
 /* TRANSMIT — green antenna */
 .zdr__xport--air .zdr__xport-glyph {
   color: var(--green-soft);
 }
+.zdr__xport--air .zdr__glyph-air {
+  filter: drop-shadow(0 0 3px var(--ok-soft));
+}
 .zdr__xport--air.is-on .zdr__xport-glyph {
   color: #fff;
-  background: radial-gradient(circle at 38% 32%, var(--green-soft), var(--bg-0) 92%);
+  background:
+    radial-gradient(circle at 38% 30%, rgba(255, 255, 255, 0.18), transparent 50%),
+    radial-gradient(circle at 50% 120%, var(--green-soft), var(--bg-0) 86%);
   border-color: var(--green-soft);
   box-shadow:
-    0 0 16px var(--ok-soft),
-    inset 0 0 10px var(--ok-soft);
+    0 0 18px var(--ok-soft),
+    0 0 6px var(--ok-soft),
+    inset 0 0 12px var(--ok-soft);
+  animation: zdr-air-pulse 1.5s var(--ease-out) infinite;
+}
+.zdr__xport--air.is-on .zdr__glyph-air {
+  filter: drop-shadow(0 0 5px rgba(255, 255, 255, 0.6));
 }
 .zdr__xport--air.is-on .zdr__xport-text {
   color: var(--ok);
+  text-shadow: 0 0 6px var(--ok-soft);
+}
+
+@keyframes zdr-air-pulse {
+  0%,
+  100% {
+    box-shadow:
+      0 0 14px var(--ok-soft),
+      0 0 5px var(--ok-soft),
+      inset 0 0 10px var(--ok-soft);
+  }
+  50% {
+    box-shadow:
+      0 0 26px var(--ok),
+      0 0 10px var(--ok-soft),
+      inset 0 0 14px var(--ok-soft);
+  }
 }
 
 /* STOP — square */
@@ -470,7 +603,13 @@
   width: 15px;
   height: 15px;
   border-radius: 2px;
-  background: var(--fg-1);
+  background: linear-gradient(180deg, var(--fg-0), var(--fg-1));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.3),
+    0 0 4px rgba(0, 0, 0, 0.5);
+}
+.zdr__xport--stop:hover:not(:disabled) .zdr__glyph-stop {
+  background: linear-gradient(180deg, #fff, var(--fg-0));
 }
 
 .zdr__xport-side {
@@ -487,6 +626,9 @@
   padding: 3px 10px;
   color: var(--amber);
   letter-spacing: 0.04em;
+  text-shadow:
+    0 0 7px var(--amber-soft),
+    0 0 2px var(--amber-soft);
 }
 
 .zdr__srctoggle {
@@ -506,9 +648,12 @@
   border-radius: var(--r-sm);
 }
 .zdr__srcbtn.is-on {
-  background: var(--accent);
-  border-color: var(--accent);
+  background: linear-gradient(180deg, var(--accent-bright), var(--accent));
+  border-color: var(--accent-line);
   color: #fff;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.25),
+    0 0 8px var(--accent-soft);
 }
 .zdr__srcbtn:disabled {
   opacity: 0.5;
@@ -525,6 +670,10 @@
   border: 1px solid var(--line);
   border-radius: var(--r-lg);
   overflow: hidden;
+  box-shadow:
+    inset 0 0 0 1px rgba(0, 0, 0, 0.6),
+    inset 0 2px 8px rgba(0, 0, 0, 0.7),
+    0 1px 0 rgba(255, 255, 255, 0.04);
 }
 .zdr__wavecanvas {
   display: block;
@@ -545,11 +694,14 @@
 /* ---- File info ---- */
 
 .zdr__info {
-  background: var(--bg-1);
+  background: linear-gradient(180deg, var(--bg-2) 0%, var(--bg-1) 100%);
   border: 1px solid var(--line);
   border-radius: var(--r-lg);
   padding: 7px 9px;
   flex: 0 0 auto;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 2px 8px rgba(0, 0, 0, 0.4);
 }
 .zdr__info-title {
   font-weight: 700;
@@ -612,10 +764,13 @@
   flex-direction: column;
   flex: 1 1 auto;
   min-height: 150px;
-  background: var(--bg-inset);
+  background: linear-gradient(180deg, var(--bg-1) 0%, var(--bg-inset) 100%);
   border: 1px solid var(--line);
   border-radius: var(--r-lg);
   padding: 7px 9px 8px;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 2px 8px rgba(0, 0, 0, 0.4);
 }
 .zdr__vmeterbody {
   display: flex;
@@ -629,6 +784,11 @@
   width: 100%;
   flex: 1 1 auto;
   min-height: 80px;
+  background: var(--bg-meter);
+  border-radius: var(--r-sm);
+  box-shadow:
+    inset 0 0 0 1px rgba(0, 0, 0, 0.6),
+    inset 0 2px 6px rgba(0, 0, 0, 0.7);
 }
 .zdr__vmeterscale {
   display: flex;
@@ -728,11 +888,255 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.zdr__notemsg {
+  margin-left: auto;
+  color: var(--ok);
+  font-size: 11px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-shadow: 0 0 6px var(--ok-soft);
+}
+
+/* ============================ Directory picker ========================= */
+
+.zdr-dirpick-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(1.5px);
+}
+
+.zdr-dirpick {
+  display: flex;
+  flex-direction: column;
+  width: min(420px, 100%);
+  max-height: min(520px, 100%);
+  color: var(--fg-1);
+  background: linear-gradient(180deg, var(--bg-2) 0%, var(--bg-1) 100%);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-lg);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    0 12px 40px rgba(0, 0, 0, 0.6);
+  outline: none;
+}
+
+.zdr-dirpick__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--line);
+  background: linear-gradient(180deg, var(--bg-3) 0%, var(--bg-2) 100%);
+  border-radius: var(--r-lg) var(--r-lg) 0 0;
+}
+.zdr-dirpick__title {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  color: var(--fg-2);
+}
+.zdr-dirpick__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--r-sm);
+  border: 1px solid var(--line);
+  background: var(--bg-2);
+  color: var(--fg-2);
+  font-size: 12px;
+  line-height: 1;
+}
+.zdr-dirpick__close:hover {
+  color: var(--fg-0);
+  background: var(--bg-3);
+}
+
+.zdr-dirpick__pathrow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px;
+}
+.zdr-dirpick__up {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 24px;
+  border-radius: var(--r-sm);
+  border: 1px solid var(--line-strong);
+  background: linear-gradient(180deg, var(--bg-3), var(--bg-2));
+  color: var(--fg-1);
+  font-size: 13px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+.zdr-dirpick__up:hover:not(:disabled) {
+  color: var(--fg-0);
+  border-color: var(--accent-line);
+}
+.zdr-dirpick__up:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.zdr-dirpick__path {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 4px 8px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--amber);
+  background: linear-gradient(180deg, #000 0%, var(--bg-meter) 60%);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-sm);
+  box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.9);
+  text-shadow: 0 0 6px var(--amber-soft);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.zdr-dirpick__list {
+  flex: 1 1 auto;
+  min-height: 120px;
+  overflow-y: auto;
+  margin: 0 10px;
+  padding: 4px;
+  background: var(--bg-inset);
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+  box-shadow: inset 0 2px 8px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.zdr-dirpick__hint {
+  padding: 14px 8px;
+  text-align: center;
+  color: var(--fg-3);
+  font-size: 11px;
+}
+.zdr-dirpick__dir {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  width: 100%;
+  padding: 5px 7px;
+  border-radius: var(--r-sm);
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--fg-1);
+  text-align: left;
+  font-size: 12px;
+}
+.zdr-dirpick__dir:hover:not(:disabled) {
+  background: var(--bg-3);
+  border-color: var(--line-strong);
+  color: var(--fg-0);
+}
+.zdr-dirpick__dir:focus-visible {
+  outline: 2px solid var(--accent-bright);
+  outline-offset: -2px;
+}
+.zdr-dirpick__dir:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.zdr-dirpick__diricon {
+  flex: 0 0 auto;
+  display: inline-flex;
+  color: var(--amber);
+}
+.zdr-dirpick__dirname {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.zdr-dirpick__chev {
+  flex: 0 0 auto;
+  color: var(--fg-3);
+  font-size: 14px;
+}
+
+.zdr-dirpick__error {
+  margin: 8px 10px 0;
+  padding: 6px 8px;
+  border-radius: var(--r-sm);
+  border: 1px solid var(--tx);
+  background: var(--tx-soft);
+  color: var(--tx);
+  font-size: 11px;
+}
+
+.zdr-dirpick__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px;
+}
+.zdr-dirpick__spacer {
+  flex: 1 1 auto;
+}
+.zdr-dirpick__btn {
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  border-radius: var(--r-sm);
+  border: 1px solid var(--line-strong);
+  background: linear-gradient(180deg, var(--bg-3), var(--bg-2));
+  color: var(--fg-1);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+.zdr-dirpick__btn:hover:not(:disabled) {
+  color: var(--fg-0);
+  border-color: var(--accent-line);
+}
+.zdr-dirpick__btn:focus-visible {
+  outline: 2px solid var(--accent-bright);
+  outline-offset: 1px;
+}
+.zdr-dirpick__btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+.zdr-dirpick__btn--reset {
+  color: var(--fg-2);
+}
+.zdr-dirpick__btn--use {
+  background: linear-gradient(180deg, var(--accent-bright), var(--accent));
+  border-color: var(--accent-line);
+  color: #fff;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.25),
+    0 0 10px var(--accent-soft);
+}
+.zdr-dirpick__btn--use:hover:not(:disabled) {
+  color: #fff;
+}
 
 /* ============================ Reduced motion ============================ */
 
 @media (prefers-reduced-motion: reduce) {
   .zdr__xport-glyph {
     transition: none;
+  }
+  .zdr__xport--air.is-on .zdr__xport-glyph {
+    animation: none;
+  }
+  .zdr-dirpick-backdrop {
+    backdrop-filter: none;
   }
 }

--- a/zeus-web/src/layout/panels/WavRecorderPanel.tsx
+++ b/zeus-web/src/layout/panels/WavRecorderPanel.tsx
@@ -11,13 +11,14 @@
 // option) any later version. See the LICENSE file at the root of this
 // repository for the full text, or https://www.gnu.org/licenses/.
 //
-// ZEUS Digital Recorder — rack-mount WAV recorder panel. Segmented LED level
+// ZEUS WAV Recorder — rack-mount WAV recorder panel. Segmented LED level
 // meter, round transport buttons, a waveform strip, a folder/file browser with
 // rename/move/delete, and a metadata column. Theming is token-only
 // (zeus-web/src/styles/tokens.css). Backed by the /api/wav/* endpoints.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import './WavRecorderPanel.css';
+import { DirectoryPickerModal } from './DirectoryPickerModal';
 import {
   fmtBytes,
   fmtClock,
@@ -30,6 +31,7 @@ import {
   breadcrumb,
   segmentZone,
   litSegments,
+  abbreviatePath,
 } from './wavRecorder.format';
 
 // ---------------------------------------------------------------------------
@@ -73,6 +75,8 @@ type ListResp = {
 
 type WaveformResp = { file: string; buckets: number[] };
 
+type RootResp = { root: string; isDefault: boolean };
+
 const IDLE_STATUS: Status = {
   state: 'idle',
   source: 'rx',
@@ -92,6 +96,11 @@ const WAVE_BUCKETS = 400;
 const STATUS_POLL_ACTIVE_MS = 90;
 const STATUS_POLL_IDLE_MS = 500;
 const LIST_POLL_MS = 1000;
+// Waveform cache bound — keep the most-recently-used N entries so a long
+// session can't grow the map without limit.
+const WAVE_CACHE_MAX = 50;
+// Below this displayed/target level the meter is treated as fully settled.
+const METER_EPS = 0.001;
 
 // ---------------------------------------------------------------------------
 // Fetch helpers
@@ -175,6 +184,33 @@ function zoneColor(c: MeterColors, index: number): string {
   }
 }
 
+/**
+ * Convert a `#rgb` / `#rrggbb` token colour to an `rgba()` string at `alpha`.
+ * Inputs that are already `rgb()`/`rgba()` are returned unchanged. Lets the
+ * canvas build glows + gradient fades from palette tokens without new hex.
+ */
+function withAlpha(color: string, alpha: number): string {
+  const c = color.trim();
+  if (c.charCodeAt(0) === 35 /* '#' */) {
+    let r = 0;
+    let g = 0;
+    let b = 0;
+    if (c.length === 4) {
+      r = parseInt(c[1]! + c[1]!, 16);
+      g = parseInt(c[2]! + c[2]!, 16);
+      b = parseInt(c[3]! + c[3]!, 16);
+    } else if (c.length >= 7) {
+      r = parseInt(c.slice(1, 3), 16);
+      g = parseInt(c.slice(3, 5), 16);
+      b = parseInt(c.slice(5, 7), 16);
+    }
+    if (Number.isFinite(r) && Number.isFinite(g) && Number.isFinite(b)) {
+      return `rgba(${r},${g},${b},${alpha})`;
+    }
+  }
+  return c;
+}
+
 /** Resize a canvas's backing store to its CSS box (DPR-aware). */
 function fitCanvas(canvas: HTMLCanvasElement): { ctx: CanvasRenderingContext2D; w: number; h: number } | null {
   const ctx = canvas.getContext('2d');
@@ -192,6 +228,37 @@ function fitCanvas(canvas: HTMLCanvasElement): { ctx: CanvasRenderingContext2D; 
   return { ctx, w, h };
 }
 
+// --- Waveform cache (relPath:mtime keyed, bounded LRU) ----------------------
+
+/** Insert/refresh a cache entry, evicting the oldest beyond WAVE_CACHE_MAX. */
+function waveCachePut(map: Map<string, number[]>, key: string, buckets: number[]): void {
+  map.delete(key); // re-insert moves it to the most-recent (Map iteration order)
+  map.set(key, buckets);
+  while (map.size > WAVE_CACHE_MAX) {
+    const oldest = map.keys().next().value;
+    if (oldest === undefined) break;
+    map.delete(oldest);
+  }
+}
+
+/** Read a cache entry and mark it most-recently-used. */
+function waveCacheGet(map: Map<string, number[]>, key: string): number[] | undefined {
+  const hit = map.get(key);
+  if (hit) {
+    map.delete(key);
+    map.set(key, hit);
+  }
+  return hit;
+}
+
+/** Drop every cache entry for a relPath, across all of its mtime variants. */
+function waveCacheDropPath(map: Map<string, number[]>, relPath: string): void {
+  const prefix = `${relPath}:`;
+  for (const k of [...map.keys()]) {
+    if (k === relPath || k.startsWith(prefix)) map.delete(k);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -204,11 +271,22 @@ export function WavRecorderPanel() {
   const [currentFolder, setCurrentFolder] = useState<string>('');
   const [selected, setSelected] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
   const [narrow, setNarrow] = useState(false);
+
+  // Save-location (recordings root) + folder picker.
+  const [root, setRoot] = useState<string>('');
+  const [rootIsDefault, setRootIsDefault] = useState(true);
+  const [pickerOpen, setPickerOpen] = useState(false);
 
   // CRUD interaction state
   const [renaming, setRenaming] = useState<string | null>(null);
   const [renameDraft, setRenameDraft] = useState('');
+  // Rename guards: `cancelRenameRef` lets Escape's unmount-blur bail without
+  // POSTing; `committingRenameRef` makes a commit single-shot so Enter (which
+  // also triggers blur on unmount) can't double-submit with a stale `from`.
+  const cancelRenameRef = useRef(false);
+  const committingRenameRef = useRef(false);
   const [moveMenu, setMoveMenu] = useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
   const [confirmFolderDelete, setConfirmFolderDelete] = useState<string | null>(null);
@@ -224,10 +302,21 @@ export function WavRecorderPanel() {
   const targetRef = useRef({ peak: 0, rms: 0, clip: false });
   const dispRef = useRef({ peak: 0, rms: 0, hold: 0 });
   const rafRef = useRef<number | null>(null);
+  // Idle-gating for the meter RAF: it stops when fully settled and is woken
+  // from the status-poll path when a non-zero level / clip / active state
+  // arrives. `wakeMeterRef` is installed by the RAF effect.
+  const meterRunningRef = useRef(false);
+  const wakeMeterRef = useRef<(() => void) | null>(null);
 
-  // Waveform cache: relPath → buckets.
+  // Waveform cache: `relPath:mtime` → buckets (bounded LRU).
   const waveCacheRef = useRef<Map<string, number[]>>(new Map());
+  // Live mirrors of the waveform inputs so the ResizeObserver can subscribe
+  // once and still read current buckets/progress on resize.
+  const waveBucketsRef = useRef<number[] | null>(null);
+  const progressRef = useRef(-1);
   const [waveBuckets, setWaveBuckets] = useState<number[] | null>(null);
+  // Bumped on theme/font change so the waveform repaints with fresh colours.
+  const [themeTick, setThemeTick] = useState(0);
 
   const errorTimer = useRef<number | null>(null);
   const flashError = useCallback((msg: string) => {
@@ -236,13 +325,51 @@ export function WavRecorderPanel() {
     errorTimer.current = window.setTimeout(() => setError(null), 4000);
   }, []);
 
+  const noticeTimer = useRef<number | null>(null);
+  const flashNotice = useCallback((msg: string) => {
+    setNotice(msg);
+    if (noticeTimer.current !== null) window.clearTimeout(noticeTimer.current);
+    noticeTimer.current = window.setTimeout(() => setNotice(null), 3500);
+  }, []);
+
+  useEffect(
+    () => () => {
+      if (errorTimer.current !== null) window.clearTimeout(errorTimer.current);
+      if (noticeTimer.current !== null) window.clearTimeout(noticeTimer.current);
+    },
+    [],
+  );
+
+  // --- Save-location (recordings root) --------------------------------------
+
+  const fetchRoot = useCallback(async () => {
+    try {
+      const r = (await fetch('/api/wav/root').then((res) => res.json())) as RootResp;
+      setRoot(typeof r.root === 'string' ? r.root : '');
+      setRootIsDefault(!!r.isDefault);
+    } catch {
+      /* transient */
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchRoot();
+  }, [fetchRoot]);
+
   // --- Status + list polling -------------------------------------------------
 
   const fetchStatus = useCallback(async () => {
     try {
       const s = (await fetch('/api/wav/status').then((r) => r.json())) as Status;
       setStatus(s);
-      targetRef.current = { peak: s.peak ?? 0, rms: s.rms ?? 0, clip: !!s.clip };
+      const peak = s.peak ?? 0;
+      const rms = s.rms ?? 0;
+      targetRef.current = { peak, rms, clip: !!s.clip };
+      // Wake the (possibly idle-stopped) meter when there's something to show
+      // or the deck is actively recording/playing.
+      if (peak > METER_EPS || rms > METER_EPS || s.clip || s.state !== 'idle') {
+        wakeMeterRef.current?.();
+      }
     } catch {
       /* transient */
     }
@@ -262,6 +389,18 @@ export function WavRecorderPanel() {
     void fetchStatus();
     void fetchList();
   }, [fetchStatus, fetchList]);
+
+  const onRootChanged = useCallback(
+    (newRoot: string, isDefault: boolean) => {
+      setRoot(newRoot);
+      setRootIsDefault(isDefault);
+      waveCacheRef.current.clear();
+      setSelected(null);
+      void fetchList();
+      flashNotice(isDefault ? 'Save folder reset to default' : 'Save folder updated');
+    },
+    [fetchList, flashNotice],
+  );
 
   // Status poll cadence depends on activity.
   const active = status.state !== 'idle';
@@ -284,6 +423,8 @@ export function WavRecorderPanel() {
   useEffect(() => {
     const refreshColors = () => {
       colorsRef.current = readColors(rootRef.current);
+      // Meter picks colours up live via its RAF; nudge the waveform to repaint.
+      setThemeTick((t) => t + 1);
     };
     refreshColors();
     const mo = new MutationObserver(refreshColors);
@@ -309,6 +450,9 @@ export function WavRecorderPanel() {
     const ro = new ResizeObserver((entries) => {
       const w = entries[0]?.contentRect.width ?? el.clientWidth;
       setNarrow(w < 640);
+      // The meter canvas re-fits its backing store only inside the RAF; wake
+      // it for a settle cycle so a resize during silence isn't left stale.
+      wakeMeterRef.current?.();
     });
     ro.observe(el);
     return () => ro.disconnect();
@@ -336,16 +480,69 @@ export function WavRecorderPanel() {
       if (target.peak >= disp.hold) disp.hold = target.peak;
       else disp.hold = Math.max(target.peak, disp.hold - (reduced ? 0.02 : 0.006));
 
-      if (canvas) drawMeter(canvas, colorsRef.current, disp.peak, disp.rms, disp.hold, target.clip);
+      if (canvas) drawMeter(canvas, colorsRef.current, disp.peak, disp.rms, disp.hold, target.clip, reduced);
       const vcanvas = vmeterCanvasRef.current;
-      if (vcanvas) drawVMeter(vcanvas, colorsRef.current, disp.peak, disp.rms, disp.hold);
+      if (vcanvas) drawVMeter(vcanvas, colorsRef.current, disp.peak, disp.rms, disp.hold, reduced);
+
+      // Idle-gate: once the displayed bar AND the incoming target are all at
+      // rest (and not clipping), draw this final settled frame and STOP. The
+      // status poll calls wake() to restart when a level/clip returns. This
+      // is the perf win — no 60fps canvas churn during silence. The active
+      // visual is untouched: while any signal is present we keep scheduling.
+      const settled =
+        !target.clip &&
+        target.peak < METER_EPS &&
+        target.rms < METER_EPS &&
+        disp.peak < METER_EPS &&
+        disp.rms < METER_EPS &&
+        disp.hold < METER_EPS;
+      if (settled) {
+        meterRunningRef.current = false;
+        rafRef.current = null;
+        return;
+      }
       rafRef.current = window.requestAnimationFrame(draw);
     };
-    rafRef.current = window.requestAnimationFrame(draw);
+
+    const wake = () => {
+      if (meterRunningRef.current) return;
+      meterRunningRef.current = true;
+      rafRef.current = window.requestAnimationFrame(draw);
+    };
+    wakeMeterRef.current = wake;
+
+    // Kick once so the wells render even if no signal ever arrives.
+    wake();
     return () => {
       if (rafRef.current !== null) window.cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+      meterRunningRef.current = false;
+      wakeMeterRef.current = null;
     };
   }, []);
+
+  // --- Selected recording + stale-selection reconciliation -------------------
+
+  const selectedRec = useMemo(
+    () => recordings.find((r) => r.relPath === selected) ?? null,
+    [recordings, selected],
+  );
+  // mtime of the selected file (0 if not in the list yet). Drives the cache
+  // key so a replaced file under the same name re-fetches instead of serving
+  // stale buckets. Only changes when the selection or its mtime changes — not
+  // on every list poll.
+  const selectedMtime = selectedRec?.modifiedUnixMs ?? 0;
+
+  // If the selected file vanishes from the list (deleted in another session,
+  // or its folder removed), clear the selection so PLAY/TX can't POST a
+  // missing file. Guard the optimistic-rename/move window: those paths
+  // await fetchList() before re-selecting, so the new relPath is already
+  // present here.
+  useEffect(() => {
+    if (selected && !recordings.some((r) => r.relPath === selected)) {
+      setSelected(null);
+    }
+  }, [recordings, selected]);
 
   // --- Waveform fetch on selection change ------------------------------------
 
@@ -354,7 +551,8 @@ export function WavRecorderPanel() {
       setWaveBuckets(null);
       return;
     }
-    const cached = waveCacheRef.current.get(selected);
+    const key = selectedMtime > 0 ? `${selected}:${selectedMtime}` : selected;
+    const cached = waveCacheGet(waveCacheRef.current, key);
     if (cached) {
       setWaveBuckets(cached);
       return;
@@ -365,14 +563,14 @@ export function WavRecorderPanel() {
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`${r.status}`))))
       .then((w: WaveformResp) => {
         const buckets = Array.isArray(w.buckets) ? w.buckets : [];
-        waveCacheRef.current.set(selected, buckets);
+        waveCachePut(waveCacheRef.current, key, buckets);
         setWaveBuckets(buckets);
       })
       .catch(() => {
         /* leave empty well; selection still valid for playback */
       });
     return () => ctrl.abort();
-  }, [selected]);
+  }, [selected, selectedMtime]);
 
   // --- Waveform redraw (buckets / progress / size) ---------------------------
 
@@ -380,18 +578,27 @@ export function WavRecorderPanel() {
   const progress = playingThis && status.durationSec > 0 ? status.seconds / status.durationSec : -1;
 
   useEffect(() => {
+    waveBucketsRef.current = waveBuckets;
+    progressRef.current = progress;
     const canvas = waveCanvasRef.current;
     if (!canvas) return;
-    drawWaveform(canvas, colorsRef.current, waveBuckets, progress);
-  }, [waveBuckets, progress, narrow]);
+    // `themeTick` is a dep so a live theme/font switch repaints with fresh
+    // colours instead of waiting for the next bucket/resize.
+    drawWaveform(canvas, colorsRef.current, waveBuckets, progress, reducedMotionRef.current);
+  }, [waveBuckets, progress, narrow, themeTick]);
 
   useEffect(() => {
     const canvas = waveCanvasRef.current;
     if (!canvas || typeof ResizeObserver === 'undefined') return;
-    const ro = new ResizeObserver(() => drawWaveform(canvas, colorsRef.current, waveBuckets, progress));
+    // Subscribe ONCE — read live buckets/progress from refs so the fast-
+    // changing `progress` (~11×/s during playback) doesn't tear down and
+    // recreate the observer every tick.
+    const ro = new ResizeObserver(() =>
+      drawWaveform(canvas, colorsRef.current, waveBucketsRef.current, progressRef.current, reducedMotionRef.current),
+    );
     ro.observe(canvas);
     return () => ro.disconnect();
-  }, [waveBuckets, progress]);
+  }, []);
 
   // --- Derived data ----------------------------------------------------------
 
@@ -406,10 +613,6 @@ export function WavRecorderPanel() {
   );
   const crumbs = useMemo(() => breadcrumb(currentFolder), [currentFolder]);
   const allFolders = useMemo(() => folders.slice().sort((a, b) => a.localeCompare(b)), [folders]);
-  const selectedRec = useMemo(
-    () => recordings.find((r) => r.relPath === selected) ?? null,
-    [recordings, selected],
-  );
 
   const recState = status.state;
   const isRecording = recState === 'recording';
@@ -492,18 +695,34 @@ export function WavRecorderPanel() {
 
   const commitRename = useCallback(
     async (from: string) => {
+      // Escape requested a cancel: bail without POSTing (the unmount-blur
+      // would otherwise commit the draft). Consume the flag.
+      if (cancelRenameRef.current) {
+        cancelRenameRef.current = false;
+        return;
+      }
+      // Single-shot: Enter + the unmount-blur both call this; only the first
+      // wins, so no stale-`from` second POST (which would 404).
+      if (committingRenameRef.current) return;
+      committingRenameRef.current = true;
+
       const name = renameDraft.trim();
       setRenaming(null);
-      if (!name) return;
+      if (!name) {
+        committingRenameRef.current = false;
+        return;
+      }
       try {
         const res = await postJson<{ relPath: string }>('/api/wav/rename', { from, name });
         if (res?.relPath) {
-          waveCacheRef.current.delete(from);
+          waveCacheDropPath(waveCacheRef.current, from);
+          await fetchList(); // ensure the new relPath is in the list before reselect
           setSelected(res.relPath);
         }
       } catch (e) {
         flashError(e instanceof Error ? e.message : 'Rename failed');
       } finally {
+        committingRenameRef.current = false;
         fetchList();
       }
     },
@@ -516,7 +735,8 @@ export function WavRecorderPanel() {
       try {
         const res = await postJson<{ relPath: string }>('/api/wav/move', { from, folder });
         if (res?.relPath) {
-          waveCacheRef.current.delete(from);
+          waveCacheDropPath(waveCacheRef.current, from);
+          await fetchList(); // ensure the moved relPath is in the list before reselect
           setSelected(res.relPath);
         }
       } catch (e) {
@@ -533,7 +753,7 @@ export function WavRecorderPanel() {
       setConfirmDelete(null);
       try {
         await postJson('/api/wav/delete', { file: relPath });
-        waveCacheRef.current.delete(relPath);
+        waveCacheDropPath(waveCacheRef.current, relPath);
         if (selected === relPath) setSelected(null);
       } catch (e) {
         flashError(e instanceof Error ? e.message : 'Delete failed');
@@ -594,6 +814,26 @@ export function WavRecorderPanel() {
               ))}
             </nav>
             <div className="zdr__libactions">
+              <button
+                type="button"
+                className="zdr__dirbtn"
+                onClick={() => setPickerOpen(true)}
+                aria-label={`Change save folder (currently ${root || 'default'})`}
+                title={`Save location: ${root || 'default'}${rootIsDefault ? ' (default)' : ''}\nClick to change`}
+              >
+                <span className="zdr__dirbtn-glyph" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" width="13" height="13" aria-hidden="true">
+                    <path
+                      d="M3 6.5A1.5 1.5 0 0 1 4.5 5h4l2 2.2H19.5A1.5 1.5 0 0 1 21 8.7v9.8a1.5 1.5 0 0 1-1.5 1.5h-15A1.5 1.5 0 0 1 3 18.5Z"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.4"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </span>
+                <span className="zdr__dirbtn-path">{root ? abbreviatePath(root, 2) : 'Default'}</span>
+              </button>
               {currentFolder && (
                 <button
                   type="button"
@@ -681,7 +921,12 @@ export function WavRecorderPanel() {
                       onChange={(e) => setRenameDraft(e.target.value)}
                       onKeyDown={(e) => {
                         if (e.key === 'Enter') void commitRename(r.relPath);
-                        if (e.key === 'Escape') setRenaming(null);
+                        if (e.key === 'Escape') {
+                          // Flag cancel BEFORE unmounting so the autoFocus
+                          // input's blur handler bails without committing.
+                          cancelRenameRef.current = true;
+                          setRenaming(null);
+                        }
                       }}
                       onBlur={() => void commitRename(r.relPath)}
                     />
@@ -745,6 +990,8 @@ export function WavRecorderPanel() {
                           aria-label={`Rename ${r.name}`}
                           title="Rename"
                           onClick={() => {
+                            cancelRenameRef.current = false;
+                            committingRenameRef.current = false;
                             setRenameDraft(r.name);
                             setRenaming(r.relPath);
                           }}
@@ -960,12 +1207,25 @@ export function WavRecorderPanel() {
           <span className="zdr__onair-dot" aria-hidden="true" />
           {status.onAir ? 'ON AIR' : status.mox ? 'MOX' : 'RX'}
         </span>
-        {error && (
+        {error ? (
           <span className="zdr__errmsg" role="alert">
             {error}
           </span>
-        )}
+        ) : notice ? (
+          <span className="zdr__notemsg" role="status">
+            {notice}
+          </span>
+        ) : null}
       </footer>
+
+      {pickerOpen && (
+        <DirectoryPickerModal
+          initialPath={root}
+          rootIsDefault={rootIsDefault}
+          onClose={() => setPickerOpen(false)}
+          onChanged={onRootChanged}
+        />
+      )}
     </div>
   );
 }
@@ -981,6 +1241,7 @@ function drawMeter(
   rms: number,
   hold: number,
   clip: boolean,
+  reduced: boolean,
 ): void {
   const fit = fitCanvas(canvas);
   if (!fit) return;
@@ -993,57 +1254,90 @@ function drawMeter(
   const rmsLit = litSegments(rms, SEGMENTS);
   const holdIdx = Math.min(SEGMENTS - 1, litSegments(hold, SEGMENTS) - 1);
 
+  // Two gradients built once per frame (reused across all 40 segments — no
+  // per-segment garbage). `glass` gives lit segments a backlit-tube sheen;
+  // `wellGrad` carves a faint inset into the dark unlit wells.
+  const glass = ctx.createLinearGradient(0, 0, 0, h);
+  glass.addColorStop(0, 'rgba(255,255,255,0.34)');
+  glass.addColorStop(0.18, 'rgba(255,255,255,0.10)');
+  glass.addColorStop(0.5, 'rgba(255,255,255,0)');
+  glass.addColorStop(0.85, 'rgba(0,0,0,0.18)');
+  glass.addColorStop(1, 'rgba(0,0,0,0.32)');
+  const wellGrad = ctx.createLinearGradient(0, 0, 0, h);
+  wellGrad.addColorStop(0, 'rgba(0,0,0,0.45)');
+  wellGrad.addColorStop(0.5, 'rgba(255,255,255,0.03)');
+  wellGrad.addColorStop(1, 'rgba(0,0,0,0.5)');
+
   for (let i = 0; i < SEGMENTS; i++) {
     const x = i * (segW + gap);
     const col = zoneColor(c, i);
-    // Well (off) segment.
+    // Well (off) segment — dark base + inset depth + hairline frame.
     ctx.fillStyle = c.well;
+    ctx.fillRect(x, 0, segW, h);
+    ctx.fillStyle = wellGrad;
     ctx.fillRect(x, 0, segW, h);
     ctx.strokeStyle = c.line;
     ctx.lineWidth = 1;
     ctx.strokeRect(x + 0.5, 0.5, segW - 1, h - 1);
 
     if (i < rmsLit) {
-      // Solid lit core (rms) — bright + glow.
+      // Illuminated core (rms) — saturated fill + zone-colour outer glow…
       ctx.save();
-      ctx.shadowColor = col;
-      ctx.shadowBlur = Math.max(2, segW * 0.5);
+      if (!reduced) {
+        ctx.shadowColor = col;
+        ctx.shadowBlur = Math.max(2, segW * 0.55);
+      }
       ctx.fillStyle = col;
       ctx.fillRect(x, 0, segW, h);
       ctx.restore();
+      // …then a glass sheen on top so it reads as a lit tube, not a flat bar.
+      ctx.fillStyle = glass;
+      ctx.fillRect(x, 0, segW, h);
     } else if (i < peakLit) {
-      // Peak overhang — dimmer, no heavy glow.
-      ctx.globalAlpha = 0.42;
+      // Peak overhang — dimmer, lighter sheen, no heavy glow.
+      ctx.globalAlpha = 0.4;
       ctx.fillStyle = col;
+      ctx.fillRect(x, 0, segW, h);
+      ctx.globalAlpha = 0.5;
+      ctx.fillStyle = glass;
       ctx.fillRect(x, 0, segW, h);
       ctx.globalAlpha = 1;
     }
   }
 
-  // Peak-hold tick.
+  // Peak-hold tick — brighter than the bar, its own glow, lit end-caps.
   if (holdIdx >= 0) {
     const x = holdIdx * (segW + gap);
     const col = zoneColor(c, holdIdx);
     ctx.save();
-    ctx.shadowColor = col;
-    ctx.shadowBlur = Math.max(3, segW * 0.7);
+    if (!reduced) {
+      ctx.shadowColor = col;
+      ctx.shadowBlur = Math.max(4, segW * 0.9);
+    }
     ctx.fillStyle = col;
     ctx.fillRect(x, 0, segW, h);
-    ctx.fillStyle = 'rgba(255,255,255,0.55)';
-    ctx.fillRect(x, 0, segW, Math.max(2, h * 0.18));
-    ctx.fillRect(x, h - Math.max(2, h * 0.18), segW, Math.max(2, h * 0.18));
     ctx.restore();
+    ctx.fillStyle = glass;
+    ctx.fillRect(x, 0, segW, h);
+    const cap = Math.max(2, h * 0.16);
+    ctx.fillStyle = 'rgba(255,255,255,0.7)';
+    ctx.fillRect(x, 0, segW, cap);
+    ctx.fillRect(x, h - cap, segW, cap);
   }
 
   // Clip flare on the last segment.
   if (clip) {
     const x = (SEGMENTS - 1) * (segW + gap);
     ctx.save();
-    ctx.shadowColor = c.red;
-    ctx.shadowBlur = segW * 1.2;
+    if (!reduced) {
+      ctx.shadowColor = c.red;
+      ctx.shadowBlur = segW * 1.3;
+    }
     ctx.fillStyle = c.red;
     ctx.fillRect(x, 0, segW, h);
     ctx.restore();
+    ctx.fillStyle = glass;
+    ctx.fillRect(x, 0, segW, h);
   }
 }
 
@@ -1052,20 +1346,30 @@ function drawWaveform(
   c: MeterColors,
   buckets: number[] | null,
   progress: number,
+  reduced: boolean,
 ): void {
   const fit = fitCanvas(canvas);
   if (!fit) return;
   const { ctx, w, h } = fit;
   ctx.clearRect(0, 0, w, h);
 
-  // Well background + centre line.
+  // Well background + a faint vertical inset so the strip reads as recessed.
   ctx.fillStyle = c.well;
   ctx.fillRect(0, 0, w, h);
-  ctx.strokeStyle = c.line;
+  const bg = ctx.createLinearGradient(0, 0, 0, h);
+  bg.addColorStop(0, 'rgba(0,0,0,0.38)');
+  bg.addColorStop(0.5, 'rgba(255,255,255,0.02)');
+  bg.addColorStop(1, 'rgba(0,0,0,0.42)');
+  ctx.fillStyle = bg;
+  ctx.fillRect(0, 0, w, h);
+
+  // Centre axis line (faint).
+  const midY = Math.round(h / 2) + 0.5;
+  ctx.strokeStyle = withAlpha(c.line, 0.9);
   ctx.lineWidth = 1;
   ctx.beginPath();
-  ctx.moveTo(0, h / 2 + 0.5);
-  ctx.lineTo(w, h / 2 + 0.5);
+  ctx.moveTo(0, midY);
+  ctx.lineTo(w, midY);
   ctx.stroke();
 
   if (!buckets || buckets.length === 0) return;
@@ -1073,7 +1377,21 @@ function drawWaveform(
   const n = buckets.length;
   const mid = h / 2;
   const colW = w / n;
-  ctx.fillStyle = c.amber;
+
+  // Amber gradient: brightest at the centre axis, fading toward the edges.
+  const grad = ctx.createLinearGradient(0, 0, 0, h);
+  grad.addColorStop(0, withAlpha(c.amber, 0.3));
+  grad.addColorStop(0.42, withAlpha(c.amber, 0.95));
+  grad.addColorStop(0.5, c.amber);
+  grad.addColorStop(0.58, withAlpha(c.amber, 0.95));
+  grad.addColorStop(1, withAlpha(c.amber, 0.3));
+
+  ctx.save();
+  if (!reduced) {
+    ctx.shadowColor = withAlpha(c.amber, 0.5);
+    ctx.shadowBlur = 4;
+  }
+  ctx.fillStyle = grad;
   for (let i = 0; i < n; i++) {
     const v = Math.max(0, Math.min(1, buckets[i] ?? 0));
     const half = Math.max(0.5, v * (h / 2 - 1));
@@ -1081,14 +1399,19 @@ function drawWaveform(
     const bw = Math.max(0.6, colW - 0.4);
     ctx.fillRect(x, mid - half, bw, half * 2);
   }
+  ctx.restore();
 
-  // Playback progress line.
+  // Playback progress: dim the un-played tail, then a crisp glowing playhead.
   if (progress >= 0) {
     const px = Math.max(0, Math.min(1, progress)) * w;
+    ctx.fillStyle = 'rgba(0,0,0,0.42)';
+    ctx.fillRect(px, 0, w - px, h);
     ctx.save();
     ctx.strokeStyle = c.accent;
-    ctx.shadowColor = c.accent;
-    ctx.shadowBlur = 6;
+    if (!reduced) {
+      ctx.shadowColor = c.accent;
+      ctx.shadowBlur = 8;
+    }
     ctx.lineWidth = 2;
     ctx.beginPath();
     ctx.moveTo(px, 0);
@@ -1102,7 +1425,14 @@ const VSEGMENTS = 28;
 
 /** Two vertical segmented LED columns (L/R). Audio is mono, so both columns
  *  read the same level — a faithful "stereo meter" face on a mono source. */
-function drawVMeter(canvas: HTMLCanvasElement, c: MeterColors, peak: number, rms: number, hold: number): void {
+function drawVMeter(
+  canvas: HTMLCanvasElement,
+  c: MeterColors,
+  peak: number,
+  rms: number,
+  hold: number,
+  reduced: boolean,
+): void {
   const fit = fitCanvas(canvas);
   if (!fit) return;
   const { ctx, w, h } = fit;
@@ -1127,34 +1457,58 @@ function drawVMeter(canvas: HTMLCanvasElement, c: MeterColors, peak: number, rms
 
   for (let col = 0; col < cols; col++) {
     const x = colGap + col * (colW + colGap);
+    // Horizontal cylinder sheen for this column (one gradient per column —
+    // gives each lit LED a rounded, backlit look).
+    const cyl = ctx.createLinearGradient(x, 0, x + colW, 0);
+    cyl.addColorStop(0, 'rgba(0,0,0,0.3)');
+    cyl.addColorStop(0.5, 'rgba(255,255,255,0.22)');
+    cyl.addColorStop(1, 'rgba(0,0,0,0.3)');
     for (let i = 0; i < VSEGMENTS; i++) {
       // i counts from bottom; y inverts.
       const y = h - (i + 1) * segH - i * vgap;
       const color = vzone(i);
+      // Dark well + faint inset.
       ctx.fillStyle = c.well;
+      ctx.fillRect(x, y, colW, segH);
+      ctx.fillStyle = 'rgba(0,0,0,0.35)';
       ctx.fillRect(x, y, colW, segH);
       if (i < rmsLit) {
         ctx.save();
-        ctx.shadowColor = color;
-        ctx.shadowBlur = Math.max(2, colW * 0.4);
+        if (!reduced) {
+          ctx.shadowColor = color;
+          ctx.shadowBlur = Math.max(2, colW * 0.45);
+        }
         ctx.fillStyle = color;
         ctx.fillRect(x, y, colW, segH);
         ctx.restore();
+        ctx.fillStyle = cyl;
+        ctx.fillRect(x, y, colW, segH);
       } else if (i < peakLit) {
-        ctx.globalAlpha = 0.42;
+        ctx.globalAlpha = 0.4;
         ctx.fillStyle = color;
+        ctx.fillRect(x, y, colW, segH);
+        ctx.globalAlpha = 0.5;
+        ctx.fillStyle = cyl;
         ctx.fillRect(x, y, colW, segH);
         ctx.globalAlpha = 1;
       }
     }
     if (holdIdx >= 0) {
       const y = h - (holdIdx + 1) * segH - holdIdx * vgap;
+      const hc = vzone(holdIdx);
       ctx.save();
-      ctx.shadowColor = vzone(holdIdx);
-      ctx.shadowBlur = Math.max(3, colW * 0.5);
-      ctx.fillStyle = vzone(holdIdx);
+      if (!reduced) {
+        ctx.shadowColor = hc;
+        ctx.shadowBlur = Math.max(3, colW * 0.6);
+      }
+      ctx.fillStyle = hc;
       ctx.fillRect(x, y, colW, segH);
       ctx.restore();
+      ctx.fillStyle = cyl;
+      ctx.fillRect(x, y, colW, segH);
+      // Bright lit cap on the held segment.
+      ctx.fillStyle = 'rgba(255,255,255,0.6)';
+      ctx.fillRect(x, y, colW, Math.max(1, segH * 0.34));
     }
   }
 }

--- a/zeus-web/src/layout/panels/WavRecorderPanel.tsx
+++ b/zeus-web/src/layout/panels/WavRecorderPanel.tsx
@@ -10,227 +10,1151 @@
 // Free Software Foundation, either version 2 of the License, or (at your
 // option) any later version. See the LICENSE file at the root of this
 // repository for the full text, or https://www.gnu.org/licenses/.
+//
+// ZEUS Digital Recorder — rack-mount WAV recorder panel. Segmented LED level
+// meter, round transport buttons, a waveform strip, a folder/file browser with
+// rename/move/delete, and a metadata column. Theming is token-only
+// (zeus-web/src/styles/tokens.css). Backed by the /api/wav/* endpoints.
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import './WavRecorderPanel.css';
+import {
+  fmtBytes,
+  fmtClock,
+  fmtDb,
+  fmtDate,
+  parentOf,
+  baseName,
+  joinFolder,
+  childFolders,
+  breadcrumb,
+  segmentZone,
+  litSegments,
+} from './wavRecorder.format';
+
+// ---------------------------------------------------------------------------
+// Wire types — mirror the /api/wav/* JSON contract exactly (camelCase).
+// ---------------------------------------------------------------------------
+
+type RecState = 'idle' | 'recording' | 'playing';
+type Source = 'rx' | 'tx';
+type FileSource = 'rx' | 'tx' | 'unknown';
 
 type Status = {
-  state: 'idle' | 'recording' | 'playing';
-  source: 'rx' | 'tx';
+  state: RecState;
+  source: Source;
   file: string | null;
   seconds: number;
+  durationSec: number;
   mox: boolean;
   onAir: boolean;
+  peak: number; // 0..1
+  rms: number; // 0..1
+  peakDb: number; // dBFS, floor -100
+  clip: boolean;
 };
 
-type Recording = { name: string; bytes: number; modifiedUnixMs: number };
+type Recording = {
+  name: string;
+  fileName: string;
+  relPath: string;
+  folder: string;
+  bytes: number;
+  durationSec: number;
+  source: FileSource;
+  modifiedUnixMs: number;
+};
 
-async function post(path: string, body?: unknown): Promise<void> {
-  await fetch(path, {
+type ListResp = {
+  root: string;
+  folders: string[];
+  recordings: Recording[];
+};
+
+type WaveformResp = { file: string; buckets: number[] };
+
+const IDLE_STATUS: Status = {
+  state: 'idle',
+  source: 'rx',
+  file: null,
+  seconds: 0,
+  durationSec: 0,
+  mox: false,
+  onAir: false,
+  peak: 0,
+  rms: 0,
+  peakDb: -100,
+  clip: false,
+};
+
+const SEGMENTS = 40;
+const WAVE_BUCKETS = 400;
+const STATUS_POLL_ACTIVE_MS = 90;
+const STATUS_POLL_IDLE_MS = 500;
+const LIST_POLL_MS = 1000;
+
+// ---------------------------------------------------------------------------
+// Fetch helpers
+// ---------------------------------------------------------------------------
+
+class HttpError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
+async function postJson<T = unknown>(path: string, body?: unknown): Promise<T> {
+  const res = await fetch(path, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: body ? JSON.stringify(body) : undefined,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
   });
+  if (!res.ok) {
+    let msg = `${res.status} ${res.statusText}`.trim();
+    try {
+      const t = await res.text();
+      if (t) msg = t.slice(0, 160);
+    } catch {
+      /* ignore */
+    }
+    throw new HttpError(res.status, msg);
+  }
+  const ct = res.headers.get('content-type') ?? '';
+  if (ct.includes('application/json')) return (await res.json()) as T;
+  return undefined as unknown as T;
 }
 
-function fmtBytes(b: number): string {
-  if (b < 1024) return `${b} B`;
-  if (b < 1024 * 1024) return `${(b / 1024).toFixed(0)} KB`;
-  return `${(b / 1024 / 1024).toFixed(1)} MB`;
+// ---------------------------------------------------------------------------
+// Canvas colour resolution (token-driven, refreshed on theme change)
+// ---------------------------------------------------------------------------
+
+type MeterColors = {
+  green: string;
+  amber: string;
+  red: string;
+  well: string;
+  line: string;
+  accent: string;
+  text: string;
+};
+
+function readColors(el: HTMLElement | null): MeterColors {
+  const fb: MeterColors = {
+    green: '#1aa84e',
+    amber: '#ffb13c',
+    red: '#ff4a59',
+    well: '#050507',
+    line: '#1f1f23',
+    accent: '#4ea6ff',
+    text: '#cccccc',
+  };
+  if (!el) return fb;
+  const cs = getComputedStyle(el);
+  const get = (n: string, f: string) => cs.getPropertyValue(n).trim() || f;
+  return {
+    green: get('--green-soft', fb.green),
+    amber: get('--amber', fb.amber),
+    red: get('--tx', fb.red),
+    well: get('--bg-meter', fb.well),
+    line: get('--line', fb.line),
+    accent: get('--accent-bright', fb.accent),
+    text: get('--fg-1', fb.text),
+  };
 }
 
-/** A single tape reel: metal flange with three windows revealing the spooled
- *  tape, a central spindle. The inner group spins via CSS when active. */
-function Reel({ active }: { active: 'rec' | 'play' | null }) {
-  const spinClass =
-    active === 'rec' ? 'reel__spin is-rec' : active === 'play' ? 'reel__spin is-play' : 'reel__spin';
-  return (
-    <svg className="reel" viewBox="0 0 100 100" aria-hidden="true">
-      {/* tape pack (revealed through the flange windows) */}
-      <circle cx="50" cy="50" r="46" fill="var(--tape)" />
-      <circle cx="50" cy="50" r="46" fill="none" stroke="var(--tape-edge)" strokeWidth="1.5" />
-      <g className={spinClass}>
-        {/* metal flange */}
-        <circle cx="50" cy="50" r="44" fill="var(--flange)" />
-        <circle cx="50" cy="50" r="44" fill="none" stroke="var(--flange-shade)" strokeWidth="2" />
-        {/* three windows showing tape underneath */}
-        {[0, 120, 240].map((deg) => {
-          const rad = (deg * Math.PI) / 180;
-          const cx = 50 + 26 * Math.cos(rad);
-          const cy = 50 + 26 * Math.sin(rad);
-          return <circle key={deg} cx={cx} cy={cy} r="11" fill="var(--tape)" stroke="var(--flange-shade)" strokeWidth="1" />;
-        })}
-        {/* hub + spindle */}
-        <circle cx="50" cy="50" r="13" fill="var(--hub)" stroke="var(--flange-shade)" strokeWidth="1.5" />
-        <circle cx="50" cy="50" r="3.5" fill="#0c0d0e" />
-        {/* a spoke so rotation is visible */}
-        <rect x="49" y="6" width="2" height="10" fill="var(--flange-shade)" />
-      </g>
-    </svg>
-  );
+function zoneColor(c: MeterColors, index: number): string {
+  switch (segmentZone(index, SEGMENTS)) {
+    case 'red':
+      return c.red;
+    case 'amber':
+      return c.amber;
+    default:
+      return c.green;
+  }
 }
+
+/** Resize a canvas's backing store to its CSS box (DPR-aware). */
+function fitCanvas(canvas: HTMLCanvasElement): { ctx: CanvasRenderingContext2D; w: number; h: number } | null {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return null;
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  const w = Math.max(1, Math.floor(canvas.clientWidth));
+  const h = Math.max(1, Math.floor(canvas.clientHeight));
+  const bw = Math.floor(w * dpr);
+  const bh = Math.floor(h * dpr);
+  if (canvas.width !== bw || canvas.height !== bh) {
+    canvas.width = bw;
+    canvas.height = bh;
+  }
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  return { ctx, w, h };
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
 
 export function WavRecorderPanel() {
-  const [status, setStatus] = useState<Status>({
-    state: 'idle', source: 'rx', file: null, seconds: 0, mox: false, onAir: false,
-  });
-  const [list, setList] = useState<Recording[]>([]);
-  const [source, setSource] = useState<'rx' | 'tx'>('rx');
-  const timer = useRef<number | null>(null);
+  const [status, setStatus] = useState<Status>(IDLE_STATUS);
+  const [folders, setFolders] = useState<string[]>([]);
+  const [recordings, setRecordings] = useState<Recording[]>([]);
+  const [recordSource, setRecordSource] = useState<Source>('rx');
+  const [currentFolder, setCurrentFolder] = useState<string>('');
+  const [selected, setSelected] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [narrow, setNarrow] = useState(false);
 
-  const refresh = useCallback(async () => {
+  // CRUD interaction state
+  const [renaming, setRenaming] = useState<string | null>(null);
+  const [renameDraft, setRenameDraft] = useState('');
+  const [moveMenu, setMoveMenu] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  const [confirmFolderDelete, setConfirmFolderDelete] = useState<string | null>(null);
+
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const meterCanvasRef = useRef<HTMLCanvasElement | null>(null);
+  const vmeterCanvasRef = useRef<HTMLCanvasElement | null>(null);
+  const waveCanvasRef = useRef<HTMLCanvasElement | null>(null);
+  const colorsRef = useRef<MeterColors>(readColors(null));
+  const reducedMotionRef = useRef(false);
+
+  // Meter smoothing state lives in refs (RAF loop owns it; no re-render churn).
+  const targetRef = useRef({ peak: 0, rms: 0, clip: false });
+  const dispRef = useRef({ peak: 0, rms: 0, hold: 0 });
+  const rafRef = useRef<number | null>(null);
+
+  // Waveform cache: relPath → buckets.
+  const waveCacheRef = useRef<Map<string, number[]>>(new Map());
+  const [waveBuckets, setWaveBuckets] = useState<number[] | null>(null);
+
+  const errorTimer = useRef<number | null>(null);
+  const flashError = useCallback((msg: string) => {
+    setError(msg);
+    if (errorTimer.current !== null) window.clearTimeout(errorTimer.current);
+    errorTimer.current = window.setTimeout(() => setError(null), 4000);
+  }, []);
+
+  // --- Status + list polling -------------------------------------------------
+
+  const fetchStatus = useCallback(async () => {
     try {
-      const [s, l] = await Promise.all([
-        fetch('/api/wav/status').then((r) => r.json()),
-        fetch('/api/wav/list').then((r) => r.json()),
-      ]);
-      setStatus(s as Status);
-      setList((l.recordings ?? []) as Recording[]);
+      const s = (await fetch('/api/wav/status').then((r) => r.json())) as Status;
+      setStatus(s);
+      targetRef.current = { peak: s.peak ?? 0, rms: s.rms ?? 0, clip: !!s.clip };
     } catch {
-      /* transient — next tick retries */
+      /* transient */
     }
   }, []);
 
+  const fetchList = useCallback(async () => {
+    try {
+      const l = (await fetch('/api/wav/list').then((r) => r.json())) as ListResp;
+      setFolders(Array.isArray(l.folders) ? l.folders : []);
+      setRecordings(Array.isArray(l.recordings) ? l.recordings : []);
+    } catch {
+      /* transient */
+    }
+  }, []);
+
+  const refresh = useCallback(() => {
+    void fetchStatus();
+    void fetchList();
+  }, [fetchStatus, fetchList]);
+
+  // Status poll cadence depends on activity.
+  const active = status.state !== 'idle';
   useEffect(() => {
-    refresh();
-    timer.current = window.setInterval(refresh, 1000);
-    return () => {
-      if (timer.current !== null) window.clearInterval(timer.current);
+    void fetchStatus();
+    const ms = active ? STATUS_POLL_ACTIVE_MS : STATUS_POLL_IDLE_MS;
+    const id = window.setInterval(() => void fetchStatus(), ms);
+    return () => window.clearInterval(id);
+  }, [active, fetchStatus]);
+
+  // List poll (slow, steady).
+  useEffect(() => {
+    void fetchList();
+    const id = window.setInterval(() => void fetchList(), LIST_POLL_MS);
+    return () => window.clearInterval(id);
+  }, [fetchList]);
+
+  // --- Theme colours + reduced-motion ---------------------------------------
+
+  useEffect(() => {
+    const refreshColors = () => {
+      colorsRef.current = readColors(rootRef.current);
     };
-  }, [refresh]);
+    refreshColors();
+    const mo = new MutationObserver(refreshColors);
+    mo.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme', 'data-fonts'] });
 
-  const recording = status.state === 'recording';
-  const playing = status.state === 'playing';
-  const idle = status.state === 'idle';
-  const reelActive: 'rec' | 'play' | null = recording ? 'rec' : playing ? 'play' : null;
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const applyRm = () => {
+      reducedMotionRef.current = mq.matches;
+    };
+    applyRm();
+    mq.addEventListener('change', applyRm);
+    return () => {
+      mo.disconnect();
+      mq.removeEventListener('change', applyRm);
+    };
+  }, []);
 
-  const onRec = async () => {
-    if (recording) await post('/api/wav/record/stop');
-    else await post('/api/wav/record/start', { source });
-    refresh();
-  };
-  const onPlay = async (file: string) => {
-    if (playing) await post('/api/wav/stop');
-    else await post('/api/wav/play', { file });
-    refresh();
-  };
-  const onDelete = async (file: string) => {
-    await fetch(`/api/wav/${encodeURIComponent(file)}`, { method: 'DELETE' });
-    refresh();
-  };
+  // --- Responsive reflow -----------------------------------------------------
 
-  const counter = recording ? status.seconds : 0;
+  useEffect(() => {
+    const el = rootRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width ?? el.clientWidth;
+      setNarrow(w < 640);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // --- Meter RAF loop --------------------------------------------------------
+
+  useEffect(() => {
+    const draw = () => {
+      const canvas = meterCanvasRef.current;
+      const disp = dispRef.current;
+      const target = targetRef.current;
+      const reduced = reducedMotionRef.current;
+
+      // Ease displayed levels: fast attack, slow release. Reduced motion snaps.
+      const ease = (cur: number, to: number) => {
+        if (reduced) return to;
+        const k = to > cur ? 0.5 : 0.08;
+        const next = cur + (to - cur) * k;
+        return Math.abs(next - to) < 0.001 ? to : next;
+      };
+      disp.peak = ease(disp.peak, target.peak);
+      disp.rms = ease(disp.rms, target.rms);
+      // Peak-hold: instant rise, slow decay.
+      if (target.peak >= disp.hold) disp.hold = target.peak;
+      else disp.hold = Math.max(target.peak, disp.hold - (reduced ? 0.02 : 0.006));
+
+      if (canvas) drawMeter(canvas, colorsRef.current, disp.peak, disp.rms, disp.hold, target.clip);
+      const vcanvas = vmeterCanvasRef.current;
+      if (vcanvas) drawVMeter(vcanvas, colorsRef.current, disp.peak, disp.rms, disp.hold);
+      rafRef.current = window.requestAnimationFrame(draw);
+    };
+    rafRef.current = window.requestAnimationFrame(draw);
+    return () => {
+      if (rafRef.current !== null) window.cancelAnimationFrame(rafRef.current);
+    };
+  }, []);
+
+  // --- Waveform fetch on selection change ------------------------------------
+
+  useEffect(() => {
+    if (!selected) {
+      setWaveBuckets(null);
+      return;
+    }
+    const cached = waveCacheRef.current.get(selected);
+    if (cached) {
+      setWaveBuckets(cached);
+      return;
+    }
+    const ctrl = new AbortController();
+    const url = `/api/wav/waveform?file=${encodeURIComponent(selected)}&buckets=${WAVE_BUCKETS}`;
+    fetch(url, { signal: ctrl.signal })
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`${r.status}`))))
+      .then((w: WaveformResp) => {
+        const buckets = Array.isArray(w.buckets) ? w.buckets : [];
+        waveCacheRef.current.set(selected, buckets);
+        setWaveBuckets(buckets);
+      })
+      .catch(() => {
+        /* leave empty well; selection still valid for playback */
+      });
+    return () => ctrl.abort();
+  }, [selected]);
+
+  // --- Waveform redraw (buckets / progress / size) ---------------------------
+
+  const playingThis = status.state === 'playing' && status.file !== null && status.file === selected;
+  const progress = playingThis && status.durationSec > 0 ? status.seconds / status.durationSec : -1;
+
+  useEffect(() => {
+    const canvas = waveCanvasRef.current;
+    if (!canvas) return;
+    drawWaveform(canvas, colorsRef.current, waveBuckets, progress);
+  }, [waveBuckets, progress, narrow]);
+
+  useEffect(() => {
+    const canvas = waveCanvasRef.current;
+    if (!canvas || typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(() => drawWaveform(canvas, colorsRef.current, waveBuckets, progress));
+    ro.observe(canvas);
+    return () => ro.disconnect();
+  }, [waveBuckets, progress]);
+
+  // --- Derived data ----------------------------------------------------------
+
+  const folderChildren = useMemo(() => childFolders(folders, currentFolder), [folders, currentFolder]);
+  const filesHere = useMemo(
+    () =>
+      recordings
+        .filter((r) => r.folder === currentFolder)
+        .slice()
+        .sort((a, b) => b.modifiedUnixMs - a.modifiedUnixMs),
+    [recordings, currentFolder],
+  );
+  const crumbs = useMemo(() => breadcrumb(currentFolder), [currentFolder]);
+  const allFolders = useMemo(() => folders.slice().sort((a, b) => a.localeCompare(b)), [folders]);
+  const selectedRec = useMemo(
+    () => recordings.find((r) => r.relPath === selected) ?? null,
+    [recordings, selected],
+  );
+
+  const recState = status.state;
+  const isRecording = recState === 'recording';
+  const isPlaying = recState === 'playing';
+  const isIdle = recState === 'idle';
+
+  // --- Transport handlers ----------------------------------------------------
+
+  const onRecord = useCallback(async () => {
+    try {
+      if (isRecording) {
+        await postJson('/api/wav/record/stop');
+      } else {
+        await postJson('/api/wav/record/start', {
+          source: recordSource,
+          folder: currentFolder || undefined,
+        });
+      }
+    } catch (e) {
+      flashError(e instanceof Error ? e.message : 'Record failed');
+    } finally {
+      refresh();
+    }
+  }, [isRecording, recordSource, currentFolder, refresh, flashError]);
+
+  const onPlay = useCallback(
+    async (dest: 'local' | 'air') => {
+      if (!selected) return;
+      try {
+        await postJson('/api/wav/play', { file: selected, dest });
+      } catch (e) {
+        flashError(e instanceof Error ? e.message : 'Playback failed');
+      } finally {
+        refresh();
+      }
+    },
+    [selected, refresh, flashError],
+  );
+
+  const onStop = useCallback(async () => {
+    try {
+      if (isRecording) await postJson('/api/wav/record/stop');
+      else await postJson('/api/wav/stop');
+    } catch (e) {
+      flashError(e instanceof Error ? e.message : 'Stop failed');
+    } finally {
+      refresh();
+    }
+  }, [isRecording, refresh, flashError]);
+
+  // --- File-system handlers --------------------------------------------------
+
+  const onNewFolder = useCallback(async () => {
+    const name = window.prompt('New folder name');
+    if (!name) return;
+    const path = joinFolder(currentFolder, name.trim());
+    if (!path) return;
+    try {
+      await postJson('/api/wav/folder/create', { path });
+    } catch (e) {
+      flashError(e instanceof Error ? e.message : 'Create folder failed');
+    } finally {
+      fetchList();
+    }
+  }, [currentFolder, fetchList, flashError]);
+
+  const onDeleteFolder = useCallback(
+    async (path: string) => {
+      try {
+        await postJson('/api/wav/folder/delete', { path });
+      } catch (e) {
+        flashError(e instanceof Error ? e.message : 'Delete folder failed');
+      } finally {
+        setConfirmFolderDelete(null);
+        fetchList();
+      }
+    },
+    [fetchList, flashError],
+  );
+
+  const commitRename = useCallback(
+    async (from: string) => {
+      const name = renameDraft.trim();
+      setRenaming(null);
+      if (!name) return;
+      try {
+        const res = await postJson<{ relPath: string }>('/api/wav/rename', { from, name });
+        if (res?.relPath) {
+          waveCacheRef.current.delete(from);
+          setSelected(res.relPath);
+        }
+      } catch (e) {
+        flashError(e instanceof Error ? e.message : 'Rename failed');
+      } finally {
+        fetchList();
+      }
+    },
+    [renameDraft, fetchList, flashError],
+  );
+
+  const onMove = useCallback(
+    async (from: string, folder: string) => {
+      setMoveMenu(null);
+      try {
+        const res = await postJson<{ relPath: string }>('/api/wav/move', { from, folder });
+        if (res?.relPath) {
+          waveCacheRef.current.delete(from);
+          setSelected(res.relPath);
+        }
+      } catch (e) {
+        flashError(e instanceof Error ? e.message : 'Move failed');
+      } finally {
+        fetchList();
+      }
+    },
+    [fetchList, flashError],
+  );
+
+  const onDeleteFile = useCallback(
+    async (relPath: string) => {
+      setConfirmDelete(null);
+      try {
+        await postJson('/api/wav/delete', { file: relPath });
+        waveCacheRef.current.delete(relPath);
+        if (selected === relPath) setSelected(null);
+      } catch (e) {
+        flashError(e instanceof Error ? e.message : 'Delete failed');
+      } finally {
+        fetchList();
+      }
+    },
+    [selected, fetchList, flashError],
+  );
+
+  // --- Readouts --------------------------------------------------------------
+
+  const peakDbText = fmtDb(status.peakDb);
+  const heldDbText = useMemo(() => {
+    // Convert the displayed peak-hold fraction back to a coarse dB label.
+    const h = dispRef.current.hold;
+    void status; // re-evaluate as status changes
+    if (h <= 0.0001) return '-∞';
+    return (20 * Math.log10(h)).toFixed(1);
+  }, [status]);
+
+  const counterText = isRecording
+    ? fmtClock(status.seconds)
+    : isPlaying
+      ? `${fmtClock(status.seconds)} / ${fmtClock(status.durationSec)}`
+      : selectedRec
+        ? `00:00 / ${fmtClock(selectedRec.durationSec)}`
+        : '00:00';
+
+  const statusLabel = isRecording
+    ? `RECORDING · ${status.source.toUpperCase()}`
+    : isPlaying
+      ? status.onAir
+        ? 'ON AIR'
+        : 'PLAYING'
+      : 'IDLE';
+
+  // --- Render ----------------------------------------------------------------
 
   return (
-    <div className="reel-deck">
-      <div className="reel-deck__deck">
-        <div className="reel-deck__reels">
-          <div className="reel-deck__tape-path" />
-          <Reel active={reelActive} />
-          <div className="reel-deck__counter" style={{ alignSelf: 'center' }}>
-            <span className={recording ? 'reel-deck__counter is-rec' : 'reel-deck__counter'}>
-              {String(Math.floor(counter / 60)).padStart(2, '0')}:
-              {String(Math.floor(counter % 60)).padStart(2, '0')}
-            </span>
-          </div>
-          <Reel active={reelActive} />
-        </div>
-
-        <div className="reel-deck__transport">
-          <button
-            className={recording ? 'reel-btn is-rec-active' : 'reel-btn'}
-            onClick={onRec}
-            disabled={playing}
-            title={recording ? 'Stop recording' : 'Start recording'}
-          >
-            {recording ? '■ STOP' : '● REC'}
-          </button>
-
-          <div style={{ display: 'flex', gap: 2, opacity: idle ? 1 : 0.5 }}>
-            {(['rx', 'tx'] as const).map((s) => (
+    <div ref={rootRef} className={`zdr${narrow ? ' zdr--narrow' : ''}`}>
+      <div className="zdr__body">
+        {/* ---- File system column ---- */}
+        <section className="zdr__library" aria-label="Recordings library">
+          <header className="zdr__libhead">
+            <nav className="zdr__crumbs" aria-label="Folder breadcrumb">
+              {crumbs.map((c, i) => (
+                <span key={c.path || 'root'} className="zdr__crumb-wrap">
+                  {i > 0 && <span className="zdr__crumb-sep">/</span>}
+                  <button
+                    type="button"
+                    className={`zdr__crumb${c.path === currentFolder ? ' is-current' : ''}`}
+                    onClick={() => setCurrentFolder(c.path)}
+                  >
+                    {c.label}
+                  </button>
+                </span>
+              ))}
+            </nav>
+            <div className="zdr__libactions">
+              {currentFolder && (
+                <button
+                  type="button"
+                  className="zdr__iconbtn"
+                  aria-label="Up one folder"
+                  title="Up one folder"
+                  onClick={() => setCurrentFolder(parentOf(currentFolder))}
+                >
+                  ↑
+                </button>
+              )}
               <button
-                key={s}
-                className={source === s ? 'reel-btn is-on' : 'reel-btn'}
-                onClick={() => setSource(s)}
-                disabled={!idle}
-                style={{ padding: '5px 9px' }}
-                title={s === 'rx' ? 'Record received audio' : 'Record your mic (transmit audio) — silent, no monitor'}
+                type="button"
+                className="zdr__iconbtn"
+                aria-label="New folder"
+                title="New folder"
+                onClick={onNewFolder}
               >
-                {s.toUpperCase()}
-              </button>
-            ))}
-          </div>
-
-          <span
-            style={{
-              marginLeft: 'auto',
-              fontWeight: status.onAir ? 700 : 400,
-              color: status.onAir ? 'var(--tx, #e63a2b)' : 'var(--text)',
-              opacity: status.onAir ? 1 : 0.8,
-            }}
-          >
-            {recording
-              ? `REC ${status.source.toUpperCase()}`
-              : status.onAir
-                ? '🔴 ON AIR'
-                : playing
-                  ? '▶ playing…'
-                  : status.mox
-                    ? 'MOX up — Play transmits'
-                    : 'idle'}
-          </span>
-        </div>
-      </div>
-
-      {/* Recordings */}
-      <div className="reel-deck__list">
-        {list.length === 0 && (
-          <div className="reel-deck__hint" style={{ padding: '6px 2px' }}>
-            No recordings yet. Hit REC to capture {source.toUpperCase()} audio.
-          </div>
-        )}
-        {list.map((r) => {
-          const isThis = playing && !!status.file && status.file.endsWith(r.name);
-          return (
-            <div key={r.name} className={isThis ? 'reel-deck__row is-playing' : 'reel-deck__row'}>
-              <button
-                className="reel-btn"
-                onClick={() => onPlay(r.name)}
-                disabled={recording}
-                style={{ padding: '2px 8px', minWidth: 38 }}
-                title={
-                  isThis
-                    ? 'Stop playback'
-                    : status.mox
-                      ? 'TRANSMIT this recording (MOX is on)'
-                      : 'Play locally (no transmit)'
-                }
-              >
-                {isThis ? '■' : status.mox ? '📡' : '▶'}
-              </button>
-              <span className="reel-deck__name" title={r.name}>
-                {r.name.replace(/^zeus-/, '')}
-              </span>
-              <span style={{ opacity: 0.55, fontSize: 11, fontVariantNumeric: 'tabular-nums' }}>
-                {fmtBytes(r.bytes)}
-              </span>
-              <button
-                className="reel-btn"
-                onClick={() => onDelete(r.name)}
-                disabled={recording || isThis}
-                style={{ padding: '2px 7px', opacity: 0.7, fontWeight: 400 }}
-                title="Delete recording"
-              >
-                ✕
+                ＋▣
               </button>
             </div>
-          );
-        })}
+          </header>
+
+          <div className="zdr__filelist">
+            {folderChildren.map((f) => (
+              <div key={f} className="zdr__folderrow">
+                <button
+                  type="button"
+                  className="zdr__folderbtn"
+                  onClick={() => setCurrentFolder(f)}
+                  title={`Open ${baseName(f)}`}
+                >
+                  <span className="zdr__glyph" aria-hidden="true">
+                    📁
+                  </span>
+                  <span className="zdr__folder-name">{baseName(f)}</span>
+                </button>
+                {confirmFolderDelete === f ? (
+                  <span className="zdr__confirm">
+                    <button
+                      type="button"
+                      className="zdr__iconbtn is-danger"
+                      aria-label="Confirm delete folder"
+                      onClick={() => onDeleteFolder(f)}
+                    >
+                      ✓
+                    </button>
+                    <button
+                      type="button"
+                      className="zdr__iconbtn"
+                      aria-label="Cancel"
+                      onClick={() => setConfirmFolderDelete(null)}
+                    >
+                      ✕
+                    </button>
+                  </span>
+                ) : (
+                  <button
+                    type="button"
+                    className="zdr__iconbtn zdr__rowdel"
+                    aria-label={`Delete folder ${baseName(f)}`}
+                    title="Delete folder"
+                    onClick={() => setConfirmFolderDelete(f)}
+                  >
+                    🗑
+                  </button>
+                )}
+              </div>
+            ))}
+
+            {filesHere.map((r) => {
+              const isSel = r.relPath === selected;
+              const isNowPlaying = isPlaying && status.file === r.relPath;
+              return (
+                <div
+                  key={r.relPath}
+                  className={`zdr__filerow${isSel ? ' is-selected' : ''}${isNowPlaying ? ' is-playing' : ''}`}
+                >
+                  {renaming === r.relPath ? (
+                    <input
+                      className="zdr__renameinput"
+                      autoFocus
+                      value={renameDraft}
+                      aria-label="New name"
+                      onChange={(e) => setRenameDraft(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') void commitRename(r.relPath);
+                        if (e.key === 'Escape') setRenaming(null);
+                      }}
+                      onBlur={() => void commitRename(r.relPath)}
+                    />
+                  ) : (
+                    <button
+                      type="button"
+                      className="zdr__filebtn"
+                      onClick={() => setSelected(r.relPath)}
+                      title={r.fileName}
+                    >
+                      <span className={`zdr__src zdr__src--${r.source}`} aria-hidden="true">
+                        {r.source === 'tx' ? 'TX' : r.source === 'rx' ? 'RX' : '··'}
+                      </span>
+                      <span className="zdr__file-name">{r.name}</span>
+                      <span className="zdr__file-meta">{fmtClock(r.durationSec)}</span>
+                      <span className="zdr__file-meta">{fmtBytes(r.bytes)}</span>
+                    </button>
+                  )}
+
+                  <div className="zdr__rowmenu">
+                    {moveMenu === r.relPath ? (
+                      <select
+                        className="zdr__moveselect"
+                        autoFocus
+                        aria-label="Move to folder"
+                        defaultValue={r.folder}
+                        onChange={(e) => void onMove(r.relPath, e.target.value)}
+                        onBlur={() => setMoveMenu(null)}
+                      >
+                        <option value="">Recordings (root)</option>
+                        {allFolders.map((f) => (
+                          <option key={f} value={f}>
+                            {f}
+                          </option>
+                        ))}
+                      </select>
+                    ) : confirmDelete === r.relPath ? (
+                      <span className="zdr__confirm">
+                        <button
+                          type="button"
+                          className="zdr__iconbtn is-danger"
+                          aria-label="Confirm delete"
+                          onClick={() => void onDeleteFile(r.relPath)}
+                        >
+                          ✓
+                        </button>
+                        <button
+                          type="button"
+                          className="zdr__iconbtn"
+                          aria-label="Cancel delete"
+                          onClick={() => setConfirmDelete(null)}
+                        >
+                          ✕
+                        </button>
+                      </span>
+                    ) : (
+                      <>
+                        <button
+                          type="button"
+                          className="zdr__iconbtn"
+                          aria-label={`Rename ${r.name}`}
+                          title="Rename"
+                          onClick={() => {
+                            setRenameDraft(r.name);
+                            setRenaming(r.relPath);
+                          }}
+                        >
+                          ✎
+                        </button>
+                        <button
+                          type="button"
+                          className="zdr__iconbtn"
+                          aria-label={`Move ${r.name}`}
+                          title="Move to folder"
+                          onClick={() => setMoveMenu(r.relPath)}
+                        >
+                          ⇄
+                        </button>
+                        <button
+                          type="button"
+                          className="zdr__iconbtn zdr__rowdel"
+                          aria-label={`Delete ${r.name}`}
+                          title="Delete"
+                          onClick={() => setConfirmDelete(r.relPath)}
+                        >
+                          🗑
+                        </button>
+                      </>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+
+            {folderChildren.length === 0 && filesHere.length === 0 && (
+              <div className="zdr__empty">
+                No recordings here. Hit <strong>REC</strong> to capture {recordSource.toUpperCase()} audio.
+              </div>
+            )}
+          </div>
+        </section>
+
+        {/* ---- Center column: meter · transport · waveform ---- */}
+        <section className="zdr__center" aria-label="Recorder console">
+          {/* Level meter */}
+          <div className="zdr__meter">
+            <div className="zdr__meterhead">
+              <span className="zdr__meterlabel">{isRecording ? 'INPUT LEVEL' : 'OUTPUT LEVEL'}</span>
+              <span className="zdr__lcd zdr__lcd--peak" aria-label="Peak level dBFS">
+                {peakDbText}
+                <small>dB</small>
+              </span>
+              <span className={`zdr__clip${status.clip ? ' is-clip' : ''}`} aria-live="polite">
+                CLIP
+              </span>
+            </div>
+            <canvas ref={meterCanvasRef} className="zdr__metercanvas" aria-hidden="true" />
+          </div>
+
+          {/* Transport */}
+          <div className="zdr__transport">
+            <button
+              type="button"
+              className={`zdr__xport zdr__xport--rec${isRecording ? ' is-on' : ''}`}
+              onClick={onRecord}
+              disabled={isPlaying}
+              aria-label={isRecording ? 'Stop recording' : 'Record'}
+              aria-pressed={isRecording}
+            >
+              <span className="zdr__xport-glyph zdr__glyph-rec" aria-hidden="true" />
+              <span className="zdr__xport-text">{isRecording ? 'REC ●' : 'REC'}</span>
+            </button>
+
+            <button
+              type="button"
+              className={`zdr__xport zdr__xport--play${isPlaying && !status.onAir ? ' is-on' : ''}`}
+              onClick={() => onPlay('local')}
+              disabled={!selected || isRecording}
+              aria-label="Play locally (monitor)"
+            >
+              <span className="zdr__xport-glyph zdr__glyph-play" aria-hidden="true" />
+              <span className="zdr__xport-text">PLAY</span>
+            </button>
+
+            <button
+              type="button"
+              className={`zdr__xport zdr__xport--air${status.onAir ? ' is-on' : ''}`}
+              onClick={() => onPlay('air')}
+              disabled={!selected || isRecording}
+              aria-label="Transmit over the air (engages MOX)"
+            >
+              <span className="zdr__xport-glyph zdr__glyph-air" aria-hidden="true">
+                <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+                  <path
+                    d="M12 3v9m0 0a3 3 0 1 0 0 6 3 3 0 0 0 0-6Zm-6.5-.5a9 9 0 0 1 13 0M8 6a5 5 0 0 1 8 0"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.6"
+                    strokeLinecap="round"
+                  />
+                </svg>
+              </span>
+              <span className="zdr__xport-text">{status.onAir ? 'ON AIR' : 'TX'}</span>
+            </button>
+
+            <button
+              type="button"
+              className="zdr__xport zdr__xport--stop"
+              onClick={onStop}
+              disabled={isIdle}
+              aria-label="Stop"
+            >
+              <span className="zdr__xport-glyph zdr__glyph-stop" aria-hidden="true" />
+              <span className="zdr__xport-text">STOP</span>
+            </button>
+
+            <div className="zdr__xport-side">
+              <div className="zdr__lcd zdr__lcd--clock" aria-label="Position">
+                {counterText}
+              </div>
+              <div className="zdr__srctoggle" role="group" aria-label="Record source">
+                {(['rx', 'tx'] as const).map((s) => (
+                  <button
+                    key={s}
+                    type="button"
+                    className={`zdr__srcbtn${recordSource === s ? ' is-on' : ''}`}
+                    onClick={() => setRecordSource(s)}
+                    disabled={!isIdle}
+                    aria-pressed={recordSource === s}
+                    title={s === 'rx' ? 'Record received audio' : 'Record transmit (mic) audio'}
+                  >
+                    {s.toUpperCase()}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Waveform */}
+          <div className="zdr__wavewrap">
+            <canvas ref={waveCanvasRef} className="zdr__wavecanvas" aria-hidden="true" />
+            {!selected && <div className="zdr__waveempty">Select a recording to view its waveform</div>}
+          </div>
+        </section>
+
+        {/* ---- Right rail: L/R meters + file info ---- */}
+        <aside className="zdr__rail" aria-label="Meters and file info">
+          {/* Vertical channel meters */}
+          <div className="zdr__vmeters">
+            <div className="zdr__railhead">METERS</div>
+            <div className="zdr__vmeterbody">
+              <canvas ref={vmeterCanvasRef} className="zdr__vmetercanvas" aria-hidden="true" />
+              <div className="zdr__vmeterscale">
+                <span>L</span>
+                <span>R</span>
+              </div>
+            </div>
+            <div className="zdr__railreadouts">
+              <span className="zdr__lcd zdr__lcd--big" aria-label="Peak level dBFS">
+                {peakDbText}
+                <small>dB</small>
+              </span>
+              <span className="zdr__lcd zdr__lcd--hold" aria-label="Held peak dBFS">
+                {heldDbText}
+                <small>pk</small>
+              </span>
+            </div>
+            <div className="zdr__railchips">
+              <span className="zdr__chip">48.0 kHz</span>
+              <span className="zdr__chip">f32 · mono</span>
+            </div>
+          </div>
+
+          {/* File info */}
+          <div className="zdr__info">
+            <div className="zdr__railhead">RECORDING FILE INFO</div>
+            <div className="zdr__info-title">{selectedRec ? selectedRec.name : 'No file selected'}</div>
+            <dl className="zdr__info-grid">
+              <div>
+                <dt>Duration</dt>
+                <dd>{selectedRec ? fmtClock(selectedRec.durationSec) : '—'}</dd>
+              </div>
+              <div>
+                <dt>Size</dt>
+                <dd>{selectedRec ? fmtBytes(selectedRec.bytes) : '—'}</dd>
+              </div>
+              <div>
+                <dt>Format</dt>
+                <dd>48 kHz · 32-bit float · mono</dd>
+              </div>
+              <div>
+                <dt>Source</dt>
+                <dd>
+                  {selectedRec
+                    ? selectedRec.source === 'tx'
+                      ? 'TX (transmit)'
+                      : selectedRec.source === 'rx'
+                        ? 'RX (receive)'
+                        : 'Unknown'
+                    : '—'}
+                </dd>
+              </div>
+              <div className="zdr__info-wide">
+                <dt>Modified</dt>
+                <dd>{selectedRec ? fmtDate(selectedRec.modifiedUnixMs) : '—'}</dd>
+              </div>
+            </dl>
+          </div>
+        </aside>
       </div>
 
-      <div className="reel-deck__hint">
-        Saves to Downloads · float32 WAV · Play with <strong>MOX up = on the air</strong>, MOX off = local
-      </div>
+      {/* Status bar */}
+      <footer className="zdr__statusbar">
+        <span className={`zdr__statepill zdr__statepill--${recState}`}>{statusLabel}</span>
+        <span className={`zdr__onair${status.onAir ? ' is-on' : ''}`}>
+          <span className="zdr__onair-dot" aria-hidden="true" />
+          {status.onAir ? 'ON AIR' : status.mox ? 'MOX' : 'RX'}
+        </span>
+        {error && (
+          <span className="zdr__errmsg" role="alert">
+            {error}
+          </span>
+        )}
+      </footer>
     </div>
   );
+}
+
+// ---------------------------------------------------------------------------
+// Canvas drawing (module-scope, pure of React)
+// ---------------------------------------------------------------------------
+
+function drawMeter(
+  canvas: HTMLCanvasElement,
+  c: MeterColors,
+  peak: number,
+  rms: number,
+  hold: number,
+  clip: boolean,
+): void {
+  const fit = fitCanvas(canvas);
+  if (!fit) return;
+  const { ctx, w, h } = fit;
+  ctx.clearRect(0, 0, w, h);
+
+  const gap = Math.max(1, Math.round(w / SEGMENTS / 6));
+  const segW = (w - gap * (SEGMENTS - 1)) / SEGMENTS;
+  const peakLit = litSegments(peak, SEGMENTS);
+  const rmsLit = litSegments(rms, SEGMENTS);
+  const holdIdx = Math.min(SEGMENTS - 1, litSegments(hold, SEGMENTS) - 1);
+
+  for (let i = 0; i < SEGMENTS; i++) {
+    const x = i * (segW + gap);
+    const col = zoneColor(c, i);
+    // Well (off) segment.
+    ctx.fillStyle = c.well;
+    ctx.fillRect(x, 0, segW, h);
+    ctx.strokeStyle = c.line;
+    ctx.lineWidth = 1;
+    ctx.strokeRect(x + 0.5, 0.5, segW - 1, h - 1);
+
+    if (i < rmsLit) {
+      // Solid lit core (rms) — bright + glow.
+      ctx.save();
+      ctx.shadowColor = col;
+      ctx.shadowBlur = Math.max(2, segW * 0.5);
+      ctx.fillStyle = col;
+      ctx.fillRect(x, 0, segW, h);
+      ctx.restore();
+    } else if (i < peakLit) {
+      // Peak overhang — dimmer, no heavy glow.
+      ctx.globalAlpha = 0.42;
+      ctx.fillStyle = col;
+      ctx.fillRect(x, 0, segW, h);
+      ctx.globalAlpha = 1;
+    }
+  }
+
+  // Peak-hold tick.
+  if (holdIdx >= 0) {
+    const x = holdIdx * (segW + gap);
+    const col = zoneColor(c, holdIdx);
+    ctx.save();
+    ctx.shadowColor = col;
+    ctx.shadowBlur = Math.max(3, segW * 0.7);
+    ctx.fillStyle = col;
+    ctx.fillRect(x, 0, segW, h);
+    ctx.fillStyle = 'rgba(255,255,255,0.55)';
+    ctx.fillRect(x, 0, segW, Math.max(2, h * 0.18));
+    ctx.fillRect(x, h - Math.max(2, h * 0.18), segW, Math.max(2, h * 0.18));
+    ctx.restore();
+  }
+
+  // Clip flare on the last segment.
+  if (clip) {
+    const x = (SEGMENTS - 1) * (segW + gap);
+    ctx.save();
+    ctx.shadowColor = c.red;
+    ctx.shadowBlur = segW * 1.2;
+    ctx.fillStyle = c.red;
+    ctx.fillRect(x, 0, segW, h);
+    ctx.restore();
+  }
+}
+
+function drawWaveform(
+  canvas: HTMLCanvasElement,
+  c: MeterColors,
+  buckets: number[] | null,
+  progress: number,
+): void {
+  const fit = fitCanvas(canvas);
+  if (!fit) return;
+  const { ctx, w, h } = fit;
+  ctx.clearRect(0, 0, w, h);
+
+  // Well background + centre line.
+  ctx.fillStyle = c.well;
+  ctx.fillRect(0, 0, w, h);
+  ctx.strokeStyle = c.line;
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(0, h / 2 + 0.5);
+  ctx.lineTo(w, h / 2 + 0.5);
+  ctx.stroke();
+
+  if (!buckets || buckets.length === 0) return;
+
+  const n = buckets.length;
+  const mid = h / 2;
+  const colW = w / n;
+  ctx.fillStyle = c.amber;
+  for (let i = 0; i < n; i++) {
+    const v = Math.max(0, Math.min(1, buckets[i] ?? 0));
+    const half = Math.max(0.5, v * (h / 2 - 1));
+    const x = i * colW;
+    const bw = Math.max(0.6, colW - 0.4);
+    ctx.fillRect(x, mid - half, bw, half * 2);
+  }
+
+  // Playback progress line.
+  if (progress >= 0) {
+    const px = Math.max(0, Math.min(1, progress)) * w;
+    ctx.save();
+    ctx.strokeStyle = c.accent;
+    ctx.shadowColor = c.accent;
+    ctx.shadowBlur = 6;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.moveTo(px, 0);
+    ctx.lineTo(px, h);
+    ctx.stroke();
+    ctx.restore();
+  }
+}
+
+const VSEGMENTS = 28;
+
+/** Two vertical segmented LED columns (L/R). Audio is mono, so both columns
+ *  read the same level — a faithful "stereo meter" face on a mono source. */
+function drawVMeter(canvas: HTMLCanvasElement, c: MeterColors, peak: number, rms: number, hold: number): void {
+  const fit = fitCanvas(canvas);
+  if (!fit) return;
+  const { ctx, w, h } = fit;
+  ctx.clearRect(0, 0, w, h);
+
+  const cols = 2;
+  const colGap = Math.max(3, w * 0.12);
+  const colW = (w - colGap * (cols + 1)) / cols;
+  const vgap = Math.max(1, Math.round(h / VSEGMENTS / 7));
+  const segH = (h - vgap * (VSEGMENTS - 1)) / VSEGMENTS;
+  const peakLit = litSegments(peak, VSEGMENTS);
+  const rmsLit = litSegments(rms, VSEGMENTS);
+  const holdIdx = Math.min(VSEGMENTS - 1, litSegments(hold, VSEGMENTS) - 1);
+
+  // Zone by vertical position (top = hot).
+  const vzone = (i: number): string => {
+    const frac = VSEGMENTS <= 1 ? 0 : i / (VSEGMENTS - 1);
+    if (frac >= 0.88) return c.red;
+    if (frac >= 0.66) return c.amber;
+    return c.green;
+  };
+
+  for (let col = 0; col < cols; col++) {
+    const x = colGap + col * (colW + colGap);
+    for (let i = 0; i < VSEGMENTS; i++) {
+      // i counts from bottom; y inverts.
+      const y = h - (i + 1) * segH - i * vgap;
+      const color = vzone(i);
+      ctx.fillStyle = c.well;
+      ctx.fillRect(x, y, colW, segH);
+      if (i < rmsLit) {
+        ctx.save();
+        ctx.shadowColor = color;
+        ctx.shadowBlur = Math.max(2, colW * 0.4);
+        ctx.fillStyle = color;
+        ctx.fillRect(x, y, colW, segH);
+        ctx.restore();
+      } else if (i < peakLit) {
+        ctx.globalAlpha = 0.42;
+        ctx.fillStyle = color;
+        ctx.fillRect(x, y, colW, segH);
+        ctx.globalAlpha = 1;
+      }
+    }
+    if (holdIdx >= 0) {
+      const y = h - (holdIdx + 1) * segH - holdIdx * vgap;
+      ctx.save();
+      ctx.shadowColor = vzone(holdIdx);
+      ctx.shadowBlur = Math.max(3, colW * 0.5);
+      ctx.fillStyle = vzone(holdIdx);
+      ctx.fillRect(x, y, colW, segH);
+      ctx.restore();
+    }
+  }
 }

--- a/zeus-web/src/layout/panels/wavRecorder.format.test.ts
+++ b/zeus-web/src/layout/panels/wavRecorder.format.test.ts
@@ -23,6 +23,7 @@ import {
   breadcrumb,
   segmentZone,
   litSegments,
+  abbreviatePath,
 } from './wavRecorder.format';
 
 describe('fmtBytes', () => {
@@ -49,6 +50,10 @@ describe('fmtClock', () => {
   it('clamps negatives and non-finite to 00:00', () => {
     expect(fmtClock(-3)).toBe('00:00');
     expect(fmtClock(NaN)).toBe('00:00');
+  });
+  it('rolls hours into minutes (mm:ss, no hour field)', () => {
+    expect(fmtClock(3661)).toBe('61:01');
+    expect(fmtClock(7200)).toBe('120:00');
   });
 });
 
@@ -89,6 +94,12 @@ describe('childFolders', () => {
   it('returns empty for a leaf', () => {
     expect(childFolders(folders, 'Nets/Weekly')).toEqual([]);
   });
+  it('does not treat a prefix-sibling as a child', () => {
+    // "DXpedition" shares the "DX" prefix but is NOT a child of "DX".
+    const f = ['DX', 'DXpedition', 'DX/2024'];
+    expect(childFolders(f, 'DX')).toEqual(['DX/2024']);
+    expect(childFolders(f, '')).toEqual(['DX', 'DXpedition']);
+  });
 });
 
 describe('breadcrumb', () => {
@@ -118,5 +129,25 @@ describe('meter ladder', () => {
     expect(litSegments(2, 40)).toBe(40);
     expect(litSegments(-1, 40)).toBe(0);
     expect(litSegments(NaN, 40)).toBe(0);
+  });
+});
+
+describe('abbreviatePath', () => {
+  it('returns empty for empty input', () => {
+    expect(abbreviatePath('')).toBe('');
+  });
+  it('leaves short paths intact', () => {
+    expect(abbreviatePath('/home')).toBe('/home');
+    expect(abbreviatePath('/home/doug')).toBe('/home/doug');
+  });
+  it('keeps the last two POSIX segments with an ellipsis prefix', () => {
+    expect(abbreviatePath('/Users/doug/Music/Recordings')).toBe('…/Music/Recordings');
+  });
+  it('keeps the last two Windows segments with a backslash separator', () => {
+    expect(abbreviatePath('C:\\Users\\Doug\\Recordings')).toBe('…\\Doug\\Recordings');
+  });
+  it('honors a custom tail length', () => {
+    expect(abbreviatePath('/a/b/c/d', 1)).toBe('…/d');
+    expect(abbreviatePath('/a/b/c/d', 3)).toBe('…/b/c/d');
   });
 });

--- a/zeus-web/src/layout/panels/wavRecorder.format.test.ts
+++ b/zeus-web/src/layout/panels/wavRecorder.format.test.ts
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+import { describe, it, expect } from 'vitest';
+import {
+  fmtBytes,
+  fmtClock,
+  fmtDb,
+  parentOf,
+  baseName,
+  joinFolder,
+  childFolders,
+  breadcrumb,
+  segmentZone,
+  litSegments,
+} from './wavRecorder.format';
+
+describe('fmtBytes', () => {
+  it('formats across magnitudes', () => {
+    expect(fmtBytes(0)).toBe('0 B');
+    expect(fmtBytes(512)).toBe('512 B');
+    expect(fmtBytes(2048)).toBe('2 KB');
+    expect(fmtBytes(5 * 1024 * 1024)).toBe('5.0 MB');
+    expect(fmtBytes(3 * 1024 * 1024 * 1024)).toBe('3.00 GB');
+  });
+  it('guards bad input', () => {
+    expect(fmtBytes(-1)).toBe('—');
+    expect(fmtBytes(NaN)).toBe('—');
+  });
+});
+
+describe('fmtClock', () => {
+  it('formats mm:ss', () => {
+    expect(fmtClock(0)).toBe('00:00');
+    expect(fmtClock(5)).toBe('00:05');
+    expect(fmtClock(65)).toBe('01:05');
+    expect(fmtClock(600)).toBe('10:00');
+  });
+  it('clamps negatives and non-finite to 00:00', () => {
+    expect(fmtClock(-3)).toBe('00:00');
+    expect(fmtClock(NaN)).toBe('00:00');
+  });
+});
+
+describe('fmtDb', () => {
+  it('floors at -infinity', () => {
+    expect(fmtDb(-100)).toBe('-∞');
+    expect(fmtDb(-120)).toBe('-∞');
+    expect(fmtDb(-26.3)).toBe('-26.3');
+    expect(fmtDb(0)).toBe('0.0');
+  });
+});
+
+describe('path helpers', () => {
+  it('parentOf', () => {
+    expect(parentOf('cq.wav')).toBe('');
+    expect(parentOf('DX/cq.wav')).toBe('DX');
+    expect(parentOf('DX/2024/cq.wav')).toBe('DX/2024');
+  });
+  it('baseName', () => {
+    expect(baseName('cq.wav')).toBe('cq.wav');
+    expect(baseName('DX/2024/cq.wav')).toBe('cq.wav');
+  });
+  it('joinFolder', () => {
+    expect(joinFolder('', 'DX')).toBe('DX');
+    expect(joinFolder('DX', 'sub')).toBe('DX/sub');
+    expect(joinFolder('DX/', '/sub/')).toBe('DX/sub');
+  });
+});
+
+describe('childFolders', () => {
+  const folders = ['DX', 'DX/2024', 'DX/2025', 'Nets', 'Nets/Weekly'];
+  it('returns immediate children of root', () => {
+    expect(childFolders(folders, '')).toEqual(['DX', 'Nets']);
+  });
+  it('returns immediate children of a subfolder', () => {
+    expect(childFolders(folders, 'DX')).toEqual(['DX/2024', 'DX/2025']);
+  });
+  it('returns empty for a leaf', () => {
+    expect(childFolders(folders, 'Nets/Weekly')).toEqual([]);
+  });
+});
+
+describe('breadcrumb', () => {
+  it('root', () => {
+    expect(breadcrumb('')).toEqual([{ label: 'Recordings', path: '' }]);
+  });
+  it('nested', () => {
+    expect(breadcrumb('DX/2024')).toEqual([
+      { label: 'Recordings', path: '' },
+      { label: 'DX', path: 'DX' },
+      { label: '2024', path: 'DX/2024' },
+    ]);
+  });
+});
+
+describe('meter ladder', () => {
+  it('classifies zones by position', () => {
+    expect(segmentZone(0, 40)).toBe('green');
+    expect(segmentZone(20, 40)).toBe('green');
+    expect(segmentZone(30, 40)).toBe('amber');
+    expect(segmentZone(39, 40)).toBe('red');
+  });
+  it('lit count clamps to 0..total', () => {
+    expect(litSegments(0, 40)).toBe(0);
+    expect(litSegments(0.5, 40)).toBe(20);
+    expect(litSegments(1, 40)).toBe(40);
+    expect(litSegments(2, 40)).toBe(40);
+    expect(litSegments(-1, 40)).toBe(0);
+    expect(litSegments(NaN, 40)).toBe(0);
+  });
+});

--- a/zeus-web/src/layout/panels/wavRecorder.format.ts
+++ b/zeus-web/src/layout/panels/wavRecorder.format.ts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Pure formatting + folder-tree helpers for the Digital Recorder panel.
+// Kept side-effect-free so they can be unit-tested without a DOM.
+
+/** Human-readable byte count: B / KB / MB / GB. */
+export function fmtBytes(b: number): string {
+  if (!Number.isFinite(b) || b < 0) return '—';
+  if (b < 1024) return `${b} B`;
+  if (b < 1024 * 1024) return `${(b / 1024).toFixed(0)} KB`;
+  if (b < 1024 * 1024 * 1024) return `${(b / 1024 / 1024).toFixed(1)} MB`;
+  return `${(b / 1024 / 1024 / 1024).toFixed(2)} GB`;
+}
+
+/** Seconds → mm:ss (clamped at 0, no negative). Hours roll into minutes. */
+export function fmtClock(seconds: number): string {
+  const s = Number.isFinite(seconds) && seconds > 0 ? Math.floor(seconds) : 0;
+  const mm = Math.floor(s / 60);
+  const ss = s % 60;
+  return `${String(mm).padStart(2, '0')}:${String(ss).padStart(2, '0')}`;
+}
+
+/** dBFS readout. The backend floors at -100; treat anything at/below as -∞. */
+export function fmtDb(db: number): string {
+  if (!Number.isFinite(db) || db <= -100) return '-∞';
+  return db.toFixed(1);
+}
+
+/** Local short date+time for a recording's modified timestamp. */
+export function fmtDate(unixMs: number): string {
+  if (!Number.isFinite(unixMs) || unixMs <= 0) return '—';
+  const d = new Date(unixMs);
+  return d.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+/** Parent folder of a forward-slash root-relative path. Root → ''. */
+export function parentOf(path: string): string {
+  const i = path.lastIndexOf('/');
+  return i < 0 ? '' : path.slice(0, i);
+}
+
+/** Last path segment (display name) of a forward-slash path. */
+export function baseName(path: string): string {
+  const i = path.lastIndexOf('/');
+  return i < 0 ? path : path.slice(i + 1);
+}
+
+/** Join a parent folder and a child segment into a root-relative path. */
+export function joinFolder(parent: string, child: string): string {
+  const p = parent.replace(/\/+$/, '');
+  const c = child.replace(/^\/+/, '').replace(/\/+$/, '');
+  return p ? `${p}/${c}` : c;
+}
+
+/** Immediate child folders of `current`, sorted by display name. */
+export function childFolders(folders: readonly string[], current: string): string[] {
+  return folders
+    .filter((f) => f !== '' && parentOf(f) === current)
+    .slice()
+    .sort((a, b) => baseName(a).localeCompare(baseName(b)));
+}
+
+/** Breadcrumb segments from root to `current`, each with its cumulative path. */
+export function breadcrumb(current: string): Array<{ label: string; path: string }> {
+  const crumbs: Array<{ label: string; path: string }> = [{ label: 'Recordings', path: '' }];
+  if (!current) return crumbs;
+  const parts = current.split('/');
+  let acc = '';
+  for (const part of parts) {
+    if (!part) continue;
+    acc = acc ? `${acc}/${part}` : part;
+    crumbs.push({ label: part, path: acc });
+  }
+  return crumbs;
+}
+
+/**
+ * Map a 0..1 peak fraction to a count of lit LED segments, and classify each
+ * segment index into its colour zone. Zones are by segment POSITION (classic
+ * LED ladder), not the overall level: green up to ~66%, amber to ~88%, red on
+ * the top. Returns a helper closure the canvas draw loop calls per segment.
+ */
+export type Zone = 'green' | 'amber' | 'red';
+export function segmentZone(index: number, total: number): Zone {
+  const frac = total <= 1 ? 0 : index / (total - 1);
+  if (frac >= 0.88) return 'red';
+  if (frac >= 0.66) return 'amber';
+  return 'green';
+}
+
+/** Number of lit segments for a given 0..1 level over `total` segments. */
+export function litSegments(level: number, total: number): number {
+  const clamped = Number.isFinite(level) ? Math.max(0, Math.min(1, level)) : 0;
+  return Math.round(clamped * total);
+}

--- a/zeus-web/src/layout/panels/wavRecorder.format.ts
+++ b/zeus-web/src/layout/panels/wavRecorder.format.ts
@@ -11,7 +11,7 @@
 // option) any later version. See the LICENSE file at the root of this
 // repository for the full text, or https://www.gnu.org/licenses/.
 //
-// Pure formatting + folder-tree helpers for the Digital Recorder panel.
+// Pure formatting + folder-tree helpers for the WAV Recorder panel.
 // Kept side-effect-free so they can be unit-tested without a DOM.
 
 /** Human-readable byte count: B / KB / MB / GB. */
@@ -109,4 +109,19 @@ export function segmentZone(index: number, total: number): Zone {
 export function litSegments(level: number, total: number): number {
   const clamped = Number.isFinite(level) ? Math.max(0, Math.min(1, level)) : 0;
   return Math.round(clamped * total);
+}
+
+/**
+ * Abbreviate an absolute filesystem path for a compact button label, keeping
+ * the last `tailSegments` path segments and prefixing an ellipsis when the
+ * path was shortened. Handles both POSIX (`/`) and Windows (`\`) separators so
+ * the label is correct regardless of the server platform. The full path still
+ * belongs in a `title` tooltip. Empty input → ''.
+ */
+export function abbreviatePath(path: string, tailSegments = 2): string {
+  if (!path) return '';
+  const sep = path.includes('\\') ? '\\' : '/';
+  const parts = path.split(/[\\/]+/).filter(Boolean);
+  if (parts.length <= tailSegments) return path;
+  return `…${sep}${parts.slice(-tailSegments).join(sep)}`;
 }

--- a/zeus-web/src/styles/all-panels.css
+++ b/zeus-web/src/styles/all-panels.css
@@ -474,6 +474,7 @@
 .workspace-tile[data-panel-id='freedvstations'] > .workspace-tile-body,
 .workspace-tile[data-panel-id='vfo'] > .workspace-tile-body,
 .workspace-tile[data-panel-id='chat'] > .workspace-tile-body,
+.workspace-tile[data-panel-id='wavrecorder'] > .workspace-tile-body,
 .workspace-tile[data-panel-id='filterpresets'] > .workspace-tile-body {
   display: flex;
   flex-direction: column;
@@ -491,6 +492,7 @@
 .workspace-tile[data-panel-id='freedvstations'] > .workspace-tile-body > *,
 .workspace-tile[data-panel-id='vfo'] > .workspace-tile-body > *,
 .workspace-tile[data-panel-id='chat'] > .workspace-tile-body > *,
+.workspace-tile[data-panel-id='wavrecorder'] > .workspace-tile-body > *,
 .workspace-tile[data-panel-id='filterpresets'] > .workspace-tile-body > * {
   flex: 1 1 auto;
   min-height: 0;


### PR DESCRIPTION
## What & why

Reworks the WAV recorder / tape deck into a high-end, rack-mount **Digital Recorder** — built to the reference render KB2UKA provided, themed entirely via Zeus tokens. Addresses every gap in the original: no level meters, flat file list, no rename, no folders, and over-the-air playback that forced the operator to key MOX manually then go back and press play.

## Highlights

**Lit-up level meters** — segmented green→amber→red LED bar with dBFS + peak-hold readouts and a CLIP latch, fed by a lock-free backend peak/RMS/clip meter folded straight off the capture and playback paths.

**File-folder system + full CRUD** — recordings now live under a managed root (`<Downloads>/Zeus Recordings`) with arbitrary folders. Browse with breadcrumbs, **rename inline**, **move to folder**, **create/delete folders**, delete files — all traversal-guarded on the server. A one-time migration pulls loose legacy `zeus-*.wav` out of Downloads into the root.

**One-click local *and* transmit** — two distinct buttons:
- **PLAY** → local monitor only, never keys.
- **TRANSMIT** → engages MOX itself and sends the recording over the air, then **auto-unkeys when the clip ends**.

**Waveform** — canvas overview of the selected clip with a live playback-progress line.

## ⚠️ Maintainer review needed (red-light items)

1. **Real-RF behavior change — auto-keying MOX.** The TRANSMIT button now keys the transmitter programmatically (new `MoxSource.Wav`, appending-only enum value). It reuses the **entire** existing `TrySetMox` path — connect-interlock, band-guard, WDSP TXA-up before the wire MOX bit, all SWR/timeout trips — so it bypasses no safety gate. Ownership is clean: it keys as `Wav`, releases only what `Wav` raised, rides an operator-held key without dropping it, and never arms PureSignal or auto-keys on connect. This is the explicitly-requested "one-click transmit," but it is new RF-keying behavior and wants a sign-off.
2. **Visual design / UX.** New panel aesthetic (built to KB2UKA's render), distinct PLAY vs TRANSMIT semantics, and the default save location moving to a managed `Zeus Recordings/` subfolder.

## Bench gate

On-radio paths (RX/TX capture, **over-the-air transmit playback**) are **not** bench-verified — they need a live rig. Please bench on the **G2** before merge. All deterministic logic (file ops, CRUD, traversal guard, meter math, header read, waveform envelope) is unit-tested headless.

## Tests & gates
- `dotnet build Zeus.slnx` — clean (0 warnings, 0 errors)
- `Zeus.Server.Tests` — **1946 passed**, 0 failed (5 pre-existing skips)
- `Zeus.Contracts.Tests` — **102 passed**
- 17 new backend WAV tests (listing, CRUD, traversal guard, meter, migration, `ReadInfo`, envelope)
- frontend `typecheck` + `build` green; 15 new formatter/zone vitest cases

## API surface (all under `/api/wav`)
`GET status · GET list · GET waveform · POST record/start · POST record/stop · POST play {dest: local|air} · POST stop · POST rename · POST move · POST folder/create · POST folder/delete · POST delete`

Cross-platform: all paths via `Path.Combine`, wire paths normalized to forward slashes, no platform-specific I/O.