### PR TITLE
Fix G2 front-panel smooth control handling

### DIFF
--- a/Zeus.Server.Hosting/FrontPanel/G2FrontPanelService.cs
+++ b/Zeus.Server.Hosting/FrontPanel/G2FrontPanelService.cs
@@ -221,7 +221,7 @@ public sealed class G2FrontPanelService : BackgroundService
         Send("ZZZS;");
 
         var ledLoop = LedPollLoop(ct);
-        var vfoLoop = VfoFlushLoop(ct);
+        var panelFlushLoop = PanelFlushLoop(ct);
         try
         {
             await ReadLoop(port, ct);
@@ -229,16 +229,17 @@ public sealed class G2FrontPanelService : BackgroundService
         finally
         {
             try { await ledLoop; } catch { /* surfaced by ReadLoop */ }
-            try { await vfoLoop; } catch { /* surfaced by ReadLoop */ }
+            try { await panelFlushLoop; } catch { /* surfaced by ReadLoop */ }
         }
     }
 
-    private async Task VfoFlushLoop(CancellationToken ct)
+    private async Task PanelFlushLoop(CancellationToken ct)
     {
         using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(16));
         while (await timer.WaitForNextTickAsync(ct))
         {
-            if (_panelType == 5) _router.FlushPendingVfo();
+            if (_panelType == 5 && _router.FlushPendingPanelWork())
+                RefreshLeds();
         }
     }
 

--- a/Zeus.Server.Hosting/FrontPanel/G2PanelActionRouter.cs
+++ b/Zeus.Server.Hosting/FrontPanel/G2PanelActionRouter.cs
@@ -42,6 +42,67 @@ namespace Zeus.Server.FrontPanel;
 /// </summary>
 public sealed class G2PanelActionRouter
 {
+    private enum ButtonAction
+    {
+        ToggleMuteRx2,
+        ToggleMuteRx1,
+        CycleMulti,
+        AtuTune,
+        ToggleTwoTone,
+        ToggleTune,
+        ToggleMox,
+        ToggleCtun,
+        ToggleLock,
+        SwapVfos,
+        CycleRitXit,
+        ClearRitXit,
+        FilterCutDefault,
+        ModePlus,
+        FilterPlus,
+        BandPlus,
+        ModeMinus,
+        FilterMinus,
+        BandMinus,
+        CopyAtoB,
+        CopyBtoA,
+        ToggleSplit,
+        ToggleSnb,
+        ToggleNb,
+        CycleNr,
+        Band160,
+        Band80,
+        Band60,
+        Band40,
+        Band30,
+        Band20,
+        Band17,
+        Band15,
+        Band12,
+        Band10,
+        Band6,
+        BandLfMf,
+        ToggleDiversity,
+    }
+
+    private enum EncoderAction
+    {
+        AfRx2,
+        AgcRx2,
+        AfRx1,
+        AgcRx1,
+        Multi,
+        Drive,
+        RitXit,
+        Atten,
+        FilterHigh,
+        FilterLow,
+        DivGain,
+        DivPhase,
+        Rit,
+        Xit,
+        Count,
+    }
+
     private readonly RadioService _radio;
     private readonly TxService _tx;
     private readonly BandMemoryStore _bandMemory;
@@ -63,6 +124,12 @@ public sealed class G2PanelActionRouter
     // off that path so a fast spin cannot backlog serial reads behind state
     // broadcasts.
     private long _pendingVfoTicks;
+
+    // Non-VFO encoder movement, accumulated by logical action. DeskHPSDR queues
+    // ANDROMEDA actions onto the GTK idle loop; this gives Zeus the same shape:
+    // serial reads only enqueue ticks, while radio-state mutations happen on a
+    // steady panel timer.
+    private readonly long[] _pendingEncoderTicks = new long[(int)EncoderAction.Count];
 
     // DeskHPSDR's action layer keeps a VFO accumulator and divides by
     // vfo_encoder_divisor before calling vfo_step(). Zeus computes the divisor
@@ -103,7 +170,7 @@ public sealed class G2PanelActionRouter
 
     // Assignable MULTI-encoder functions (Thetis MultiTable ∩ Zeus backend).
     // Index cycled by the MULTI push-button; the MULTI encoder calls Apply.
-    private readonly (string Name, Action<int> Apply)[] _multi;
+    private readonly (string Name, EncoderAction Target)[] _multi;
 
     public G2PanelActionRouter(
         RadioService radio,
@@ -118,19 +185,19 @@ public sealed class G2PanelActionRouter
         _toolbarSettings = toolbarSettings;
         _log = log;
 
-        _multi = new (string, Action<int>)[]
+        _multi = new (string, EncoderAction)[]
         {
-            ("RX1 AF Gain",     AdjustAfRx1),
-            ("RX2 AF Gain",     AdjustAfRx2),
-            ("RX1 AGC",         AdjustAgcRx1),
-            ("RX1 Step Atten",  AdjustAtten),
-            ("Filter High Cut", AdjustFilterHigh),
-            ("Filter Low Cut",  AdjustFilterLow),
-            ("RIT",             AdjustRit),
-            ("XIT",             AdjustXit),
-            ("TX Drive",        AdjustDrive),
-            ("Diversity Gain",  AdjustDivGain),
-            ("Diversity Phase", AdjustDivPhase),
+            ("RX1 AF Gain",     EncoderAction.AfRx1),
+            ("RX2 AF Gain",     EncoderAction.AfRx2),
+            ("RX1 AGC",         EncoderAction.AgcRx1),
+            ("RX1 Step Atten",  EncoderAction.Atten),
+            ("Filter High Cut", EncoderAction.FilterHigh),
+            ("Filter Low Cut",  EncoderAction.FilterLow),
+            ("RIT",             EncoderAction.Rit),
+            ("XIT",             EncoderAction.Xit),
+            ("TX Drive",        EncoderAction.Drive),
+            ("Diversity Gain",  EncoderAction.DivGain),
+            ("Diversity Phase", EncoderAction.DivPhase),
         };
     }
 
@@ -157,26 +224,62 @@ public sealed class G2PanelActionRouter
         Interlocked.Add(ref _pendingVfoTicks, steps);
     }
 
-    public void FlushPendingVfo()
+    public bool FlushPendingVfo()
     {
         long ticks = Interlocked.Exchange(ref _pendingVfoTicks, 0);
-        if (ticks == 0) return;
+        if (ticks == 0) return false;
 
         try
         {
             int stepHz = _toolbarSettings.CurrentStepHz;
             var divided = DivideVfoEncoderTicks(_vfoTickAccumulator, ticks, stepHz);
             _vfoTickAccumulator = divided.RemainderTicks;
-            if (divided.LogicalSteps == 0) return;
+            if (divided.LogicalSteps == 0) return false;
 
             var s = _radio.Snapshot();
             _radio.SetVfo(ApplyVfoSteps(s.VfoHz, divided.LogicalSteps, stepHz));
+            return true;
         }
         catch (Exception ex)
         {
             _log.LogWarning(ex, "g2panel.vfo.flush.error ticks={Ticks}", ticks);
+            return false;
         }
     }
+
+    public bool FlushPendingEncoders()
+    {
+        bool applied = false;
+        for (int i = 0; i < (int)EncoderAction.Count; i++)
+        {
+            long ticks = Interlocked.Exchange(ref _pendingEncoderTicks[i], 0);
+            if (ticks == 0) continue;
+
+            var action = (EncoderAction)i;
+            try
+            {
+                ApplyEncoderAction(action, ClampToInt(ticks));
+                applied = true;
+            }
+            catch (Exception ex)
+            {
+                _log.LogWarning(ex, "g2panel.encoder.flush.error action={Action} ticks={Ticks}", action, ticks);
+            }
+        }
+        return applied;
+    }
+
+    public bool FlushPendingPanelWork()
+    {
+        bool vfoApplied = FlushPendingVfo();
+        bool encodersApplied = FlushPendingEncoders();
+        return vfoApplied || encodersApplied;
+    }
+
+    private static int ClampToInt(long ticks) =>
+        ticks > int.MaxValue ? int.MaxValue :
+        ticks < int.MinValue ? int.MinValue :
+        (int)ticks;
 
     internal static int VfoEncoderDivisorForStep(int stepHz)
     {
@@ -219,67 +322,125 @@ public sealed class G2PanelActionRouter
     {
         // Derive transitions from the shared previous value, exactly as the
         // panel firmware expects (short press = tr01; long press = tr12).
-        bool tr01 = _lastV == 0 && v == 1;
-        bool tr12 = _lastV == 1 && v == 2;
-        bool tr10 = _lastV == 1 && v == 0;
+        var action = ButtonActionForTransition(p, _lastV, v);
         _lastV = v;
 
-        switch (p)
+        if (action is not null)
+        {
+            FlushPendingPanelWork();
+            ApplyButtonAction(action.Value);
+        }
+    }
+
+    private static ButtonAction? ButtonActionForTransition(int p, int previousV, int v)
+    {
+        bool tr01 = previousV == 0 && v == 1;
+        bool tr10 = previousV == 1 && v == 0;
+
+        return p switch
         {
             // Encoder push-buttons -------------------------------------------
-            case 1: if (tr01) ToggleMute(1); break;   // MUTE_RX2
-            case 2: if (tr01) ToggleMute(0); break;   // MUTE_RX1
-            case 3: if (tr01) CycleMulti(); break;    // MULTI encoder button
+            1 when tr01 => ButtonAction.ToggleMuteRx2,
+            2 when tr01 => ButtonAction.ToggleMuteRx1,
+            3 when tr01 => ButtonAction.CycleMulti,
 
             // Four buttons left of the screen --------------------------------
-            case 4: if (tr01) _radio.RequestAtuTune(AtuTunePulseMs); break;  // ATU
-            case 5: if (tr01) ToggleTwoTone(); break;
-            case 6: if (tr01) ToggleTune(); break;
-            case 7: if (tr01) ToggleMox(); break;
+            4 when tr01 => ButtonAction.AtuTune,
+            5 when tr01 => ButtonAction.ToggleTwoTone,
+            6 when tr01 => ButtonAction.ToggleTune,
+            7 when tr01 => ButtonAction.ToggleMox,
 
             // Buttons below the VFO knob -------------------------------------
-            case 8: if (tr01) ToggleCtun(); break;
-            case 9: if (tr01) ToggleLock(); break;    // LOCK
+            8 when tr01 => ButtonAction.ToggleCtun,
+            9 when tr01 => ButtonAction.ToggleLock,
 
             // Right-hand buttons ---------------------------------------------
-            case 10: if (tr01) _radio.SwapVfos(); break;                  // A/B
-            case 11: if (tr01) CycleRitXit(); break;                      // RITSELECT
-            case 12: if (tr01) ClearRitXit(); break;                      // RIT/XIT clear
-            case 13: if (tr01) FilterCutDefault(); break;                 // filter reset
+            10 when tr01 => ButtonAction.SwapVfos,
+            11 when tr01 => ButtonAction.CycleRitXit,
+            12 when tr01 => ButtonAction.ClearRitXit,
+            13 when tr01 => ButtonAction.FilterCutDefault,
 
             // 4x3 pad — "no Band" layer (Mode/Filter/Band stepping) ----------
             // Long-press (tr12) would open an on-panel menu in Thetis; Zeus
             // uses its web UI for menus, so the long action is a no-op.
-            case 14: if (tr10) StepMode(+1); break;
-            case 15: if (tr10) StepFilter(+1); break;
-            case 16: if (tr01) StepBand(+1); break;
-            case 17: if (tr01) StepMode(-1); break;
-            case 18: if (tr01) StepFilter(-1); break;
-            case 19: if (tr01) StepBand(-1); break;
-            case 20: if (tr01) CopyAtoB(); break;                          // A>B
-            case 21: if (tr01) CopyBtoA(); break;                          // B>A
-            case 22: if (tr01) ToggleSplit(); break;                       // SPLIT
-            case 23: if (tr10) ToggleSnb(); break;                         // F1
-            case 24: if (tr10) ToggleNb(); break;                          // F2
-            case 25: if (tr10) CycleNr(); break;                           // F3
+            14 when tr10 => ButtonAction.ModePlus,
+            15 when tr10 => ButtonAction.FilterPlus,
+            16 when tr01 => ButtonAction.BandPlus,
+            17 when tr01 => ButtonAction.ModeMinus,
+            18 when tr01 => ButtonAction.FilterMinus,
+            19 when tr01 => ButtonAction.BandMinus,
+            20 when tr01 => ButtonAction.CopyAtoB,
+            21 when tr01 => ButtonAction.CopyBtoA,
+            22 when tr01 => ButtonAction.ToggleSplit,
+            23 when tr10 => ButtonAction.ToggleSnb,
+            24 when tr10 => ButtonAction.ToggleNb,
+            25 when tr10 => ButtonAction.CycleNr,
 
             // 4x3 pad — "Band" layer (direct band select) -------------------
-            case 27: if (tr01) SelectBand("160m"); break;
-            case 28: if (tr01) SelectBand("80m"); break;
-            case 29: if (tr01) SelectBand("60m"); break;
-            case 30: if (tr01) SelectBand("40m"); break;
-            case 31: if (tr01) SelectBand("30m"); break;
-            case 32: if (tr01) SelectBand("20m"); break;
-            case 33: if (tr01) SelectBand("17m"); break;
-            case 34: if (tr01) SelectBand("15m"); break;
-            case 35: if (tr01) SelectBand("12m"); break;
-            case 36: if (tr01) SelectBand("10m"); break;
-            case 37: if (tr01) SelectBand("6m"); break;
-            case 38: if (tr01) SelectLfMf(); break;                        // LF/MF
+            27 when tr01 => ButtonAction.Band160,
+            28 when tr01 => ButtonAction.Band80,
+            29 when tr01 => ButtonAction.Band60,
+            30 when tr01 => ButtonAction.Band40,
+            31 when tr01 => ButtonAction.Band30,
+            32 when tr01 => ButtonAction.Band20,
+            33 when tr01 => ButtonAction.Band17,
+            34 when tr01 => ButtonAction.Band15,
+            35 when tr01 => ButtonAction.Band12,
+            36 when tr01 => ButtonAction.Band10,
+            37 when tr01 => ButtonAction.Band6,
+            38 when tr01 => ButtonAction.BandLfMf,
 
-            case 41: if (tr01) ToggleDiversity(); break;                   // DIV
+            41 when tr01 => ButtonAction.ToggleDiversity,
 
-            default: break; // 26, 39, 40, 42-50 reserved/unused on the G2-Ultra
+            _ => null, // 26, 39, 40, 42-50 reserved/unused on the G2-Ultra
+        };
+    }
+
+    internal static string? G2UltraButtonActionNameForTransition(int p, int previousV, int v) =>
+        ButtonActionForTransition(p, previousV, v)?.ToString();
+
+    private void ApplyButtonAction(ButtonAction action)
+    {
+        switch (action)
+        {
+            case ButtonAction.ToggleMuteRx2: ToggleMute(1); break;
+            case ButtonAction.ToggleMuteRx1: ToggleMute(0); break;
+            case ButtonAction.CycleMulti: CycleMulti(); break;
+            case ButtonAction.AtuTune: _radio.RequestAtuTune(AtuTunePulseMs); break;
+            case ButtonAction.ToggleTwoTone: ToggleTwoTone(); break;
+            case ButtonAction.ToggleTune: ToggleTune(); break;
+            case ButtonAction.ToggleMox: ToggleMox(); break;
+            case ButtonAction.ToggleCtun: ToggleCtun(); break;
+            case ButtonAction.ToggleLock: ToggleLock(); break;
+            case ButtonAction.SwapVfos: _radio.SwapVfos(); break;
+            case ButtonAction.CycleRitXit: CycleRitXit(); break;
+            case ButtonAction.ClearRitXit: ClearRitXit(); break;
+            case ButtonAction.FilterCutDefault: FilterCutDefault(); break;
+            case ButtonAction.ModePlus: StepMode(+1); break;
+            case ButtonAction.FilterPlus: StepFilter(+1); break;
+            case ButtonAction.BandPlus: StepBand(+1); break;
+            case ButtonAction.ModeMinus: StepMode(-1); break;
+            case ButtonAction.FilterMinus: StepFilter(-1); break;
+            case ButtonAction.BandMinus: StepBand(-1); break;
+            case ButtonAction.CopyAtoB: CopyAtoB(); break;
+            case ButtonAction.CopyBtoA: CopyBtoA(); break;
+            case ButtonAction.ToggleSplit: ToggleSplit(); break;
+            case ButtonAction.ToggleSnb: ToggleSnb(); break;
+            case ButtonAction.ToggleNb: ToggleNb(); break;
+            case ButtonAction.CycleNr: CycleNr(); break;
+            case ButtonAction.Band160: SelectBand("160m"); break;
+            case ButtonAction.Band80: SelectBand("80m"); break;
+            case ButtonAction.Band60: SelectBand("60m"); break;
+            case ButtonAction.Band40: SelectBand("40m"); break;
+            case ButtonAction.Band30: SelectBand("30m"); break;
+            case ButtonAction.Band20: SelectBand("20m"); break;
+            case ButtonAction.Band17: SelectBand("17m"); break;
+            case ButtonAction.Band15: SelectBand("15m"); break;
+            case ButtonAction.Band12: SelectBand("12m"); break;
+            case ButtonAction.Band10: SelectBand("10m"); break;
+            case ButtonAction.Band6: SelectBand("6m"); break;
+            case ButtonAction.BandLfMf: SelectLfMf(); break;
+            case ButtonAction.ToggleDiversity: ToggleDiversity(); break;
         }
     }
 
@@ -287,21 +448,65 @@ public sealed class G2PanelActionRouter
 
     private void HandleEncoder(int p, int ticks)
     {
-        switch (p)
+        var action = EncoderActionFor(p);
+        if (action is null) return;
+
+        if (action == EncoderAction.Multi)
         {
-            case 1: AdjustAfRx2(ticks); break;        // RX2 AF gain
-            case 2: Unmapped("AGC_GAIN_RX2 (no per-RX AGC top)"); break;
-            case 3: AdjustAfRx1(ticks); break;        // RX1 AF gain
-            case 4: AdjustAgcRx1(ticks); break;       // RX1 AGC top
-            case 5: ApplyMulti(ticks); break;         // MULTI encoder
-            case 6: AdjustDrive(ticks); break;        // TX drive
-            case 7: AdjustRitXit(ticks); break;       // RIT/XIT offset (silk RIT/ATTN inner)
-            case 8: AdjustAtten(ticks); break;        // RX attenuator (silk RIT/ATTN outer)
-            case 9: AdjustFilterHigh(ticks); break;   // filter cut high
-            case 10: AdjustFilterLow(ticks); break;   // filter cut low
-            case 11: AdjustDivGain(ticks); break;     // diversity gain
-            case 12: AdjustDivPhase(ticks); break;    // diversity phase
-            default: break;
+            ApplyMulti(ticks);
+        }
+        else
+        {
+            QueueEncoder(action.Value, ticks);
+        }
+    }
+
+    private static EncoderAction? EncoderActionFor(int p) => p switch
+    {
+        1 => EncoderAction.AfRx2,
+        2 => EncoderAction.AgcRx2,
+        3 => EncoderAction.AfRx1,
+        4 => EncoderAction.AgcRx1,
+        5 => EncoderAction.Multi,
+        6 => EncoderAction.Drive,
+        7 => EncoderAction.RitXit,
+        8 => EncoderAction.Atten,
+        9 => EncoderAction.FilterHigh,
+        10 => EncoderAction.FilterLow,
+        11 => EncoderAction.DivGain,
+        12 => EncoderAction.DivPhase,
+        _ => null,
+    };
+
+    internal static string? G2UltraEncoderActionName(int p) =>
+        EncoderActionFor(p)?.ToString();
+
+    private void QueueEncoder(EncoderAction action, int ticks)
+    {
+        if (ticks == 0) return;
+        Interlocked.Add(ref _pendingEncoderTicks[(int)action], ticks);
+    }
+
+    private void ApplyEncoderAction(EncoderAction action, int ticks)
+    {
+        switch (action)
+        {
+            case EncoderAction.AfRx2: AdjustAfRx2(ticks); break;
+            case EncoderAction.AgcRx2: AdjustAgcRx2(ticks); break;
+            case EncoderAction.AfRx1: AdjustAfRx1(ticks); break;
+            case EncoderAction.AgcRx1: AdjustAgcRx1(ticks); break;
+            case EncoderAction.Drive: AdjustDrive(ticks); break;
+            case EncoderAction.RitXit: AdjustRitXit(ticks); break;
+            case EncoderAction.Atten: AdjustAtten(ticks); break;
+            case EncoderAction.FilterHigh: AdjustFilterHigh(ticks); break;
+            case EncoderAction.FilterLow: AdjustFilterLow(ticks); break;
+            case EncoderAction.DivGain: AdjustDivGain(ticks); break;
+            case EncoderAction.DivPhase: AdjustDivPhase(ticks); break;
+            case EncoderAction.Rit: AdjustRit(ticks); break;
+            case EncoderAction.Xit: AdjustXit(ticks); break;
+            case EncoderAction.Multi:
+            case EncoderAction.Count:
+                break;
         }
     }
 
@@ -321,6 +526,18 @@ public sealed class G2PanelActionRouter
     }
 
     private void AdjustAgcRx1(int ticks)
+    {
+        AdjustAgcTop(ticks);
+    }
+
+    private void AdjustAgcRx2(int ticks)
+    {
+        // Zeus currently exposes AGC-T as one shared receiver-DSP ceiling.
+        // Keep the DeskHPSDR RX2 AGC encoder live by driving that shared slider.
+        AdjustAgcTop(ticks);
+    }
+
+    private void AdjustAgcTop(int ticks)
     {
         var s = _radio.Snapshot();
         _radio.SetAgcTop(s.AgcTopDb + ticks * AgcStepDb);
@@ -397,7 +614,7 @@ public sealed class G2PanelActionRouter
         _log.LogInformation("g2panel.multi.select {Name}", _multi[_multiIndex].Name);
     }
 
-    private void ApplyMulti(int ticks) => _multi[_multiIndex].Apply(ticks);
+    private void ApplyMulti(int ticks) => QueueEncoder(_multi[_multiIndex].Target, ticks);
 
     // ---- Button action helpers ---------------------------------------------
 

--- a/tests/Zeus.Server.Tests/G2PanelProtocolTests.cs
+++ b/tests/Zeus.Server.Tests/G2PanelProtocolTests.cs
@@ -58,6 +58,108 @@ public sealed class G2PanelProtocolTests
     }
 
     [Theory]
+    [InlineData(1, "AfRx2")]
+    [InlineData(2, "AgcRx2")]
+    [InlineData(3, "AfRx1")]
+    [InlineData(4, "AgcRx1")]
+    [InlineData(5, "Multi")]
+    [InlineData(6, "Drive")]
+    [InlineData(7, "RitXit")]
+    [InlineData(8, "Atten")]
+    [InlineData(9, "FilterHigh")]
+    [InlineData(10, "FilterLow")]
+    [InlineData(11, "DivGain")]
+    [InlineData(12, "DivPhase")]
+    public void G2_ultra_encoder_map_matches_deskhpsdr_type5_defaults(
+        int encoderId,
+        string expectedAction)
+    {
+        Assert.Equal(expectedAction, G2PanelActionRouter.G2UltraEncoderActionName(encoderId));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(13)]
+    [InlineData(20)]
+    public void G2_ultra_unassigned_encoder_ids_are_ignored(int encoderId)
+    {
+        Assert.Null(G2PanelActionRouter.G2UltraEncoderActionName(encoderId));
+    }
+
+    [Theory]
+    [InlineData(1, 0, 1, "ToggleMuteRx2")]
+    [InlineData(2, 0, 1, "ToggleMuteRx1")]
+    [InlineData(3, 0, 1, "CycleMulti")]
+    [InlineData(4, 0, 1, "AtuTune")]
+    [InlineData(5, 0, 1, "ToggleTwoTone")]
+    [InlineData(6, 0, 1, "ToggleTune")]
+    [InlineData(7, 0, 1, "ToggleMox")]
+    [InlineData(8, 0, 1, "ToggleCtun")]
+    [InlineData(9, 0, 1, "ToggleLock")]
+    [InlineData(10, 0, 1, "SwapVfos")]
+    [InlineData(11, 0, 1, "CycleRitXit")]
+    [InlineData(12, 0, 1, "ClearRitXit")]
+    [InlineData(13, 0, 1, "FilterCutDefault")]
+    [InlineData(14, 1, 0, "ModePlus")]
+    [InlineData(15, 1, 0, "FilterPlus")]
+    [InlineData(16, 0, 1, "BandPlus")]
+    [InlineData(17, 0, 1, "ModeMinus")]
+    [InlineData(18, 0, 1, "FilterMinus")]
+    [InlineData(19, 0, 1, "BandMinus")]
+    [InlineData(20, 0, 1, "CopyAtoB")]
+    [InlineData(21, 0, 1, "CopyBtoA")]
+    [InlineData(22, 0, 1, "ToggleSplit")]
+    [InlineData(23, 1, 0, "ToggleSnb")]
+    [InlineData(24, 1, 0, "ToggleNb")]
+    [InlineData(25, 1, 0, "CycleNr")]
+    [InlineData(27, 0, 1, "Band160")]
+    [InlineData(28, 0, 1, "Band80")]
+    [InlineData(29, 0, 1, "Band60")]
+    [InlineData(30, 0, 1, "Band40")]
+    [InlineData(31, 0, 1, "Band30")]
+    [InlineData(32, 0, 1, "Band20")]
+    [InlineData(33, 0, 1, "Band17")]
+    [InlineData(34, 0, 1, "Band15")]
+    [InlineData(35, 0, 1, "Band12")]
+    [InlineData(36, 0, 1, "Band10")]
+    [InlineData(37, 0, 1, "Band6")]
+    [InlineData(38, 0, 1, "BandLfMf")]
+    [InlineData(41, 0, 1, "ToggleDiversity")]
+    public void G2_ultra_button_map_matches_deskhpsdr_type5_defaults(
+        int buttonId,
+        int previousValue,
+        int value,
+        string expectedAction)
+    {
+        Assert.Equal(expectedAction, G2PanelActionRouter.G2UltraButtonActionNameForTransition(
+            buttonId,
+            previousValue,
+            value));
+    }
+
+    [Theory]
+    [InlineData(14)]
+    [InlineData(15)]
+    [InlineData(16)]
+    [InlineData(23)]
+    [InlineData(24)]
+    [InlineData(25)]
+    public void G2_ultra_menu_long_press_transitions_are_ignored_by_zeus(int buttonId)
+    {
+        Assert.Null(G2PanelActionRouter.G2UltraButtonActionNameForTransition(buttonId, 1, 2));
+    }
+
+    [Theory]
+    [InlineData(26)]
+    [InlineData(39)]
+    [InlineData(40)]
+    [InlineData(42)]
+    public void G2_ultra_reserved_buttons_are_ignored(int buttonId)
+    {
+        Assert.Null(G2PanelActionRouter.G2UltraButtonActionNameForTransition(buttonId, 0, 1));
+    }
+
+    [Theory]
     [InlineData(1, 1)]
     [InlineData(10, 1)]
     [InlineData(50, 5)]


### PR DESCRIPTION
## Summary
- batch G2 VFO and slider/knob encoder ticks on the 16 ms panel loop for smoother control updates
- audit and pin the G2 Ultra type-5 encoder and button mappings against DeskHPSDR defaults
- keep RX2 AGC encoder active by routing it to Zeus's current shared AGC-T control until per-RX AGC-T exists

## Verification
- dotnet test tests\Zeus.Server.Tests\Zeus.Server.Tests.csproj --filter FullyQualifiedName~G2PanelProtocolTests --no-build
- dotnet build Zeus.slnx --no-restore