### PR TITLE
fix: refresh plugin settings after TX profile apply

### DIFF
--- a/zeus-web/src/components/AudioSuiteWindow.tsx
+++ b/zeus-web/src/components/AudioSuiteWindow.tsx
@@ -1049,6 +1049,7 @@ export function AudioSuiteWindow({
   const loadRxMasterBypassFromServer = useAudioSuiteStore(
     (s) => s.loadRxMasterBypassFromServer,
   );
+  const pluginSettingsRevision = useAudioSuiteStore((s) => s.pluginSettingsRevision);
   const setPosition = useCallback(
     (nextX: number, nextY: number) => setWindowPosition(route, nextX, nextY),
     [route, setWindowPosition],
@@ -2074,7 +2075,9 @@ export function AudioSuiteWindow({
         }}
       >
         {SelectedComponent ? (
-          <SelectedComponent />
+          <SelectedComponent
+            key={`${selectedPanel!.pluginId}::${selectedPanel!.panelId}::${pluginSettingsRevision}`}
+          />
         ) : (
           <span
             style={{ color: 'var(--fg-3)', fontSize: 12, fontStyle: 'italic' }}

--- a/zeus-web/src/state/audio-suite-store.test.ts
+++ b/zeus-web/src/state/audio-suite-store.test.ts
@@ -231,6 +231,7 @@ describe('audio-suite-store profile selection', () => {
     expect(useAudioSuiteStore.getState().selectedProfile).toBe('Native x1');
     expect(useAudioSuiteStore.getState().chainOrder).toEqual(['noise-gate', 'compressor']);
     expect(useAudioSuiteStore.getState().masterBypassed).toBe(false);
+    expect(useAudioSuiteStore.getState().pluginSettingsRevision).toBe(1);
   });
 
   it('switches to the processing mode returned by a profile apply', async () => {
@@ -260,6 +261,7 @@ describe('audio-suite-store profile selection', () => {
     expect(useAudioSuiteStore.getState().chainOrder).toEqual([
       'com.openhpsdr.zeus.vst.comp',
     ]);
+    expect(useAudioSuiteStore.getState().pluginSettingsRevision).toBe(1);
   });
 
   it('switches back to native mode returned by a profile apply', async () => {
@@ -297,6 +299,7 @@ describe('audio-suite-store profile selection', () => {
     expect(useAudioSuiteStore.getState().chainOrder).toEqual([
       'com.openhpsdr.zeus.samples.eq',
     ]);
+    expect(useAudioSuiteStore.getState().pluginSettingsRevision).toBe(1);
   });
 
   it('applies RX profiles through the RX suite endpoint only', async () => {
@@ -344,6 +347,7 @@ describe('audio-suite-store profile selection', () => {
     expect(useAudioSuiteStore.getState().rxVstEngineActive).toBe(true);
     expect(useAudioSuiteStore.getState().rxVstActivePlugins).toBe(1);
     expect(useAudioSuiteStore.getState().rxVstDegradedBlocks).toBe(3);
+    expect(useAudioSuiteStore.getState().pluginSettingsRevision).toBe(1);
   });
 
   it('reports profile apply failures', async () => {
@@ -357,6 +361,7 @@ describe('audio-suite-store profile selection', () => {
 
     expect(result).toEqual({ ok: false, error: 'missing profile' });
     expect(useAudioSuiteStore.getState().selectedProfile).toBe('');
+    expect(useAudioSuiteStore.getState().pluginSettingsRevision).toBe(0);
   });
 
   it('mirrors preview onto the TX monitor store', async () => {

--- a/zeus-web/src/state/audio-suite-store.ts
+++ b/zeus-web/src/state/audio-suite-store.ts
@@ -156,6 +156,7 @@ interface AudioSuiteState {
   // survives a reload — purely a presentation preference, never sent
   // to the server.
   collapsed: Record<string, boolean>;
+  pluginSettingsRevision: number;
 
   // Chips+detail layout: which chain plugin is loaded in the detail
   // pane. Presentation-only, persisted to localStorage. A null or stale
@@ -202,6 +203,7 @@ interface AudioSuiteState {
   // Rack collapse plumbing.
   toggleCollapsed(pluginId: string): void;
   setAllCollapsed(collapsed: boolean, pluginIds: string[]): void;
+  bumpPluginSettingsRevision(): void;
   toggleSidebar(): void;
   toggleSidebarForRoute(route: AudioSuiteRoute): void;
 
@@ -427,6 +429,7 @@ export const useAudioSuiteStore = create<AudioSuiteState>()(
       engineSupportLoaded: false,
       isDragging: false,
       collapsed: {},
+      pluginSettingsRevision: 0,
       selectedChainId: null,
       rxSelectedChainId: null,
       sidebarCollapsed: false,
@@ -561,6 +564,9 @@ export const useAudioSuiteStore = create<AudioSuiteState>()(
           for (const id of pluginIds) next[id] = collapsed;
           return { collapsed: next };
         }),
+
+      bumpPluginSettingsRevision: () =>
+        set((s) => ({ pluginSettingsRevision: s.pluginSettingsRevision + 1 })),
 
       toggleSidebar: () =>
         set((s) => ({ sidebarCollapsed: !s.sidebarCollapsed })),
@@ -786,6 +792,7 @@ export const useAudioSuiteStore = create<AudioSuiteState>()(
               await get().loadMasterBypassFromServer();
             }
           }
+          get().bumpPluginSettingsRevision();
           return { ok: true };
         } catch (err) {
 

--- a/zeus-web/src/state/tx-audio-profile-store.test.ts
+++ b/zeus-web/src/state/tx-audio-profile-store.test.ts
@@ -44,6 +44,7 @@ function makeProfile(id: string, name: string, mode: 'native' | 'vst' = 'native'
 describe('tx-audio-profile-store', () => {
   beforeEach(() => {
     useTxAudioProfileStore.setState({ profiles: [], loaded: false, lastLoadedId: null, busy: false });
+    useAudioSuiteStore.setState(useAudioSuiteStore.getInitialState(), true);
     vi.restoreAllMocks();
   });
 
@@ -119,6 +120,7 @@ describe('tx-audio-profile-store', () => {
     expect(audio.chainOrder).toEqual(['comp', 'eq']);
     expect(audio.processingMode).toBe('vst');
     expect(audio.masterBypassed).toBe(true);
+    expect(audio.pluginSettingsRevision).toBe(1);
   });
 
   it('remove() drops the row and clears a matching selection', async () => {
@@ -142,6 +144,7 @@ describe('tx-audio-profile-store — dirty tracking', () => {
     useTxAudioProfileStore.setState({
       profiles: [], loaded: false, lastLoadedId: null, busy: false, dirty: false, baseline: null,
     });
+    useAudioSuiteStore.setState(useAudioSuiteStore.getInitialState(), true);
     // Deterministic clean live state for the snapshot to read.
     useTxStore.setState({ micGainDb: 0, levelerMaxGainDb: 8 });
     vi.restoreAllMocks();

--- a/zeus-web/src/state/tx-audio-profile-store.ts
+++ b/zeus-web/src/state/tx-audio-profile-store.ts
@@ -190,6 +190,7 @@ export const useTxAudioProfileStore = create<TxAudioProfileState>((set, get) => 
         vstEngineAvailable: result.engineAvailable,
       });
       await audio.loadChainOrderFromServer();
+      useAudioSuiteStore.getState().bumpPluginSettingsRevision();
 
       set({ lastLoadedId: trimmed, busy: false });
       // Live state now matches the just-applied profile: that is the clean point.


### PR DESCRIPTION
Finishes fix/zeus-vdcq-tx-profile-plugin-parameters-refresh-only-after-restart.

Target: develop
Beads: zeus-vdcq