### PR TITLE
fix(tx-audio): harden recovered profile imports

### DIFF
--- a/Zeus.Server.Hosting/TxAudioProfileService.cs
+++ b/Zeus.Server.Hosting/TxAudioProfileService.cs
@@ -107,17 +107,7 @@ public sealed class TxAudioProfileService : IHostedService
         var parsed = TxAudioProfileStore.ParseJson(json)
             ?? throw new ArgumentException("File is not a valid TX audio profile (could not parse JSON).");
 
-        // Harden nullable members so a sparse file can't produce nulls that the
-        // ApplyAsync path iterates/dereferences.
-        var clean = parsed with
-        {
-            TxLeveling = parsed.TxLeveling ?? new TxLevelingConfig(),
-            CfcConfig = parsed.CfcConfig ?? CfcConfig.Default,
-            ChainOrder = parsed.ChainOrder ?? new List<string>(),
-            ChainParked = parsed.ChainParked ?? new List<string>(),
-            VstPluginStates = parsed.VstPluginStates ?? new Dictionary<string, string>(),
-            NativePluginStates = parsed.NativePluginStates ?? new Dictionary<string, Dictionary<string, string>>(),
-        };
+        var clean = SanitizeForCurrentInstall(parsed, fallbackName);
 
         var baseName = !string.IsNullOrWhiteSpace(clean.Name) ? clean.Name!.Trim()
             : !string.IsNullOrWhiteSpace(fallbackName) ? fallbackName!.Trim()
@@ -131,7 +121,7 @@ public sealed class TxAudioProfileService : IHostedService
             id = Slugify(name);
         }
 
-        var saved = _store.Upsert(clean with { Id = id, Name = name });
+        var saved = _store.Upsert(SanitizeForCurrentInstall(clean with { Id = id, Name = name }, name));
         _log.LogInformation("TX audio profile imported as '{Name}' (id={Id})", saved.Name, saved.Id);
         return saved;
     }
@@ -221,8 +211,9 @@ public sealed class TxAudioProfileService : IHostedService
     /// </summary>
     public async Task<TxAudioProfileDto?> ApplyAsync(string id, CancellationToken ct = default)
     {
-        var profile = _store.Get(id);
-        if (profile is null) return null;
+        var stored = _store.Get(id);
+        if (stored is null) return null;
+        var profile = SanitizeForCurrentInstall(stored, stored.Name);
 
         ApplyScalars(profile);
 
@@ -271,9 +262,55 @@ public sealed class TxAudioProfileService : IHostedService
 
     private bool IsVstPlugin(string pluginId)
     {
+        if (LooksLikeVstPluginId(pluginId)) return true;
         var p = _manager.Find(pluginId);
         return !string.IsNullOrEmpty(p?.Loaded.Manifest.Audio?.Vst3Path);
     }
+
+    private TxAudioProfileDto SanitizeForCurrentInstall(TxAudioProfileDto profile, string? fallbackName)
+    {
+        var clean = TxAudioProfileStore.Sanitize(profile, fallbackName: fallbackName);
+        var nativeMode = !string.Equals(clean.ProcessingMode, "vst", StringComparison.OrdinalIgnoreCase);
+
+        var order = new List<string>(clean.ChainOrder.Count);
+        var seenOrder = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var id in clean.ChainOrder)
+        {
+            if (nativeMode && IsVstPlugin(id)) continue;
+            if (seenOrder.Add(id)) order.Add(id);
+        }
+
+        var parked = new List<string>(clean.ChainParked.Count);
+        var seenParked = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var id in clean.ChainParked)
+        {
+            if (seenOrder.Contains(id)) continue;
+            if (seenParked.Add(id)) parked.Add(id);
+        }
+
+        var nativeStates = new Dictionary<string, Dictionary<string, string>>(StringComparer.Ordinal);
+        foreach (var (id, state) in clean.NativePluginStates)
+        {
+            if (nativeMode && IsVstPlugin(id)) continue;
+            nativeStates[id] = state;
+        }
+
+        return clean with
+        {
+            ChainOrder = order,
+            ChainParked = parked,
+            VstPluginStates = nativeMode
+                ? new Dictionary<string, string>(StringComparer.Ordinal)
+                : clean.VstPluginStates,
+            NativePluginStates = nativeStates,
+        };
+    }
+
+    private static bool LooksLikeVstPluginId(string pluginId) =>
+        pluginId.Contains(".vst.", StringComparison.OrdinalIgnoreCase)
+        || pluginId.Contains(".rxvst.", StringComparison.OrdinalIgnoreCase)
+        || pluginId.Contains(".au.", StringComparison.OrdinalIgnoreCase)
+        || pluginId.Contains(".rxau.", StringComparison.OrdinalIgnoreCase);
 
     private static string Slugify(string name)
     {

--- a/Zeus.Server.Hosting/TxAudioProfileStartupRepairService.cs
+++ b/Zeus.Server.Hosting/TxAudioProfileStartupRepairService.cs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using Microsoft.Extensions.Hosting;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Early repair for native TX audio profiles imported by older builds that
+/// accidentally unparked VST/AU plugins. Runs before AudioPluginBridge adopts
+/// active plugins, so a poisoned last-loaded profile cannot force a VST/AU load
+/// during startup before TxAudioProfileService gets to sanitize the replay.
+/// </summary>
+public sealed class TxAudioProfileStartupRepairService : IHostedService
+{
+    private readonly TxAudioProfileStore _profiles;
+    private readonly ChainOrderStore _chainOrder;
+    private readonly ILogger<TxAudioProfileStartupRepairService> _log;
+
+    public TxAudioProfileStartupRepairService(
+        TxAudioProfileStore profiles,
+        ChainOrderStore chainOrder,
+        ILogger<TxAudioProfileStartupRepairService> log)
+    {
+        _profiles = profiles;
+        _chainOrder = chainOrder;
+        _log = log;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        try { RepairNativeProfileVstChain(); }
+        catch (Exception ex) { _log.LogWarning(ex, "TX audio profile startup repair failed"); }
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private void RepairNativeProfileVstChain()
+    {
+        var lastId = _profiles.GetLastLoadedId();
+        if (string.IsNullOrWhiteSpace(lastId)) return;
+
+        var profile = _profiles.Get(lastId);
+        if (profile is null) return;
+        if (string.Equals(profile.ProcessingMode, "vst", StringComparison.OrdinalIgnoreCase)) return;
+
+        var unsafeIds = profile.ChainOrder
+            .Where(LooksLikeVstOrAuPluginId)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        if (unsafeIds.Length == 0) return;
+
+        var order = _chainOrder.GetOrder();
+        if (order is null || order.Count == 0) return;
+
+        var parked = new HashSet<string>(_chainOrder.GetParked(), StringComparer.Ordinal);
+        var ordered = new HashSet<string>(order, StringComparer.Ordinal);
+        var changed = false;
+        foreach (var id in unsafeIds)
+        {
+            if (ordered.Contains(id))
+                changed |= parked.Add(id);
+        }
+
+        if (!changed) return;
+
+        _chainOrder.SetState(order, parked.ToList());
+        _log.LogWarning(
+            "Parked {Count} VST/AU plugin(s) from native last-loaded TX audio profile '{ProfileId}' before audio-chain startup",
+            unsafeIds.Length,
+            profile.Id);
+    }
+
+    private static bool LooksLikeVstOrAuPluginId(string pluginId) =>
+        pluginId.Contains(".vst.", StringComparison.OrdinalIgnoreCase)
+        || pluginId.Contains(".rxvst.", StringComparison.OrdinalIgnoreCase)
+        || pluginId.Contains(".au.", StringComparison.OrdinalIgnoreCase)
+        || pluginId.Contains(".rxau.", StringComparison.OrdinalIgnoreCase);
+}

--- a/Zeus.Server.Hosting/TxAudioProfileStore.cs
+++ b/Zeus.Server.Hosting/TxAudioProfileStore.cs
@@ -44,6 +44,9 @@ public sealed class TxAudioProfileStore : IDisposable
     // importable). LiteDB stays the source of truth; the folder is a write-through
     // mirror — best-effort, never allowed to break a DB write.
     private const string ProfileDirName = "tx-audio-profiles";
+    private const int DefaultLowCutHz = 150;
+    private const int DefaultHighCutHz = 2900;
+    private const int DefaultTargetSpectralDensity = 55;
 
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<TxAudioProfileEntry> _profiles;
@@ -86,6 +89,60 @@ public sealed class TxAudioProfileStore : IDisposable
 
     public static string NormalizeId(string id) => (id ?? "").Trim().ToLowerInvariant();
 
+    public static TxAudioProfileDto Sanitize(TxAudioProfileDto profile, string? fallbackId = null, string? fallbackName = null)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+
+        var id = NormalizeId(profile.Id);
+        if (string.IsNullOrWhiteSpace(id))
+            id = NormalizeId(fallbackId ?? "");
+        if (string.IsNullOrWhiteSpace(id))
+            id = "profile";
+
+        var name = !string.IsNullOrWhiteSpace(profile.Name)
+            ? profile.Name.Trim()
+            : !string.IsNullOrWhiteSpace(fallbackName)
+                ? fallbackName.Trim()
+                : id;
+
+        var low = Math.Clamp(Math.Abs(profile.LowCutHz), 0, 10_000);
+        var high = Math.Clamp(Math.Abs(profile.HighCutHz), 0, 10_000);
+        if (high < low) (low, high) = (high, low);
+        if (low == 0 && high == 0)
+        {
+            low = DefaultLowCutHz;
+            high = DefaultHighCutHz;
+        }
+
+        var now = DateTime.UtcNow;
+        var created = profile.CreatedUtc == default ? now : profile.CreatedUtc.ToUniversalTime();
+        var updated = profile.UpdatedUtc == default ? created : profile.UpdatedUtc.ToUniversalTime();
+
+        return profile with
+        {
+            Id = id,
+            Name = name,
+            MicGainDb = Math.Clamp(profile.MicGainDb, -40, 10),
+            LevelerMaxGainDb = ClampFinite(profile.LevelerMaxGainDb, 0.0, 20.0, 8.0),
+            TxLeveling = SanitizeTxLeveling(profile.TxLeveling),
+            CfcConfig = SanitizeCfc(profile.CfcConfig),
+            LowCutHz = low,
+            HighCutHz = high,
+            ProcessingMode = string.Equals(profile.ProcessingMode, "vst", StringComparison.OrdinalIgnoreCase)
+                ? "vst"
+                : "native",
+            ChainOrder = CleanStringList(profile.ChainOrder),
+            ChainParked = CleanStringList(profile.ChainParked),
+            VstPluginStates = CleanStringDictionary(profile.VstPluginStates),
+            NativePluginStates = CleanNestedStringDictionary(profile.NativePluginStates),
+            TargetSpectralDensity = Math.Clamp(profile.TargetSpectralDensity, 0, 100) == 0 && profile.TargetSpectralDensity != 0
+                ? DefaultTargetSpectralDensity
+                : Math.Clamp(profile.TargetSpectralDensity, 0, 100),
+            CreatedUtc = created,
+            UpdatedUtc = updated,
+        };
+    }
+
     public IReadOnlyList<TxAudioProfileDto> GetAll()
     {
         lock (_sync)
@@ -120,7 +177,8 @@ public sealed class TxAudioProfileStore : IDisposable
     public TxAudioProfileDto Upsert(TxAudioProfileDto profile)
     {
         ArgumentNullException.ThrowIfNull(profile);
-        var id = NormalizeId(profile.Id);
+        var clean = Sanitize(profile);
+        var id = clean.Id;
         var nowUtc = DateTime.UtcNow;
 
         lock (_sync)
@@ -131,7 +189,7 @@ public sealed class TxAudioProfileStore : IDisposable
             var created = existing is null
                 ? nowUtc
                 : (TryDeserialize(existing)?.CreatedUtc ?? existing.CreatedUtc);
-            var normalized = profile with { Id = id, CreatedUtc = created, UpdatedUtc = nowUtc };
+            var normalized = clean with { Id = id, CreatedUtc = created, UpdatedUtc = nowUtc };
             var json = JsonSerializer.Serialize(normalized, JsonOptions);
 
             if (existing is null)
@@ -252,13 +310,93 @@ public sealed class TxAudioProfileStore : IDisposable
     {
         try
         {
-            return JsonSerializer.Deserialize<TxAudioProfileDto>(entry.ProfileJson, JsonOptions);
+            var parsed = JsonSerializer.Deserialize<TxAudioProfileDto>(entry.ProfileJson, JsonOptions);
+            return parsed is null ? null : Sanitize(parsed, entry.ProfileId);
         }
         catch (Exception ex)
         {
             _log.LogWarning(ex, "Ignoring invalid TX audio profile {ProfileId}", entry.ProfileId);
             return null;
         }
+    }
+
+    private static TxLevelingConfig SanitizeTxLeveling(TxLevelingConfig? cfg)
+    {
+        if (cfg is null) return new TxLevelingConfig();
+        return cfg with
+        {
+            AlcMaxGainDb = ClampFinite(cfg.AlcMaxGainDb, 0.0, 120.0, 3.0),
+            AlcDecayMs = Math.Clamp(cfg.AlcDecayMs, 1, 50),
+            LevelerDecayMs = Math.Clamp(cfg.LevelerDecayMs, 1, 5000),
+            CompressorGainDb = ClampFinite(cfg.CompressorGainDb, 0.0, 20.0, 0.0),
+        };
+    }
+
+    private static CfcConfig SanitizeCfc(CfcConfig? cfg)
+    {
+        if (cfg?.Bands is not { Length: 10 })
+            return CfcConfig.Default;
+
+        var defaults = CfcConfig.Default.Bands;
+        var bands = new CfcBand[10];
+        for (var i = 0; i < bands.Length; i++)
+        {
+            var band = cfg.Bands[i] ?? defaults[i];
+            var fallback = defaults[i];
+            bands[i] = new CfcBand(
+                FreqHz: ClampFinite(band.FreqHz, 0.0, 20_000.0, fallback.FreqHz),
+                CompLevelDb: ClampFinite(band.CompLevelDb, -60.0, 60.0, fallback.CompLevelDb),
+                PostGainDb: ClampFinite(band.PostGainDb, -60.0, 60.0, fallback.PostGainDb));
+        }
+
+        return cfg with
+        {
+            PreCompDb = ClampFinite(cfg.PreCompDb, -60.0, 60.0, 0.0),
+            PrePeqDb = ClampFinite(cfg.PrePeqDb, -60.0, 60.0, 0.0),
+            Bands = bands,
+        };
+    }
+
+    private static double ClampFinite(double value, double min, double max, double fallback) =>
+        double.IsFinite(value) ? Math.Clamp(value, min, max) : fallback;
+
+    private static List<string> CleanStringList(IEnumerable<string>? source)
+    {
+        var result = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var raw in source ?? Enumerable.Empty<string>())
+        {
+            if (string.IsNullOrWhiteSpace(raw)) continue;
+            var value = raw.Trim();
+            if (seen.Add(value)) result.Add(value);
+        }
+        return result;
+    }
+
+    private static Dictionary<string, string> CleanStringDictionary(IDictionary<string, string>? source)
+    {
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (source is null) return result;
+        foreach (var (key, value) in source)
+        {
+            if (string.IsNullOrWhiteSpace(key) || value is null) continue;
+            result[key.Trim()] = value;
+        }
+        return result;
+    }
+
+    private static Dictionary<string, Dictionary<string, string>> CleanNestedStringDictionary(
+        IDictionary<string, Dictionary<string, string>>? source)
+    {
+        var result = new Dictionary<string, Dictionary<string, string>>(StringComparer.Ordinal);
+        if (source is null) return result;
+        foreach (var (key, value) in source)
+        {
+            if (string.IsNullOrWhiteSpace(key)) continue;
+            var cleaned = CleanStringDictionary(value);
+            if (cleaned.Count > 0) result[key.Trim()] = cleaned;
+        }
+        return result;
     }
 
     public void Dispose() => _db.Dispose();

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -699,6 +699,7 @@ public static class ZeusHost
         builder.Services.AddSingleton<ChainOrderService>();
         builder.Services.AddSingleton<RxChainOrderStore>();
         builder.Services.AddSingleton<RxChainOrderService>();
+        builder.Services.AddHostedService<TxAudioProfileStartupRepairService>();
 
         // AudioProfileService — named snapshots of the chain config
         // (active order + parked set + master bypass). Persists to

--- a/tests/Zeus.Server.Tests/TxAudioProfileServiceTests.cs
+++ b/tests/Zeus.Server.Tests/TxAudioProfileServiceTests.cs
@@ -257,6 +257,93 @@ public sealed class TxAudioProfileServiceTests : IDisposable
         Assert.NotNull(imported.TxLeveling);
     }
 
+    [Fact]
+    public void Import_NativeProfile_StripsVstEntriesFromActiveChain()
+    {
+        const string json = """
+        {
+          "id": "voodoo-4k",
+          "name": "VooDoo 4K",
+          "micGainDb": -1,
+          "levelerMaxGainDb": 7,
+          "txLeveling": { "levelerEnabled": true },
+          "cfcConfig": {
+            "enabled": true,
+            "postEqEnabled": true,
+            "preCompDb": 0.5,
+            "prePeqDb": 0,
+            "bands": [
+              { "freqHz": 80, "compLevelDb": 0.5, "postGainDb": -4 },
+              { "freqHz": 150, "compLevelDb": 1, "postGainDb": -2 },
+              { "freqHz": 250, "compLevelDb": 2, "postGainDb": -1 },
+              { "freqHz": 500, "compLevelDb": 3, "postGainDb": 0 },
+              { "freqHz": 900, "compLevelDb": 4, "postGainDb": 0.5 },
+              { "freqHz": 1500, "compLevelDb": 5, "postGainDb": 1 },
+              { "freqHz": 2200, "compLevelDb": 4.5, "postGainDb": 1.5 },
+              { "freqHz": 2800, "compLevelDb": 3.5, "postGainDb": 1.5 },
+              { "freqHz": 3500, "compLevelDb": 2, "postGainDb": -1 },
+              { "freqHz": 5000, "compLevelDb": 1, "postGainDb": -3 }
+            ]
+          },
+          "lowCutHz": 0,
+          "highCutHz": 4000,
+          "processingMode": "native",
+          "chainOrder": [
+            "com.openhpsdr.zeus.samples.noisegate",
+            "com.openhpsdr.zeus.vst.clear",
+            "com.openhpsdr.zeus.samples.eq"
+          ],
+          "chainParked": [ "com.openhpsdr.zeus.vst.clear" ],
+          "vstPluginStates": { "com.openhpsdr.zeus.vst.clear": "opaque" },
+          "nativePluginStates": {
+            "com.openhpsdr.zeus.samples.eq": { "bypass": "true" }
+          },
+          "targetSpectralDensity": 55
+        }
+        """;
+
+        var imported = _service.ImportProfile(json, "ignored");
+
+        Assert.Equal("voodoo-4k", imported.Id);
+        Assert.Equal("native", imported.ProcessingMode);
+        Assert.DoesNotContain("com.openhpsdr.zeus.vst.clear", imported.ChainOrder);
+        Assert.Contains("com.openhpsdr.zeus.samples.noisegate", imported.ChainOrder);
+        Assert.Contains("com.openhpsdr.zeus.samples.eq", imported.ChainOrder);
+        Assert.Empty(imported.VstPluginStates);
+        Assert.Equal("true", imported.NativePluginStates["com.openhpsdr.zeus.samples.eq"]["bypass"]);
+    }
+
+    [Fact]
+    public async Task Apply_NativeStoredProfile_DoesNotReplayVstChain()
+    {
+        await _mode.StartAsync(CancellationToken.None);
+        _profileStore.Upsert(new TxAudioProfileDto(
+            Id: "unsafe",
+            Name: "Unsafe",
+            MicGainDb: 0,
+            LevelerMaxGainDb: 8,
+            TxLeveling: new TxLevelingConfig(),
+            CfcConfig: CfcConfig.Default,
+            LowCutHz: 150,
+            HighCutHz: 2900,
+            ProcessingMode: "native",
+            MasterBypass: false,
+            ChainOrder: new List<string> { "com.openhpsdr.zeus.vst.clear", "com.openhpsdr.zeus.samples.eq" },
+            ChainParked: new List<string>(),
+            VstPluginStates: new Dictionary<string, string> { ["com.openhpsdr.zeus.vst.clear"] = "opaque" },
+            NativePluginStates: new Dictionary<string, Dictionary<string, string>>(),
+            TargetSpectralDensity: 55,
+            CreatedUtc: DateTime.UtcNow,
+            UpdatedUtc: DateTime.UtcNow));
+
+        var applied = await _service.ApplyAsync("unsafe");
+
+        Assert.NotNull(applied);
+        Assert.DoesNotContain("com.openhpsdr.zeus.vst.clear", applied!.ChainOrder);
+        Assert.Empty(applied.VstPluginStates);
+        Assert.Equal("unsafe", _service.LastLoadedId);
+    }
+
     public void Dispose()
     {
         _engine.DisposeAsync().AsTask().GetAwaiter().GetResult();

--- a/tests/Zeus.Server.Tests/TxAudioProfileStoreTests.cs
+++ b/tests/Zeus.Server.Tests/TxAudioProfileStoreTests.cs
@@ -184,4 +184,71 @@ public class TxAudioProfileStoreTests : IDisposable
         Assert.Null(TxAudioProfileStore.ParseJson("not json"));
         Assert.Null(TxAudioProfileStore.ParseJson(""));
     }
+
+    [Fact]
+    public void Upsert_SanitizesSparseUnsafeProfile()
+    {
+        using var store = NewStore();
+        var saved = store.Upsert(Sample("", "", mic: 99) with
+        {
+            LevelerMaxGainDb = double.PositiveInfinity,
+            TxLeveling = new TxLevelingConfig(
+                AlcMaxGainDb: double.NaN,
+                AlcDecayMs: -1,
+                LevelerDecayMs: 99_999,
+                CompressorGainDb: double.NaN),
+            CfcConfig = new CfcConfig(true, true, 0, 0, Array.Empty<CfcBand>()),
+            LowCutHz = 0,
+            HighCutHz = 0,
+            ChainOrder = null!,
+            ChainParked = null!,
+            VstPluginStates = null!,
+            NativePluginStates = null!,
+            TargetSpectralDensity = -1,
+        });
+
+        Assert.Equal("profile", saved.Id);
+        Assert.Equal("profile", saved.Name);
+        Assert.Equal(10, saved.MicGainDb);
+        Assert.Equal(8, saved.LevelerMaxGainDb);
+        Assert.Equal(3, saved.TxLeveling.AlcMaxGainDb);
+        Assert.Equal(1, saved.TxLeveling.AlcDecayMs);
+        Assert.Equal(5000, saved.TxLeveling.LevelerDecayMs);
+        Assert.Equal(10, saved.CfcConfig.Bands.Length);
+        Assert.Equal(150, saved.LowCutHz);
+        Assert.Equal(2900, saved.HighCutHz);
+        Assert.Empty(saved.ChainOrder);
+        Assert.Empty(saved.VstPluginStates);
+        Assert.Empty(saved.NativePluginStates);
+        Assert.Equal(55, saved.TargetSpectralDensity);
+    }
+
+    [Fact]
+    public async Task StartupRepair_ParksVstIdsFromNativeLastLoadedProfile()
+    {
+        using var profiles = NewStore();
+        using var chain = new ChainOrderStore(NullLogger<ChainOrderStore>.Instance, _dbPath);
+        const string vstId = "com.openhpsdr.zeus.vst.clear";
+        const string nativeId = "com.openhpsdr.zeus.samples.eq";
+
+        profiles.Upsert(Sample("unsafe", "Unsafe") with
+        {
+            ProcessingMode = "native",
+            ChainOrder = new List<string> { vstId, nativeId },
+            ChainParked = new List<string>(),
+            VstPluginStates = new Dictionary<string, string> { [vstId] = "opaque" },
+        });
+        profiles.SetLastLoadedId("unsafe");
+        chain.SetState(new List<string> { vstId, nativeId }, new List<string>());
+
+        var repair = new TxAudioProfileStartupRepairService(
+            profiles,
+            chain,
+            NullLogger<TxAudioProfileStartupRepairService>.Instance);
+
+        await repair.StartAsync(CancellationToken.None);
+
+        Assert.Contains(vstId, chain.GetParked());
+        Assert.DoesNotContain(nativeId, chain.GetParked());
+    }
 }


### PR DESCRIPTION
## Summary
- sanitize TX audio profile DTOs at the store boundary so sparse or malformed recovered JSON cannot persist null/unsafe fields
- strip VST/AU chain entries from native-mode TX profiles during import/apply so native recovered profiles cannot unpark hosted plugins
- add an early startup repair that parks VST/AU IDs from a native last-loaded profile before the audio bridge adopts plugins

## Tests
- `git diff --check`
- `dotnet test tests\Zeus.Server.Tests\Zeus.Server.Tests.csproj --filter FullyQualifiedName~TxAudioProfile -v minimal` (25 passed)

## Notes
Built and verified a local installer for user recovery from this branch after the profile/startup tests passed.
