### PR TITLE
test(web): align Smart NR state fixture zoom

### DIFF
--- a/zeus-web/src/components/SmartNrController.test.tsx
+++ b/zeus-web/src/components/SmartNrController.test.tsx
@@ -105,7 +105,7 @@ function mockState(nr: NrConfigDto): RadioStateDto {
     wdspNr3RnnrAvailable: false,
     nr3ModelName: null,
     zoomLevel: 1,
-    workspaceZoomPct: 100,
+    workspaceZoomPct: conn.workspaceZoomPct,
     psEnabled: false,
     psAuto: true,
     psPtol: false,


### PR DESCRIPTION
Summary: Aligns the Smart NR RadioStateDto test fixture with the connection store's workspaceZoomPct instead of a hardcoded default. Verification: npm --prefix zeus-web run build.