### PR TITLE
fix: prevent native audio opens blocking desktop startup

### DIFF
--- a/Zeus.Server.Hosting/NativeAudioSink.cs
+++ b/Zeus.Server.Hosting/NativeAudioSink.cs
@@ -93,6 +93,10 @@ internal sealed class NativeAudioSink : IRxAudioSink, IPreviewAudioSink, IHosted
     // (History: 20 ms underran badly, 60 ms underran under load — both #733/#742.)
     private const int PlaybackPrebufferSamples = 5760;
 
+    // Keep selected/default playback opens bounded for the same reason as native
+    // mic capture: stale OS audio endpoints must not block desktop startup.
+    private static readonly TimeSpan DeviceOpenTimeout = TimeSpan.FromSeconds(5);
+
     // Effective prebuffer cushion actually in force — max(floor, 4×callbackFrames),
     // recomputed per callback once the device's real period is known. Reported in
     // diagnostics so a report shows the cushion that was active.
@@ -129,6 +133,7 @@ internal sealed class NativeAudioSink : IRxAudioSink, IPreviewAudioSink, IHosted
 
     private MiniAudioOutput? _output;
     private string? _activeOutputDeviceId;
+    private bool _shutdown;
     private bool _disposed;
 
     // Mute flag for the Photino-side Mute/Unmute button. Read on the DSP
@@ -245,11 +250,19 @@ internal sealed class NativeAudioSink : IRxAudioSink, IPreviewAudioSink, IHosted
     /// </summary>
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        lock (_deviceSync)
+        var thread = new Thread(() =>
         {
-            if (_output != null) return Task.CompletedTask;
-            OpenOutputLocked(ConfiguredOutputDeviceId);
-        }
+            lock (_deviceSync)
+            {
+                if (_shutdown || _output != null) return;
+                OpenOutputLocked(ConfiguredOutputDeviceId);
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "zeus-output-start",
+        };
+        thread.Start();
 
         // Subscribe to TX-active edges so we can drain the ring on TX-on.
         // The radio sample clock and the WASAPI playback clock drift relative
@@ -281,6 +294,7 @@ internal sealed class NativeAudioSink : IRxAudioSink, IPreviewAudioSink, IHosted
         }
         lock (_deviceSync)
         {
+            _shutdown = true;
             try { _output?.Stop(); }
             catch (Exception ex) { _log.LogWarning(ex, "audio.native.rx stop threw"); }
         }
@@ -306,43 +320,82 @@ internal sealed class NativeAudioSink : IRxAudioSink, IPreviewAudioSink, IHosted
 
     private void OpenOutputLocked(string? requestedDeviceId)
     {
-        try
+        var selected = !string.IsNullOrWhiteSpace(requestedDeviceId);
+        var output = OpenOutputTimeboxed(requestedDeviceId, out var failure);
+        if (output != null)
         {
-            _output = CreateOutput(requestedDeviceId);
-            _output.Start();
-            _activeOutputDeviceId = NormalizeDeviceId(requestedDeviceId);
-            _log.LogInformation(
-                "audio.native.rx open device={Device} rate={Rate}Hz channels={Channels} version={Version}",
-                _activeOutputDeviceId is null ? "default" : "selected",
-                _output.SampleRate, _output.Channels, MiniAudioInterop.Version());
-            return;
-        }
-        catch (Exception ex) when (!string.IsNullOrWhiteSpace(requestedDeviceId))
-        {
-            _log.LogWarning(ex, "audio.native.rx selected output open failed; falling back to default");
-            CloseOutputLocked(dispose: true);
-        }
-        catch (Exception ex)
-        {
-            _log.LogWarning(ex, "audio.native.rx open failed; RX audio output disabled");
-            CloseOutputLocked(dispose: true);
+            AdoptOutputLocked(output, requestedDeviceId);
             return;
         }
 
-        try
+        LogOpenGaveUp(selected ? "selected" : "default", failure);
+        if (!selected)
         {
-            _output = CreateOutput(null);
-            _output.Start();
-            _activeOutputDeviceId = null;
-            _log.LogInformation(
-                "audio.native.rx open device=default rate={Rate}Hz channels={Channels} version={Version}",
-                _output.SampleRate, _output.Channels, MiniAudioInterop.Version());
+            _log.LogWarning("audio.native.rx RX audio output disabled (no usable playback device)");
+            return;
         }
-        catch (Exception fallbackEx)
+
+        var fallback = OpenOutputTimeboxed(null, out var fallbackFailure);
+        if (fallback != null)
         {
-            _log.LogWarning(fallbackEx, "audio.native.rx default fallback open failed; RX audio output disabled");
-            CloseOutputLocked(dispose: true);
+            AdoptOutputLocked(fallback, null);
+            return;
         }
+
+        LogOpenGaveUp("default fallback", fallbackFailure);
+        _log.LogWarning("audio.native.rx RX audio output disabled (no usable playback device)");
+    }
+
+    private MiniAudioOutput? OpenOutputTimeboxed(string? requestedDeviceId, out Exception? failure) =>
+        TimeboxedNativeOpen.Run(
+            () =>
+            {
+                MiniAudioOutput? output = null;
+                try
+                {
+                    output = CreateOutput(requestedDeviceId);
+                    output.Start();
+                    return output;
+                }
+                catch
+                {
+                    if (output != null)
+                    {
+                        try { output.Stop(); } catch { /* best effort */ }
+                        output.Dispose();
+                    }
+                    throw;
+                }
+            },
+            static output =>
+            {
+                try { output.Stop(); } catch { /* best effort */ }
+                output.Dispose();
+            },
+            DeviceOpenTimeout,
+            out failure);
+
+    private void AdoptOutputLocked(MiniAudioOutput output, string? requestedDeviceId)
+    {
+        _output = output;
+        _activeOutputDeviceId = NormalizeDeviceId(requestedDeviceId);
+        _log.LogInformation(
+            "audio.native.rx open device={Device} rate={Rate}Hz channels={Channels} version={Version}",
+            _activeOutputDeviceId is null ? "default" : "selected",
+            output.SampleRate, output.Channels, MiniAudioInterop.Version());
+    }
+
+    private void LogOpenGaveUp(string which, Exception? failure)
+    {
+        if (failure != null)
+        {
+            _log.LogWarning(failure, "audio.native.rx {Which} output open failed", which);
+            return;
+        }
+
+        _log.LogWarning(
+            "audio.native.rx {Which} output open timed out after {Timeout:0.#}s; not blocking host startup",
+            which, DeviceOpenTimeout.TotalSeconds);
     }
 
     private MiniAudioOutput CreateOutput(string? deviceId) =>
@@ -599,6 +652,7 @@ internal sealed class NativeAudioSink : IRxAudioSink, IPreviewAudioSink, IHosted
         _disposed = true;
         lock (_deviceSync)
         {
+            _shutdown = true;
             CloseOutputLocked(dispose: true);
         }
     }

--- a/Zeus.Server.Hosting/NativeMicCapture.cs
+++ b/Zeus.Server.Hosting/NativeMicCapture.cs
@@ -15,6 +15,7 @@
 // the selected OS input device instead of getUserMedia.
 
 using System.Runtime.InteropServices;
+using System.Threading;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Hosting;
 using Zeus.Contracts;
@@ -54,6 +55,11 @@ internal sealed class NativeMicCapture : IHostedService, IDisposable
     // adds wire churn for no visible gain. See report for the trade-off.
     private const int PeakWindowSamples = 4800;     // 100 ms @ 48 kHz
 
+    // A native capture-device open can block inside miniaudio indefinitely when
+    // Windows reports a stale / exclusive / malformed endpoint. Keep that off
+    // the host startup path and bound individual selected/default attempts.
+    private static readonly TimeSpan DeviceOpenTimeout = TimeSpan.FromSeconds(5);
+
     private readonly TxAudioIngest _ingest;
     private readonly StreamingHub _hub;
     private readonly AudioPluginBridge _bridge;
@@ -62,6 +68,7 @@ internal sealed class NativeMicCapture : IHostedService, IDisposable
 
     private MiniAudioInput? _input;
     private readonly object _deviceSync = new();
+    private bool _shutdown;
     private string? _activeInputDeviceId;
     private readonly float[] _accum = new float[MicBlockSamples];
     private int _accumFill;
@@ -102,11 +109,19 @@ internal sealed class NativeMicCapture : IHostedService, IDisposable
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        lock (_deviceSync)
+        var thread = new Thread(() =>
         {
-            if (_input != null) return Task.CompletedTask;
-            OpenInputLocked(ConfiguredInputDeviceId);
-        }
+            lock (_deviceSync)
+            {
+                if (_shutdown || _input != null) return;
+                OpenInputLocked(ConfiguredInputDeviceId);
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "zeus-mic-start",
+        };
+        thread.Start();
         return Task.CompletedTask;
     }
 
@@ -114,6 +129,7 @@ internal sealed class NativeMicCapture : IHostedService, IDisposable
     {
         lock (_deviceSync)
         {
+            _shutdown = true;
             try { _input?.Stop(); }
             catch (Exception ex) { _log.LogWarning(ex, "audio.native.tx stop threw"); }
         }
@@ -124,6 +140,7 @@ internal sealed class NativeMicCapture : IHostedService, IDisposable
     {
         lock (_deviceSync)
         {
+            _shutdown = true;
             CloseInputLocked(dispose: true);
         }
     }
@@ -145,45 +162,74 @@ internal sealed class NativeMicCapture : IHostedService, IDisposable
 
     private void OpenInputLocked(string? requestedDeviceId)
     {
-        try
+        var selected = !string.IsNullOrWhiteSpace(requestedDeviceId);
+        var input = OpenInputTimeboxed(requestedDeviceId, out var failure);
+        if (input != null)
         {
-            _input = CreateInput(requestedDeviceId);
-            _input.Start();
-            _activeInputDeviceId = NormalizeDeviceId(requestedDeviceId);
-            _log.LogInformation(
-                "audio.native.tx mic open device={Device} rate={Rate}Hz channels={Channels}",
-                _activeInputDeviceId is null ? "default" : "selected",
-                _input.SampleRate, _input.Channels);
-            return;
-        }
-        catch (Exception ex) when (!string.IsNullOrWhiteSpace(requestedDeviceId))
-        {
-            _log.LogWarning(ex, "audio.native.tx selected mic open failed; falling back to default");
-            CloseInputLocked(dispose: true);
-        }
-        catch (Exception ex)
-        {
-            // Don't kill the host; desktop mode without a working mic should
-            // still RX. The operator may not even have a mic plugged in.
-            _log.LogWarning(ex, "audio.native.tx mic open failed; TX uplink disabled");
-            CloseInputLocked(dispose: true);
+            AdoptInputLocked(input, requestedDeviceId);
             return;
         }
 
-        try
+        LogOpenGaveUp(selected ? "selected" : "default", failure);
+        if (!selected)
         {
-            _input = CreateInput(null);
-            _input.Start();
-            _activeInputDeviceId = null;
-            _log.LogInformation(
-                "audio.native.tx mic open device=default rate={Rate}Hz channels={Channels}",
-                _input.SampleRate, _input.Channels);
+            _log.LogWarning("audio.native.tx TX uplink disabled (no usable mic input)");
+            return;
         }
-        catch (Exception fallbackEx)
+
+        var fallback = OpenInputTimeboxed(null, out var fallbackFailure);
+        if (fallback != null)
         {
-            _log.LogWarning(fallbackEx, "audio.native.tx default mic fallback open failed; TX uplink disabled");
-            CloseInputLocked(dispose: true);
+            AdoptInputLocked(fallback, null);
+            return;
         }
+
+        LogOpenGaveUp("default fallback", fallbackFailure);
+        _log.LogWarning("audio.native.tx TX uplink disabled (no usable mic input)");
+    }
+
+    private MiniAudioInput? OpenInputTimeboxed(string? requestedDeviceId, out Exception? failure) =>
+        TimeboxedNativeOpen.Run(
+            () =>
+            {
+                MiniAudioInput? input = null;
+                try
+                {
+                    input = CreateInput(requestedDeviceId);
+                    input.Start();
+                    return input;
+                }
+                catch
+                {
+                    input?.Dispose();
+                    throw;
+                }
+            },
+            static input => input.Dispose(),
+            DeviceOpenTimeout,
+            out failure);
+
+    private void AdoptInputLocked(MiniAudioInput input, string? requestedDeviceId)
+    {
+        _input = input;
+        _activeInputDeviceId = NormalizeDeviceId(requestedDeviceId);
+        _log.LogInformation(
+            "audio.native.tx mic open device={Device} rate={Rate}Hz channels={Channels}",
+            _activeInputDeviceId is null ? "default" : "selected",
+            input.SampleRate, input.Channels);
+    }
+
+    private void LogOpenGaveUp(string which, Exception? failure)
+    {
+        if (failure != null)
+        {
+            _log.LogWarning(failure, "audio.native.tx {Which} mic open failed", which);
+            return;
+        }
+
+        _log.LogWarning(
+            "audio.native.tx {Which} mic open timed out after {Timeout:0.#}s; not blocking host startup",
+            which, DeviceOpenTimeout.TotalSeconds);
     }
 
     private MiniAudioInput CreateInput(string? deviceId) =>

--- a/Zeus.Server.Hosting/TimeboxedNativeOpen.cs
+++ b/Zeus.Server.Hosting/TimeboxedNativeOpen.cs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus - OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2026 Brian Keating (EI6LF), Christian Suarez (N9WAR), and contributors.
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Runs a potentially-blocking native device open on a throwaway background
+/// thread and gives up after a bounded budget.
+/// </summary>
+internal static class TimeboxedNativeOpen
+{
+    public static T? Run<T>(Func<T> open, Action<T> dispose, TimeSpan timeout, out Exception? error)
+        where T : class
+    {
+        var gate = new object();
+        T? opened = null;
+        Exception? workerError = null;
+        var produced = false;
+        var orphaned = false;
+
+        var worker = new Thread(() =>
+        {
+            T? local = null;
+            Exception? err = null;
+            try
+            {
+                local = open();
+            }
+            catch (Exception ex)
+            {
+                err = ex;
+            }
+
+            lock (gate)
+            {
+                if (orphaned)
+                {
+                    if (local != null)
+                    {
+                        try { dispose(local); } catch { /* best effort */ }
+                    }
+                    return;
+                }
+
+                opened = local;
+                workerError = err;
+                produced = true;
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "zeus-native-open",
+        };
+        worker.Start();
+
+        if (worker.Join(timeout))
+        {
+            lock (gate)
+            {
+                error = workerError;
+                return opened;
+            }
+        }
+
+        lock (gate)
+        {
+            if (produced)
+            {
+                error = workerError;
+                return opened;
+            }
+
+            orphaned = true;
+        }
+
+        error = null;
+        return null;
+    }
+}

--- a/tests/Zeus.Server.Tests/TimeboxedNativeOpenTests.cs
+++ b/tests/Zeus.Server.Tests/TimeboxedNativeOpenTests.cs
@@ -1,0 +1,70 @@
+using System.Diagnostics;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public sealed class TimeboxedNativeOpenTests
+{
+    [Fact]
+    public void Run_ReturnsResult_WhenOpenCompletesWithinBudget()
+    {
+        var result = TimeboxedNativeOpen.Run(
+            () => "opened",
+            static _ => throw new InvalidOperationException("dispose should not run"),
+            TimeSpan.FromSeconds(1),
+            out var error);
+
+        Assert.Equal("opened", result);
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void Run_ReturnsError_WhenOpenThrowsWithinBudget()
+    {
+        var expected = new InvalidOperationException("failed");
+
+        var result = TimeboxedNativeOpen.Run<string>(
+            () => throw expected,
+            static _ => throw new InvalidOperationException("dispose should not run"),
+            TimeSpan.FromSeconds(1),
+            out var error);
+
+        Assert.Null(result);
+        Assert.Same(expected, error);
+    }
+
+    [Fact]
+    public void Run_TimesOut_AndDisposesLateResult()
+    {
+        using var allowOpenToFinish = new ManualResetEventSlim(false);
+        using var disposed = new ManualResetEventSlim(false);
+        var elapsed = Stopwatch.StartNew();
+
+        var result = TimeboxedNativeOpen.Run(
+            () =>
+            {
+                allowOpenToFinish.Wait();
+                return new DisposableProbe(disposed);
+            },
+            static probe => probe.Dispose(),
+            TimeSpan.FromMilliseconds(100),
+            out var error);
+
+        elapsed.Stop();
+        Assert.Null(result);
+        Assert.Null(error);
+        Assert.True(elapsed.Elapsed < TimeSpan.FromSeconds(2));
+
+        allowOpenToFinish.Set();
+        Assert.True(disposed.Wait(TimeSpan.FromSeconds(2)));
+    }
+
+    private sealed class DisposableProbe : IDisposable
+    {
+        private readonly ManualResetEventSlim _disposed;
+
+        public DisposableProbe(ManualResetEventSlim disposed) => _disposed = disposed;
+
+        public void Dispose() => _disposed.Set();
+    }
+}


### PR DESCRIPTION
## Summary
- Prevent desktop startup from blocking on native audio device opens.
- Move RX playback and TX mic open attempts off the hosted-service startup critical path.
- Bound selected/default miniaudio opens with a dedicated-thread timeout and dispose late/orphaned native handles.

## Root cause
The user log for 0.10.0-nightly.20260626.6d93f90 reached `desktop: app.StartAsync (Kestrel + hosted services)` and never logged `host started` after preferences existed. In that installed build, desktop native audio devices were opened synchronously during `IHostedService.StartAsync`; a stale, exclusive, or malformed saved Windows audio endpoint can park inside miniaudio before Photino is created.

## Verification
- `dotnet build Zeus.slnx`
- `dotnet test tests\\Zeus.Server.Tests\\Zeus.Server.Tests.csproj --no-build --filter "FullyQualifiedName~TimeboxedNativeOpenTests|FullyQualifiedName~NativeAudioSinkRegistrationTests|FullyQualifiedName~NativeMicCaptureSanitizerTests"` (14 passed)
- `npm --prefix zeus-web run test` (118 files / 1067 tests passed)

## Note
The full `dotnet test Zeus.slnx` gate was attempted first and reproduced the repo's known Windows `Zeus.Server.Tests` full-suite hang pattern; I stopped the orphaned test process tree after the command wrapper timed out.

Beads: zeus-m4x9