### PR TITLE
feat(web): move workspace-zoom control into the transport footer

### DIFF
--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -73,6 +73,7 @@ import { MoxButton } from './components/MoxButton';
 import { PreampButton } from './components/PreampButton';
 import { PsToggleButton } from './components/PsToggleButton';
 import { PaTempChip } from './components/PaTempChip';
+import { WorkspaceZoomControls } from './components/WorkspaceZoomControls';
 import { QrzStatusPill } from './components/QrzStatusPill';
 import { RotatorStatusPill } from './components/RotatorStatusPill';
 import ReportProblemButton from './components/report-problem/ReportProblemButton';
@@ -1157,6 +1158,7 @@ export default function App() {
         <button type="button" className="btn ghost hide-mobile">RIT</button>
         <button type="button" className="btn ghost hide-mobile">SAVE MEM</button>
         <div className="spacer" style={{ flex: 1 }} />
+        <WorkspaceZoomControls />
         <PaTempChip />
         <div className="chip hide-mobile">
           <span className="k">PRE</span>

--- a/zeus-web/src/components/WorkspaceZoomControls.tsx
+++ b/zeus-web/src/components/WorkspaceZoomControls.tsx
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Workspace-zoom cluster (ZOOM − | nn% | +) for the bottom transport bar. Steps
+// the server-persisted WorkspaceZoomPct, which scales the panel-grid cell pitch
+// in FlexWorkspace; the percent readout doubles as a reset-to-100% button.
+// Optimistic store write + POST + applyState reconcile, mirroring how the
+// spectral-zoom controls talk to the server. Lives in the footer beside the PA
+// temperature chip so workspace-level status reads together.
+
+import { useCallback, useEffect, useRef } from 'react';
+import { Minus, Plus } from 'lucide-react';
+import {
+  setWorkspaceZoom,
+  WORKSPACE_ZOOM_DEFAULT,
+  WORKSPACE_ZOOM_MAX,
+  WORKSPACE_ZOOM_MIN,
+  WORKSPACE_ZOOM_STEP,
+} from '../api/client';
+import { useConnectionStore } from '../state/connection-store';
+
+export function WorkspaceZoomControls() {
+  const pct = useConnectionStore((s) => s.workspaceZoomPct);
+  const setWorkspaceZoomPct = useConnectionStore((s) => s.setWorkspaceZoomPct);
+  const abortRef = useRef<AbortController | null>(null);
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const apply = useCallback(
+    (next: number) => {
+      const clamped = Math.min(
+        WORKSPACE_ZOOM_MAX,
+        Math.max(WORKSPACE_ZOOM_MIN, Math.round(next)),
+      );
+      if (clamped === useConnectionStore.getState().workspaceZoomPct) return;
+      setWorkspaceZoomPct(clamped); // optimistic — grid rescales immediately
+      abortRef.current?.abort();
+      const ctrl = new AbortController();
+      abortRef.current = ctrl;
+      setWorkspaceZoom(clamped, ctrl.signal)
+        .then((s) => {
+          if (!ctrl.signal.aborted) useConnectionStore.getState().applyState(s);
+        })
+        .catch(() => {
+          // Network/abort error: keep the optimistic value; the 1 Hz state
+          // poll reconciles to server truth on the next tick.
+        });
+    },
+    [setWorkspaceZoomPct],
+  );
+
+  return (
+    <div
+      className="workspace-zoom-controls hide-mobile"
+      role="group"
+      aria-label="Workspace zoom"
+    >
+      <span className="k">ZOOM</span>
+      <button
+        type="button"
+        className="workspace-zoom-btn"
+        onClick={() => apply(pct - WORKSPACE_ZOOM_STEP)}
+        disabled={pct <= WORKSPACE_ZOOM_MIN}
+        title="Zoom workspace out"
+        aria-label="Zoom workspace out"
+      >
+        <Minus size={12} strokeWidth={2.4} aria-hidden />
+      </button>
+      <button
+        type="button"
+        className="workspace-zoom-readout"
+        onClick={() => apply(WORKSPACE_ZOOM_DEFAULT)}
+        title="Reset workspace zoom to 100%"
+        aria-label={`Workspace zoom ${pct}% — click to reset to 100%`}
+      >
+        {pct}%
+      </button>
+      <button
+        type="button"
+        className="workspace-zoom-btn"
+        onClick={() => apply(pct + WORKSPACE_ZOOM_STEP)}
+        disabled={pct >= WORKSPACE_ZOOM_MAX}
+        title="Zoom workspace in"
+        aria-label="Zoom workspace in"
+      >
+        <Plus size={12} strokeWidth={2.4} aria-hidden />
+      </button>
+    </div>
+  );
+}

--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -33,17 +33,10 @@ import {
   type LayoutItem,
 } from 'react-grid-layout';
 import { absoluteStrategy } from 'react-grid-layout/core';
-import { Minus, Plus, Puzzle, Settings } from 'lucide-react';
+import { Plus, Puzzle, Settings } from 'lucide-react';
 import { useWorkspace } from './WorkspaceContext';
 import { parseLayoutOrDefault, useLayoutStore } from '../state/layout-store';
 import { useConnectionStore } from '../state/connection-store';
-import {
-  setWorkspaceZoom,
-  WORKSPACE_ZOOM_DEFAULT,
-  WORKSPACE_ZOOM_MAX,
-  WORKSPACE_ZOOM_MIN,
-  WORKSPACE_ZOOM_STEP,
-} from '../api/client';
 import { getPanelDef } from './panels';
 import {
   WORKSPACE_RESIZE_COMPACTOR,
@@ -194,19 +187,16 @@ export function FlexWorkspace({
       />
       <TerminatorLines active={terminatorActive} />
       {showAddPanelModal && !addPanelOpen && (
-        <>
-          <WorkspaceZoomControls />
-          <button
-            type="button"
-            className="workspace-add-panel-btn"
-            onClick={() => setAddPanelOpen(true)}
-            disabled={!isLoaded}
-            title="Add a panel to this workspace"
-            aria-label="Add panel"
-          >
-            <Plus size={18} strokeWidth={2.2} aria-hidden />
-          </button>
-        </>
+        <button
+          type="button"
+          className="workspace-add-panel-btn"
+          onClick={() => setAddPanelOpen(true)}
+          disabled={!isLoaded}
+          title="Add a panel to this workspace"
+          aria-label="Add panel"
+        >
+          <Plus size={18} strokeWidth={2.2} aria-hidden />
+        </button>
       )}
       {showAddPanelModal && addPanelOpen && (
         <AddPanelModal
@@ -233,78 +223,6 @@ export function FlexWorkspace({
           </p>
         </ConfirmDialog>
       )}
-    </div>
-  );
-}
-
-// Floating workspace-zoom cluster (− | nn% | +) that sits beside the Add Panel
-// button. Steps the server-persisted WorkspaceZoomPct; the percent readout
-// doubles as a reset-to-100% button. Optimistic store write + POST + applyState
-// reconcile, mirroring how the spectral-zoom controls talk to the server.
-function WorkspaceZoomControls() {
-  const pct = useConnectionStore((s) => s.workspaceZoomPct);
-  const setWorkspaceZoomPct = useConnectionStore((s) => s.setWorkspaceZoomPct);
-  const abortRef = useRef<AbortController | null>(null);
-  useEffect(() => () => abortRef.current?.abort(), []);
-
-  const apply = useCallback(
-    (next: number) => {
-      const clamped = Math.min(
-        WORKSPACE_ZOOM_MAX,
-        Math.max(WORKSPACE_ZOOM_MIN, Math.round(next)),
-      );
-      if (clamped === useConnectionStore.getState().workspaceZoomPct) return;
-      setWorkspaceZoomPct(clamped); // optimistic — grid rescales immediately
-      abortRef.current?.abort();
-      const ctrl = new AbortController();
-      abortRef.current = ctrl;
-      setWorkspaceZoom(clamped, ctrl.signal)
-        .then((s) => {
-          if (!ctrl.signal.aborted) useConnectionStore.getState().applyState(s);
-        })
-        .catch(() => {
-          // Network/abort error: keep the optimistic value; the 1 Hz state
-          // poll reconciles to server truth on the next tick.
-        });
-    },
-    [setWorkspaceZoomPct],
-  );
-
-  return (
-    <div
-      className="workspace-zoom-controls"
-      role="group"
-      aria-label="Workspace zoom"
-    >
-      <button
-        type="button"
-        className="workspace-zoom-btn"
-        onClick={() => apply(pct - WORKSPACE_ZOOM_STEP)}
-        disabled={pct <= WORKSPACE_ZOOM_MIN}
-        title="Zoom workspace out"
-        aria-label="Zoom workspace out"
-      >
-        <Minus size={14} strokeWidth={2.4} aria-hidden />
-      </button>
-      <button
-        type="button"
-        className="workspace-zoom-readout"
-        onClick={() => apply(WORKSPACE_ZOOM_DEFAULT)}
-        title="Reset workspace zoom to 100%"
-        aria-label={`Workspace zoom ${pct}% — click to reset to 100%`}
-      >
-        {pct}%
-      </button>
-      <button
-        type="button"
-        className="workspace-zoom-btn"
-        onClick={() => apply(pct + WORKSPACE_ZOOM_STEP)}
-        disabled={pct >= WORKSPACE_ZOOM_MAX}
-        title="Zoom workspace in"
-        aria-label="Zoom workspace in"
-      >
-        <Plus size={14} strokeWidth={2.4} aria-hidden />
-      </button>
     </div>
   );
 }

--- a/zeus-web/src/styles/all-panels.css
+++ b/zeus-web/src/styles/all-panels.css
@@ -727,62 +727,61 @@
   opacity: 1;
 }
 
-/* Workspace zoom cluster (− | nn% | +) — a floating pill sitting to the LEFT
- * of the round Add Panel button. Same chrome vocabulary so the two read as a
- * matched pair of workspace-level affordances. */
+/* Workspace zoom cluster (ZOOM − | nn% | +) — lives in the bottom transport
+ * bar beside the PA-temperature chip. Styled to the footer .chip vocabulary
+ * (dark inset, hairline border) so it reads as a matched status affordance
+ * rather than a floating pill. */
 .workspace-zoom-controls {
-  position: absolute;
-  right: 54px;
-  bottom: 12px;
-  z-index: 5;
   display: inline-flex;
   align-items: center;
-  height: 34px;
-  padding: 0 2px;
-  border-radius: 999px;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.015)),
-    rgba(12, 13, 15, 0.72);
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  box-shadow:
-    0 8px 20px rgba(0, 0, 0, 0.28),
-    inset 0 1px 0 rgba(255, 255, 255, 0.09);
-  opacity: 0.68;
-  transition:
-    opacity var(--dur-fast),
-    border-color var(--dur-fast);
+  gap: 2px;
+  height: 22px;
+  padding: 0 4px;
+  border-radius: var(--r-xs);
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  transition: border-color var(--dur-fast);
 }
 .workspace-zoom-controls:hover,
 .workspace-zoom-controls:focus-within {
-  opacity: 1;
-  border-color: rgba(255, 255, 255, 0.24);
+  border-color: rgba(255, 255, 255, 0.16);
+}
+.workspace-zoom-controls > .k {
+  color: var(--fg-2);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-size: 9px;
+  margin-right: 2px;
 }
 .workspace-zoom-btn,
 .workspace-zoom-readout {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  height: 28px;
+  height: 18px;
   padding: 0;
   border: none;
   background: transparent;
   color: var(--fg-1);
   font-family: var(--font-sans);
   cursor: pointer;
-  border-radius: 999px;
+  border-radius: var(--r-xs);
   transition:
     background var(--dur-fast),
     color var(--dur-fast);
 }
 .workspace-zoom-btn {
-  width: 28px;
+  width: 18px;
 }
 .workspace-zoom-readout {
-  min-width: 44px;
-  padding: 0 6px;
-  font-size: 12px;
+  min-width: 34px;
+  padding: 0 4px;
+  font-size: 10px;
+  font-weight: 700;
   font-variant-numeric: tabular-nums;
   letter-spacing: 0.01em;
+  color: var(--fg-0);
 }
 .workspace-zoom-btn:hover:not(:disabled),
 .workspace-zoom-readout:hover {


### PR DESCRIPTION
## What

Moves the **workspace-zoom** control (`ZOOM − nn% +`) from its floating pill at the bottom-right of the workspace into the bottom **transport bar, next to the PA-temperature chip**.

## Why

The zoom % is workspace-level status; grouping it with the other footer chips (PA TEMP, PRE, RADIO) reads more naturally than a floating pill hovering over the panel grid by the Add Panel button.

## Changes

- Extract `WorkspaceZoomControls` out of `FlexWorkspace.tsx` into its own `components/WorkspaceZoomControls.tsx`.
- Render it in the `.transport` footer immediately before `<PaTempChip />`.
- Remove the floating-pill render (and its now-unused `Minus` / `WORKSPACE_ZOOM_*` / `setWorkspaceZoom` imports) from `FlexWorkspace`.
- Restyle `.workspace-zoom-controls` from an absolute-positioned floating pill into the footer `.chip` vocabulary (dark inset, hairline border, 9px `ZOOM` label, tabular-nums readout); `hide-mobile` like the sibling chips.

**Behaviour is unchanged:** optimistic step + `POST /api/ui/workspace-zoom` + `applyState` reconcile, with the percent readout doubling as a click-to-reset-to-100% button. This is a pure UI-relocation + restyle — no plumbing, store, or backend changes.

## Verification

- `tsc -b --noEmit` clean.
- No dangling references to the removed symbols in `FlexWorkspace`.

Visual placement (footer, desktop) is best eyeballed in a real browser via the web-dev stack — the headless preview renders the mobile layout, which has no transport footer.