### PR TITLE
refactor(server): consolidate prefs stores onto single shared LiteDB

### DIFF
--- a/Zeus.Plugins.Host/PluginSettingsStore.cs
+++ b/Zeus.Plugins.Host/PluginSettingsStore.cs
@@ -16,6 +16,7 @@ namespace Zeus.Plugins.Host;
 /// </summary>
 public sealed class PluginSettingsStore : IDisposable
 {
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly string _dbPath;
     private readonly ILogger<PluginSettingsStore>? _log;
@@ -30,7 +31,8 @@ public sealed class PluginSettingsStore : IDisposable
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _log?.LogInformation("PluginSettingsStore initialised at {Path}", dbPath);
     }
 
@@ -100,7 +102,7 @@ public sealed class PluginSettingsStore : IDisposable
     internal static string CollectionName(string pluginId)
         => "plugin_" + pluginId.Replace('.', '_').Replace('-', '_');
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 
     private sealed class ScopedSettings : IPluginSettings
     {

--- a/Zeus.Plugins.Host/SharedLiteDatabase.cs
+++ b/Zeus.Plugins.Host/SharedLiteDatabase.cs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using LiteDB;
+
+namespace Zeus.Data;
+
+// Process-wide, reference-counted registry of LiteDatabase instances keyed by
+// normalized file path. Guarantees EXACTLY ONE LiteDatabase (one LiteEngine)
+// per physical database file per process.
+//
+// Why this exists (the corruption root cause): Zeus had ~40 stores that each
+// did `new LiteDatabase("Filename=...;Connection=shared")` against the SAME
+// zeus-prefs.db (and two more against the encrypted zeus.db). Many independent
+// engines on one file — each with its own page cache and its own
+// open/checkpoint/close lifecycle — is the documented LiteDB corruption
+// antipattern: an interrupted write (power loss, the app killed on a network
+// change) can leave the shared -log half-checkpointed and brick the file.
+// LiteDB's own guidance is the opposite: a LiteDatabase is thread-safe and is
+// meant to be opened ONCE and shared.
+//
+// Every store now Acquire()s a lease here instead of opening its own database.
+// The underlying database is opened on the first lease for a given path and
+// disposed — flushing a clean WAL checkpoint to disk — when the last lease for
+// that path is released. Reference counting (rather than a single DI singleton)
+// is deliberate: it serves both production (all stores resolve the same prefs
+// path → one engine) and the test suites (each test points its stores at an
+// isolated temp file → its own engine, disposed when that test's stores
+// dispose, after which a reopen of the same path sees the flushed data).
+public static class SharedLiteDatabase
+{
+    private sealed class Entry
+    {
+        public required LiteDatabase Database { get; init; }
+        public int RefCount;
+    }
+
+    private static readonly object Gate = new();
+    private static readonly Dictionary<string, Entry> Open = new(PathComparer);
+
+    // Windows and macOS default to case-insensitive filesystems; Linux is
+    // case-sensitive. Key the registry to match so two spellings of the same
+    // file collapse to one engine where the OS treats them as one file.
+    private static StringComparer PathComparer =>
+        OperatingSystem.IsLinux() ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+
+    // A borrowed handle to a shared database. The store holds this for its
+    // lifetime and disposes it (NOT the LiteDatabase directly) when it is
+    // disposed. Disposing the lease decrements the refcount; the last release
+    // closes the underlying database. Idempotent and thread-safe.
+    public sealed class Lease : IDisposable
+    {
+        private readonly string _key;
+        private int _disposed;
+
+        internal Lease(string key, LiteDatabase database)
+        {
+            _key = key;
+            Database = database;
+        }
+
+        public LiteDatabase Database { get; }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+            Release(_key);
+        }
+    }
+
+    /// <summary>
+    /// Acquire a lease on the single shared database for <paramref name="dbPath"/>,
+    /// opening it on first use. The caller MUST dispose the returned lease (never
+    /// the underlying <see cref="LiteDatabase"/>). Thread-safe.
+    /// </summary>
+    public static Lease Acquire(string dbPath, string? password = null)
+    {
+        if (string.IsNullOrWhiteSpace(dbPath))
+            throw new ArgumentException("Database path is required.", nameof(dbPath));
+
+        var key = Normalize(dbPath);
+
+        // Make sure the directory exists before LiteDB tries to create the file.
+        var dir = Path.GetDirectoryName(key);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        lock (Gate)
+        {
+            if (Open.TryGetValue(key, out var existing))
+            {
+                existing.RefCount++;
+                return new Lease(key, existing.Database);
+            }
+
+            var db = OpenWithRetry(key, password);
+            Open[key] = new Entry { Database = db, RefCount = 1 };
+            return new Lease(key, db);
+        }
+    }
+
+    private static void Release(string key)
+    {
+        lock (Gate)
+        {
+            if (!Open.TryGetValue(key, out var entry)) return;
+            if (--entry.RefCount > 0) return;
+
+            Open.Remove(key);
+            try
+            {
+                entry.Database.Dispose(); // flushes the WAL checkpoint to disk
+            }
+            catch
+            {
+                // A failed checkpoint at shutdown must never throw out of a
+                // Dispose path. The next launch's integrity guard handles a file
+                // left in a bad state.
+            }
+        }
+    }
+
+    // Open the database exclusively (LiteDB's default "direct" connection — one
+    // engine, no per-operation reopen churn). A short bounded retry absorbs the
+    // one realistic transient on the single-process design: an on-access virus
+    // scanner (common on Windows) holding a just-created file for a few hundred
+    // milliseconds. A non-lock exception — a corrupt/torn file — is NOT a
+    // transient and is not retried: it propagates immediately so the caller's
+    // startup integrity guard (PrefsDbPath.EnsureUsable) can move the file aside
+    // before any store opens it.
+    private static LiteDatabase OpenWithRetry(string path, string? password)
+    {
+        Exception? lastLock = null;
+        for (int attempt = 0; attempt < 10; attempt++)
+        {
+            try
+            {
+                return new LiteDatabase(ConnectionString(path, password));
+            }
+            catch (Exception ex) when (IsTransientLock(ex))
+            {
+                lastLock = ex;
+                Thread.Sleep(100 + attempt * 50);
+            }
+        }
+
+        throw lastLock ?? new IOException($"Unable to open database '{path}'.");
+    }
+
+    private static string ConnectionString(string path, string? password)
+    {
+        var s = $"Filename={path}";
+        if (!string.IsNullOrEmpty(password)) s += $";Password={password}";
+        return s;
+    }
+
+    private static bool IsTransientLock(Exception ex) =>
+        ex is IOException
+        || ex is UnauthorizedAccessException
+        || ex.InnerException is IOException
+        || ex.InnerException is UnauthorizedAccessException;
+
+    private static string Normalize(string path) => Path.GetFullPath(path);
+
+    /// <summary>Number of distinct database files currently open. Diagnostics/tests.</summary>
+    public static int OpenCount
+    {
+        get { lock (Gate) { return Open.Count; } }
+    }
+}

--- a/Zeus.Server.Hosting/AntennaSettingsStore.cs
+++ b/Zeus.Server.Hosting/AntennaSettingsStore.cs
@@ -34,6 +34,7 @@ namespace Zeus.Server;
 
 public sealed class AntennaSettingsStore : IDisposable
 {
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<AntennaBandEntry> _bands;
     private readonly ILogger<AntennaSettingsStore> _log;
@@ -51,7 +52,8 @@ public sealed class AntennaSettingsStore : IDisposable
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _bands = _db.GetCollection<AntennaBandEntry>("antenna_bands");
         _bands.EnsureIndex(x => x.Band, unique: true);
 
@@ -134,7 +136,7 @@ public sealed class AntennaSettingsStore : IDisposable
     private static RxAuxInputSel ClampAux(byte v) =>
         v <= (byte)RxAuxInputSel.Bypass ? (RxAuxInputSel)v : RxAuxInputSel.None;
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 }
 
 /// <summary>

--- a/Zeus.Server.Hosting/AudioChainSettingsStore.cs
+++ b/Zeus.Server.Hosting/AudioChainSettingsStore.cs
@@ -24,6 +24,7 @@ namespace Zeus.Server;
 /// </summary>
 public sealed class AudioChainSettingsStore : IDisposable
 {
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<AudioChainSettingsEntry> _state;
     private readonly ILogger<AudioChainSettingsStore> _log;
@@ -37,7 +38,8 @@ public sealed class AudioChainSettingsStore : IDisposable
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _state = _db.GetCollection<AudioChainSettingsEntry>("audio_chain_settings");
 
         _log.LogInformation("AudioChainSettingsStore initialized at {Path}", dbPath);
@@ -117,7 +119,7 @@ public sealed class AudioChainSettingsStore : IDisposable
         }
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 }
 
 public sealed class AudioChainSettingsEntry

--- a/Zeus.Server.Hosting/AudioDeviceSettingsStore.cs
+++ b/Zeus.Server.Hosting/AudioDeviceSettingsStore.cs
@@ -8,6 +8,7 @@ public sealed record AudioDeviceSettings(string? InputDeviceId, string? OutputDe
 
 public sealed class AudioDeviceSettingsStore : IDisposable
 {
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<AudioDeviceSettingsEntry> _docs;
     private readonly ILogger<AudioDeviceSettingsStore> _log;
@@ -25,7 +26,8 @@ public sealed class AudioDeviceSettingsStore : IDisposable
             Directory.CreateDirectory(dir);
         }
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _docs = _db.GetCollection<AudioDeviceSettingsEntry>("audio_device_settings");
 
         _log.LogInformation("AudioDeviceSettingsStore initialized at {Path}", dbPath);
@@ -75,7 +77,7 @@ public sealed class AudioDeviceSettingsStore : IDisposable
         }
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 
     private AudioDeviceSettingsEntry GetOrCreateEntry() =>
         _docs.FindAll().FirstOrDefault() ?? new AudioDeviceSettingsEntry();

--- a/Zeus.Server.Hosting/AudioProcessingModeStore.cs
+++ b/Zeus.Server.Hosting/AudioProcessingModeStore.cs
@@ -30,6 +30,7 @@ public enum AudioProcessingMode
 /// </summary>
 public sealed class AudioProcessingModeStore : IDisposable
 {
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<AudioProcessingModeEntry> _state;
     private readonly ILogger<AudioProcessingModeStore> _log;
@@ -43,7 +44,8 @@ public sealed class AudioProcessingModeStore : IDisposable
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _state = _db.GetCollection<AudioProcessingModeEntry>("audio_processing_mode");
 
         _log.LogInformation("AudioProcessingModeStore initialized at {Path}", dbPath);
@@ -78,7 +80,7 @@ public sealed class AudioProcessingModeStore : IDisposable
         }
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 }
 
 public sealed class AudioProcessingModeEntry

--- a/Zeus.Server.Hosting/AudioProfileStore.cs
+++ b/Zeus.Server.Hosting/AudioProfileStore.cs
@@ -27,6 +27,7 @@ namespace Zeus.Server;
 /// </summary>
 public sealed class AudioProfileStore : IDisposable
 {
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<AudioProfileEntry> _profiles;
     private readonly ILogger<AudioProfileStore> _log;
@@ -40,7 +41,8 @@ public sealed class AudioProfileStore : IDisposable
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _profiles = _db.GetCollection<AudioProfileEntry>("audio_profiles");
         _profiles.EnsureIndex(x => x.Name, unique: true);
 
@@ -115,7 +117,7 @@ public sealed class AudioProfileStore : IDisposable
             return _profiles.DeleteMany(p => p.Name == name) > 0;
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 }
 
 public sealed class AudioProfileEntry

--- a/Zeus.Server.Hosting/AudioSettingsStore.cs
+++ b/Zeus.Server.Hosting/AudioSettingsStore.cs
@@ -35,6 +35,7 @@ namespace Zeus.Server;
 
 public sealed class AudioSettingsStore : IDisposable
 {
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<AudioFrontEndEntry> _rows;
     private readonly ILogger<AudioSettingsStore> _log;
@@ -52,7 +53,8 @@ public sealed class AudioSettingsStore : IDisposable
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _rows = _db.GetCollection<AudioFrontEndEntry>("audio_frontend");
 
         _log.LogInformation("AudioSettingsStore initialized at {Path}", dbPath);
@@ -114,7 +116,7 @@ public sealed class AudioSettingsStore : IDisposable
     private static TxAudioSource ClampSource(byte raw) =>
         Enum.IsDefined(typeof(TxAudioSource), raw) ? (TxAudioSource)raw : TxAudioSource.Host;
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 }
 
 /// <summary>

--- a/Zeus.Server.Hosting/BandMemoryStore.cs
+++ b/Zeus.Server.Hosting/BandMemoryStore.cs
@@ -54,6 +54,7 @@ namespace Zeus.Server;
 // juggling two LiteDB connections to the same file.
 public sealed class BandMemoryStore : IDisposable
 {
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<BandMemoryEntry> _entries;
     private readonly ILogger<BandMemoryStore> _log;
@@ -69,7 +70,8 @@ public sealed class BandMemoryStore : IDisposable
             Directory.CreateDirectory(dir);
         }
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _entries = _db.GetCollection<BandMemoryEntry>("band_memory");
         // Pre-existing rows can violate the unique-Band invariant if they were
         // written by a build before EnsureIndex(unique:true) was added, or by a
@@ -152,7 +154,7 @@ public sealed class BandMemoryStore : IDisposable
         _entries.Update(existing);
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 
 }
 

--- a/Zeus.Server.Hosting/BandPlanStore.cs
+++ b/Zeus.Server.Hosting/BandPlanStore.cs
@@ -24,6 +24,7 @@ namespace Zeus.Server;
 public sealed class BandPlanStore : IDisposable
 {
     private readonly ILogger<BandPlanStore> _log;
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<BandPlanOverrideRecord> _overrides;
 
@@ -46,7 +47,8 @@ public sealed class BandPlanStore : IDisposable
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _overrides = _db.GetCollection<BandPlanOverrideRecord>("band_plan_overrides");
         _overrides.EnsureIndex(x => x.RegionId, unique: true);
 
@@ -109,7 +111,7 @@ public sealed class BandPlanStore : IDisposable
     public bool HasOverride(string regionId) =>
         _overrides.Exists(x => x.RegionId == regionId);
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 
     private void LoadShippedData()
     {

--- a/Zeus.Server.Hosting/BandPrefsStore.cs
+++ b/Zeus.Server.Hosting/BandPrefsStore.cs
@@ -18,6 +18,7 @@ public sealed class BandPrefsStore : IDisposable
     private const string DefaultRegionId = "IARU_R1";
     private const string PrefsKey = "default";
 
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<BandPrefsEntry> _coll;
 
@@ -28,7 +29,8 @@ public sealed class BandPrefsStore : IDisposable
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _coll = _db.GetCollection<BandPrefsEntry>("band_plan_prefs");
         _coll.EnsureIndex(x => x.Key, unique: true);
     }
@@ -69,7 +71,7 @@ public sealed class BandPrefsStore : IDisposable
         }
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 
 }
 

--- a/Zeus.Server.Hosting/BottomPinStore.cs
+++ b/Zeus.Server.Hosting/BottomPinStore.cs
@@ -18,6 +18,7 @@ namespace Zeus.Server;
 // every browser pointed at the Zeus instance.
 public sealed class BottomPinStore : IDisposable
 {
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<BottomPinEntry> _docs;
     private readonly ILogger<BottomPinStore> _log;
@@ -33,7 +34,8 @@ public sealed class BottomPinStore : IDisposable
             Directory.CreateDirectory(dir);
         }
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _docs = _db.GetCollection<BottomPinEntry>("bottom_pin");
 
         _log.LogInformation("BottomPinStore initialized at {Path}", dbPath);
@@ -64,7 +66,7 @@ public sealed class BottomPinStore : IDisposable
         }
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 
 }
 

--- a/Zeus.Server.Hosting/CfcPresetStore.cs
+++ b/Zeus.Server.Hosting/CfcPresetStore.cs
@@ -16,6 +16,7 @@ public sealed class CfcPresetStore : IDisposable
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<CfcPresetEntry> _presets;
     private readonly ILogger<CfcPresetStore> _log;
@@ -29,7 +30,8 @@ public sealed class CfcPresetStore : IDisposable
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _presets = _db.GetCollection<CfcPresetEntry>("cfc_presets");
         _presets.EnsureIndex(x => x.NormalizedName, unique: true);
 
@@ -99,7 +101,7 @@ public sealed class CfcPresetStore : IDisposable
         }
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 
     internal static string CleanName(string name)
     {

--- a/Zeus.Server.Hosting/ChainOrderStore.cs
+++ b/Zeus.Server.Hosting/ChainOrderStore.cs
@@ -21,6 +21,7 @@ namespace Zeus.Server;
 /// </summary>
 public sealed class ChainOrderStore : IDisposable
 {
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<ChainOrderEntry> _state;
     private readonly ILogger<ChainOrderStore> _log;
@@ -34,7 +35,8 @@ public sealed class ChainOrderStore : IDisposable
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _state = _db.GetCollection<ChainOrderEntry>("audio_chain_order");
 
         _log.LogInformation("ChainOrderStore initialized at {Path}", dbPath);
@@ -115,7 +117,7 @@ public sealed class ChainOrderStore : IDisposable
         }
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 }
 
 public sealed class ChainOrderEntry

--- a/Zeus.Server.Hosting/ChatEnabledStore.cs
+++ b/Zeus.Server.Hosting/ChatEnabledStore.cs
@@ -16,6 +16,7 @@ namespace Zeus.Server;
 /// </summary>
 public sealed class ChatEnabledStore : IDisposable
 {
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<ChatEnabledEntry> _state;
     private readonly ILogger<ChatEnabledStore> _log;
@@ -29,7 +30,8 @@ public sealed class ChatEnabledStore : IDisposable
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _state = _db.GetCollection<ChatEnabledEntry>("chat_enabled");
 
         _log.LogInformation("ChatEnabledStore initialized at {Path}", dbPath);
@@ -99,7 +101,7 @@ public sealed class ChatEnabledStore : IDisposable
         }
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 }
 
 public sealed class ChatEnabledEntry

--- a/Zeus.Server.Hosting/CredentialStore.cs
+++ b/Zeus.Server.Hosting/CredentialStore.cs
@@ -49,6 +49,7 @@ namespace Zeus.Server;
 
 public sealed class CredentialStore : IDisposable
 {
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<StoredCredential> _credentials;
     private readonly ILogger<CredentialStore> _log;
@@ -79,7 +80,8 @@ public sealed class CredentialStore : IDisposable
             _log.LogInformation("Created credential store directory: {Dir}", dir);
         }
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _credentials = _db.GetCollection<StoredCredential>("credentials");
         _credentials.EnsureIndex(x => x.Service, unique: true);
 
@@ -137,7 +139,7 @@ public sealed class CredentialStore : IDisposable
 
     public void Dispose()
     {
-        _db?.Dispose();
+        _dbLease.Dispose();
     }
 }
 

--- a/Zeus.Server.Hosting/CwSettingsStore.cs
+++ b/Zeus.Server.Hosting/CwSettingsStore.cs
@@ -43,6 +43,7 @@ public sealed class CwSettingsStore : IDisposable
     /// reject runaway paste / accidental long strings at the API edge.</summary>
     public const int MaxMacroChars = 200;
 
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<CwSettingsEntry> _docs;
     private readonly ILogger<CwSettingsStore> _log;
@@ -56,7 +57,8 @@ public sealed class CwSettingsStore : IDisposable
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _docs = _db.GetCollection<CwSettingsEntry>("cw_settings");
 
         _log.LogInformation("CwSettingsStore initialized at {Path}", dbPath);
@@ -139,7 +141,7 @@ public sealed class CwSettingsStore : IDisposable
         }
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 
     private static CwSettingsEntry SeedDefaultsEntry() => new()
     {

--- a/Zeus.Server.Hosting/DisplayIntelligenceSettingsStore.cs
+++ b/Zeus.Server.Hosting/DisplayIntelligenceSettingsStore.cs
@@ -14,6 +14,7 @@ public sealed class DisplayIntelligenceSettingsStore : IDisposable
     private const int LegacyWaterfallReliefDepth = 48;
     private const int LegacyWaterfallSmoothness = 42;
 
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<DisplayIntelligenceSettingsEntry> _docs;
     private readonly ILogger<DisplayIntelligenceSettingsStore> _log;
@@ -29,7 +30,8 @@ public sealed class DisplayIntelligenceSettingsStore : IDisposable
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _docs = _db.GetCollection<DisplayIntelligenceSettingsEntry>("display_intelligence_settings");
 
         _log.LogInformation("DisplayIntelligenceSettingsStore initialized at {Path}", dbPath);
@@ -179,7 +181,7 @@ public sealed class DisplayIntelligenceSettingsStore : IDisposable
             ? fallback
             : Math.Clamp(value, min, max);
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 }
 
 public sealed class DisplayIntelligenceSettingsEntry

--- a/Zeus.Server.Hosting/DisplaySettingsStore.cs
+++ b/Zeus.Server.Hosting/DisplaySettingsStore.cs
@@ -68,6 +68,7 @@ public sealed class DisplaySettingsStore : IDisposable
         v.HasValue && !double.IsNaN(v.Value) && !double.IsInfinity(v.Value)
         && v.Value >= 0.0 && v.Value <= TxAvgTauMaxMs;
 
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<DisplaySettingsEntry> _docs;
     private readonly ILogger<DisplaySettingsStore> _log;
@@ -83,7 +84,8 @@ public sealed class DisplaySettingsStore : IDisposable
             Directory.CreateDirectory(dir);
         }
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _docs = _db.GetCollection<DisplaySettingsEntry>("display_settings");
 
         _log.LogInformation("DisplaySettingsStore initialized at {Path}", dbPath);
@@ -212,7 +214,7 @@ public sealed class DisplaySettingsStore : IDisposable
         }
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 
     private static string NormalizeMode(string? raw) =>
         raw switch

--- a/Zeus.Server.Hosting/DspSettingsStore.cs
+++ b/Zeus.Server.Hosting/DspSettingsStore.cs
@@ -14,6 +14,7 @@ namespace Zeus.Server;
 // because LiteDB's BsonMapper races on parallel construction (commit b57c12d).
 public sealed class DspSettingsStore : IDisposable
 {
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<DspSettingsEntry> _entries;
     private readonly ILogger<DspSettingsStore> _log;
@@ -27,7 +28,8 @@ public sealed class DspSettingsStore : IDisposable
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _entries = _db.GetCollection<DspSettingsEntry>("dsp_settings");
         _entries.EnsureIndex(x => x.ProfileId, unique: true);
 
@@ -580,7 +582,7 @@ public sealed class DspSettingsStore : IDisposable
             ? mode
             : NrMode.Off;
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 
 }
 

--- a/Zeus.Server.Hosting/FilterPresetStore.cs
+++ b/Zeus.Server.Hosting/FilterPresetStore.cs
@@ -44,6 +44,7 @@ public sealed class FilterPresetStore : IDisposable
         }
     }
 
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<FilterPresetStoreEntry> _entries;
     private readonly ILogger<FilterPresetStore> _log;
@@ -60,7 +61,8 @@ public sealed class FilterPresetStore : IDisposable
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _entries = _db.GetCollection<FilterPresetStoreEntry>("filter_presets");
         _entries.EnsureIndex("ModeKey", "$.ModeKey", unique: true);
 
@@ -142,7 +144,7 @@ public sealed class FilterPresetStore : IDisposable
         }
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 
     // Sentinel mode key used for pane-visibility and other ribbon-scope flags
     // that aren't tied to any particular RX mode. Keeps the schema flat while

--- a/Zeus.Server.Hosting/LayoutStore.cs
+++ b/Zeus.Server.Hosting/LayoutStore.cs
@@ -62,6 +62,7 @@ namespace Zeus.Server;
 //     no radio is connected.
 public sealed class LayoutStore : IDisposable
 {
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<LayoutEntry> _legacy;
     private readonly ILiteCollection<RadioLayoutsEntry> _v2;
@@ -78,7 +79,8 @@ public sealed class LayoutStore : IDisposable
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _legacy = _db.GetCollection<LayoutEntry>("ui_layout");
         _legacy.EnsureIndex(x => x.ProfileId, unique: true);
         _v2 = _db.GetCollection<RadioLayoutsEntry>("ui_layouts_v2");
@@ -442,7 +444,7 @@ public sealed class LayoutStore : IDisposable
         return trimmed.Length > 256 ? trimmed[..256] : trimmed;
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 
 }
 

--- a/Zeus.Server.Hosting/LogService.cs
+++ b/Zeus.Server.Hosting/LogService.cs
@@ -52,6 +52,7 @@ namespace Zeus.Server;
 
 public sealed class LogService : IDisposable
 {
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<LogEntryDocument> _logs;
     private readonly ILogger<LogService> _log;
@@ -69,7 +70,8 @@ public sealed class LogService : IDisposable
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _logs = _db.GetCollection<LogEntryDocument>("logs");
         _logs.EnsureIndex(x => x.Id, unique: true);
         _logs.EnsureIndex(x => x.QsoDateTimeUtc);
@@ -264,7 +266,7 @@ public sealed class LogService : IDisposable
 
     public void Dispose()
     {
-        _db?.Dispose();
+        _dbLease.Dispose();
     }
 
     private static LogEntry DocumentToEntry(LogEntryDocument doc) => new(

--- a/Zeus.Server.Hosting/NrUiPrefsStore.cs
+++ b/Zeus.Server.Hosting/NrUiPrefsStore.cs
@@ -22,6 +22,7 @@ namespace Zeus.Server;
 // Lives in zeus-prefs.db alongside the other non-sensitive preferences.
 public sealed class NrUiPrefsStore : IDisposable
 {
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<NrUiPrefsEntry> _docs;
     private readonly ILogger<NrUiPrefsStore> _log;
@@ -37,7 +38,8 @@ public sealed class NrUiPrefsStore : IDisposable
             Directory.CreateDirectory(dir);
         }
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _docs = _db.GetCollection<NrUiPrefsEntry>("nr_ui_prefs");
 
         _log.LogInformation("NrUiPrefsStore initialized at {Path}", dbPath);
@@ -79,7 +81,7 @@ public sealed class NrUiPrefsStore : IDisposable
         }
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 }
 
 public sealed class NrUiPrefsEntry

--- a/Zeus.Server.Hosting/PaSettingsStore.cs
+++ b/Zeus.Server.Hosting/PaSettingsStore.cs
@@ -34,6 +34,7 @@ namespace Zeus.Server;
 // the next C&C/HPC tick.
 public sealed class PaSettingsStore : IDisposable
 {
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<PaBandEntry> _bands;
     private readonly ILiteCollection<PaGlobalEntry> _globals;
@@ -52,7 +53,8 @@ public sealed class PaSettingsStore : IDisposable
             Directory.CreateDirectory(dir);
         }
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _bands = _db.GetCollection<PaBandEntry>("pa_bands");
         _bands.EnsureIndex(x => x.Band, unique: true);
         _globals = _db.GetCollection<PaGlobalEntry>("pa_globals");
@@ -212,7 +214,7 @@ public sealed class PaSettingsStore : IDisposable
         Changed?.Invoke();
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 
 }
 

--- a/Zeus.Server.Hosting/PanWfSplitStore.cs
+++ b/Zeus.Server.Hosting/PanWfSplitStore.cs
@@ -27,6 +27,7 @@ public sealed class PanWfSplitStore : IDisposable
     public const double MinPanPercent = 10.0;
     public const double MaxPanPercent = 90.0;
 
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<PanWfSplitEntry> _docs;
     private readonly ILogger<PanWfSplitStore> _log;
@@ -42,7 +43,8 @@ public sealed class PanWfSplitStore : IDisposable
             Directory.CreateDirectory(dir);
         }
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _docs = _db.GetCollection<PanWfSplitEntry>("pan_wf_split");
 
         _log.LogInformation("PanWfSplitStore initialized at {Path}", dbPath);
@@ -80,7 +82,7 @@ public sealed class PanWfSplitStore : IDisposable
         return v;
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 }
 
 public sealed class PanWfSplitEntry

--- a/Zeus.Server.Hosting/PreferredRadioStore.cs
+++ b/Zeus.Server.Hosting/PreferredRadioStore.cs
@@ -40,6 +40,7 @@ namespace Zeus.Server;
 // no output power, or hardware damage. Only use if you understand your hardware.
 public sealed class PreferredRadioStore : IDisposable
 {
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<PreferredRadioEntry> _entries;
     private readonly ILogger<PreferredRadioStore> _log;
@@ -55,7 +56,8 @@ public sealed class PreferredRadioStore : IDisposable
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _entries = _db.GetCollection<PreferredRadioEntry>("preferred_radio");
 
         _log.LogInformation("PreferredRadioStore initialized at {Path}", dbPath);
@@ -385,7 +387,7 @@ public sealed class PreferredRadioStore : IDisposable
         Changed?.Invoke();
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 
 }
 

--- a/Zeus.Server.Hosting/PrefsDbPath.cs
+++ b/Zeus.Server.Hosting/PrefsDbPath.cs
@@ -302,10 +302,25 @@ public static class PrefsDbPath
         return ProfilesDirName + "/" + safe + ".db";
     }
 
+    // True when the file at <paramref name="path"/> opens as a real LiteDB
+    // database (header + every collection's first data page readable). Used to
+    // reject a corrupt or wrong-type file at IMPORT time, so a bad upload is
+    // refused up front with a clear message instead of silently becoming a reset
+    // database the next time the profile is activated (EnsureUsable would move
+    // it aside on launch — losing the operator's settings without warning).
+    public static bool IsValidDatabase(string path) =>
+        Probe(path, null) != ProbeResult.Corrupt;
+
+    // Delete a database file and its LiteDB -log sidecar, best effort.
+    private static void TryDeleteDbFiles(string path)
+    {
+        try { if (File.Exists(path)) File.Delete(path); } catch { /* best effort */ }
+        try { if (File.Exists(path + "-log")) File.Delete(path + "-log"); } catch { /* best effort */ }
+    }
+
     // Copy an existing .db into profiles/<name>.db. Derives the name from the
     // source file when name is null/blank. Refuses to overwrite an existing
-    // profile. The source is NOT validated as a real LiteDB — a bad file simply
-    // won't load when activated.
+    // profile, and rejects a file that is not a valid LiteDB database.
     public static string ImportProfile(string sourcePath, string? name)
     {
         if (string.IsNullOrWhiteSpace(sourcePath))
@@ -326,14 +341,19 @@ public static class PrefsDbPath
             throw new InvalidOperationException($"A profile named \"{safe}\" already exists.");
 
         File.Copy(sourcePath, target, overwrite: false);
+        if (!IsValidDatabase(target))
+        {
+            TryDeleteDbFiles(target);
+            throw new InvalidOperationException(
+                "That file is not a valid Zeus settings database (it may be corrupt or a different kind of file).");
+        }
         return ProfilesDirName + "/" + safe + ".db";
     }
 
     // Save an uploaded .db stream into profiles/<name>.db. Used by the file-
     // picker import in the UI, which uploads the chosen file's bytes (the
     // webview can't hand the server a filesystem path). Refuses to overwrite an
-    // existing profile; the stream is NOT validated as a real LiteDB — a bad
-    // file simply won't load when activated.
+    // existing profile, and rejects a file that is not a valid LiteDB database.
     public static string ImportProfileFromStream(Stream source, string name)
     {
         ArgumentNullException.ThrowIfNull(source);
@@ -346,8 +366,16 @@ public static class PrefsDbPath
         if (File.Exists(target))
             throw new InvalidOperationException($"A profile named \"{safe}\" already exists.");
 
+        // Close the file handle before validating so the probe can open it.
         using (var dest = File.Create(target))
             source.CopyTo(dest);
+
+        if (!IsValidDatabase(target))
+        {
+            TryDeleteDbFiles(target);
+            throw new InvalidOperationException(
+                "That file is not a valid Zeus settings database (it may be corrupt or a different kind of file).");
+        }
         return ProfilesDirName + "/" + safe + ".db";
     }
 

--- a/Zeus.Server.Hosting/PsSettingsStore.cs
+++ b/Zeus.Server.Hosting/PsSettingsStore.cs
@@ -45,6 +45,7 @@ namespace Zeus.Server;
 // owns its own calibrated value.
 public sealed class PsSettingsStore : IDisposable
 {
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<PsSettingsEntry> _entries;
     private readonly ILogger<PsSettingsStore> _log;
@@ -58,7 +59,8 @@ public sealed class PsSettingsStore : IDisposable
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _entries = _db.GetCollection<PsSettingsEntry>("ps_settings");
         _entries.EnsureIndex(x => x.ProfileId, unique: true);
 
@@ -84,7 +86,7 @@ public sealed class PsSettingsStore : IDisposable
         }
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 
 }
 

--- a/Zeus.Server.Hosting/PttSettingsStore.cs
+++ b/Zeus.Server.Hosting/PttSettingsStore.cs
@@ -29,6 +29,7 @@ namespace Zeus.Server;
 
 public sealed class PttSettingsStore : IDisposable
 {
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<PttSettingsEntry> _rows;
     private readonly ILogger<PttSettingsStore> _log;
@@ -45,7 +46,8 @@ public sealed class PttSettingsStore : IDisposable
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _rows = _db.GetCollection<PttSettingsEntry>("ptt_settings");
 
         _log.LogInformation("PttSettingsStore initialized at {Path}", dbPath);
@@ -86,7 +88,7 @@ public sealed class PttSettingsStore : IDisposable
         Changed?.Invoke();
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 }
 
 public sealed class PttSettingsEntry

--- a/Zeus.Server.Hosting/RadioStateStore.cs
+++ b/Zeus.Server.Hosting/RadioStateStore.cs
@@ -38,6 +38,7 @@ namespace Zeus.Server;
 // Both share zeus-prefs.db with the other preference stores.
 public sealed class RadioStateStore : IDisposable
 {
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<RadioStateEntry> _state;
     private readonly ILiteCollection<BoardSampleRateEntry> _boardRates;
@@ -52,7 +53,8 @@ public sealed class RadioStateStore : IDisposable
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _state = _db.GetCollection<RadioStateEntry>("radio_state");
         _boardRates = _db.GetCollection<BoardSampleRateEntry>("board_sample_rates");
         _boardRates.EnsureIndex(x => x.BoardKey, unique: true);
@@ -123,7 +125,7 @@ public sealed class RadioStateStore : IDisposable
         }
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 
     private static string BoardKey(HpsdrBoardKind board, OrionMkIIVariant variant) =>
         board == HpsdrBoardKind.OrionMkII

--- a/Zeus.Server.Hosting/RotctldConfigStore.cs
+++ b/Zeus.Server.Hosting/RotctldConfigStore.cs
@@ -25,6 +25,7 @@ public sealed class RotctldConfigStore : IDisposable
 {
     public const int MaxSlots = 4;
 
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<MultiEntry> _multi;
     private readonly ILiteCollection<LegacyEntry> _legacy;
@@ -36,7 +37,8 @@ public sealed class RotctldConfigStore : IDisposable
         _log = log;
         var dbPath = dbPathOverride ?? PrefsDbPath.Get();
         Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _multi = _db.GetCollection<MultiEntry>("rotctld_multi_config");
         _multi.EnsureIndex(e => e.Id, unique: true);
         _legacy = _db.GetCollection<LegacyEntry>("rotctld_config");
@@ -100,7 +102,7 @@ public sealed class RotctldConfigStore : IDisposable
         }
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 
     private const int SingletonId = 1;
 

--- a/Zeus.Server.Hosting/RxAudioProfileStore.cs
+++ b/Zeus.Server.Hosting/RxAudioProfileStore.cs
@@ -8,6 +8,7 @@ namespace Zeus.Server;
 /// </summary>
 public sealed class RxAudioProfileStore : IDisposable
 {
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<RxAudioProfileEntry> _profiles;
     private readonly ILiteCollection<RxAudioProfileSelectionEntry> _selection;
@@ -22,7 +23,8 @@ public sealed class RxAudioProfileStore : IDisposable
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _profiles = _db.GetCollection<RxAudioProfileEntry>("rx_audio_profiles");
         _profiles.EnsureIndex(x => x.Name, unique: true);
         _selection = _db.GetCollection<RxAudioProfileSelectionEntry>("rx_audio_profile_selection");
@@ -128,7 +130,7 @@ public sealed class RxAudioProfileStore : IDisposable
         }
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 
     private string? GetSelectedProfileUnderLock() =>
         _selection.FindAll().FirstOrDefault()?.Name;

--- a/Zeus.Server.Hosting/RxChainOrderStore.cs
+++ b/Zeus.Server.Hosting/RxChainOrderStore.cs
@@ -10,6 +10,7 @@ namespace Zeus.Server;
 /// </summary>
 public sealed class RxChainOrderStore : IDisposable
 {
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<RxChainOrderEntry> _state;
     private readonly ILogger<RxChainOrderStore> _log;
@@ -23,7 +24,8 @@ public sealed class RxChainOrderStore : IDisposable
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _state = _db.GetCollection<RxChainOrderEntry>("rx_audio_chain_order");
 
         _log.LogInformation("RxChainOrderStore initialized at {Path}", dbPath);
@@ -72,7 +74,7 @@ public sealed class RxChainOrderStore : IDisposable
         }
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 }
 
 public sealed class RxChainOrderEntry

--- a/Zeus.Server.Hosting/SpotsSettingsStore.cs
+++ b/Zeus.Server.Hosting/SpotsSettingsStore.cs
@@ -24,6 +24,7 @@ namespace Zeus.Server;
 /// </summary>
 public sealed class SpotsSettingsStore : IDisposable
 {
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<SpotsSettingsEntry> _state;
     private readonly ILogger<SpotsSettingsStore> _log;
@@ -37,7 +38,8 @@ public sealed class SpotsSettingsStore : IDisposable
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _state = _db.GetCollection<SpotsSettingsEntry>("spots_settings");
 
         _log.LogInformation("SpotsSettingsStore initialized at {Path}", dbPath);
@@ -155,7 +157,7 @@ public sealed class SpotsSettingsStore : IDisposable
         UpdatedUtc = nowUtc,
     };
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 }
 
 public sealed class SpotsSettingsEntry

--- a/Zeus.Server.Hosting/TciConfigStore.cs
+++ b/Zeus.Server.Hosting/TciConfigStore.cs
@@ -30,6 +30,7 @@ namespace Zeus.Server;
 // uses Upsert keyed by ProfileId; here the row identity is implicit.
 public sealed class TciConfigStore : IDisposable
 {
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<TciConfigEntry> _entries;
     private readonly ILogger<TciConfigStore> _log;
@@ -43,7 +44,8 @@ public sealed class TciConfigStore : IDisposable
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _entries = _db.GetCollection<TciConfigEntry>("tci_config");
 
         _log.LogInformation("TciConfigStore initialized at {Path}", dbPath);
@@ -89,7 +91,7 @@ public sealed class TciConfigStore : IDisposable
         }
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 
 }
 

--- a/Zeus.Server.Hosting/ThemeSettingsStore.cs
+++ b/Zeus.Server.Hosting/ThemeSettingsStore.cs
@@ -20,6 +20,7 @@ namespace Zeus.Server;
 // DisplaySettingsStore + NrUiPrefsStore.
 public sealed class ThemeSettingsStore : IDisposable
 {
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<ThemeSettingsEntry> _docs;
     private readonly ILogger<ThemeSettingsStore> _log;
@@ -35,7 +36,8 @@ public sealed class ThemeSettingsStore : IDisposable
             Directory.CreateDirectory(dir);
         }
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _docs = _db.GetCollection<ThemeSettingsEntry>("theme_settings");
 
         _log.LogInformation("ThemeSettingsStore initialized at {Path}", dbPath);
@@ -75,7 +77,7 @@ public sealed class ThemeSettingsStore : IDisposable
         }
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 
     private static string NormalizeTheme(string? raw) =>
         raw switch

--- a/Zeus.Server.Hosting/ToolbarSettingsStore.cs
+++ b/Zeus.Server.Hosting/ToolbarSettingsStore.cs
@@ -29,6 +29,7 @@ public sealed class ToolbarSettingsStore : IDisposable
     public const int DefaultStepHz = 500;
     public const int MaxStepHz = 5_000;
 
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<ToolbarSettingsEntry> _docs;
     private readonly ILogger<ToolbarSettingsStore> _log;
@@ -46,7 +47,8 @@ public sealed class ToolbarSettingsStore : IDisposable
             Directory.CreateDirectory(dir);
         }
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _docs = _db.GetCollection<ToolbarSettingsEntry>("toolbar_settings");
 
         _log.LogInformation("ToolbarSettingsStore initialized at {Path}", dbPath);
@@ -111,7 +113,7 @@ public sealed class ToolbarSettingsStore : IDisposable
         }
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 
     internal static int NormalizeStepHz(int? stepHz) =>
         stepHz is >= 1 and <= MaxStepHz ? stepHz.Value : DefaultStepHz;

--- a/Zeus.Server.Hosting/TxAudioProfileStore.cs
+++ b/Zeus.Server.Hosting/TxAudioProfileStore.cs
@@ -48,6 +48,7 @@ public sealed class TxAudioProfileStore : IDisposable
     private const int DefaultHighCutHz = 2900;
     private const int DefaultTargetSpectralDensity = 55;
 
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<TxAudioProfileEntry> _profiles;
     private readonly ILiteCollection<TxAudioProfileLastLoadedEntry> _lastLoaded;
@@ -68,7 +69,8 @@ public sealed class TxAudioProfileStore : IDisposable
         var prefsDir = Path.GetDirectoryName(Path.GetFullPath(dbPath));
         _profileDir = Path.Combine(string.IsNullOrEmpty(prefsDir) ? "." : prefsDir, ProfileDirName);
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _profiles = _db.GetCollection<TxAudioProfileEntry>("tx_audio_profiles");
         // Race-safe unique index seed (FilterPresetStore pattern): parallel
         // WebApplicationFactory hosts on CI can both reach EnsureIndex; swallow
@@ -399,7 +401,7 @@ public sealed class TxAudioProfileStore : IDisposable
         return result;
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 }
 
 public sealed class TxAudioProfileEntry

--- a/Zeus.Server.Hosting/TxFidelityPolicyStore.cs
+++ b/Zeus.Server.Hosting/TxFidelityPolicyStore.cs
@@ -14,6 +14,7 @@ public sealed class TxFidelityPolicyStore : IDisposable
     public const string DefaultProfileId = "studio-ssb";
     public const int DefaultTargetSpectralDensity = 55;
 
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<TxFidelityPolicyEntry> _policy;
     private readonly ILogger<TxFidelityPolicyStore> _log;
@@ -27,7 +28,8 @@ public sealed class TxFidelityPolicyStore : IDisposable
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _policy = _db.GetCollection<TxFidelityPolicyEntry>("tx_fidelity_policy");
 
         _log.LogInformation("TxFidelityPolicyStore initialized at {Path}", dbPath);
@@ -77,7 +79,7 @@ public sealed class TxFidelityPolicyStore : IDisposable
     private static int ClampDensity(int density) =>
         Math.Clamp(density, 0, 100);
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 }
 
 public sealed class TxFidelityPolicyEntry

--- a/Zeus.Server.Hosting/TxStationProfileStore.cs
+++ b/Zeus.Server.Hosting/TxStationProfileStore.cs
@@ -22,6 +22,7 @@ public sealed class TxStationProfileStore : IDisposable
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
     };
 
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<TxStationProfileEntry> _profiles;
     private readonly ILogger<TxStationProfileStore> _log;
@@ -35,7 +36,8 @@ public sealed class TxStationProfileStore : IDisposable
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _profiles = _db.GetCollection<TxStationProfileEntry>("tx_station_profiles");
         _profiles.EnsureIndex(x => x.ProfileId, unique: true);
 
@@ -108,7 +110,7 @@ public sealed class TxStationProfileStore : IDisposable
         }
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 }
 
 public sealed class TxStationProfileEntry

--- a/Zeus.Server.Hosting/WindowGeometryStore.cs
+++ b/Zeus.Server.Hosting/WindowGeometryStore.cs
@@ -36,6 +36,7 @@ public sealed class WindowGeometryStore : IDisposable
     public const int MinWidth = 1280;
     public const int MinHeight = 800;
 
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
     private readonly LiteDatabase _db;
     private readonly ILiteCollection<WindowGeometryEntry> _docs;
     private readonly ILogger<WindowGeometryStore> _log;
@@ -51,7 +52,8 @@ public sealed class WindowGeometryStore : IDisposable
             Directory.CreateDirectory(dir);
         }
 
-        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
         _docs = _db.GetCollection<WindowGeometryEntry>("window_geometry");
 
         _log.LogInformation("WindowGeometryStore initialized at {Path}", dbPath);
@@ -90,7 +92,7 @@ public sealed class WindowGeometryStore : IDisposable
     private static int ClampWidth(int v) => v < MinWidth ? DefaultWidth : v;
     private static int ClampHeight(int v) => v < MinHeight ? DefaultHeight : v;
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose() => _dbLease.Dispose();
 }
 
 // Normal-size geometry plus maximized flag. Plain Hosting-layer record — not a

--- a/tests/Zeus.Plugins.Host.Tests/AuHostAudioPluginTests.cs
+++ b/tests/Zeus.Plugins.Host.Tests/AuHostAudioPluginTests.cs
@@ -11,6 +11,9 @@ namespace Zeus.Plugins.Host.Tests;
 /// identity (no filesystem check), the gate still applies, and bridge
 /// failure / gated-off / uninitialised states all pass audio through clean.
 /// </summary>
+// Shares the process-global NativeLoadEnabledOverride static and ZEUS_*_VST_LOAD
+// env vars with the other load-gate tests — serialise to avoid a cross-class race.
+[Collection("LoadSensitive")]
 public class AuHostAudioPluginTests : IDisposable
 {
     public AuHostAudioPluginTests() => VstHostAudioPlugin.NativeLoadEnabledOverride = true;

--- a/tests/Zeus.Plugins.Host.Tests/AudioBlockFormatDispatchTests.cs
+++ b/tests/Zeus.Plugins.Host.Tests/AudioBlockFormatDispatchTests.cs
@@ -12,6 +12,9 @@ namespace Zeus.Plugins.Host.Tests;
 /// and a default manifest still loads via a VST3 path (filesystem identity),
 /// not an AU registry triple.
 /// </summary>
+// Sets the process-global NativeLoadEnabledOverride static in its ctor —
+// serialise with the other load-gate tests so it can't clobber their override.
+[Collection("LoadSensitive")]
 public class AudioBlockFormatDispatchTests : IDisposable
 {
     public AudioBlockFormatDispatchTests() => VstHostAudioPlugin.NativeLoadEnabledOverride = true;

--- a/tests/Zeus.Plugins.Host.Tests/SharedLiteDatabaseTests.cs
+++ b/tests/Zeus.Plugins.Host.Tests/SharedLiteDatabaseTests.cs
@@ -1,0 +1,127 @@
+using LiteDB;
+using Zeus.Data;
+
+namespace Zeus.Plugins.Host.Tests;
+
+// Behavioural contract for the single-instance database registry that replaced
+// ~40 independent `new LiteDatabase(...;Connection=shared)` opens (the LiteDB
+// corruption antipattern). Assertions use reference identity and on-disk
+// persistence rather than the process-global OpenCount, so they stay correct
+// when xUnit runs test classes in parallel.
+public sealed class SharedLiteDatabaseTests : IDisposable
+{
+    private readonly List<string> _paths = new();
+
+    private string TempPath()
+    {
+        var p = Path.Combine(Path.GetTempPath(), "zeus-sharedlitedb-" + Guid.NewGuid().ToString("N") + ".db");
+        _paths.Add(p);
+        return p;
+    }
+
+    public void Dispose()
+    {
+        foreach (var p in _paths)
+        {
+            try { File.Delete(p); } catch { /* best effort */ }
+            try { File.Delete(p + "-log"); } catch { /* best effort */ }
+        }
+    }
+
+    private sealed class Doc
+    {
+        public int Id { get; set; }
+        public string V { get; set; } = "";
+    }
+
+    [Fact]
+    public void SamePath_SharesOneEngine()
+    {
+        var p = TempPath();
+        using var a = SharedLiteDatabase.Acquire(p);
+        using var b = SharedLiteDatabase.Acquire(p);
+
+        Assert.Same(a.Database, b.Database);
+
+        a.Database.GetCollection<Doc>("c").Insert(new Doc { Id = 1, V = "x" });
+        // A write through one lease is immediately visible through the other —
+        // proof they are the same engine, not two caches over one file.
+        Assert.Equal("x", b.Database.GetCollection<Doc>("c").FindById(1).V);
+    }
+
+    [Fact]
+    public void DistinctPaths_GetDistinctEngines()
+    {
+        using var a = SharedLiteDatabase.Acquire(TempPath());
+        using var b = SharedLiteDatabase.Acquire(TempPath());
+        Assert.NotSame(a.Database, b.Database);
+    }
+
+    [Fact]
+    public void Refcount_KeepsEngineAliveUntilLastRelease_ThenReopensFresh()
+    {
+        var p = TempPath();
+        var a = SharedLiteDatabase.Acquire(p);
+        var b = SharedLiteDatabase.Acquire(p);
+        var engine = a.Database;
+
+        a.Dispose(); // b still holds a reference
+        Assert.Same(engine, b.Database);
+        // The engine is still open and usable while any lease is held.
+        b.Database.GetCollection<Doc>("c").Insert(new Doc { Id = 1, V = "ok" });
+
+        b.Dispose(); // last release closes + checkpoints to disk
+
+        using var c = SharedLiteDatabase.Acquire(p);
+        Assert.NotSame(engine, c.Database); // a brand-new engine after full release
+    }
+
+    [Fact]
+    public void LastRelease_CheckpointsToDisk_SoReopenSeesData()
+    {
+        var p = TempPath();
+        var a = SharedLiteDatabase.Acquire(p);
+        a.Database.GetCollection<Doc>("c").Insert(new Doc { Id = 1, V = "persist" });
+        a.Dispose();
+
+        using var b = SharedLiteDatabase.Acquire(p);
+        Assert.Equal("persist", b.Database.GetCollection<Doc>("c").FindById(1).V);
+    }
+
+    [Fact]
+    public void DoubleDispose_IsSafe_AndDoesNotOverRelease()
+    {
+        var p = TempPath();
+        var outer = SharedLiteDatabase.Acquire(p); // keep the engine alive
+        var inner = SharedLiteDatabase.Acquire(p);
+
+        inner.Dispose();
+        inner.Dispose(); // must be a no-op, not a second decrement
+
+        // The engine is still alive (outer holds it); a double-dispose did not
+        // corrupt the refcount.
+        outer.Database.GetCollection<Doc>("c").Insert(new Doc { Id = 1, V = "y" });
+        Assert.Equal("y", outer.Database.GetCollection<Doc>("c").FindById(1).V);
+        outer.Dispose();
+    }
+
+    [Fact]
+    public void ConcurrentAcquireRelease_DoesNotCorrupt()
+    {
+        var p = TempPath();
+        // Pin the engine open for the whole storm so it is opened/closed exactly
+        // once at the boundaries, and many leases come and go in between.
+        using (var pin = SharedLiteDatabase.Acquire(p))
+        {
+            pin.Database.GetCollection<Doc>("c").Insert(new Doc { Id = 1, V = "0" });
+            Parallel.For(0, 256, i =>
+            {
+                using var lease = SharedLiteDatabase.Acquire(p);
+                lease.Database.GetCollection<Doc>("c").Upsert(new Doc { Id = 1, V = i.ToString() });
+            });
+        }
+
+        using var reopen = SharedLiteDatabase.Acquire(p);
+        Assert.NotNull(reopen.Database.GetCollection<Doc>("c").FindById(1));
+    }
+}

--- a/tests/Zeus.Plugins.Host.Tests/VstHostAudioPluginTests.cs
+++ b/tests/Zeus.Plugins.Host.Tests/VstHostAudioPluginTests.cs
@@ -4,6 +4,13 @@ using Zeus.Plugins.Host.Audio;
 
 namespace Zeus.Plugins.Host.Tests;
 
+// Mutates the process-global VstHostAudioPlugin.NativeLoadEnabledOverride
+// static and the ZEUS_*_VST_LOAD env vars. Serialise with the other
+// load-gate tests so a sibling class's ctor can't reassert the override
+// mid-test (that race surfaced as an intermittent windows-arm64 flake:
+// the kill-switch test fell through to file validation and threw
+// "VST3 path not found").
+[Collection("LoadSensitive")]
 public class VstHostAudioPluginTests : IDisposable
 {
     // Native load is gated OFF by default (real .vst3 loads can crash the
@@ -215,7 +222,7 @@ public class VstHostAudioPluginTests : IDisposable
             Environment.SetEnvironmentVariable("ZEUS_ENABLE_VST_LOAD", previousEnable);
             Environment.SetEnvironmentVariable("ZEUS_DISABLE_VST_LOAD", previousDisable);
             Environment.SetEnvironmentVariable("ZEUS_DISABLE_TX_VST_LOAD", previousTxDisable);
-            VstHostAudioPlugin.NativeLoadEnabledOverride = true;
+            VstHostAudioPlugin.NativeLoadEnabledOverride = null;
         }
     }
 
@@ -247,7 +254,7 @@ public class VstHostAudioPluginTests : IDisposable
             Environment.SetEnvironmentVariable("ZEUS_ENABLE_VST_LOAD", previousEnable);
             Environment.SetEnvironmentVariable("ZEUS_DISABLE_VST_LOAD", previousDisable);
             Environment.SetEnvironmentVariable("ZEUS_DISABLE_TX_VST_LOAD", previousTxDisable);
-            VstHostAudioPlugin.NativeLoadEnabledOverride = true;
+            VstHostAudioPlugin.NativeLoadEnabledOverride = null;
         }
     }
 
@@ -287,7 +294,7 @@ public class VstHostAudioPluginTests : IDisposable
             Environment.SetEnvironmentVariable("ZEUS_ENABLE_VST_LOAD", previousEnable);
             Environment.SetEnvironmentVariable("ZEUS_DISABLE_VST_LOAD", previousDisable);
             Environment.SetEnvironmentVariable("ZEUS_DISABLE_RX_VST_LOAD", previousRxDisable);
-            VstHostAudioPlugin.NativeLoadEnabledOverride = true;
+            VstHostAudioPlugin.NativeLoadEnabledOverride = null;
         }
     }
 }

--- a/tests/Zeus.Server.Tests/LegacyZeusDbMigrationTests.cs
+++ b/tests/Zeus.Server.Tests/LegacyZeusDbMigrationTests.cs
@@ -138,10 +138,17 @@ public sealed class LegacyZeusDbMigrationTests : IDisposable
 
         LegacyZeusDbMigration.RunIfNeeded(_dir, _configPath, _logbookPath, NullLogger.Instance);
 
-        using var verify = new CredentialStore(NullLogger<CredentialStore>.Instance, _configPath);
-        var c = await verify.GetAsync("svc0");
-        Assert.NotNull(c);
-        Assert.Equal("keep-me", c!.Username);
+        using (var verify = new CredentialStore(NullLogger<CredentialStore>.Instance, _configPath))
+        {
+            var c = await verify.GetAsync("svc0");
+            Assert.NotNull(c);
+            Assert.Equal("keep-me", c!.Username);
+        }
+
+        // Dispose the store (releasing its shared lease and flushing the
+        // direct-mode engine's exclusive file lock) BEFORE the Count() verifier
+        // opens its own connection. Windows will not allow a second open while
+        // the store's engine still holds the file; Linux/macOS tolerate it.
         Assert.Equal(1, Count(_configPath, "credentials"));
     }
 }

--- a/tests/Zeus.Server.Tests/PrefsDbPathTests.cs
+++ b/tests/Zeus.Server.Tests/PrefsDbPathTests.cs
@@ -102,4 +102,21 @@ public class PrefsDbPathTests : IDisposable
         Assert.True(File.Exists(_dbPath));
         Assert.Empty(CorruptBackups()); // load-bearing: a busy DB is NEVER wiped
     }
+
+    // ---- Import validation (#: reject a corrupt/wrong-type upload up front) --
+
+    [Fact]
+    public void IsValidDatabase_TrueForRealDatabase()
+    {
+        WriteValidDb(_dbPath);
+        Assert.True(PrefsDbPath.IsValidDatabase(_dbPath));
+    }
+
+    [Fact]
+    public void IsValidDatabase_FalseForGarbage()
+    {
+        // What a user might accidentally pick in the file picker — a non-DB file.
+        File.WriteAllBytes(_dbPath, Enumerable.Repeat((byte)0xAB, 9000).ToArray());
+        Assert.False(PrefsDbPath.IsValidDatabase(_dbPath));
+    }
 }


### PR DESCRIPTION
## Summary
- Consolidates prefs-store LiteDB access behind a shared lease/database helper.
- Moves multiple prefs-backed stores to the shared database lifetime path.
- Keeps this as draft because the change is cross-cutting and the source commit is explicitly WIP.

## Verification
- `dotnet test tests/Zeus.Plugins.Host.Tests/Zeus.Plugins.Host.Tests.csproj --filter "FullyQualifiedName~SharedLiteDatabaseTests" -v minimal` -> 6 passed
- `dotnet test tests/Zeus.Server.Tests/Zeus.Server.Tests.csproj --filter "FullyQualifiedName~PrefsDbPathTests|FullyQualifiedName~ToolbarSettingsPersistenceTests|FullyQualifiedName~TxAudioProfileStoreTests" -v minimal /p:SpaBuildOutput=C:\Users\Admin\Desktop\openhpsdr-zeus\zeus-web\package.json` -> 31 passed