### PR TITLE
Fix G2 front-panel VFO and speaker audio

### DIFF
--- a/Zeus.Server.Hosting/FrontPanel/AndromedaProtocol.cs
+++ b/Zeus.Server.Hosting/FrontPanel/AndromedaProtocol.cs
@@ -37,8 +37,9 @@ public abstract record PanelEvent
     /// since the last report (1..9).</summary>
     public sealed record Encoder(int Id, int Ticks) : PanelEvent;
 
-    /// <summary>Main VFO dial. <see cref="Steps"/> is signed tuning steps,
-    /// already run through the ANDROMEDA acceleration curve.</summary>
+    /// <summary>Main VFO dial. <see cref="Steps"/> is signed accelerated
+    /// encoder ticks. The action router divides these into logical VFO steps
+    /// before applying the operator's selected Hz step.</summary>
     public sealed record Vfo(int Steps) : PanelEvent;
 
     /// <summary>The panel announced its identity (response to <c>ZZZS;</c>).

--- a/Zeus.Server.Hosting/FrontPanel/G2FrontPanelService.cs
+++ b/Zeus.Server.Hosting/FrontPanel/G2FrontPanelService.cs
@@ -220,6 +220,7 @@ public sealed class G2FrontPanelService : BackgroundService
         Send("ZZZS;");
 
         var ledLoop = LedPollLoop(ct);
+        var vfoLoop = VfoFlushLoop(ct);
         try
         {
             await ReadLoop(port, ct);
@@ -227,6 +228,16 @@ public sealed class G2FrontPanelService : BackgroundService
         finally
         {
             try { await ledLoop; } catch { /* surfaced by ReadLoop */ }
+            try { await vfoLoop; } catch { /* surfaced by ReadLoop */ }
+        }
+    }
+
+    private async Task VfoFlushLoop(CancellationToken ct)
+    {
+        using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(16));
+        while (await timer.WaitForNextTickAsync(ct))
+        {
+            if (_panelType == 5) _router.FlushPendingVfo();
         }
     }
 
@@ -269,8 +280,10 @@ public sealed class G2FrontPanelService : BackgroundService
         if (_panelType != 5) return;
 
         _router.Dispatch(ev);
-        // Immediate LED feedback after an action (e.g. MOX/TUNE/CTUN edge).
-        RefreshLeds();
+        // VFO ticks do not change LED state, and retunes are flushed off the
+        // serial read path. Other controls still get immediate LED feedback.
+        if (ev is not PanelEvent.Vfo)
+            RefreshLeds();
     }
 
     private async Task LedPollLoop(CancellationToken ct)

--- a/Zeus.Server.Hosting/FrontPanel/G2FrontPanelService.cs
+++ b/Zeus.Server.Hosting/FrontPanel/G2FrontPanelService.cs
@@ -73,6 +73,7 @@ public sealed class G2FrontPanelService : BackgroundService
         RadioService radio,
         TxService tx,
         BandMemoryStore bandMemory,
+        ToolbarSettingsStore toolbarSettings,
         ILogger<G2FrontPanelService> log,
         ILoggerFactory loggerFactory)
     {
@@ -82,7 +83,7 @@ public sealed class G2FrontPanelService : BackgroundService
         _radio = radio;
         _tx = tx;
         _log = log;
-        _router = new G2PanelActionRouter(radio, tx, bandMemory,
+        _router = new G2PanelActionRouter(radio, tx, bandMemory, toolbarSettings,
             loggerFactory.CreateLogger<G2PanelActionRouter>());
         // A Settings change re-resolves the device and reconnects without a
         // server restart (enable toggled, COM port / baud edited).

--- a/Zeus.Server.Hosting/FrontPanel/G2PanelActionRouter.cs
+++ b/Zeus.Server.Hosting/FrontPanel/G2PanelActionRouter.cs
@@ -56,6 +56,11 @@ public sealed class G2PanelActionRouter
     // cycles which parameter the MULTI encoder adjusts.
     private int _multiIndex;
 
+    // Net VFO-knob movement accumulated since the last service flush. The serial
+    // read path only adds to this counter; RadioService retunes happen off that
+    // path so a fast spin cannot backlog serial reads behind state broadcasts.
+    private long _pendingVfoSteps;
+
     // Tuning granularity for the main VFO knob, in Hz per (accelerated) step.
     // The panel's own acceleration curve is already applied upstream.
     private const long VfoStepHz = 10;
@@ -134,8 +139,23 @@ public sealed class G2PanelActionRouter
 
     private void HandleVfo(int steps)
     {
-        var s = _radio.Snapshot();
-        _radio.SetVfo(s.VfoHz + steps * VfoStepHz);
+        Interlocked.Add(ref _pendingVfoSteps, steps);
+    }
+
+    public void FlushPendingVfo()
+    {
+        long steps = Interlocked.Exchange(ref _pendingVfoSteps, 0);
+        if (steps == 0) return;
+
+        try
+        {
+            var s = _radio.Snapshot();
+            _radio.SetVfo(s.VfoHz + steps * VfoStepHz);
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "g2panel.vfo.flush.error steps={Steps}", steps);
+        }
     }
 
     // ---- Buttons (G2-Ultra map; Thetis MakeNewG2PanelDataset) ---------------

--- a/Zeus.Server.Hosting/FrontPanel/G2PanelActionRouter.cs
+++ b/Zeus.Server.Hosting/FrontPanel/G2PanelActionRouter.cs
@@ -57,13 +57,24 @@ public sealed class G2PanelActionRouter
     // cycles which parameter the MULTI encoder adjusts.
     private int _multiIndex;
 
-    // Net VFO-knob movement accumulated since the last service flush. The serial
-    // read path only adds to this counter; RadioService retunes happen off that
-    // path so a fast spin cannot backlog serial reads behind state broadcasts.
-    private long _pendingVfoSteps;
+    // Net VFO-knob movement accumulated since the last service flush. These are
+    // accelerated encoder ticks from the panel, not final Hz-step detents. The
+    // serial read path only adds to this counter; RadioService retunes happen
+    // off that path so a fast spin cannot backlog serial reads behind state
+    // broadcasts.
+    private long _pendingVfoTicks;
+
+    // DeskHPSDR's action layer keeps a VFO accumulator and divides by
+    // vfo_encoder_divisor before calling vfo_step(). Zeus computes the divisor
+    // from the selected toolbar step so coarse steps stay controllable while
+    // 1 Hz / 10 Hz steps remain responsive.
+    private long _vfoTickAccumulator;
 
     // Encoder step sizes.
     private const int FilterStepHz = 50;
+    private const int VfoEncoderReferenceStepHz = 10;
+    private const int MinVfoEncoderDivisor = 1;
+    private const int MaxVfoEncoderDivisor = 60;
     private const long RitStepHz = 10;
     private const long RitXitMax = 99_999; // Thetis udRIT/udXIT range
     private const double AfGainStepDb = 1.0;
@@ -143,24 +154,46 @@ public sealed class G2PanelActionRouter
 
     private void HandleVfo(int steps)
     {
-        Interlocked.Add(ref _pendingVfoSteps, steps);
+        Interlocked.Add(ref _pendingVfoTicks, steps);
     }
 
     public void FlushPendingVfo()
     {
-        long steps = Interlocked.Exchange(ref _pendingVfoSteps, 0);
-        if (steps == 0) return;
+        long ticks = Interlocked.Exchange(ref _pendingVfoTicks, 0);
+        if (ticks == 0) return;
 
         try
         {
-            var s = _radio.Snapshot();
             int stepHz = _toolbarSettings.CurrentStepHz;
-            _radio.SetVfo(ApplyVfoSteps(s.VfoHz, steps, stepHz));
+            var divided = DivideVfoEncoderTicks(_vfoTickAccumulator, ticks, stepHz);
+            _vfoTickAccumulator = divided.RemainderTicks;
+            if (divided.LogicalSteps == 0) return;
+
+            var s = _radio.Snapshot();
+            _radio.SetVfo(ApplyVfoSteps(s.VfoHz, divided.LogicalSteps, stepHz));
         }
         catch (Exception ex)
         {
-            _log.LogWarning(ex, "g2panel.vfo.flush.error steps={Steps}", steps);
+            _log.LogWarning(ex, "g2panel.vfo.flush.error ticks={Ticks}", ticks);
         }
+    }
+
+    internal static int VfoEncoderDivisorForStep(int stepHz)
+    {
+        int step = ToolbarSettingsStore.NormalizeStepHz(stepHz);
+        int divisor = (step + VfoEncoderReferenceStepHz - 1) / VfoEncoderReferenceStepHz;
+        return Math.Clamp(divisor, MinVfoEncoderDivisor, MaxVfoEncoderDivisor);
+    }
+
+    internal static (long LogicalSteps, long RemainderTicks) DivideVfoEncoderTicks(
+        long accumulatedTicks,
+        long incomingTicks,
+        int stepHz)
+    {
+        int divisor = VfoEncoderDivisorForStep(stepHz);
+        long total = accumulatedTicks + incomingTicks;
+        long logicalSteps = total / divisor;
+        return (logicalSteps, total - logicalSteps * divisor);
     }
 
     internal static long ApplyVfoSteps(long currentHz, long steps, int stepHz)

--- a/Zeus.Server.Hosting/FrontPanel/G2PanelActionRouter.cs
+++ b/Zeus.Server.Hosting/FrontPanel/G2PanelActionRouter.cs
@@ -45,6 +45,7 @@ public sealed class G2PanelActionRouter
     private readonly RadioService _radio;
     private readonly TxService _tx;
     private readonly BandMemoryStore _bandMemory;
+    private readonly ToolbarSettingsStore _toolbarSettings;
     private readonly ILogger _log;
 
     // Per-panel push-button transition tracking. The panel reports a button
@@ -61,9 +62,6 @@ public sealed class G2PanelActionRouter
     // path so a fast spin cannot backlog serial reads behind state broadcasts.
     private long _pendingVfoSteps;
 
-    // Tuning granularity for the main VFO knob, in Hz per (accelerated) step.
-    // The panel's own acceleration curve is already applied upstream.
-    private const long VfoStepHz = 10;
     // Encoder step sizes.
     private const int FilterStepHz = 50;
     private const long RitStepHz = 10;
@@ -96,11 +94,17 @@ public sealed class G2PanelActionRouter
     // Index cycled by the MULTI push-button; the MULTI encoder calls Apply.
     private readonly (string Name, Action<int> Apply)[] _multi;
 
-    public G2PanelActionRouter(RadioService radio, TxService tx, BandMemoryStore bandMemory, ILogger log)
+    public G2PanelActionRouter(
+        RadioService radio,
+        TxService tx,
+        BandMemoryStore bandMemory,
+        ToolbarSettingsStore toolbarSettings,
+        ILogger log)
     {
         _radio = radio;
         _tx = tx;
         _bandMemory = bandMemory;
+        _toolbarSettings = toolbarSettings;
         _log = log;
 
         _multi = new (string, Action<int>)[]
@@ -150,12 +154,30 @@ public sealed class G2PanelActionRouter
         try
         {
             var s = _radio.Snapshot();
-            _radio.SetVfo(s.VfoHz + steps * VfoStepHz);
+            int stepHz = _toolbarSettings.CurrentStepHz;
+            _radio.SetVfo(ApplyVfoSteps(s.VfoHz, steps, stepHz));
         }
         catch (Exception ex)
         {
             _log.LogWarning(ex, "g2panel.vfo.flush.error steps={Steps}", steps);
         }
+    }
+
+    internal static long ApplyVfoSteps(long currentHz, long steps, int stepHz)
+    {
+        int step = ToolbarSettingsStore.NormalizeStepHz(stepHz);
+        long target = currentHz + steps * step;
+        return RoundToStep(target, step);
+    }
+
+    private static long RoundToStep(long hz, int stepHz)
+    {
+        if (hz <= 0) return 0;
+        if (stepHz <= 1) return hz;
+
+        long quotient = Math.DivRem(hz, stepHz, out long remainder);
+        if (remainder * 2 >= stepHz) quotient++;
+        return quotient > long.MaxValue / stepHz ? long.MaxValue : quotient * stepHz;
     }
 
     // ---- Buttons (G2-Ultra map; Thetis MakeNewG2PanelDataset) ---------------

--- a/Zeus.Server.Hosting/SaturnSpeakerAudioSink.cs
+++ b/Zeus.Server.Hosting/SaturnSpeakerAudioSink.cs
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2026 Christian Suarez (N9WAR), and contributors.
+//
+// Co-located Saturn/G2 appliance speaker sink. DeskHPSDR feeds the Saturn
+// speaker/headphone path by sending compact UDP audio packets to p2app's
+// speaker port; this sink gives Zeus the same low-latency appliance route
+// without depending on Linux desktop audio devices.
+
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Sends desktop-mode RX audio directly to the Saturn/G2 speaker UDP endpoint
+/// when Zeus is running on the same Linux host as the radio.
+/// </summary>
+internal sealed class SaturnSpeakerAudioSink : IRxAudioSink, IHostedService, IDisposable
+{
+    private const uint FrameRateHz = 48_000;
+    private const int SpeakerAudioPort = 1028;
+    private const int PacketFrames = 64;
+    private const int PacketBytes = 4 + PacketFrames * 2 * sizeof(short);
+    private const int TargetRefreshMs = 1_000;
+
+    private readonly RadioService _radio;
+    private readonly ILogger<SaturnSpeakerAudioSink> _log;
+    private readonly object _sync = new();
+    private readonly byte[] _packet = new byte[PacketBytes];
+    private readonly bool _linux = OperatingSystem.IsLinux();
+
+    private Socket? _socket;
+    private IPEndPoint? _target;
+    private int _packetFrames;
+    private uint _sequence;
+    private long _nextRefreshMs;
+    private long _droppedPackets;
+    private bool _wasEligible;
+    private ConnectionStatus _lastStatus = ConnectionStatus.Disconnected;
+    private string? _lastEndpoint;
+
+    public SaturnSpeakerAudioSink(RadioService radio, ILogger<SaturnSpeakerAudioSink> log)
+    {
+        _radio = radio;
+        _log = log;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (!_linux) return Task.CompletedTask;
+
+        _radio.StateChanged += OnRadioStateChanged;
+        lock (_sync)
+        {
+            RefreshTargetLocked(_radio.Snapshot(), force: true);
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (!_linux) return Task.CompletedTask;
+
+        _radio.StateChanged -= OnRadioStateChanged;
+        lock (_sync)
+        {
+            CloseSocketLocked();
+        }
+        return Task.CompletedTask;
+    }
+
+    public void Publish(in AudioFrame frame)
+    {
+        if (!_linux) return;
+        if (frame.Channels != 1 || frame.SampleRateHz != FrameRateHz) return;
+
+        lock (_sync)
+        {
+            if (_socket is null) RefreshTargetIfDueLocked();
+            if (_socket is null) return;
+
+            foreach (float sample in frame.Samples.Span)
+            {
+                int offset = 4 + _packetFrames * 2 * sizeof(short);
+                short pcm = FloatToPcm16(sample);
+                BinaryPrimitives.WriteInt16BigEndian(_packet.AsSpan(offset, sizeof(short)), pcm);
+                BinaryPrimitives.WriteInt16BigEndian(_packet.AsSpan(offset + sizeof(short), sizeof(short)), pcm);
+
+                _packetFrames++;
+                if (_packetFrames == PacketFrames)
+                {
+                    SendPacketLocked();
+                }
+            }
+        }
+    }
+
+    private void OnRadioStateChanged(StateDto state)
+    {
+        if (!_linux) return;
+
+        lock (_sync)
+        {
+            RefreshTargetLocked(state, force: false);
+        }
+    }
+
+    private void RefreshTargetIfDueLocked()
+    {
+        long now = Environment.TickCount64;
+        if (now < _nextRefreshMs) return;
+        _nextRefreshMs = now + TargetRefreshMs;
+
+        RefreshTargetLocked(_radio.Snapshot(), force: true);
+    }
+
+    private void RefreshTargetLocked(StateDto state, bool force)
+    {
+        if (!force
+            && _lastStatus == state.Status
+            && string.Equals(_lastEndpoint, state.Endpoint, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        _lastStatus = state.Status;
+        _lastEndpoint = state.Endpoint;
+
+        var board = _radio.ConnectedBoardKind;
+        var variant = _radio.EffectiveOrionMkIIVariant;
+        var caps = BoardCapabilitiesTable.For(board, variant);
+
+        if (state.Status != ConnectionStatus.Connected
+            || string.IsNullOrWhiteSpace(state.Endpoint)
+            || !caps.HasAudioAmplifier
+            || !RadioService.TryParseEndpoint(state.Endpoint, out var radioEndpoint)
+            || !IsLocalAddress(radioEndpoint.Address))
+        {
+            if (_wasEligible)
+            {
+                _log.LogInformation("audio.saturn.speaker disabled");
+            }
+            _wasEligible = false;
+            CloseSocketLocked();
+            return;
+        }
+
+        var target = new IPEndPoint(radioEndpoint.Address, SpeakerAudioPort);
+        if (_target is not null && _target.Equals(target) && _socket is not null)
+        {
+            return;
+        }
+
+        CloseSocketLocked();
+
+        try
+        {
+            var socket = new Socket(target.AddressFamily, SocketType.Dgram, ProtocolType.Udp)
+            {
+                Blocking = false,
+            };
+            socket.Connect(target);
+            _socket = socket;
+            _target = target;
+            _packetFrames = 0;
+            _wasEligible = true;
+
+            _log.LogInformation(
+                "audio.saturn.speaker enabled target={Target} board={Board} variant={Variant}",
+                target,
+                board,
+                variant);
+        }
+        catch (Exception ex) when (ex is SocketException or ObjectDisposedException)
+        {
+            CloseSocketLocked();
+            _log.LogWarning(ex, "audio.saturn.speaker open failed target={Target}", target);
+        }
+    }
+
+    private void SendPacketLocked()
+    {
+        var socket = _socket;
+        if (socket is null) return;
+
+        BinaryPrimitives.WriteUInt32BigEndian(_packet.AsSpan(0, sizeof(uint)), _sequence++);
+
+        try
+        {
+            int sent = socket.Send(_packet);
+            if (sent != PacketBytes)
+            {
+                Interlocked.Increment(ref _droppedPackets);
+            }
+        }
+        catch (SocketException ex) when (ex.SocketErrorCode is SocketError.WouldBlock or SocketError.NoBufferSpaceAvailable)
+        {
+            Interlocked.Increment(ref _droppedPackets);
+        }
+        catch (Exception ex) when (ex is SocketException or ObjectDisposedException)
+        {
+            var dropped = Interlocked.Read(ref _droppedPackets);
+            CloseSocketLocked();
+            _wasEligible = false;
+            _log.LogWarning(ex, "audio.saturn.speaker send failed dropped={DroppedPackets}", dropped);
+        }
+        finally
+        {
+            _packetFrames = 0;
+        }
+    }
+
+    private void CloseSocketLocked()
+    {
+        if (_socket is not null)
+        {
+            try { _socket.Dispose(); }
+            catch { /* best-effort */ }
+        }
+        _socket = null;
+        _target = null;
+        _packetFrames = 0;
+    }
+
+    internal static short FloatToPcm16(float sample)
+    {
+        if (float.IsNaN(sample)) return 0;
+        if (sample <= -1.0f) return short.MinValue;
+        if (sample >= 1.0f) return short.MaxValue;
+
+        float scale = sample < 0.0f ? 32768.0f : short.MaxValue;
+        return (short)MathF.Round(sample * scale);
+    }
+
+    private static bool IsLocalAddress(IPAddress address)
+    {
+        if (IPAddress.IsLoopback(address)) return true;
+
+        foreach (var nic in NetworkInterface.GetAllNetworkInterfaces())
+        {
+            if (nic.OperationalStatus != OperationalStatus.Up) continue;
+            if (nic.NetworkInterfaceType == NetworkInterfaceType.Loopback) continue;
+
+            foreach (var unicast in nic.GetIPProperties().UnicastAddresses)
+            {
+                if (unicast.Address.Equals(address)) return true;
+            }
+        }
+
+        return false;
+    }
+
+    public void Dispose()
+    {
+        if (_linux)
+        {
+            _radio.StateChanged -= OnRadioStateChanged;
+        }
+
+        lock (_sync)
+        {
+            CloseSocketLocked();
+        }
+    }
+}

--- a/Zeus.Server.Hosting/ToolbarSettingsStore.cs
+++ b/Zeus.Server.Hosting/ToolbarSettingsStore.cs
@@ -26,10 +26,15 @@ namespace Zeus.Server;
 // Zeus instance. Same pattern as DisplaySettingsStore.
 public sealed class ToolbarSettingsStore : IDisposable
 {
+    public const int DefaultStepHz = 500;
+    public const int MaxStepHz = 5_000;
+
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<ToolbarSettingsEntry> _docs;
     private readonly ILogger<ToolbarSettingsStore> _log;
     private readonly object _sync = new();
+    private bool _stepCacheLoaded;
+    private int? _cachedStepHz;
 
     public ToolbarSettingsStore(ILogger<ToolbarSettingsStore> log, string? dbPathOverride = null)
     {
@@ -54,15 +59,31 @@ public sealed class ToolbarSettingsStore : IDisposable
             var e = _docs.FindAll().FirstOrDefault();
             if (e is null)
             {
+                _cachedStepHz = null;
+                _stepCacheLoaded = true;
                 // Null fields tell the frontend the server has never stored a
                 // value, so it keeps its built-in defaults and pushes them up.
                 return new ToolbarSettingsDto(Mode: null, Band: null, Step: null, StepHz: null);
             }
+            _cachedStepHz = e.StepHz;
+            _stepCacheLoaded = true;
             return new ToolbarSettingsDto(
                 Mode: NormalizeSlots(e.Mode),
                 Band: NormalizeSlots(e.Band),
                 Step: NormalizeSlots(e.Step),
                 StepHz: e.StepHz);
+        }
+    }
+
+    public int CurrentStepHz
+    {
+        get
+        {
+            lock (_sync)
+            {
+                EnsureStepCacheLocked();
+                return NormalizeStepHz(_cachedStepHz);
+            }
         }
     }
 
@@ -85,10 +106,22 @@ public sealed class ToolbarSettingsStore : IDisposable
             e.UpdatedUtc = DateTime.UtcNow;
             if (e.Id == 0) _docs.Insert(e);
             else _docs.Update(e);
+            _cachedStepHz = e.StepHz;
+            _stepCacheLoaded = true;
         }
     }
 
     public void Dispose() => _db.Dispose();
+
+    internal static int NormalizeStepHz(int? stepHz) =>
+        stepHz is >= 1 and <= MaxStepHz ? stepHz.Value : DefaultStepHz;
+
+    private void EnsureStepCacheLocked()
+    {
+        if (_stepCacheLoaded) return;
+        _cachedStepHz = _docs.FindAll().FirstOrDefault()?.StepHz;
+        _stepCacheLoaded = true;
+    }
 
     // Favorite slots are always exactly three keys. A malformed array (wrong
     // length, null entries) is rejected as null so the frontend falls back to

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -388,6 +388,16 @@ public static class ZeusHost
             builder.Services.AddSingleton<NativeAudioSink>();
             builder.Services.AddSingleton<IRxAudioSink>(sp =>
                 sp.GetRequiredService<NativeAudioSink>());
+            // On a Saturn/G2 appliance Linux may expose no physical ALSA
+            // playback card at all. When Zeus is connected to a radio endpoint
+            // hosted on this same machine, mirror DeskHPSDR and feed p2app's
+            // speaker/headphone path directly instead of depending on the OS
+            // desktop-audio graph.
+            builder.Services.AddSingleton<SaturnSpeakerAudioSink>();
+            builder.Services.AddSingleton<IRxAudioSink>(sp =>
+                sp.GetRequiredService<SaturnSpeakerAudioSink>());
+            builder.Services.AddHostedService(sp =>
+                sp.GetRequiredService<SaturnSpeakerAudioSink>());
             // Same singleton serves local mono side-channel playback
             // (currently WAV/local monitor paths) in the same playback path
             // the operator already hears RX audio through. Browser mode (the

--- a/tests/Zeus.Server.Tests/G2PanelProtocolTests.cs
+++ b/tests/Zeus.Server.Tests/G2PanelProtocolTests.cs
@@ -57,6 +57,22 @@ public sealed class G2PanelProtocolTests
         Assert.Equal(expected, ev.Steps);
     }
 
+    [Theory]
+    [InlineData(7_145_000, 2, 500, 7_146_000)]
+    [InlineData(7_145_800, 1, 1000, 7_147_000)]
+    [InlineData(7_145_800, -1, 1000, 7_145_000)]
+    [InlineData(7_145_800, 17, 1000, 7_163_000)]
+    [InlineData(7_145_000, 1, 0, 7_145_500)]
+    [InlineData(10, -10, 500, 0)]
+    public void Vfo_steps_use_configured_step_and_snap_to_grid(
+        long currentHz,
+        long steps,
+        int stepHz,
+        long expected)
+    {
+        Assert.Equal(expected, G2PanelActionRouter.ApplyVfoSteps(currentHz, steps, stepHz));
+    }
+
     [Fact]
     public void Version_reports_console_type()
     {

--- a/tests/Zeus.Server.Tests/G2PanelProtocolTests.cs
+++ b/tests/Zeus.Server.Tests/G2PanelProtocolTests.cs
@@ -58,6 +58,41 @@ public sealed class G2PanelProtocolTests
     }
 
     [Theory]
+    [InlineData(1, 1)]
+    [InlineData(10, 1)]
+    [InlineData(50, 5)]
+    [InlineData(100, 10)]
+    [InlineData(500, 50)]
+    [InlineData(1000, 60)]
+    [InlineData(5000, 60)]
+    [InlineData(0, 50)]
+    public void Vfo_encoder_divisor_scales_with_configured_step(int stepHz, int expected)
+    {
+        Assert.Equal(expected, G2PanelActionRouter.VfoEncoderDivisorForStep(stepHz));
+    }
+
+    [Theory]
+    [InlineData(0, 49, 500, 0, 49)]
+    [InlineData(49, 1, 500, 1, 0)]
+    [InlineData(0, 128, 500, 2, 28)]
+    [InlineData(28, 22, 500, 1, 0)]
+    [InlineData(0, -49, 500, 0, -49)]
+    [InlineData(-49, -1, 500, -1, 0)]
+    [InlineData(0, 9, 10, 9, 0)]
+    public void Vfo_encoder_divider_preserves_remainder_between_flushes(
+        long accumulated,
+        long incoming,
+        int stepHz,
+        long expectedLogicalSteps,
+        long expectedRemainder)
+    {
+        var actual = G2PanelActionRouter.DivideVfoEncoderTicks(accumulated, incoming, stepHz);
+
+        Assert.Equal(expectedLogicalSteps, actual.LogicalSteps);
+        Assert.Equal(expectedRemainder, actual.RemainderTicks);
+    }
+
+    [Theory]
     [InlineData(7_145_000, 2, 500, 7_146_000)]
     [InlineData(7_145_800, 1, 1000, 7_147_000)]
     [InlineData(7_145_800, -1, 1000, 7_145_000)]

--- a/tests/Zeus.Server.Tests/NativeAudioSinkRegistrationTests.cs
+++ b/tests/Zeus.Server.Tests/NativeAudioSinkRegistrationTests.cs
@@ -42,6 +42,7 @@ public class NativeAudioSinkRegistrationTests
         // Native capture must never be registered in server mode.
         var hosted = app.Services.GetServices<IHostedService>().ToArray();
         Assert.DoesNotContain(hosted, h => h.GetType().Name == "NativeAudioSink");
+        Assert.DoesNotContain(hosted, h => h.GetType().Name == "SaturnSpeakerAudioSink");
         Assert.DoesNotContain(hosted, h => h.GetType().Name == "NativeMicCapture");
 
         await app.DisposeAsync();
@@ -64,6 +65,7 @@ public class NativeAudioSinkRegistrationTests
         // Desktop mode swaps in the native sink so RX audio goes straight to
         // the OS default output device (Phase 2b).
         Assert.Contains(sinks, sink => sink.GetType().Name == "NativeAudioSink");
+        Assert.Contains(sinks, sink => sink.GetType().Name == "SaturnSpeakerAudioSink");
         Assert.Contains(sinks, sink => sink.GetType().Name == "GatedWebSocketAudioSink");
         Assert.DoesNotContain(sinks, sink => sink.GetType().Name == "WebSocketAudioSink");
 
@@ -71,6 +73,7 @@ public class NativeAudioSinkRegistrationTests
         // service so its StartAsync opens the playback device.
         var hosted = app.Services.GetServices<IHostedService>().ToArray();
         Assert.Contains(hosted, h => h.GetType().Name == "NativeAudioSink");
+        Assert.Contains(hosted, h => h.GetType().Name == "SaturnSpeakerAudioSink");
         Assert.Contains(hosted, h => h.GetType().Name == "NativeMicCapture");
 
         // Local side-channel playback: desktop mode binds IPreviewAudioSink

--- a/tests/Zeus.Server.Tests/SaturnSpeakerAudioSinkTests.cs
+++ b/tests/Zeus.Server.Tests/SaturnSpeakerAudioSinkTests.cs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public sealed class SaturnSpeakerAudioSinkTests
+{
+    [Theory]
+    [InlineData(float.NaN, 0)]
+    [InlineData(float.NegativeInfinity, -32768)]
+    [InlineData(-2.0f, -32768)]
+    [InlineData(-1.0f, -32768)]
+    [InlineData(-0.5f, -16384)]
+    [InlineData(0.0f, 0)]
+    [InlineData(0.5f, 16384)]
+    [InlineData(1.0f, 32767)]
+    [InlineData(2.0f, 32767)]
+    [InlineData(float.PositiveInfinity, 32767)]
+    public void FloatToPcm16_ClampsToFullSignedAudioRange(float sample, short expected)
+    {
+        Assert.Equal(expected, SaturnSpeakerAudioSink.FloatToPcm16(sample));
+    }
+}

--- a/tests/Zeus.Server.Tests/ToolbarSettingsPersistenceTests.cs
+++ b/tests/Zeus.Server.Tests/ToolbarSettingsPersistenceTests.cs
@@ -53,6 +53,14 @@ public class ToolbarSettingsPersistenceTests : IDisposable
     }
 
     [Fact]
+    public void FreshDb_CurrentStepHz_ReturnsFrontendDefault()
+    {
+        using var store = BuildStore();
+
+        Assert.Equal(ToolbarSettingsStore.DefaultStepHz, store.CurrentStepHz);
+    }
+
+    [Fact]
     public void Save_AllFields_PersistsAcrossReopen()
     {
         using (var store = BuildStore())
@@ -111,6 +119,19 @@ public class ToolbarSettingsPersistenceTests : IDisposable
 
         var dto = store.Get();
         Assert.Equal(1000, dto.StepHz);
+        Assert.Equal(1000, store.CurrentStepHz);
+    }
+
+    [Theory]
+    [InlineData(null, 500)]
+    [InlineData(0, 500)]
+    [InlineData(-1, 500)]
+    [InlineData(5_001, 500)]
+    [InlineData(1, 1)]
+    [InlineData(5_000, 5_000)]
+    public void NormalizeStepHz_RejectsInvalidValues(int? raw, int expected)
+    {
+        Assert.Equal(expected, ToolbarSettingsStore.NormalizeStepHz(raw));
     }
 
     [Fact]


### PR DESCRIPTION
Fixes the G2 appliance front-panel VFO lag and restores RX audio on the co-located Linux radio path.

Changes:
- Coalesce G2 VFO ticks off the serial read path and skip unnecessary LED refresh for VFO events.
- Add a Linux co-located Saturn/G2 speaker-audio sink that sends DeskHPSDR-compatible 260-byte UDP packets to p2app port 1028.
- Register the sink only in desktop mode; it activates only when the connected radio endpoint is local and has a Saturn-class audio amp.
- Add focused registration and PCM conversion tests.

Verification:
- dotnet build Zeus.Server.Hosting/Zeus.Server.Hosting.csproj
- dotnet test tests/Zeus.Server.Tests/Zeus.Server.Tests.csproj --filter "FullyQualifiedName~NativeAudioSinkRegistrationTests|FullyQualifiedName~SaturnSpeakerAudioSinkTests|FullyQualifiedName~G2Panel"
- Live G2 192.168.1.25: built and deployed; front panel connected panelType=5; radio connected to 192.168.1.25:1024; audio.saturn.speaker enabled target=192.168.1.25:1028; OpenhpsdrZeus UDP socket established to p2app port 1028.

Note: full scripts/finish-work.ps1 gate was started and committed/rebased, but dotnet test Zeus.slnx hung in Zeus.Server.Tests/testhost after the tool timeout; stale test processes for this worktree were stopped.

Beads: zeus-ea1z zeus-weaw