### PR TITLE
fix(remote): WAN connect (host TURN) + Opus RX audio + chat/QRZ + LAN-browser TLS

### DIFF
--- a/Zeus.Server.Hosting/Remote/RemoteWebRtcService.cs
+++ b/Zeus.Server.Hosting/Remote/RemoteWebRtcService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Net.Http;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Net;
 
@@ -47,8 +48,9 @@ public sealed class RemoteWebRtcService
             ?? throw new RemoteAccessDisabledException();
 
         var id = Guid.NewGuid();
+        var ice = await GetIceServersAsync(ct);
         var session = new RemoteWebRtcSession(
-            verifier, _log, IceServers(), _hub, _httpFactory, _loopbackBaseUrl);
+            verifier, _log, ice, _hub, _httpFactory, _loopbackBaseUrl);
         _sessions[id] = session;
         session.Closed += () =>
         {
@@ -68,9 +70,104 @@ public sealed class RemoteWebRtcService
                 s.Close();
     }
 
-    // STUN only here; the production path swaps in Cloudflare TURN credentials
-    // minted by the broker (Phase 3) for NAT/CGNAT traversal.
-    private static List<RTCIceServer> IceServers() =>
+    internal const string TurnHttpClientName = "RemoteTurn";
+
+    /// <summary>Broker endpoint that mints short-lived Cloudflare TURN credentials.
+    /// Overridable for tests / self-hosted brokers via ZEUS_REMOTE_TURN_URL.</summary>
+    private static string TurnUrl =>
+        Environment.GetEnvironmentVariable("ZEUS_REMOTE_TURN_URL")?.Trim() is { Length: > 0 } u
+            ? u
+            : "https://remote.openhpsdrzeus.com/turn";
+
+    /// <summary>
+    /// Gather the ICE servers for a session. The HOST (this radio) sits behind the
+    /// operator's NAT/CGNAT, so STUN alone only yields a server-reflexive candidate
+    /// that a symmetric NAT won't accept inbound — across the internet that means no
+    /// candidate pair forms and the data channels never open ("remote API request
+    /// timed out / won't connect"). Fetching the broker-minted TURN credentials lets
+    /// the host gather a relay candidate too, so traversal works regardless of NAT
+    /// type (the browser already does the same via /turn). Falls back to STUN-only if
+    /// the broker is unreachable — fine on the LAN, may still fail over the internet.
+    /// </summary>
+    private async Task<List<RTCIceServer>> GetIceServersAsync(CancellationToken ct)
+    {
+        if (_httpFactory is not null)
+        {
+            try
+            {
+                using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                timeout.CancelAfter(TimeSpan.FromSeconds(5));
+                var client = _httpFactory.CreateClient(TurnHttpClientName);
+                using var resp = await client.PostAsync(TurnUrl, content: null, timeout.Token);
+                resp.EnsureSuccessStatusCode();
+                var json = await resp.Content.ReadAsStringAsync(timeout.Token);
+                var parsed = ParseIceServers(json);
+                if (parsed.Count > 0)
+                {
+                    _log.LogInformation(
+                        "rtc.remote ICE: {Count} server(s) from broker TURN ({Relay} relay)",
+                        parsed.Count,
+                        parsed.Count(s => s.urls?.StartsWith("turn", StringComparison.OrdinalIgnoreCase) == true));
+                    return parsed;
+                }
+            }
+            catch (Exception ex)
+            {
+                _log.LogWarning(ex,
+                    "rtc.remote TURN fetch failed; STUN-only fallback (NAT traversal may fail across the internet)");
+            }
+        }
+        return StunFallback();
+    }
+
+    /// <summary>
+    /// Parse a broker <c>/turn</c> JSON body (<c>{"iceServers":[{urls,username?,credential?}]}</c>)
+    /// into SIPSorcery ICE servers. <c>urls</c> may be a string or an array; each URL becomes
+    /// its own entry. Only schemes SIPSorcery reliably gathers from are kept — STUN and UDP TURN;
+    /// <c>turns:</c> (TLS) and <c>transport=tcp</c> entries are dropped so a parse/transport quirk
+    /// in one URL can't poison candidate gathering.
+    /// </summary>
+    internal static List<RTCIceServer> ParseIceServers(string json)
+    {
+        var into = new List<RTCIceServer>();
+        using var doc = JsonDocument.Parse(json);
+        if (!doc.RootElement.TryGetProperty("iceServers", out var arr)
+            || arr.ValueKind != JsonValueKind.Array)
+            return into;
+
+        foreach (var entry in arr.EnumerateArray())
+        {
+            string? username = entry.TryGetProperty("username", out var u)
+                && u.ValueKind == JsonValueKind.String ? u.GetString() : null;
+            string? credential = entry.TryGetProperty("credential", out var c)
+                && c.ValueKind == JsonValueKind.String ? c.GetString() : null;
+
+            if (!entry.TryGetProperty("urls", out var urls)) continue;
+            if (urls.ValueKind == JsonValueKind.String)
+                AddUrl(into, urls.GetString(), username, credential);
+            else if (urls.ValueKind == JsonValueKind.Array)
+                foreach (var url in urls.EnumerateArray())
+                    if (url.ValueKind == JsonValueKind.String)
+                        AddUrl(into, url.GetString(), username, credential);
+        }
+        return into;
+    }
+
+    private static void AddUrl(List<RTCIceServer> into, string? url, string? username, string? credential)
+    {
+        if (string.IsNullOrWhiteSpace(url)) return;
+        var lower = url.ToLowerInvariant();
+        bool keep = lower.StartsWith("stun:") || lower.StartsWith("stuns:")
+            || (lower.StartsWith("turn:") && !lower.Contains("transport=tcp"));
+        if (!keep) return; // drop turns:(TLS) + turn transport=tcp
+
+        var server = new RTCIceServer { urls = url };
+        if (!string.IsNullOrEmpty(username)) server.username = username;
+        if (!string.IsNullOrEmpty(credential)) server.credential = credential;
+        into.Add(server);
+    }
+
+    private static List<RTCIceServer> StunFallback() =>
     [
         new RTCIceServer { urls = "stun:stun.cloudflare.com:3478" },
     ];

--- a/Zeus.Server.Hosting/Remote/RemoteWebRtcSession.cs
+++ b/Zeus.Server.Hosting/Remote/RemoteWebRtcSession.cs
@@ -60,14 +60,16 @@ public sealed class RemoteWebRtcSession
     private int _lastAudioSeq = -1;
     private bool _audioWired;
 
-    // SOTA RX audio (opt-in, bench-gated): when ZEUS_REMOTE_OPUS_RX is set, RX
-    // audio is Opus-encoded onto the outbound WebRTC audio track instead of raw
-    // PCM over the unreliable "frames" data channel — native browser jitter
-    // buffer + PLC + ~50× less bandwidth. Default OFF so the proven PCM path is
-    // unchanged until this is bench-verified against a real radio + internet hop.
+    // SOTA RX audio: RX audio is Opus-encoded onto the outbound WebRTC audio
+    // track instead of raw PCM over the unreliable "frames" data channel — the
+    // browser's native adaptive jitter buffer + packet-loss concealment make it
+    // robust over an internet hop (the PCM path has neither: maxRetransmits:0,
+    // no reorder/jitter handling, so WAN loss = choppy/silent audio) at ~50×
+    // less bandwidth. Default ON; set ZEUS_REMOTE_OPUS_RX=0 to fall back to the
+    // legacy PCM-over-datachannel path if the Opus track ever misbehaves.
     internal static readonly bool OpusRxEnabled =
         (Environment.GetEnvironmentVariable("ZEUS_REMOTE_OPUS_RX") ?? "")
-            .Trim() is "1" or "true" or "TRUE" or "True";
+            .Trim() is not ("0" or "false" or "FALSE" or "False" or "off" or "OFF");
     private RemoteRxAudioPipeline? _rxAudio;
 
     // Post-unlock binary stream-request control frames (RX monitoring, Phase A):
@@ -106,20 +108,22 @@ public sealed class RemoteWebRtcSession
     ///   /api/remote/password   — remote-access session password store/status
     ///                            (a write here would let a remote change the
     ///                            very password gating it)
-    ///   /api/qrz               — QRZ status carries the signed-in operator's
-    ///                            callsign/identity; login/credentials live here
-    ///   /api/chat              — chat identity/roster/friends derive from the
-    ///                            QRZ session; conservative full-prefix deny
     ///   /api/prefs/databases/export — downloads the entire prefs LiteDB
     ///                            (contains the QRZ password + remote verifier)
     ///   /api/log/export        — full logbook export (PII / ADIF dump)
+    ///
+    /// NOTE: /api/qrz and /api/chat were previously fully denied here, but the
+    /// remote operator IS the authenticated station owner (SPAKE2+ session
+    /// password proven) — they should reach QRZ lookup and chat exactly as they
+    /// do at the desk (1:1 remote). Both are now allowed; the residual exposure
+    /// (a remote session can change the QRZ login/API key, and chat posts under
+    /// the station callsign) is accepted as operator-equivalent access. The
+    /// truly destructive surfaces above stay denied.
     /// Conservative by design: when unsure, deny.
     /// </summary>
     private static readonly string[] DeniedPathPrefixes =
     {
         "/api/remote/password",
-        "/api/qrz",
-        "/api/chat",
         "/api/prefs/databases/export",
         "/api/log/export",
     };

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -365,9 +365,22 @@ public static class ZeusHost
         // panel (esp. for remote operators whose browser can't reach the radio's
         // LAN). No auto-redirect — LanProxyService follows + re-validates each hop
         // against the private-range rule itself.
+        //
+        // Accept self-signed / hostname-mismatched TLS certs: LAN devices the
+        // operator browses to (routers at 192.168.x.1, NAS, printers, IoT) almost
+        // universally serve HTTPS with a self-signed cert, which a default
+        // HttpClient rejects ("The SSL connection could not be established"). The
+        // target is already constrained to RFC1918/ULA private space by
+        // LanProxyService.TryValidateTarget, so this only ever relaxes validation
+        // for the operator's own private network — never a public host.
         builder.Services.AddHttpClient(LanProxyService.HttpClientName,
                 c => c.Timeout = TimeSpan.FromSeconds(15))
-            .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler { AllowAutoRedirect = false });
+            .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+            {
+                AllowAutoRedirect = false,
+                ServerCertificateCustomValidationCallback =
+                    HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
+            });
         builder.Services.AddSingleton<LanProxyService>();
         // RX audio publish seam (Phase 1). DspPipelineService.PublishAudio
         // fans each AudioFrame across every registered IRxAudioSink.

--- a/tests/Zeus.Server.Tests/RemoteWebRtcSessionTests.cs
+++ b/tests/Zeus.Server.Tests/RemoteWebRtcSessionTests.cs
@@ -326,6 +326,50 @@ public sealed class RemoteWebRtcSessionTests
     }
 
     [Fact]
+    public async Task PostUnlock_QrzLookupAndChat_ReachLoopback()
+    {
+        // The remote operator is the authenticated station owner, so QRZ lookup
+        // and chat are 1:1 with the desk — formerly denied, now tunnelled. Only
+        // the credential/secret exfil paths above stay refused.
+        var seen = new List<string>();
+        var factory = new StubHttpClientFactory((req) =>
+        {
+            seen.Add(req.RequestUri!.AbsolutePath);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"ok\":true}", Encoding.UTF8, "application/json"),
+            };
+        });
+        ApiSession(factory, out var server);
+        await using var client = new ProverClient(Password);
+        await UnlockAsync(server, client);
+
+        var qrz = await SendApiUntilReply(
+            client, 31, "POST", "/api/qrz/lookup", "{\"call\":\"KB2UKA\"}", "application/json");
+        using (var d = JsonDocument.Parse(qrz))
+            Assert.Equal(200, d.RootElement.GetProperty("status").GetInt32());
+
+        var chat = await SendApiUntilReply(
+            client, 32, "POST", "/api/chat/send", "{\"text\":\"hi\"}", "application/json");
+        using (var d = JsonDocument.Parse(chat))
+            Assert.Equal(200, d.RootElement.GetProperty("status").GetInt32());
+
+        Assert.Contains("/api/qrz/lookup", seen);
+        Assert.Contains("/api/chat/send", seen);
+        Assert.Equal(2, factory.CallCount);
+
+        server.Close();
+    }
+
+    [Fact]
+    public void OpusRx_IsEnabledByDefault()
+    {
+        // RX audio defaults to the Opus WebRTC-track path (jitter buffer + PLC,
+        // robust over the internet). ZEUS_REMOTE_OPUS_RX=0 opts back to PCM.
+        Assert.True(RemoteWebRtcSession.OpusRxEnabled);
+    }
+
+    [Fact]
     public async Task PreUnlock_ApiInput_DoesNothing()
     {
         var factory = new StubHttpClientFactory(_ =>

--- a/tests/Zeus.Server.Tests/RemoteWebRtcSessionTests.cs
+++ b/tests/Zeus.Server.Tests/RemoteWebRtcSessionTests.cs
@@ -370,6 +370,40 @@ public sealed class RemoteWebRtcSessionTests
     }
 
     [Fact]
+    public void ParseIceServers_FlattensUrls_KeepsStunAndUdpTurn_WithCredentials()
+    {
+        // Real broker /turn body shape: stun array (no creds) + turn array with a
+        // shared username/credential, including TLS + TCP transports we must drop.
+        const string json = """
+        {"iceServers":[
+          {"urls":["stun:stun.cloudflare.com:3478","stun:stun.cloudflare.com:53"]},
+          {"urls":[
+            "turn:turnv2.realtime.cloudflare.com:3478?transport=udp",
+            "turn:turn.cloudflare.com:3478?transport=tcp",
+            "turns:turn.cloudflare.com:5349?transport=tcp",
+            "turn:turn.cloudflare.com:53?transport=udp"
+          ],"username":"user123","credential":"cred456"}
+        ]}
+        """;
+
+        var servers = Zeus.Server.Hosting.Remote.RemoteWebRtcService.ParseIceServers(json);
+
+        // 2 stun + 2 udp turn kept; tcp + turns(TLS) dropped.
+        Assert.Equal(4, servers.Count);
+        var turns = servers.Where(s => s.urls.StartsWith("turn:", StringComparison.OrdinalIgnoreCase)).ToList();
+        Assert.Equal(2, turns.Count);
+        Assert.All(turns, t => Assert.DoesNotContain("transport=tcp", t.urls));
+        Assert.All(turns, t =>
+        {
+            Assert.Equal("user123", t.username);
+            Assert.Equal("cred456", t.credential);
+        });
+        // STUN entries carry no credentials and there is a relay candidate source.
+        Assert.Contains(servers, s => s.urls == "stun:stun.cloudflare.com:3478");
+        Assert.DoesNotContain(servers, s => s.urls.StartsWith("turns:", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public async Task PreUnlock_ApiInput_DoesNothing()
     {
         var factory = new StubHttpClientFactory(_ =>


### PR DESCRIPTION
Makes remote operation work end-to-end across the internet, 1:1 with the desk. **All server-side** — no Cloudflare/SPA redeploy needed; the host must run this build.

## 0. Won't connect outside the LAN ("Remote API request timed out") — the big one
The radio **host configured STUN only** — the code comment admits "Phase 3" TURN was never wired. Behind NAT/CGNAT the host gathered only a server-reflexive candidate that a symmetric NAT won't accept inbound, so across the internet no ICE candidate pair formed, the data channels never opened, and the SPA reported "Remote API request timed out." LAN worked because host candidates suffice there.

- `RemoteWebRtcService` now fetches the broker-minted Cloudflare TURN credentials (`POST /turn`, the same source the browser uses) before answering each offer, so the host gathers a **relay candidate** too → traversal succeeds regardless of NAT type.
- Falls back to STUN-only if the broker is unreachable. Override via `ZEUS_REMOTE_TURN_URL`.
- Parser keeps STUN + UDP TURN, drops `turns:`(TLS)/`transport=tcp` so a transport quirk can't poison SIPSorcery gathering.

## 1. RX audio (no sound remotely, though TX worked)
RX audio defaulted to raw PCM over the unreliable `frames` data channel (no jitter buffer) → choppy/silent over WAN. The SOTA Opus-track path existed but was gated off.
- `ZEUS_REMOTE_OPUS_RX` now **default ON**: RX rides the WebRTC Opus track (browser-native jitter buffer + PLC, ~50× less bandwidth). `=0` reverts to PCM. Needs on-air confirmation.

## 2. Chat + QRZ didn't work remotely
`/api/qrz` and `/api/chat` were in the tunnel always-deny list. The remote operator is the authenticated station owner (SPAKE2+), so both are now allowed (1:1).
- Still denied: `/api/remote/password`, `/api/prefs/databases/export`, `/api/log/export`, and the PureSignal write-deny (`/api/tx/ps`, KB2UKA hard-stop) is untouched.
- Accepted trade-off: a remote session can change QRZ login/API key, and chat posts under the station callsign — operator-equivalent access.

## 3. LAN browser: "The SSL connection could not be established"
The `ZeusLanProxy` HttpClient rejected routers' self-signed certs. It now accepts self-signed/mismatched certs — scoped to RFC1918/ULA targets only (via `LanProxyService.TryValidateTarget`), never a public host.

## Tests
`dotnet test … --filter RemoteWebRtcSession|LanProxy` → **47/47 pass**, including new:
- `ParseIceServers_FlattensUrls_KeepsStunAndUdpTurn_WithCredentials`
- `PostUnlock_QrzLookupAndChat_ReachLoopback`
- `OpusRx_IsEnabledByDefault`

Existing denylist/traversal tests (prefs-DB export, PureSignal) unchanged and green.