### PR TITLE
fix: update desktop rebuild from org develop

### DIFF
--- a/scripts/launch-zeus-desktop.cmd
+++ b/scripts/launch-zeus-desktop.cmd
@@ -3,7 +3,23 @@ setlocal EnableDelayedExpansion
 REM Launch the freshly built Zeus desktop app.
 REM This script lives in <repo>\scripts; the built exe is under
 REM <repo>\OpenhpsdrZeus\bin\Debug\net10.0\OpenhpsdrZeus.exe.
-set "EXE=%~dp0..\OpenhpsdrZeus\bin\Debug\net10.0\OpenhpsdrZeus.exe"
+set "REPO=%~dp0.."
+set "EXE=%REPO%\OpenhpsdrZeus\bin\Debug\net10.0\OpenhpsdrZeus.exe"
+
+if not exist "%REPO%\OpenhpsdrZeus\OpenhpsdrZeus.csproj" (
+  echo This launcher is not inside a Zeus source checkout.
+  echo Current launcher folder:
+  echo   %~dp0
+  echo.
+  echo Run the launcher from:
+  echo   ^<checkout^>\scripts\launch-zeus-desktop.cmd
+  echo.
+  echo Example:
+  echo   %%USERPROFILE%%\Desktop\openhpsdr-zeus\scripts\launch-zeus-desktop.cmd
+  echo.
+  pause
+  exit /b 1
+)
 
 if not exist "%EXE%" (
   echo Zeus has not been built yet.

--- a/scripts/rebuild-zeus-desktop.cmd
+++ b/scripts/rebuild-zeus-desktop.cmd
@@ -1,8 +1,11 @@
 @echo off
-setlocal
+setlocal EnableDelayedExpansion
 title Rebuild Zeus Desktop
 REM Run from the repo root (this script lives in <repo>\scripts).
 cd /d "%~dp0.."
+set "ZEUS_ORG_REMOTE=OpenHPSDR-Zeus-org"
+set "ZEUS_ORG_URL=https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus.git"
+set "ZEUS_ORG_BRANCH=develop"
 
 echo ============================================================
 echo  Rebuilding Zeus desktop app
@@ -10,7 +13,7 @@ echo  Repo: %CD%
 echo ============================================================
 echo.
 
-echo [1/5] Checking build prerequisites...
+echo [1/6] Checking build prerequisites...
 where npm >nul 2>&1
 if errorlevel 1 (
   echo.
@@ -40,46 +43,122 @@ if errorlevel 1 (
   exit /b 1
 )
 
+where git >nul 2>&1
+if errorlevel 1 (
+  echo.
+  echo *** Missing prerequisite: git is not on PATH. ***
+  echo Install Git for Windows, then close and reopen this window so PATH is refreshed.
+  echo.
+  echo Recommended Windows command:
+  echo   winget install Git.Git
+  echo.
+  echo Or install it from:
+  echo   https://git-scm.com/download/win
+  echo.
+  pause
+  exit /b 1
+)
+
+git rev-parse --is-inside-work-tree >nul 2>&1
+if errorlevel 1 (
+  echo.
+  echo *** This folder is not a Zeus Git checkout. ***
+  echo Current folder:
+  echo   %CD%
+  echo.
+  echo Run this script from the full openhpsdr-zeus source checkout, not
+  echo from a copied scripts folder or your Windows user profile folder.
+  echo.
+  echo Fresh setup:
+  echo   cd /d "%%USERPROFILE%%\Desktop"
+  echo   git clone --recurse-submodules %ZEUS_ORG_URL%
+  echo   cd openhpsdr-zeus
+  echo   scripts\rebuild-zeus-desktop.cmd
+  echo.
+  pause
+  exit /b 1
+)
+
 echo.
-echo [2/5] Syncing frontend model submodule...
+echo [2/6] Updating checkout from %ZEUS_ORG_REMOTE%/%ZEUS_ORG_BRANCH%...
+set "DIRTY="
+for /f "delims=" %%i in ('git status --porcelain') do set "DIRTY=1"
+if defined DIRTY (
+  echo.
+  echo *** Working tree has local changes. ***
+  echo Commit, stash, or discard local edits before updating from %ZEUS_ORG_REMOTE%/%ZEUS_ORG_BRANCH%.
+  echo.
+  git status --short
+  echo.
+  pause
+  exit /b 1
+)
+
+git remote get-url "%ZEUS_ORG_REMOTE%" >nul 2>&1
+if errorlevel 1 (
+  git remote add "%ZEUS_ORG_REMOTE%" "%ZEUS_ORG_URL%"
+  if errorlevel 1 (
+    echo.
+    echo *** Could not add %ZEUS_ORG_REMOTE% remote. ***
+    echo.
+    pause
+    exit /b 1
+  )
+)
+
+git fetch "%ZEUS_ORG_REMOTE%" "%ZEUS_ORG_BRANCH%"
+if errorlevel 1 (
+  echo.
+  echo *** Could not fetch %ZEUS_ORG_REMOTE%/%ZEUS_ORG_BRANCH%. ***
+  echo Check the network connection and Git remote access, then run this again.
+  echo.
+  pause
+  exit /b 1
+)
+
+git show-ref --verify --quiet "refs/heads/%ZEUS_ORG_BRANCH%"
+if errorlevel 1 (
+  git switch --create "%ZEUS_ORG_BRANCH%" --track "%ZEUS_ORG_REMOTE%/%ZEUS_ORG_BRANCH%"
+  if errorlevel 1 (
+    echo.
+    echo *** Could not create local %ZEUS_ORG_BRANCH% branch from %ZEUS_ORG_REMOTE%/%ZEUS_ORG_BRANCH%. ***
+    echo.
+    pause
+    exit /b 1
+  )
+) else (
+  git branch --set-upstream-to="%ZEUS_ORG_REMOTE%/%ZEUS_ORG_BRANCH%" "%ZEUS_ORG_BRANCH%"
+  if errorlevel 1 (
+    echo.
+    echo *** Could not set local %ZEUS_ORG_BRANCH% to track %ZEUS_ORG_REMOTE%/%ZEUS_ORG_BRANCH%. ***
+    echo.
+    pause
+    exit /b 1
+  )
+
+  git switch "%ZEUS_ORG_BRANCH%"
+  if errorlevel 1 (
+    echo.
+    echo *** Could not switch to local %ZEUS_ORG_BRANCH% branch. ***
+    echo.
+    pause
+    exit /b 1
+  )
+
+  git pull --ff-only "%ZEUS_ORG_REMOTE%" "%ZEUS_ORG_BRANCH%"
+  if errorlevel 1 (
+    echo.
+    echo *** Local %ZEUS_ORG_BRANCH% is not a clean fast-forward from %ZEUS_ORG_REMOTE%/%ZEUS_ORG_BRANCH%. ***
+    echo Resolve the branch state manually, then run this again.
+    echo.
+    pause
+    exit /b 1
+  )
+)
+
+echo.
+echo [3/6] Syncing frontend model submodule...
 if not exist "zeus-web\external\deepcw-engine\model.onnx" (
-  where git >nul 2>&1
-  if errorlevel 1 (
-    echo.
-    echo *** Missing prerequisite: git is not on PATH. ***
-    echo Zeus needs Git to fetch the DeepCW model submodule for this checkout.
-    echo Install Git for Windows, then close and reopen this window so PATH is refreshed.
-    echo.
-    echo Recommended Windows command:
-    echo   winget install Git.Git
-    echo.
-    echo Or install it from:
-    echo   https://git-scm.com/download/win
-    echo.
-    pause
-    exit /b 1
-  )
-
-  git rev-parse --is-inside-work-tree >nul 2>&1
-  if errorlevel 1 (
-    echo.
-    echo *** This folder is not a Zeus Git checkout. ***
-    echo Current folder:
-    echo   %CD%
-    echo.
-    echo Run this script from the full openhpsdr-zeus source checkout, not
-    echo from a copied scripts folder or your Windows user profile folder.
-    echo.
-    echo Fresh setup:
-    echo   cd /d "%%USERPROFILE%%\Desktop"
-    echo   git clone --recurse-submodules https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus.git
-    echo   cd openhpsdr-zeus
-    echo   scripts\rebuild-zeus-desktop.cmd
-    echo.
-    pause
-    exit /b 1
-  )
-
   git submodule update --init --recursive zeus-web/external/deepcw-engine
   if errorlevel 1 (
     echo.
@@ -99,13 +178,13 @@ if not exist "zeus-web\external\deepcw-engine\model.onnx" (
 )
 
 echo.
-echo [3/5] Stopping any running Zeus instance (frees locked DLLs)...
+echo [4/6] Stopping any running Zeus instance (frees locked DLLs)...
 taskkill /IM OpenhpsdrZeus.exe /F >nul 2>&1
 REM Give the OS a moment to release the file handles before we rebuild.
 ping -n 2 127.0.0.1 >nul
 
 echo.
-echo [4/5] Restoring and building frontend (zeus-web -^> wwwroot)...
+echo [5/6] Restoring and building frontend (zeus-web -^> wwwroot)...
 echo.
 call npm --prefix zeus-web ci
 if errorlevel 1 (
@@ -127,7 +206,7 @@ if errorlevel 1 (
 )
 
 echo.
-echo [5/5] Building backend (dotnet build OpenhpsdrZeus)...
+echo [6/6] Building backend (dotnet build OpenhpsdrZeus)...
 echo.
 dotnet build OpenhpsdrZeus -c Debug
 if errorlevel 1 (


### PR DESCRIPTION
Updates the Windows desktop rebuild flow to explicitly fetch and switch/create local develop from OpenHPSDR-Zeus-org/develop before rebuilding. Also keeps the launcher from masking copied-script shortcut mistakes.\n\nBeads: zeus-alb0