### PR TITLE
feat(web): prefer NR3 for speech-like Smart NR

### DIFF
--- a/Zeus.Server.Hosting/FrontendDspSceneDiagnosticsService.cs
+++ b/Zeus.Server.Hosting/FrontendDspSceneDiagnosticsService.cs
@@ -787,6 +787,7 @@ public sealed class FrontendDspSceneDiagnosticsService
         {
             "NR1" => "Anr",
             "NR2" => "Emnr",
+            "NR3" => "Rnnr",
             "NR4" => "Sbnr",
             "LIGHT" => "Off",
             "NOTCH" => "Off",
@@ -817,6 +818,7 @@ public sealed class FrontendDspSceneDiagnosticsService
         {
             "ANR" => "Anr",
             "EMNR" => "Emnr",
+            "RNNR" => "Rnnr",
             "SBNR" => "Sbnr",
             _ => null,
         };

--- a/tests/Zeus.Server.Tests/FrontendDspSceneDiagnosticsServiceTests.cs
+++ b/tests/Zeus.Server.Tests/FrontendDspSceneDiagnosticsServiceTests.cs
@@ -616,6 +616,22 @@ public sealed class FrontendDspSceneDiagnosticsServiceTests
         Assert.Equal("aligned", root.GetProperty("runtimeAlignmentStatus").GetString());
     }
 
+    [Fact]
+    public void SmartNrCondition_ReportsAlignedRnnrRuntime()
+    {
+        var service = new FrontendDspSceneDiagnosticsService();
+        PublishScene(service, smartNrProfile: "NR3");
+
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(
+            service.SmartNrCondition(Runtime(requested: "Rnnr", effective: "Rnnr")),
+            CamelCaseJson));
+        var root = doc.RootElement;
+
+        Assert.Equal("Rnnr", root.GetProperty("expectedNrMode").GetString());
+        Assert.True(root.GetProperty("runtimeAligned").GetBoolean());
+        Assert.Equal("aligned", root.GetProperty("runtimeAlignmentStatus").GetString());
+    }
+
     [Theory]
     [InlineData(null)]
     [InlineData("   ")]

--- a/zeus-web/src/components/SmartNrController.test.tsx
+++ b/zeus-web/src/components/SmartNrController.test.tsx
@@ -53,6 +53,12 @@ function extremelyWeakSignal(): Float32Array {
   return spec;
 }
 
+function speechLikeSsbCopy(): Float32Array {
+  const spec = new Float32Array(WIDTH).fill(NOISE_DB);
+  for (let i = 64; i < 164; i += 4) spec[i] = NOISE_DB + 32;
+  return spec;
+}
+
 function quietNoise(): Float32Array {
   return new Float32Array(WIDTH).fill(NOISE_DB);
 }
@@ -339,6 +345,22 @@ describe('SmartNrController', () => {
     expect(setNrMock).toHaveBeenCalledTimes(1);
     expect(setNrMock.mock.calls[0]?.[0].nrMode).toBe('Sbnr');
     expect(useSmartNrStore.getState().status?.reason).toContain('Weak-signal assist');
+  });
+
+  it('applies NR3 for speech-like SSB when an RNNoise model is installed', () => {
+    useConnectionStore.setState({
+      mode: 'USB',
+      wdspNr3RnnrAvailable: true,
+      nr3ModelName: 'hf-voice.rnn',
+    });
+
+    for (let i = 0; i < 6; i++) feed(speechLikeSsbCopy());
+
+    expect(setNrMock).toHaveBeenCalledTimes(1);
+    expect(setNrMock.mock.calls[0]?.[0].nrMode).toBe('Rnnr');
+    expect(setNrMock.mock.calls[0]?.[0].snbEnabled).toBe(false);
+    expect(useSmartNrStore.getState().status?.profile).toBe('NR3');
+    expect(useSmartNrStore.getState().status?.reason).toContain('neural speech');
   });
 
   it('times out a stuck hardware diagnostics request and retries on a later sample', async () => {

--- a/zeus-web/src/components/SmartNrController.tsx
+++ b/zeus-web/src/components/SmartNrController.tsx
@@ -186,6 +186,15 @@ export function SmartNrController() {
         return;
       }
       refreshDspCapabilities(now);
+      const runtimeCapabilities: SmartNrDspCapabilities = {
+        ...(dspCapabilities ?? {
+          wdspActive: true,
+          wdspEmnrPost2Available: true,
+          wdspNr4SbnrAvailable: true,
+        }),
+        wdspNr3RnnrAvailable: conn.wdspNr3RnnrAvailable,
+        nr3ModelName: conn.nr3ModelName,
+      };
 
       const display = useDisplayStore.getState();
       const rxMeters = useRxMetersStore.getState();
@@ -214,6 +223,7 @@ export function SmartNrController() {
           adcHeadroomDb: rx.adcHeadroomDb,
           agcGain: rx.agcGain,
         },
+        dsp: runtimeCapabilities,
         current: conn.nr,
         mode: conn.mode,
       });
@@ -221,7 +231,7 @@ export function SmartNrController() {
 
       const capability = adaptSmartNrToDspCapabilities(
         shapeSmartNrRecommendation(rec, settings),
-        dspCapabilities,
+        runtimeCapabilities,
       );
       const shaped = capability.nr;
       const heldByRxChain = shouldHoldForRxChain(rx);

--- a/zeus-web/src/components/nr/Nr3ModelPanel.test.tsx
+++ b/zeus-web/src/components/nr/Nr3ModelPanel.test.tsx
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useConnectionStore } from '../../state/connection-store';
+import { Nr3ModelPanel } from './Nr3ModelPanel';
+
+describe('Nr3ModelPanel', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    useConnectionStore.setState({
+      wdspNr3RnnrAvailable: true,
+      nr3ModelName: null,
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  function renderPanel() {
+    act(() => {
+      root.render(<Nr3ModelPanel />);
+    });
+  }
+
+  function linkByLabel(label: string): HTMLAnchorElement | undefined {
+    return Array.from(container.querySelectorAll<HTMLAnchorElement>('a'))
+      .find((a) => a.getAttribute('aria-label') === label);
+  }
+
+  it('links users to official RNNoise model sources', () => {
+    renderPanel();
+
+    const xiphModels = linkByLabel('Open the Xiph RNNoise model data directory');
+    const rnnoiseRepo = linkByLabel('Open the official RNNoise source repository');
+
+    if (!xiphModels || !rnnoiseRepo) throw new Error('NR3 model source links were not rendered');
+    expect(xiphModels.getAttribute('href')).toBe('https://media.xiph.org/rnnoise/models/');
+    expect(xiphModels.getAttribute('target')).toBe('_blank');
+    expect(rnnoiseRepo.getAttribute('href')).toBe('https://gitlab.xiph.org/xiph/rnnoise');
+    expect(rnnoiseRepo.getAttribute('target')).toBe('_blank');
+  });
+
+  it('keeps model source links visible when NR3 is unavailable', () => {
+    useConnectionStore.setState({
+      wdspNr3RnnrAvailable: false,
+      nr3ModelName: null,
+    });
+
+    renderPanel();
+
+    expect(linkByLabel('Open the Xiph RNNoise model data directory')).toBeDefined();
+    expect(linkByLabel('Open the official RNNoise source repository')).toBeDefined();
+  });
+});

--- a/zeus-web/src/components/nr/Nr3ModelPanel.tsx
+++ b/zeus-web/src/components/nr/Nr3ModelPanel.tsx
@@ -21,6 +21,7 @@
 // cycle. See NrControls / DspPanel nrCycleFor().
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { ExternalLink } from 'lucide-react';
 import {
   downloadNr3Model,
   removeNr3Model,
@@ -28,6 +29,41 @@ import {
   type RadioStateDto,
 } from '../../api/client';
 import { useConnectionStore } from '../../state/connection-store';
+
+const RNNOISE_MODEL_DATA_URL = 'https://media.xiph.org/rnnoise/models/';
+const RNNOISE_REPO_URL = 'https://gitlab.xiph.org/xiph/rnnoise';
+
+function ModelSourceLinks() {
+  return (
+    <div className="nr-settings__row nr-settings__source-row">
+      <span className="nr-settings__label">Sources</span>
+      <div className="nr-settings__source-links">
+        <a
+          className="nr-settings__button"
+          href={RNNOISE_MODEL_DATA_URL}
+          target="_blank"
+          rel="noreferrer"
+          title="Open the Xiph RNNoise model data directory"
+          aria-label="Open the Xiph RNNoise model data directory"
+        >
+          <ExternalLink size={12} aria-hidden />
+          Xiph models
+        </a>
+        <a
+          className="nr-settings__button"
+          href={RNNOISE_REPO_URL}
+          target="_blank"
+          rel="noreferrer"
+          title="Open the official RNNoise source repository"
+          aria-label="Open the official RNNoise source repository"
+        >
+          <ExternalLink size={12} aria-hidden />
+          RNNoise repo
+        </a>
+      </div>
+    </div>
+  );
+}
 
 export function Nr3ModelPanel() {
   const available = useConnectionStore((s) => s.wdspNr3RnnrAvailable);
@@ -91,6 +127,7 @@ export function Nr3ModelPanel() {
           NR3 (RNNoise) is not available in this build — the loaded WDSP library
           was compiled without RNNoise support.
         </p>
+        <ModelSourceLinks />
       </div>
     );
   }
@@ -104,6 +141,8 @@ export function Nr3ModelPanel() {
           ? `Installed model: ${modelName}. NR3 is now in the NR cycle.`
           : 'No model installed — NR3 is hidden until you install an RNNoise weights file. Zeus ships no model; bring your own.'}
       </p>
+
+      <ModelSourceLinks />
 
       <div className="nr-settings__row">
         <span className="nr-settings__label">File</span>

--- a/zeus-web/src/dsp/smart-nr.test.ts
+++ b/zeus-web/src/dsp/smart-nr.test.ts
@@ -5,6 +5,7 @@ import { NR_CONFIG_DEFAULT } from '../api/client';
 import {
   adaptSmartNrToDspCapabilities,
   analyzeSmartNrCondition,
+  labelSmartNrProfile,
   recommendSmartNr,
   shapeSmartNrRecommendation,
 } from './smart-nr';
@@ -22,6 +23,16 @@ function noise(): Float32Array {
 
 function confidence(value = 0): Float32Array {
   return new Float32Array(WIDTH).fill(value);
+}
+
+function speechLikeSsbCopy(): { spec: Float32Array; conf: Float32Array } {
+  const spec = noise();
+  const conf = confidence();
+  for (let i = 64; i < 164; i += 4) {
+    spec[i] = NOISE_DB + 32;
+    conf[i] = 0.86;
+  }
+  return { spec, conf };
 }
 
 describe('smart NR supervisor', () => {
@@ -243,12 +254,7 @@ describe('smart NR supervisor', () => {
   });
 
   it('uses low-artifact NR2 for live-diagnostic coherent SSB copy assist', () => {
-    const spec = noise();
-    const conf = confidence();
-    for (let i = 64; i < 164; i += 4) {
-      spec[i] = NOISE_DB + 32;
-      conf[i] = 0.86;
-    }
+    const { spec, conf } = speechLikeSsbCopy();
 
     const rec = recommendSmartNr({
       spectrum: spec,
@@ -262,12 +268,62 @@ describe('smart NR supervisor', () => {
     expect(rec.condition.denseNoise).toBe(false);
     expect(rec.condition.tonalInterference).toBe(false);
     expect(rec.condition.coherentCopySignal).toBe(true);
+    expect(rec.condition.speechLikeVoice).toBe(true);
     expect(rec.nr.nrMode).toBe('Emnr');
     expect(rec.nr.emnrPost2Factor).toBe(11);
     expect(rec.nr.emnrPost2Nlevel).toBe(11);
     expect(rec.nr.nbMode).toBe('Off');
     expect(rec.nr.snbEnabled).toBe(false);
     expect(rec.reason).toContain('copy-assist');
+  });
+
+  it('prefers installed NR3/RNNoise for speech-like SSB copy', () => {
+    const { spec, conf } = speechLikeSsbCopy();
+
+    const rec = recommendSmartNr({
+      spectrum: spec,
+      floor: floor(),
+      confidence: conf,
+      current: { ...NR_CONFIG_DEFAULT },
+      mode: 'USB',
+      dsp: {
+        wdspActive: true,
+        wdspEmnrPost2Available: true,
+        wdspNr4SbnrAvailable: true,
+        wdspNr3RnnrAvailable: true,
+        nr3ModelName: 'hf-voice.rnn',
+      },
+    })!;
+
+    expect(rec.condition.speechLikeVoice).toBe(true);
+    expect(rec.condition.weakSparse).toBe(false);
+    expect(rec.nr.nrMode).toBe('Rnnr');
+    expect(rec.nr.snbEnabled).toBe(false);
+    expect(labelSmartNrProfile(rec.nr)).toBe('NR3');
+    expect(rec.reason).toContain('neural speech');
+  });
+
+  it('keeps fragile weak SSB on NR2 even when NR3 is installed', () => {
+    const spec = noise();
+    spec[120] = NOISE_DB + 14;
+
+    const rec = recommendSmartNr({
+      spectrum: spec,
+      floor: floor(),
+      current: { ...NR_CONFIG_DEFAULT },
+      mode: 'LSB',
+      dsp: {
+        wdspActive: true,
+        wdspEmnrPost2Available: true,
+        wdspNr4SbnrAvailable: true,
+        wdspNr3RnnrAvailable: true,
+        nr3ModelName: 'hf-voice.rnn',
+      },
+    })!;
+
+    expect(rec.condition.weakSparse).toBe(true);
+    expect(rec.condition.speechLikeVoice).toBe(false);
+    expect(rec.nr.nrMode).toBe('Emnr');
   });
 
   it('treats spread coherent SSB peaks as copy assist instead of a notch-only case', () => {
@@ -546,6 +602,25 @@ describe('smart NR supervisor', () => {
     expect(adapted.nr.emnrAeRun).toBe(true);
     expect(adapted.capabilityLimited).toBe(true);
     expect(adapted.capabilityRecommendation).toContain('post2');
+  });
+
+  it('downgrades NR3 recommendations to NR2 when no RNNoise model is ready', () => {
+    const adapted = adaptSmartNrToDspCapabilities(
+      { ...NR_CONFIG_DEFAULT, nrMode: 'Rnnr' },
+      {
+        wdspActive: true,
+        wdspEmnrPost2Available: true,
+        wdspNr4SbnrAvailable: true,
+        wdspNr3RnnrAvailable: true,
+        nr3ModelName: null,
+      },
+    );
+
+    expect(adapted.nr.nrMode).toBe('Emnr');
+    expect(adapted.nr.emnrAeRun).toBe(true);
+    expect(adapted.nr.emnrPost2Run).toBe(true);
+    expect(adapted.capabilityLimited).toBe(true);
+    expect(adapted.capabilityRecommendation).toContain('NR3/RNNoise');
   });
 
 });

--- a/zeus-web/src/dsp/smart-nr.ts
+++ b/zeus-web/src/dsp/smart-nr.ts
@@ -37,6 +37,7 @@ export type SmartNrCondition = {
   denseNoise: boolean;
   impulsiveNoise: boolean;
   tonalInterference: boolean;
+  speechLikeVoice: boolean;
 };
 
 export type SmartNrRecommendation = {
@@ -48,7 +49,10 @@ export type SmartNrRecommendation = {
 export type SmartNrDspCapabilities = Pick<
   HardwareDspDiagnosticsDto,
   'wdspActive' | 'wdspEmnrPost2Available' | 'wdspNr4SbnrAvailable'
->;
+> & {
+  wdspNr3RnnrAvailable?: boolean;
+  nr3ModelName?: string | null;
+};
 
 export type SmartNrCapabilityAdaptation = {
   nr: NrConfigDto;
@@ -68,6 +72,7 @@ export type SmartNrInput = {
   floor: Float32Array | null;
   confidence?: Float32Array | null;
   rx?: SmartNrRxContext | null;
+  dsp?: SmartNrDspCapabilities | null;
   current: NrConfigDto;
   mode: RxMode;
 };
@@ -80,6 +85,7 @@ export type SmartNrRxContext = {
 
 export function labelSmartNrProfile(nr: NrConfigDto): string {
   if (nr.nbMode !== 'Off' && nr.snbEnabled) return `${nr.nbMode}+SNB`;
+  if (nr.nrMode === 'Rnnr') return 'NR3';
   if (nr.nrMode === 'Sbnr') return 'NR4';
   if (nr.nrMode === 'Emnr') return 'NR2';
   if (nr.nrMode === 'Anr') return 'NR1';
@@ -172,6 +178,22 @@ export function adaptSmartNrToDspCapabilities(
     notes.push('NR4/SBNR unavailable in the active WDSP build; using NR2/EMNR fallback.');
   }
 
+  if (next.nrMode === 'Rnnr' && !nr3Ready(capabilities)) {
+    next = {
+      ...next,
+      nrMode: 'Emnr',
+      emnrGainMethod: 2,
+      emnrNpeMethod: 0,
+      emnrAeRun: true,
+      emnrPost2Run: capabilities.wdspEmnrPost2Available !== false,
+      emnrPost2Factor: 11,
+      emnrPost2Nlevel: 11,
+      emnrPost2Rate: 5,
+      emnrPost2Taper: 12,
+    };
+    notes.push('NR3/RNNoise is not ready; using NR2/EMNR speech fallback.');
+  }
+
   if (next.nrMode === 'Emnr' && capabilities.wdspEmnrPost2Available === false && next.emnrPost2Run !== false) {
     next = {
       ...next,
@@ -224,6 +246,10 @@ function finiteConfidence(confidence: Float32Array | null, index: number, useCon
   if (!useConfidence) return 1;
   const c = confidence![index]!;
   return Number.isFinite(c) ? Math.max(0, Math.min(1, c)) : 0;
+}
+
+function nr3Ready(capabilities: SmartNrDspCapabilities | null | undefined): boolean {
+  return capabilities?.wdspNr3RnnrAvailable === true && !!capabilities.nr3ModelName;
 }
 
 export function analyzeSmartNrCondition(
@@ -347,9 +373,20 @@ export function analyzeSmartNrCondition(
     occupancy12 < 0.12 &&
     copyAssistSpread &&
     coherentOccupancy6 < 0.14;
+  const speechLikeVoice =
+    !impulsiveNoise &&
+    hasSignal &&
+    maxSnrDb >= 8 &&
+    maxSnrDb < 45 &&
+    tonalPeakCount >= 8 &&
+    tonalPeakCount <= 128 &&
+    occupancy12 < 0.22 &&
+    coherentOccupancy6 >= 0.025 &&
+    coherentOccupancy6 < 0.22;
   const tonalInterference =
     !impulsiveNoise &&
     !coherentCopySignal &&
+    !speechLikeVoice &&
     tonalPeakCount > 0 &&
     tonalPeakCount <= 24 &&
     maxSnrDb >= 18 &&
@@ -378,6 +415,7 @@ export function analyzeSmartNrCondition(
     denseNoise,
     impulsiveNoise,
     tonalInterference,
+    speechLikeVoice,
   };
 }
 
@@ -481,6 +519,18 @@ function withNr2(current: NrConfigDto, c: SmartNrCondition): NrConfigDto {
   };
 }
 
+function withNr3(current: NrConfigDto, c: SmartNrCondition): NrConfigDto {
+  return {
+    ...current,
+    nrMode: 'Rnnr',
+    anfEnabled: false,
+    snbEnabled: false,
+    nbpNotchesEnabled: false,
+    nbMode: c.impulsiveNoise ? 'Nb2' : 'Off',
+    nbThreshold: c.impulsiveNoise ? impulsiveBlankerThreshold(current) : current.nbThreshold,
+  };
+}
+
 function quietProfile(current: NrConfigDto, c: SmartNrCondition): NrConfigDto {
   return {
     ...current,
@@ -497,6 +547,7 @@ export function recommendSmartNr(input: SmartNrInput): SmartNrRecommendation | n
   const baseCondition = analyzeSmartNrCondition(input.spectrum, input.floor, input.confidence ?? null);
   if (!baseCondition) return null;
   const condition = applyRxWeakSignalEvidence(baseCondition, input.rx);
+  const neuralVoiceReady = nr3Ready(input.dsp);
 
   let nr: NrConfigDto;
   let reason: string;
@@ -514,10 +565,20 @@ export function recommendSmartNr(input: SmartNrInput): SmartNrRecommendation | n
         ? 'Impulsive-noise profile: engage NB2/SNB while keeping NR2/NR4 conservative.'
       : 'CW/digital profile: NR2/NR4 with conservative blanking.';
   } else if (isVoiceSsb(input.mode)) {
-    nr = condition.weakSparse || condition.denseNoise || condition.coherentCopySignal
+    const useNeuralVoice =
+      neuralVoiceReady &&
+      condition.speechLikeVoice &&
+      !condition.weakSparse &&
+      !condition.rxAssistedWeakSignal &&
+      !condition.coherentSubthresholdSignal;
+    nr = useNeuralVoice
+      ? withNr3(input.current, condition)
+      : condition.weakSparse || condition.denseNoise || condition.coherentCopySignal
       ? withNr2(input.current, condition)
       : quietProfile(input.current, condition);
-    reason = condition.rxAssistedWeakSignal
+    reason = useNeuralVoice
+      ? 'SSB neural speech profile: installed NR3/RNNoise model is ready; use neural post-demod cleanup for speech-like copy.'
+      : condition.rxAssistedWeakSignal
       ? 'Weak-signal assist: AGC/RX telemetry confirms marginal SSB copy; use NR2/EMNR and RX Suite VST cleanup.'
       : condition.coherentSubthresholdSignal
       ? 'SSB coherent weak-signal profile: temporal confidence confirms a subthreshold ridge; use NR2/EMNR plus RX Suite VST cleanup.'

--- a/zeus-web/src/styles/nr-settings.css
+++ b/zeus-web/src/styles/nr-settings.css
@@ -160,12 +160,32 @@
   border-radius: var(--r-sm);
   cursor: pointer;
   box-shadow: inset 0 1px 0 var(--btn-hl);
+  text-decoration: none;
+  white-space: nowrap;
 }
 .nr-settings__button:hover { filter: brightness(1.1); }
 .nr-settings__button:active { transform: translateY(1px); }
+.nr-settings__button:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 2px;
+}
+.nr-settings__button svg {
+  flex: 0 0 auto;
+}
 .nr-settings__button--primary {
   color: var(--btn-active-text);
   background: linear-gradient(180deg, var(--btn-active-top) 0%, var(--btn-active-bot) 100%);
+}
+
+.nr-settings__source-row {
+  align-items: flex-start;
+}
+
+.nr-settings__source-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
 }
 
 /* ===========================================================


### PR DESCRIPTION
## Summary
- Extends Smart NR scene heuristics to recognize speech-like SSB conditions.
- Prefers NR3/RNNoise when the model is available, with NR2 fallback when it is not.
- Adds model-panel source details and focused tests for the decision path.

Issue: zeus-dvx5

## Verification
- `dotnet test tests/Zeus.Server.Tests/Zeus.Server.Tests.csproj --filter "FullyQualifiedName~FrontendDspSceneDiagnosticsServiceTests" -v minimal /p:SpaBuildOutput=C:\Users\Admin\Desktop\openhpsdr-zeus\zeus-web\package.json` -> 23 passed
- `npm --prefix zeus-web run test -- src/dsp/smart-nr.test.ts src/components/SmartNrController.test.tsx src/components/nr/Nr3ModelPanel.test.tsx` -> 40 passed