### PR TITLE
fix(tx-audio): refresh plugin settings on profile import

### DIFF
--- a/Zeus.Server.Hosting/AudioPluginBridge.cs
+++ b/Zeus.Server.Hosting/AudioPluginBridge.cs
@@ -1288,6 +1288,92 @@ public sealed class AudioPluginBridge : IHostedService, IAsyncDisposable
     }
 
     /// <summary>
+    /// Recycle already-active TX plugins so they re-read their
+    /// <see cref="Zeus.Plugins.Contracts.IPluginSettings"/> values after a TX
+    /// audio profile restore. Profile apply writes plugin settings directly to
+    /// LiteDB; an initialized plugin would otherwise keep its prior in-memory
+    /// defaults until the next Zeus restart.
+    /// </summary>
+    public void ReloadActiveTxPlugins(IReadOnlyCollection<string> pluginIds)
+    {
+        if (pluginIds.Count == 0) return;
+
+        var requested = new HashSet<string>(pluginIds, StringComparer.Ordinal);
+        var reload = new List<(string Id, IAudioPlugin Plugin, string SlotName)>();
+
+        lock (_lock)
+        {
+            foreach (var id in requested)
+            {
+                if (!_idToPlugin.TryGetValue(id, out var plugin)) continue;
+                if (!_idToSlot.TryGetValue(id, out var slot)) continue;
+                if (!_txInitializedIds.Remove(id)) continue;
+
+                var slotName = _txIdToSlotName.TryGetValue(id, out var s)
+                    ? s
+                    : "tx.post-leveler";
+                reload.Add((id, plugin, slotName));
+                _chain.ClearSlot(slot);
+            }
+        }
+
+        if (reload.Count == 0) return;
+
+        foreach (var item in reload)
+        {
+            try
+            {
+                item.Plugin.ShutdownAudioAsync(CancellationToken.None)
+                    .GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                _log.LogWarning(ex,
+                    "Audio plugin {Id} ShutdownAudioAsync threw during TX profile reload",
+                    item.Id);
+            }
+        }
+
+        var failed = new List<string>();
+        foreach (var item in reload)
+        {
+            if (!EnsureTxPluginInitialized(item.Id, item.Plugin, item.SlotName))
+                failed.Add(item.Id);
+        }
+
+        if (failed.Count > 0)
+        {
+            lock (_lock)
+            {
+                foreach (var id in failed)
+                {
+                    if (_idToSlot.Remove(id, out var slot))
+                        _chain.ClearSlot(slot);
+                    _idToPlugin.Remove(id);
+                    _txIdToSlotName.Remove(id);
+                    _txInitializedIds.Remove(id);
+                }
+                if (_chainOrder is not null) ReapplySlotsUnderLock();
+            }
+
+            foreach (var id in failed)
+                _chainOrder?.OnPluginDetached(id);
+        }
+        else
+        {
+            lock (_lock)
+            {
+                if (_chainOrder is not null) ReapplySlotsUnderLock();
+            }
+        }
+
+        RefreshPreviewEnabled();
+        _log.LogInformation(
+            "Reloaded {Count} active TX audio plugin(s) after profile restore",
+            reload.Count - failed.Count);
+    }
+
+    /// <summary>
     /// Lazily load the native resources of any TX plugin that is currently
     /// ACTIVE (un-parked) in the operator's order but not yet initialized.
     /// Native instantiation is deferred until a plugin enters the live chain

--- a/Zeus.Server.Hosting/TxAudioProfileService.cs
+++ b/Zeus.Server.Hosting/TxAudioProfileService.cs
@@ -42,6 +42,7 @@ public sealed class TxAudioProfileService : IHostedService
     private readonly TxFidelityPolicyStore _fidelity;
     private readonly PluginManager _manager;
     private readonly PluginSettingsStore _pluginSettings;
+    private readonly AudioPluginBridge _audioBridge;
     private readonly ILogger<TxAudioProfileService> _log;
 
     public TxAudioProfileService(
@@ -53,6 +54,7 @@ public sealed class TxAudioProfileService : IHostedService
         TxFidelityPolicyStore fidelity,
         PluginManager manager,
         PluginSettingsStore pluginSettings,
+        AudioPluginBridge audioBridge,
         ILogger<TxAudioProfileService> log)
     {
         _store = store;
@@ -63,6 +65,7 @@ public sealed class TxAudioProfileService : IHostedService
         _fidelity = fidelity;
         _manager = manager;
         _pluginSettings = pluginSettings;
+        _audioBridge = audioBridge;
         _log = log;
     }
 
@@ -227,10 +230,13 @@ public sealed class TxAudioProfileService : IHostedService
         var targetMode = string.Equals(profile.ProcessingMode, "vst", StringComparison.OrdinalIgnoreCase)
             ? AudioProcessingMode.Vst : AudioProcessingMode.Native;
         await _mode.SetModeAsync(targetMode, ct).ConfigureAwait(false);
-        // ApplyMembershipAndOrder fires OrderChanged -> AudioChain rebuild ->
-        // native plugins re-read PluginSettingsStore (restored above), and the
-        // VST engine reloads its chain with the armed states.
+        // ApplyMembershipAndOrder fires OrderChanged -> AudioChain rebuild.
+        // Newly-active native plugins initialize after the restored settings
+        // above. Already-active native plugins need one explicit recycle so
+        // their in-memory controls and DSP state re-read PluginSettingsStore
+        // immediately instead of waiting for a Zeus restart.
         _chainOrder.ApplyMembershipAndOrder(profile.ChainOrder, profile.ChainParked);
+        _audioBridge.ReloadActiveTxPlugins(profile.NativePluginStates.Keys.ToArray());
         _masterBypass.SetMasterBypassed(profile.MasterBypass);
 
         _store.SetLastLoadedId(profile.Id);

--- a/tests/Zeus.Server.Tests/AudioPluginBridgeTxDeferredInitTests.cs
+++ b/tests/Zeus.Server.Tests/AudioPluginBridgeTxDeferredInitTests.cs
@@ -61,6 +61,31 @@ public sealed class AudioPluginBridgeTxDeferredInitTests
         Assert.Equal(1, spy.InitCount);
     }
 
+    [Fact]
+    public void ReloadActiveTxPlugins_RecyclesInitializedLiveTxPlugin()
+    {
+        using var fx = new TxOrderFixture();
+        var bridge = NewBridgeWithChainOrder(fx.Service);
+        var spy = new SpyTxPlugin();
+        const string pluginId = "com.openhpsdr.zeus.samples.eq";
+
+        fx.Service.OnPluginAttached(pluginId, []);
+        TxPluginMap(bridge)[pluginId] = spy;
+        TxSlotNameMap(bridge)[pluginId] = "tx.post-leveler";
+        ApplyChainOrder(bridge);
+
+        Assert.Equal(1, spy.InitCount);
+        Assert.Equal(0, spy.ShutdownCount);
+        Assert.Same(spy, TxChain(bridge).GetSlot(0));
+
+        bridge.ReloadActiveTxPlugins([pluginId]);
+
+        Assert.Equal(2, spy.InitCount);
+        Assert.Equal(1, spy.ShutdownCount);
+        Assert.Contains(pluginId, TxInitializedSet(bridge));
+        Assert.Same(spy, TxChain(bridge).GetSlot(0));
+    }
+
     // -- harness ---------------------------------------------------------
 
     private static AudioPluginBridge NewBridgeWithChainOrder(ChainOrderService chainOrder)
@@ -147,6 +172,7 @@ public sealed class AudioPluginBridgeTxDeferredInitTests
     private sealed class SpyTxPlugin : IAudioPlugin
     {
         public int InitCount { get; private set; }
+        public int ShutdownCount { get; private set; }
         public string DisplayName => "Spy TX";
         public AudioPluginRequirements Requirements => new(48_000, 1, 1_024);
 
@@ -159,6 +185,10 @@ public sealed class AudioPluginBridgeTxDeferredInitTests
         public void Process(ReadOnlySpan<float> input, Span<float> output, AudioBlockContext ctx) =>
             input.CopyTo(output);
 
-        public Task ShutdownAudioAsync(CancellationToken ct) => Task.CompletedTask;
+        public Task ShutdownAudioAsync(CancellationToken ct)
+        {
+            ShutdownCount++;
+            return Task.CompletedTask;
+        }
     }
 }

--- a/tests/Zeus.Server.Tests/TxAudioProfileServiceTests.cs
+++ b/tests/Zeus.Server.Tests/TxAudioProfileServiceTests.cs
@@ -25,6 +25,7 @@ public sealed class TxAudioProfileServiceTests : IDisposable
     private readonly VstEngineController _engine;
     private readonly RadioService _radio;
     private readonly ChainOrderService _chainOrder;
+    private readonly AudioPluginBridge _bridge;
     private readonly AudioChainMasterBypassService _masterBypass;
     private readonly AudioProcessingModeService _mode;
     private readonly TxAudioProfileService _service;
@@ -55,11 +56,12 @@ public sealed class TxAudioProfileServiceTests : IDisposable
 
         var hub = new StreamingHub(NullLogger<StreamingHub>.Instance);
         _chainOrder = new ChainOrderService(_orderStore, hub, NullLogger<ChainOrderService>.Instance);
+        _bridge = new AudioPluginBridge(
+            isMoxOn: () => false, isMonitorOn: () => false,
+            log: NullLogger<AudioPluginBridge>.Instance);
         _masterBypass = new AudioChainMasterBypassService(
             _chainSettings,
-            new AudioPluginBridge(
-                isMoxOn: () => false, isMonitorOn: () => false,
-                log: NullLogger<AudioPluginBridge>.Instance),
+            _bridge,
             hub,
             NullLogger<AudioChainMasterBypassService>.Instance);
         _mode = new AudioProcessingModeService(
@@ -68,7 +70,7 @@ public sealed class TxAudioProfileServiceTests : IDisposable
 
         _service = new TxAudioProfileService(
             _profileStore, _radio, _chainOrder, _masterBypass, _mode, _fidelity,
-            _pluginManager, _pluginSettings,
+            _pluginManager, _pluginSettings, _bridge,
             NullLogger<TxAudioProfileService>.Instance);
     }
 

--- a/zeus-web/src/components/AudioSuiteWindow.tsx
+++ b/zeus-web/src/components/AudioSuiteWindow.tsx
@@ -971,6 +971,7 @@ export function AudioSuiteWindow({
   embedded = false,
 }: { route?: AudioSuiteRoute; embedded?: boolean } = {}) {
   const isRxSuite = route === 'rx';
+  const txProfileApplyRevision = useTxAudioProfileStore((s) => s.applyRevision);
   const isOpen = useAudioSuiteStore((s) => (isRxSuite ? s.rxOpen : s.txOpen));
   const close = useAudioSuiteStore((s) => (isRxSuite ? s.closeRx : s.closeTx));
   const x = useAudioSuiteStore((s) => (isRxSuite ? s.rxX : s.txX));
@@ -1049,7 +1050,6 @@ export function AudioSuiteWindow({
   const loadRxMasterBypassFromServer = useAudioSuiteStore(
     (s) => s.loadRxMasterBypassFromServer,
   );
-  const pluginSettingsRevision = useAudioSuiteStore((s) => s.pluginSettingsRevision);
   const setPosition = useCallback(
     (nextX: number, nextY: number) => setWindowPosition(route, nextX, nextY),
     [route, setWindowPosition],
@@ -1594,6 +1594,11 @@ export function AudioSuiteWindow({
     [chainPanels, effectiveSelectedId],
   );
   const SelectedComponent = selectedPanel?.component ?? null;
+  const selectedComponentKey = selectedPanel
+    ? isRxSuite
+      ? `${selectedPanel.pluginId}::${selectedPanel.panelId}`
+      : `${selectedPanel.pluginId}::${selectedPanel.panelId}::${txProfileApplyRevision}`
+    : undefined;
 
   // Embedded mode (rendered inline inside Audio Tools) is always
   // visible; the floating window only renders when opened.
@@ -2075,9 +2080,7 @@ export function AudioSuiteWindow({
         }}
       >
         {SelectedComponent ? (
-          <SelectedComponent
-            key={`${selectedPanel!.pluginId}::${selectedPanel!.panelId}::${pluginSettingsRevision}`}
-          />
+          <SelectedComponent key={selectedComponentKey} />
         ) : (
           <span
             style={{ color: 'var(--fg-3)', fontSize: 12, fontStyle: 'italic' }}

--- a/zeus-web/src/components/TxAudioProfileBar.tsx
+++ b/zeus-web/src/components/TxAudioProfileBar.tsx
@@ -155,8 +155,8 @@ export function TxAudioProfileBar({ compact = false }: TxAudioProfileBarProps) {
     }
   };
 
-  // Import: open the OS file picker; the chosen .json is uploaded and ADDED to
-  // the catalog (never auto-applied).
+  // Import: open the OS file picker; the chosen .json is uploaded, saved, then
+  // immediately applied so recovered/shared profiles become live in one action.
   const onImportPick = () => {
     setNotice(null);
     fileInputRef.current?.click();
@@ -173,7 +173,7 @@ export function TxAudioProfileBar({ compact = false }: TxAudioProfileBarProps) {
       setNotice({ tone: 'error', text: result.error ?? 'Profile import failed.' });
       return;
     }
-    setNotice({ tone: 'ok', text: `Imported "${file.name}".` });
+    setNotice({ tone: 'ok', text: `Imported and loaded "${file.name}".` });
   };
 
   // Export: download the selected profile as a .json file.

--- a/zeus-web/src/state/tx-audio-profile-store.test.ts
+++ b/zeus-web/src/state/tx-audio-profile-store.test.ts
@@ -43,8 +43,15 @@ function makeProfile(id: string, name: string, mode: 'native' | 'vst' = 'native'
 
 describe('tx-audio-profile-store', () => {
   beforeEach(() => {
-    useTxAudioProfileStore.setState({ profiles: [], loaded: false, lastLoadedId: null, busy: false });
-    useAudioSuiteStore.setState(useAudioSuiteStore.getInitialState(), true);
+    useTxAudioProfileStore.setState({
+      profiles: [],
+      loaded: false,
+      lastLoadedId: null,
+      busy: false,
+      dirty: false,
+      baseline: null,
+      applyRevision: 0,
+    });
     vi.restoreAllMocks();
   });
 
@@ -115,12 +122,49 @@ describe('tx-audio-profile-store', () => {
     expect(hydrateSpy).toHaveBeenCalledWith(fakeState);
     expect(loadChainSpy).toHaveBeenCalled();
     expect(useTxAudioProfileStore.getState().lastLoadedId).toBe('dx-punch');
+    expect(useTxAudioProfileStore.getState().applyRevision).toBe(1);
     // The Audio Suite store reconciled from the apply response.
     const audio = useAudioSuiteStore.getState();
     expect(audio.chainOrder).toEqual(['comp', 'eq']);
     expect(audio.processingMode).toBe('vst');
     expect(audio.masterBypassed).toBe(true);
-    expect(audio.pluginSettingsRevision).toBe(1);
+  });
+
+  it('importProfile() imports then immediately applies the imported profile', async () => {
+    const applyStateSpy = vi.spyOn(useConnectionStore.getState(), 'applyState');
+    const hydrateSpy = vi.spyOn(useTxStore.getState(), 'hydrateFromState');
+    const loadChainSpy = vi
+      .spyOn(useAudioSuiteStore.getState(), 'loadChainOrderFromServer')
+      .mockResolvedValue();
+
+    const imported = makeProfile('voodoo-4k', 'VooDoo 4K');
+    const fakeState = { status: 'Connected', mode: 'USB' } as unknown as RadioStateDto;
+    vi.spyOn(client, 'importTxAudioProfile').mockResolvedValue(imported);
+    vi.spyOn(client, 'fetchTxAudioProfiles').mockResolvedValue([imported]);
+    vi.spyOn(client, 'fetchLastLoadedTxAudioProfile').mockResolvedValue({ id: null });
+    vi.spyOn(client, 'applyTxAudioProfile').mockResolvedValue({
+      profile: imported,
+      state: fakeState,
+      pluginIds: ['com.openhpsdr.zeus.samples.eq'],
+      parked: [],
+      processingMode: 'native',
+      engineActive: false,
+      engineAvailable: false,
+      masterBypass: false,
+    });
+
+    const file = new File(['{}'], 'voodoo-4k.json', { type: 'application/json' });
+    const result = await useTxAudioProfileStore.getState().importProfile(file);
+
+    expect(result.ok).toBe(true);
+    expect(client.importTxAudioProfile).toHaveBeenCalledWith(file, undefined);
+    expect(client.applyTxAudioProfile).toHaveBeenCalledWith('voodoo-4k');
+    expect(applyStateSpy).toHaveBeenCalledWith(fakeState);
+    expect(hydrateSpy).toHaveBeenCalledWith(fakeState);
+    expect(loadChainSpy).toHaveBeenCalled();
+    expect(useTxAudioProfileStore.getState().lastLoadedId).toBe('voodoo-4k');
+    expect(useTxAudioProfileStore.getState().applyRevision).toBe(1);
+    expect(useTxAudioProfileStore.getState().dirty).toBe(false);
   });
 
   it('remove() drops the row and clears a matching selection', async () => {
@@ -142,9 +186,14 @@ describe('tx-audio-profile-store', () => {
 describe('tx-audio-profile-store — dirty tracking', () => {
   beforeEach(() => {
     useTxAudioProfileStore.setState({
-      profiles: [], loaded: false, lastLoadedId: null, busy: false, dirty: false, baseline: null,
+      profiles: [],
+      loaded: false,
+      lastLoadedId: null,
+      busy: false,
+      dirty: false,
+      baseline: null,
+      applyRevision: 0,
     });
-    useAudioSuiteStore.setState(useAudioSuiteStore.getInitialState(), true);
     // Deterministic clean live state for the snapshot to read.
     useTxStore.setState({ micGainDb: 0, levelerMaxGainDb: 8 });
     vi.restoreAllMocks();

--- a/zeus-web/src/state/tx-audio-profile-store.ts
+++ b/zeus-web/src/state/tx-audio-profile-store.ts
@@ -28,6 +28,7 @@ import {
   fetchTxAudioProfiles,
   importTxAudioProfile,
   saveTxAudioProfile,
+  type ApplyTxAudioProfileResultDto,
   type TxAudioProfileDto,
 } from '../api/client';
 import { useAudioSuiteStore } from './audio-suite-store';
@@ -80,6 +81,8 @@ interface TxAudioProfileState {
   dirty: boolean;
   /** Snapshot of the live settings as they were at the last apply/save (clean). */
   baseline: string | null;
+  /** Bumped after a successful profile apply/import so plugin panels remount and refetch settings. */
+  applyRevision: number;
 
   /** Re-baseline to the current live state (called after apply/save => clean). */
   markClean(): void;
@@ -94,7 +97,7 @@ interface TxAudioProfileState {
   apply(id: string): Promise<TxAudioProfileMutationResult>;
   /** Delete a profile by id. */
   remove(id: string): Promise<TxAudioProfileMutationResult>;
-  /** Import a profile from a user-picked .json file; ADDS it (never applies it). */
+  /** Import a profile from a user-picked .json file and apply it immediately. */
   importProfile(file: File, name?: string): Promise<TxAudioProfileMutationResult>;
   /** Download a saved profile by id as a .json file. */
   exportProfile(id: string): Promise<TxAudioProfileMutationResult>;
@@ -104,6 +107,28 @@ function errorText(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+async function reconcileAppliedProfile(result: ApplyTxAudioProfileResultDto): Promise<void> {
+  // Drive the live UI from the returned StateDto — same body the existing
+  // reconcilers parse (mic/leveler/cfc/filter all live in StateDto).
+  const conn = useConnectionStore.getState();
+  const tx = useTxStore.getState();
+  conn.applyState(result.state);
+  tx.hydrateFromState(result.state);
+
+  // Reconcile the Audio Suite chain/mode/bypass from the apply response, then
+  // resync the full chain order + parked set from the server so the rack UI
+  // (and any open Audio Suite window) reflects the applied chain.
+  const audio = useAudioSuiteStore.getState();
+  useAudioSuiteStore.setState({
+    chainOrder: result.pluginIds,
+    processingMode: result.processingMode,
+    masterBypassed: result.masterBypass,
+    vstEngineActive: result.engineActive,
+    vstEngineAvailable: result.engineAvailable,
+  });
+  await audio.loadChainOrderFromServer();
+}
+
 export const useTxAudioProfileStore = create<TxAudioProfileState>((set, get) => ({
   profiles: [],
   loaded: false,
@@ -111,6 +136,7 @@ export const useTxAudioProfileStore = create<TxAudioProfileState>((set, get) => 
   busy: false,
   dirty: false,
   baseline: null,
+  applyRevision: 0,
 
   markClean: () => {
     set({ baseline: snapshotTxAudioLive(), dirty: false });
@@ -170,29 +196,9 @@ export const useTxAudioProfileStore = create<TxAudioProfileState>((set, get) => 
     set({ busy: true });
     try {
       const result = await applyTxAudioProfile(trimmed);
+      await reconcileAppliedProfile(result);
 
-      // Drive the live UI from the returned StateDto — same body the existing
-      // reconcilers parse (mic/leveler/cfc/filter all live in StateDto).
-      const conn = useConnectionStore.getState();
-      const tx = useTxStore.getState();
-      conn.applyState(result.state);
-      tx.hydrateFromState(result.state);
-
-      // Reconcile the Audio Suite chain/mode/bypass from the apply response, then
-      // resync the full chain order + parked set from the server so the rack UI
-      // (and any open Audio Suite window) reflects the applied chain.
-      const audio = useAudioSuiteStore.getState();
-      useAudioSuiteStore.setState({
-        chainOrder: result.pluginIds,
-        processingMode: result.processingMode,
-        masterBypassed: result.masterBypass,
-        vstEngineActive: result.engineActive,
-        vstEngineAvailable: result.engineAvailable,
-      });
-      await audio.loadChainOrderFromServer();
-      useAudioSuiteStore.getState().bumpPluginSettingsRevision();
-
-      set({ lastLoadedId: trimmed, busy: false });
+      set((s) => ({ lastLoadedId: trimmed, busy: false, applyRevision: s.applyRevision + 1 }));
       // Live state now matches the just-applied profile: that is the clean point.
       get().markClean();
       return { ok: true };
@@ -228,14 +234,18 @@ export const useTxAudioProfileStore = create<TxAudioProfileState>((set, get) => 
     set({ busy: true });
     try {
       const imported = await importTxAudioProfile(file, name);
-      // Import only ADDS to the catalog (it doesn't apply or change the
-      // selection). Refresh the list so the new row appears in the dropdown.
+      // Import a recovered/shared profile and make it live immediately. Refresh
+      // the list first so the new row appears in the dropdown even if applying
+      // the profile fails later.
       await get().load();
-      set({ busy: false });
       // Defensive: ensure the imported row is present even if the reload raced.
       if (!get().profiles.some((p) => p.id === imported.id)) {
         set((s) => ({ profiles: [...s.profiles, imported].sort((a, b) => a.id.localeCompare(b.id)) }));
       }
+      const applied = await applyTxAudioProfile(imported.id);
+      await reconcileAppliedProfile(applied);
+      set((s) => ({ lastLoadedId: imported.id, busy: false, applyRevision: s.applyRevision + 1 }));
+      get().markClean();
       return { ok: true };
     } catch (err) {
       set({ busy: false });


### PR DESCRIPTION
## Summary
- Refreshes active native TX audio plugin settings after TX profile import/apply.
- Remounts the TX plugin panel on profile apply revision so UI-visible plugin state stays current.
- Adds backend and frontend coverage for the live refresh path.

Issue: zeus-p5lv

## Verification
- `dotnet test tests/Zeus.Server.Tests/Zeus.Server.Tests.csproj --filter "FullyQualifiedName~AudioPluginBridgeTxDeferredInitTests|FullyQualifiedName~TxAudioProfileServiceTests" -v minimal /p:SpaBuildOutput=C:\Users\Admin\Desktop\openhpsdr-zeus\zeus-web\package.json` -> 14 passed
- `npm --prefix zeus-web run test -- src/state/tx-audio-profile-store.test.ts` -> 11 passed