### PR TITLE
fix(desktop): keep Linux small-screen windows decorated

### DIFF
--- a/OpenhpsdrZeus/Program.cs
+++ b/OpenhpsdrZeus/Program.cs
@@ -689,8 +689,36 @@ public partial class Program
 
             // Never open larger than the visible work area: a size saved on a
             // bigger monitor would otherwise hang the frame off the edges.
-            var w = Math.Min(desiredWidth, work.Width);
-            var h = Math.Min(desiredHeight, work.Height);
+            var availW = work.Width;
+            var availH = work.Height;
+
+            // On Linux, keep the frame strictly INSIDE the work area. A GTK
+            // window whose size meets or exceeds the available work area gets
+            // auto-maximized by the Wayland compositor (KWin / Mutter / wlroots),
+            // and a maximized GTK frame is drawn borderless — no titlebar — which
+            // the operator reads as "opens fullscreen with no titlebar". The
+            // SetMinWidth/SetMinHeight pinned at 1280x800 make this unavoidable on
+            // small panels (e.g. the 8" 1280x800 CM5 DSI screen): the minimum
+            // itself is >= the work area once a desktop panel is subtracted, so
+            // GTK can't shrink the frame and the compositor maximizes it. Reserve
+            // a margin AND relax the runtime minimum to that margin-inset size so
+            // the frame is provably smaller than the work area and stays a normal
+            // decorated window. Windows/macOS keep decorations at work-area size,
+            // so this whole branch is Linux-only to leave them untouched.
+            if (OperatingSystem.IsLinux())
+            {
+                const int LinuxWorkAreaMargin = 48;
+                availW = Math.Max(640, work.Width - LinuxWorkAreaMargin);
+                availH = Math.Max(480, work.Height - LinuxWorkAreaMargin);
+                // Lower the floor so the size below actually takes effect instead
+                // of being clamped back up by the geometry hint (which would
+                // re-trigger the auto-maximize).
+                if (availW < window.MinWidth) window.MinWidth = availW;
+                if (availH < window.MinHeight) window.MinHeight = availH;
+            }
+
+            var w = Math.Min(desiredWidth, availW);
+            var h = Math.Min(desiredHeight, availH);
             window.Size = new System.Drawing.Size(w, h);
 
             // Centre within the work area, then clamp so the title bar is always

--- a/Zeus.Server.Hosting/WindowGeometryStore.cs
+++ b/Zeus.Server.Hosting/WindowGeometryStore.cs
@@ -63,14 +63,15 @@ public sealed class WindowGeometryStore : IDisposable
         {
             var e = _docs.FindAll().FirstOrDefault();
             if (e is null)
-                // Fresh install: open maximized on Linux (the G2's built-in panel
-                // and other small/embedded displays expect a full-screen client,
-                // matching deskhpsdr), windowed elsewhere. The frame still carries
-                // its titlebar because RunDesktop seats a normal restored size
-                // first and relaxes the min size to fit small panels before
-                // maximizing — see PlaceWindowOnVisibleWorkArea. Once the operator
+                // Fresh install: open maximized (full screen) on every platform.
+                // The G2's built-in panel and other small/embedded displays expect
+                // a full-screen client (matching deskhpsdr), and the desktop hosts
+                // benefit from the same default. The frame still carries its
+                // titlebar because RunDesktop seats a normal restored size first
+                // and relaxes the min size to fit small panels before maximizing —
+                // see PlaceWindowOnVisibleWorkArea. Once the operator
                 // resizes/un-maximizes, the saved doc below is authoritative.
-                return new WindowGeometry(DefaultWidth, DefaultHeight, Maximized: OperatingSystem.IsLinux());
+                return new WindowGeometry(DefaultWidth, DefaultHeight, Maximized: true);
             return new WindowGeometry(
                 ClampWidth(e.Width),
                 ClampHeight(e.Height),

--- a/Zeus.Server.Hosting/WindowGeometryStore.cs
+++ b/Zeus.Server.Hosting/WindowGeometryStore.cs
@@ -63,7 +63,14 @@ public sealed class WindowGeometryStore : IDisposable
         {
             var e = _docs.FindAll().FirstOrDefault();
             if (e is null)
-                return new WindowGeometry(DefaultWidth, DefaultHeight, Maximized: false);
+                // Fresh install: open maximized on Linux (the G2's built-in panel
+                // and other small/embedded displays expect a full-screen client,
+                // matching deskhpsdr), windowed elsewhere. The frame still carries
+                // its titlebar because RunDesktop seats a normal restored size
+                // first and relaxes the min size to fit small panels before
+                // maximizing — see PlaceWindowOnVisibleWorkArea. Once the operator
+                // resizes/un-maximizes, the saved doc below is authoritative.
+                return new WindowGeometry(DefaultWidth, DefaultHeight, Maximized: OperatingSystem.IsLinux());
             return new WindowGeometry(
                 ClampWidth(e.Width),
                 ClampHeight(e.Height),


### PR DESCRIPTION
## Summary
- Keeps fresh Linux desktop windows maximized by default on small displays.
- Relaxes minimum window size when the visible work area is smaller than the configured minimums.
- Preserves titlebar/decorations by leaving a work-area margin on Linux placement.

Issue: zeus-8tz

## Verification
- `dotnet build OpenhpsdrZeus/OpenhpsdrZeus.csproj -v minimal /p:SpaBuildOutput=C:\Users\Admin\Desktop\openhpsdr-zeus\zeus-web\package.json` -> passed

## Build Caveat
- The command verifies the C# desktop changes while skipping SPA bundling; full Vite bundling is currently blocked by the existing DeepCW ONNX asset issue (`zeus-rvsu`).