### PR TITLE
feat: wire the CW key jack for Protocol-2 radios (#1032)

### DIFF
--- a/Zeus.Protocol2/CwKeyerWireConfig.cs
+++ b/Zeus.Protocol2/CwKeyerWireConfig.cs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+using Zeus.Contracts;
+
+namespace Zeus.Protocol2;
+
+/// <summary>
+/// Operator-driven CW keyer configuration carried into the Protocol-2
+/// TxSpecific packet (port 1026, bytes 5-13/17). This is the seam that
+/// activates the radio's <b>internal (FPGA) iambic keyer</b> so a physical
+/// straight key / paddle plugged into the rear KEY jack actually keys the
+/// transmitter — the missing piece behind issue #1032 on the G2 (and every
+/// other Protocol-2 board).
+///
+/// <para>
+/// On Protocol 2 the host does NOT key CW: once <see cref="Active"/> is set
+/// (in CW mode) the radio's gateware shapes the dits/dahs, keys the PA, and
+/// — with break-in — handles TX/RX switching itself. The host only has to
+/// publish this config in the TxSpecific packet. This mirrors pihpsdr
+/// <c>new_protocol.c</c> <c>new_protocol_tx_specific</c> (transmit_specific_buffer
+/// bytes 5-17) and the OpenHPSDR Ethernet Protocol v4.4 "Transmitter
+/// Specific" packet (§ pp.29-30).
+/// </para>
+///
+/// <para>
+/// Fields here are the values an operator changes (CW mode active, keyer
+/// mode, speed, sidetone). The remaining gateware parameters
+/// (weight / spacing / reversed / break-in / hang / RF-delay / ramp) are
+/// pinned to Thetis/pihpsdr-faithful defaults inside
+/// <see cref="Protocol2Client.ComposeCmdTxBuffer"/>, exactly as the
+/// Protocol-1 path pins them in <c>ControlFrame</c>.
+/// </para>
+/// </summary>
+public readonly record struct CwKeyerWireConfig
+{
+    /// <summary>
+    /// True when the operating (TX/VFO-A) mode is CWU/CWL. Gates TxSpecific
+    /// byte-5 bit-1 ("CW selected"): when false the byte stays 0 and the
+    /// CmdTx tail is byte-identical to a non-CW transmit, so SSB/AM/FM/DIG
+    /// wire form is unchanged.
+    /// </summary>
+    public bool Active { get; init; }
+
+    /// <summary>Straight / Iambic-A / Iambic-B. Straight passes an external
+    /// keyer or bug through untouched (gateware does no element timing).</summary>
+    public CwKeyerMode Mode { get; init; }
+
+    /// <summary>Keyer speed in WPM. TxSpecific byte 9. The gateware ignores it
+    /// in straight-key mode but it also clamps the RF-delay (900/WPM), so a
+    /// sane value is always sent.</summary>
+    public int SpeedWpm { get; init; }
+
+    /// <summary>Radio-generated sidetone frequency in Hz. TxSpecific bytes 7-8
+    /// (big-endian). Shares the operator's CW pitch.</summary>
+    public int SidetoneHz { get; init; }
+
+    /// <summary>Radio-generated sidetone level, 0-127 (0 disables the sidetone
+    /// bit). TxSpecific byte 6. Derived from the operator's sidetone gain.</summary>
+    public byte SidetoneLevel { get; init; }
+
+    /// <summary>A neutral, inactive config (no CW) — the default for every
+    /// non-CW transmit and for callers/tests that don't drive CW.</summary>
+    public static CwKeyerWireConfig Inactive => default;
+}

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -307,6 +307,55 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     private byte _micControl;
     private byte _lineInGain;
 
+    // Internal (FPGA) CW keyer config — issue #1032. Wire-encoded into the
+    // TxSpecific (CmdTx, port 1026) packet bytes 5-13/17. These are the
+    // operator-driven values (CW-mode active, keyer mode, speed, sidetone);
+    // the remaining gateware parameters are pinned to the Cw* constants
+    // below, mirroring how the Protocol-1 path pins weight/spacing/reverse in
+    // ControlFrame. Latched by SetCwKeyerConfig and re-pushed on the next
+    // CmdTx, exactly like the audio front-end bytes. All-default (Inactive)
+    // leaves byte 5 = 0, so a non-CW transmit is byte-identical to today.
+    private bool _cwActive;
+    private CwKeyerMode _cwMode;
+    private int _cwSpeedWpm;
+    private int _cwSidetoneHz;
+    private byte _cwSidetoneLevel;
+
+    // TxSpecific byte-5 CW mode_control bit layout — pihpsdr new_protocol.c
+    // new_protocol_tx_specific (transmit_specific_buffer[5]) and OpenHPSDR
+    // Ethernet Protocol v4.4 "Transmitter Specific" packet (pp.29-30). Public
+    // so the wire-format golden tests can assert the canonical bit positions.
+    public const byte CwModeCwSelected   = 0x02; // bit1 — internal keyer / CW selected
+    public const byte CwModeReverse      = 0x04; // bit2 — swap dit/dah paddles
+    public const byte CwModeIambic       = 0x08; // bit3 — iambic (Mode A)
+    public const byte CwModeModeB        = 0x20; // bit5 — Mode B (set with Iambic)
+    public const byte CwModeSidetone     = 0x10; // bit4 — radio sidetone enable
+    public const byte CwModeStrictSpacing = 0x40; // bit6 — strict char spacing
+    public const byte CwModeBreakIn      = 0x80; // bit7 — break-in (radio handles TX/RX)
+
+    // Gateware keyer parameters that have no operator UI yet (mirrors the
+    // Protocol-1 neutral defaults in ControlFrame). Held as constants and
+    // sent on every CW transmit.
+    //   Weight  : TxSpecific byte 10, 50% => 1:1 dit:dah (pihpsdr default).
+    //   Spacing : strict letter spacing off (bug/keyer pass-through).
+    //   Reverse : paddles un-swapped.
+    //   BreakIn : ON. *Load-bearing for issue #1032* — without break-in the
+    //             radio will not switch to TX on key-down, so the jack stays
+    //             silent (the original bug). Semi/full/off is a CW-operator
+    //             preference and a candidate follow-up control; ON is the only
+    //             value that makes "plug a key in and it works" true.
+    //   HangMs  : semi-break-in tail before the radio drops back to RX.
+    //   RfDelayMs: PTT-to-RF (key-down) delay; gateware-clamped to 900/WPM
+    //             (pihpsdr "FPGA iambic keyer bug" workaround, byte 13).
+    //   RampMs  : CW envelope rise/fall; Thetis forces 9 (setup.cs:29327).
+    private const byte CwKeyerWeight    = 50;
+    private const bool CwKeyerSpacing   = false;
+    private const bool CwKeyerReverse   = false;
+    private const bool CwKeyerBreakIn   = true;
+    private const int  CwKeyerHangMs    = 300;
+    private const int  CwKeyerRfDelayMs = 8;
+    private const byte CwKeyerRampMs    = 9;
+
     // TxSpecific byte-50 mic_control bit layout (Thetis network.c:1226-1233).
     // Public so the wire-format golden tests can assert against the canonical
     // bit positions. The byte itself is resolved upstream from the selected
@@ -1877,8 +1926,37 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
 
     private void SendCmdTx()
     {
-        var p = ComposeCmdTxBuffer(_seqCmdTx++, (ushort)_sampleRateKhz, _txStepAttnDb, _paEnabled, _psFeedbackEnabled, _micControl, _lineInGain);
+        var cw = new CwKeyerWireConfig
+        {
+            Active = Volatile.Read(ref _cwActive),
+            Mode = _cwMode,
+            SpeedWpm = _cwSpeedWpm,
+            SidetoneHz = _cwSidetoneHz,
+            SidetoneLevel = _cwSidetoneLevel,
+        };
+        var p = ComposeCmdTxBuffer(_seqCmdTx++, (ushort)_sampleRateKhz, _txStepAttnDb, _paEnabled, _psFeedbackEnabled, _micControl, _lineInGain, cw);
         _sock!.SendTo(p, new IPEndPoint(_radioEndpoint!.Address, 1026));
+    }
+
+    /// <summary>
+    /// Configure the radio's <b>internal (FPGA) CW keyer</b> — issue #1032.
+    /// On Protocol 2 the host does not key CW: setting this (in CW mode) arms
+    /// the gateware so a physical key/paddle on the rear KEY jack keys the
+    /// transmitter directly. Latches the operator values and re-pushes the
+    /// TxSpecific packet so the radio honours them on the next transmit cycle
+    /// (load-bearing — the radio keeps its last-remembered config otherwise,
+    /// the same pihpsdr transmit_specific risk noted on the audio front-end).
+    /// No-op on the wire until the RX task is live; the values are latched and
+    /// emitted on the first CmdTx after connect.
+    /// </summary>
+    public void SetCwKeyerConfig(in CwKeyerWireConfig cw)
+    {
+        Volatile.Write(ref _cwActive, cw.Active);
+        _cwMode = cw.Mode;
+        _cwSpeedWpm = cw.SpeedWpm;
+        _cwSidetoneHz = cw.SidetoneHz;
+        _cwSidetoneLevel = cw.SidetoneLevel;
+        if (_rxTask is not null) SendCmdTx();
     }
 
     /// <summary>
@@ -1923,12 +2001,49 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // 57/58/59) — operator's normal voice TX has been validated working
     // with that wire form on G2 MkII, so we don't ship a wire change
     // beyond the PS-armed window in this patch.
-    internal static byte[] ComposeCmdTxBuffer(uint seq, ushort sampleRateKhz, byte txStepAttnDb, bool paEnabled, bool psEnabled, byte micControl = 0, byte lineInGain = 0)
+    internal static byte[] ComposeCmdTxBuffer(uint seq, ushort sampleRateKhz, byte txStepAttnDb, bool paEnabled, bool psEnabled, byte micControl = 0, byte lineInGain = 0, CwKeyerWireConfig cw = default)
     {
         var p = new byte[60];
         WriteBeU32(p, 0, seq);
         p[4] = 1;                 // num_dac
         WriteBeU16(p, 14, sampleRateKhz);
+
+        // Internal (FPGA) CW keyer — issue #1032. Byte 5 is the CW mode_control
+        // bitfield and is set ONLY in CW mode (cw.Active); bytes 6-13/17 carry
+        // the keyer parameters. Layout = pihpsdr new_protocol.c
+        // new_protocol_tx_specific (transmit_specific_buffer[5..17]) and
+        // OpenHPSDR Ethernet Protocol v4.4 "Transmitter Specific" (pp.29-30).
+        // When cw.Active is false byte 5 stays 0 and the CW bytes stay 0, so a
+        // non-CW (SSB/AM/FM/DIG) transmit is byte-identical to the historical
+        // wire form. The host never sets MOX for internal CW — the gateware
+        // self-keys off the rear KEY jack once byte-5 bit-1 is set.
+        if (cw.Active)
+        {
+            // Gateware-pinned bits use ternary-OR (not `if`) so the const
+            // false/true folds to an expression rather than unreachable code.
+            byte mode = CwModeCwSelected;
+            mode |= CwKeyerReverse ? CwModeReverse : (byte)0;
+            // Straight = no element timing (external keyer/bug pass-through);
+            // Iambic-A sets the iambic bit; Iambic-B sets iambic + Mode B.
+            if (cw.Mode == CwKeyerMode.IambicA) mode |= CwModeIambic;
+            else if (cw.Mode == CwKeyerMode.IambicB) mode |= (byte)(CwModeIambic | CwModeModeB);
+            mode |= cw.SidetoneLevel != 0 ? CwModeSidetone : (byte)0;
+            mode |= CwKeyerSpacing ? CwModeStrictSpacing : (byte)0;
+            mode |= CwKeyerBreakIn ? CwModeBreakIn : (byte)0;
+            p[5] = mode;
+
+            p[6] = (byte)(cw.SidetoneLevel & 0x7F);
+            WriteBeU16(p, 7, (ushort)Math.Clamp(cw.SidetoneHz, 0, 0xFFFF));
+            int wpm = Math.Clamp(cw.SpeedWpm, 1, 60);
+            p[9] = (byte)wpm;
+            p[10] = CwKeyerWeight;
+            WriteBeU16(p, 11, (ushort)Math.Clamp(CwKeyerHangMs, 0, 0xFFFF));
+            // RF (key-down) delay, clamped to 900/WPM — pihpsdr's documented
+            // FPGA iambic-keyer-bug workaround (new_protocol.c:1500-1503).
+            int rfDelay = Math.Min(CwKeyerRfDelayMs, 900 / wpm);
+            p[13] = (byte)Math.Clamp(rfDelay, 0, 255);
+            p[17] = CwKeyerRampMs;
+        }
 
         // Audio front-end (external-audio-jacks re-port). Byte 50 = mic_control
         // flags, byte 51 = line_in_gain — Thetis network.c:1234,1236. Both

--- a/Zeus.Server.Hosting/CwEngine.cs
+++ b/Zeus.Server.Hosting/CwEngine.cs
@@ -269,6 +269,9 @@ public sealed class CwEngine : BackgroundService
                 Reason: err ?? "MOX refused"));
             return;
         }
+        // Host CW now owns the air — disarm the P2 internal keyer so the
+        // gateware doesn't self-key against this host-keyed send (#1032).
+        _radio.SetHostCwKeying(true);
         Notify(new CwEngineStatus(CwEngineState.Sending, job.Text, job.Wpm, queueDepth));
         _log.LogInformation(
             "cw.send text={Text} wpm={Wpm} mode={Mode} txVfo={TxVfo} txHz={TxHz}Hz lo={Lo}Hz baseband={Bb}Hz loRealigned={LoRealigned}",
@@ -374,6 +377,9 @@ public sealed class CwEngine : BackgroundService
                 Reason: err ?? "MOX refused"));
             return;
         }
+        // Host CW (raw keyer/logger) owns the air — disarm the P2 internal
+        // keyer for the duration so the gateware doesn't self-key too (#1032).
+        _radio.SetHostCwKeying(true);
         Notify(new CwEngineStatus(CwEngineState.Sending, "<keyer>", 0, queueDepth));
         _log.LogInformation(
             "cw.keyer.down txVfo={TxVfo} txHz={TxHz}Hz baseband={Bb}Hz durationMs={Dur} loRealigned={LoR}",
@@ -459,6 +465,10 @@ public sealed class CwEngine : BackgroundService
 
     private void TryReleaseMox(string reason)
     {
+        // Host CW is done keying — re-arm the P2 internal keyer (cleared
+        // unconditionally, even if UI/trip took MOX from us, so a paddle works
+        // again the moment this host send ends). No-op on P1. (#1032)
+        _radio.SetHostCwKeying(false);
         // Only release MOX if we still own it — UI or trip may have already
         // dropped it under us. Idempotent at the TxService layer either way.
         if (_tx.MoxOwner == MoxSource.Cwx)

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -127,12 +127,19 @@ public sealed class RadioService : IDisposable
     // edge is crossed or a PA setting is edited, we recompute without needing
     // to wait for the next SetDrive call.
     private int _drivePct;
-    // On-board CW keyer config (C&C 0x0B), forwarded to the connected P1
-    // client and re-pushed on reconnect. Seeded from CwSettingsStore in the
-    // ctor; updated at runtime via SetCwKeyerConfig from the CW settings
-    // endpoint. Default mode 0 (straight) is safe — see zeus-bks.
+    // On-board CW keyer config, forwarded to the connected client and
+    // re-pushed on reconnect. Seeded from CwSettingsStore in the ctor; updated
+    // at runtime via SetCwKeyerConfig from the CW settings endpoint. Default
+    // mode 0 (straight) is safe — see zeus-bks.
+    //   P1: speed + mode go to C&C register 0x0B (already wired).
+    //   P2: speed + mode + sidetone arm the radio's internal keyer via the
+    //       TxSpecific packet — issue #1032. Sidetone freq/gain are cached
+    //       here too so the P2 keyer's radio-generated sidetone tracks the
+    //       operator's CW pitch/level.
     private int _cwKeyerWpm;
     private int _cwKeyerMode;
+    private int _cwSidetoneHz = CwSettingsStore.DefaultSidetoneHz;
+    private double _cwSidetoneGainDb = CwSettingsStore.DefaultSidetoneGainDb;
     // Independent TUN drive %. When TUN is keyed, the recompute uses this in
     // place of _drivePct so the operator can pre-set a lower tune level (and
     // the same per-band PA gain gives equal watts at equal percentages). piHPSDR
@@ -413,6 +420,8 @@ public sealed class RadioService : IDisposable
             var cw = cwSettingsStore.Get();
             Volatile.Write(ref _cwKeyerWpm, cw.Wpm);
             Volatile.Write(ref _cwKeyerMode, (int)cw.KeyerMode);
+            _cwSidetoneHz = cw.SidetoneHz;
+            _cwSidetoneGainDb = cw.SidetoneGainDb;
         }
 
         // Load persisted DSP settings from the store, or use defaults if not found
@@ -1879,7 +1888,15 @@ public sealed class RadioService : IDisposable
         // needs the new tuning before the next IQ block arrives. P2 is
         // pushed via DspPipelineService.OnRadioStateChanged.
         if (!targetBAtSet)
+        {
             ActiveClient?.SetVfoAHz(CwOffset.EffectiveLoHz(mode, newVfoAHz));
+            // Entering/leaving CW toggles the P2 internal keyer (TxSpecific
+            // byte-5 CW-select). Re-push so a paddle keys the radio the moment
+            // the operator is in CW, and the bit clears on the way back to
+            // SSB/AM/FM. P1's keyer is mode-agnostic (always-on in CW via the
+            // 0x0B rotation) so this is a no-op there. Issue #1032.
+            PushCwToP2();
+        }
 
         return Snapshot();
     }
@@ -2681,17 +2698,98 @@ public sealed class RadioService : IDisposable
     }
 
     /// <summary>
-    /// Forward the on-board CW keyer config (speed + mode) to the connected
-    /// radio's C&amp;C register 0x0B, and remember it so a reconnect re-applies
-    /// it. Called by the CW settings endpoint whenever the operator changes
-    /// WPM or keyer mode. No-op (cached only) when no radio is connected.
-    /// See zeus-bks.
+    /// Forward the on-board CW keyer config to the connected radio and
+    /// remember it so a reconnect re-applies it. Called by the CW settings
+    /// endpoint whenever the operator changes WPM, keyer mode, or sidetone.
+    /// No-op (cached only) when no radio is connected. See zeus-bks.
+    /// <list type="bullet">
+    /// <item>P1: speed + mode go to C&amp;C register 0x0B (already wired).</item>
+    /// <item>P2: speed + mode + sidetone arm the radio's internal keyer via
+    /// the TxSpecific packet so a paddle on the rear KEY jack keys the
+    /// transmitter — issue #1032.</item>
+    /// </list>
     /// </summary>
-    public void SetCwKeyerConfig(int wpm, CwKeyerMode mode)
+    public void SetCwKeyerConfig(int wpm, CwKeyerMode mode, int sidetoneHz, double sidetoneGainDb)
     {
         Volatile.Write(ref _cwKeyerWpm, wpm);
         Volatile.Write(ref _cwKeyerMode, (int)mode);
+        lock (_sync) { _cwSidetoneHz = sidetoneHz; _cwSidetoneGainDb = sidetoneGainDb; }
         ActiveClient?.SetCwKeyerConfig(wpm, mode);
+        PushCwToP2();
+    }
+
+    // 1 while a host-driven CW source (CwEngine / MoxSource.Cwx — keyboard,
+    // macros, TCI/CAT keying) is keying. The P2 internal (FPGA) keyer must NOT
+    // be armed at the same time: doing so would put two T/R masters on the air
+    // (host MOX + carrier IQ vs. the gateware self-keying with break-in). This
+    // mirrors pihpsdr, which only arms the internal keyer when
+    // !CAT_cw && !MIDI_cw (new_protocol.c:1463-1465). Gating on the host CW
+    // source (not host MOX) is deliberate: a paddle-driven internal-keyer TX
+    // can raise host MOX via an opt-in PTT-IN→MOX setting, and gating on MOX
+    // there would oscillate (disarm→drop→re-arm). Volatile int for lock-free
+    // cross-thread reads in PushCwToP2.
+    private int _hostCwKeying;
+
+    /// <summary>
+    /// Mark the host CW sender (CwEngine, <see cref="MoxSource.Cwx"/>) as
+    /// keying or idle. While keying, the Protocol-2 internal keyer is disarmed
+    /// (TxSpecific byte-5 cleared) so host-keyed and FPGA-keyed CW are mutually
+    /// exclusive — the pihpsdr model. Re-pushes immediately so the arm state
+    /// tracks the host sender edge. No-op on P1 (no <c>_p2Client</c>).
+    /// </summary>
+    public void SetHostCwKeying(bool active)
+    {
+        Volatile.Write(ref _hostCwKeying, active ? 1 : 0);
+        PushCwToP2();
+    }
+
+    /// <summary>
+    /// Map the operator's CW sidetone gain (dB) onto the Protocol-2 radio
+    /// sidetone level (0-127, TxSpecific byte 6). A muted sidetone (gain at or
+    /// below the floor) sends level 0, which clears the sidetone bit.
+    /// </summary>
+    private static byte CwSidetoneLevelFromGainDb(double gainDb)
+    {
+        if (gainDb <= -60.0) return 0;
+        double level = 100.0 * Math.Pow(10.0, gainDb / 20.0);
+        return (byte)Math.Clamp((int)Math.Round(level), 0, 127);
+    }
+
+    /// <summary>
+    /// Push the internal-keyer config to the Protocol-2 client (no-op on P1,
+    /// whose keyer is driven via <c>ActiveClient</c>). The radio's internal
+    /// keyer is armed only in CW mode (byte-5 bit-1), so this is called on
+    /// connect, on a CW-settings change, and on every mode change so byte 5
+    /// toggles as the operator enters/leaves CW.
+    /// </summary>
+    private void PushCwToP2()
+    {
+        var p2 = _p2Client;
+        if (p2 is null) return;
+        // Snapshot mode + sidetone together under the one lock — the sidetone
+        // fields are non-atomic (double) and written from the settings thread,
+        // so reading them lock-free would risk a torn value on 32-bit ARM (Pi).
+        RxMode mode;
+        int sidetoneHz;
+        double sidetoneGainDb;
+        lock (_sync)
+        {
+            mode = _state.Mode;
+            sidetoneHz = _cwSidetoneHz;
+            sidetoneGainDb = _cwSidetoneGainDb;
+        }
+        // Arm only in CW mode AND when the host CW sender is idle (see
+        // SetHostCwKeying) — never two T/R masters at once.
+        bool active = mode is RxMode.CWU or RxMode.CWL
+            && Volatile.Read(ref _hostCwKeying) == 0;
+        p2.SetCwKeyerConfig(new Zeus.Protocol2.CwKeyerWireConfig
+        {
+            Active = active,
+            Mode = (CwKeyerMode)Volatile.Read(ref _cwKeyerMode),
+            SpeedWpm = Volatile.Read(ref _cwKeyerWpm),
+            SidetoneHz = sidetoneHz,
+            SidetoneLevel = CwSidetoneLevelFromGainDb(sidetoneGainDb),
+        });
     }
 
     // Independent TUN drive %. Applies on the very next frame if TUN is already
@@ -3939,6 +4037,11 @@ public sealed class RadioService : IDisposable
         // operator sees realistic numbers when they open the PA panel.
         RecomputePaAndPush();
         ApplyG2AdcOptionsToP2Client(client, ConnectedBoardKind);
+        // Arm the internal CW keyer with the operator's persisted WPM / mode /
+        // sidetone so a paddle on the rear KEY jack works on first connect
+        // without touching the CW panel — mirrors the P1 connect push. Byte-5
+        // CW-select only actually engages once the radio is in CW mode. #1032.
+        PushCwToP2();
         // Fire AFTER the state mutation + PA recompute so subscribers see a
         // fully-coherent RadioService when they read board kind / snapshot.
         if (client is not null) P2Connected?.Invoke(client);

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -1925,11 +1925,12 @@ public static class ZeusEndpoints
             var snapshot = store.Save(req);
             sidetone.SetPitchHz(snapshot.SidetoneHz);
             sidetone.SetGainDb(snapshot.SidetoneGainDb);
-            // Forward keyer speed (WPM) + mode to the radio's on-board iambic
-            // keyer (C&C 0x0B) so a paddle keys at the panel speed. No-op when
-            // no radio is connected (the value is cached + re-pushed on the
-            // next connect). See zeus-bks.
-            radio.SetCwKeyerConfig(snapshot.Wpm, snapshot.KeyerMode);
+            // Forward keyer speed (WPM) + mode + sidetone to the radio's
+            // on-board iambic keyer so a paddle keys at the panel speed:
+            // P1 → C&C 0x0B; P2 → TxSpecific internal-keyer arm (#1032). No-op
+            // when no radio is connected (cached + re-pushed on the next
+            // connect). See zeus-bks.
+            radio.SetCwKeyerConfig(snapshot.Wpm, snapshot.KeyerMode, snapshot.SidetoneHz, snapshot.SidetoneGainDb);
             return Results.Ok(snapshot);
         });
 

--- a/tests/Zeus.Protocol2.Tests/CmdTxCwKeyerTests.cs
+++ b/tests/Zeus.Protocol2.Tests/CmdTxCwKeyerTests.cs
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Zeus.Contracts;
+
+namespace Zeus.Protocol2.Tests;
+
+/// <summary>
+/// GOLDEN-BYTE tests for the Protocol-2 internal (FPGA) CW keyer — issue
+/// #1032. The TxSpecific (CmdTx, port 1026) packet carries the CW config that
+/// arms the radio's own keyer so a physical key/paddle on the rear KEY jack
+/// keys the transmitter. Byte map verified against pihpsdr new_protocol.c
+/// new_protocol_tx_specific (transmit_specific_buffer[5..17]) and the OpenHPSDR
+/// Ethernet Protocol v4.4 "Transmitter Specific" packet (pp.29-30):
+///   byte 5    = CW mode_control bitfield
+///   byte 6    = sidetone level (0-127)
+///   bytes 7-8 = sidetone frequency (Hz, big-endian)
+///   byte 9    = keyer speed (WPM)
+///   byte 10   = keyer weight
+///   bytes 11-12 = hang delay (ms, big-endian)
+///   byte 13   = RF (key-down) delay (ms, clamped to 900/WPM)
+///   byte 17   = CW envelope ramp (ms)
+///
+/// DEFAULT-UNSENT: with CW inactive, every CW byte stays 0 — so a non-CW
+/// (SSB/AM/FM/DIG) transmit is byte-identical to the pre-feature emission.
+/// </summary>
+public class CmdTxCwKeyerTests
+{
+    private static byte[] Compose(CwKeyerWireConfig cw) =>
+        Protocol2Client.ComposeCmdTxBuffer(
+            seq: 1, sampleRateKhz: 48, txStepAttnDb: 0, paEnabled: true, psEnabled: false,
+            micControl: 0, lineInGain: 0, cw: cw);
+
+    private static CwKeyerWireConfig ActiveCw(
+        CwKeyerMode mode = CwKeyerMode.Straight, int wpm = 22, int sidetoneHz = 600, byte level = 0) =>
+        new() { Active = true, Mode = mode, SpeedWpm = wpm, SidetoneHz = sidetoneHz, SidetoneLevel = level };
+
+    // ---- mode_control byte-5 bit positions are locked to the wire spec ----
+
+    [Fact]
+    public void CwModeBitConstants_MatchWireSpec()
+    {
+        Assert.Equal((byte)0x02, Protocol2Client.CwModeCwSelected);
+        Assert.Equal((byte)0x04, Protocol2Client.CwModeReverse);
+        Assert.Equal((byte)0x08, Protocol2Client.CwModeIambic);
+        Assert.Equal((byte)0x10, Protocol2Client.CwModeSidetone);
+        Assert.Equal((byte)0x20, Protocol2Client.CwModeModeB);
+        Assert.Equal((byte)0x40, Protocol2Client.CwModeStrictSpacing);
+        Assert.Equal((byte)0x80, Protocol2Client.CwModeBreakIn);
+    }
+
+    [Theory]
+    // Straight key, no sidetone: CW-selected (0x02) + break-in (0x80) = 0x82.
+    [InlineData(CwKeyerMode.Straight, (byte)0,  (byte)0x82)]
+    // Straight key, sidetone on: + sidetone bit (0x10) = 0x92.
+    [InlineData(CwKeyerMode.Straight, (byte)40, (byte)0x92)]
+    // Iambic A: + iambic (0x08) = 0x8A.
+    [InlineData(CwKeyerMode.IambicA,  (byte)0,  (byte)0x8A)]
+    // Iambic B: + iambic (0x08) + Mode B (0x20) = 0xAA.
+    [InlineData(CwKeyerMode.IambicB,  (byte)0,  (byte)0xAA)]
+    public void CmdTx_CwActive_Byte5_ModeControlIsLocked(CwKeyerMode mode, byte level, byte expected)
+    {
+        var p = Compose(ActiveCw(mode: mode, level: level));
+        Assert.Equal(expected, p[5]);
+    }
+
+    [Fact]
+    public void CmdTx_CwActive_SidetoneFreqIsBigEndian_AndLevelInByte6()
+    {
+        var p = Compose(ActiveCw(sidetoneHz: 700, level: 64));
+        Assert.Equal((byte)64, p[6]);                 // level
+        Assert.Equal((byte)(700 >> 8), p[7]);         // freq high (BE)
+        Assert.Equal((byte)(700 & 0xFF), p[8]);       // freq low
+        Assert.Equal(700, (p[7] << 8) | p[8]);
+    }
+
+    [Theory]
+    [InlineData(5)]
+    [InlineData(22)]
+    [InlineData(60)]
+    public void CmdTx_CwActive_WpmInByte9_WeightHangRampPinned(int wpm)
+    {
+        var p = Compose(ActiveCw(wpm: wpm));
+        Assert.Equal((byte)wpm, p[9]);                // keyer speed
+        Assert.Equal((byte)50, p[10]);                // weight pinned 50%
+        Assert.Equal(300, (p[11] << 8) | p[12]);      // hang delay BE, 300 ms
+        Assert.Equal((byte)9, p[17]);                 // ramp pinned 9 ms (Thetis)
+        // RF delay = min(8, 900/wpm); 900/wpm >= 15 for wpm<=60, so always 8.
+        Assert.Equal((byte)Math.Min(8, 900 / wpm), p[13]);
+    }
+
+    [Fact]
+    public void CmdTx_CwActive_WpmIsClampedTo_1_60()
+    {
+        Assert.Equal((byte)1, Compose(ActiveCw(wpm: 0))[9]);    // clamp low
+        Assert.Equal((byte)60, Compose(ActiveCw(wpm: 200))[9]); // clamp high
+    }
+
+    [Fact]
+    public void CmdTx_CwActive_DoesNotDisturbSampleRate_Audio_OrAttenuatorBytes()
+    {
+        // CW bytes (5-13, 17) are disjoint from sample-rate (14-15), audio
+        // (50/51) and step-attenuator (57/58/59) bytes.
+        var p = Protocol2Client.ComposeCmdTxBuffer(
+            seq: 1, sampleRateKhz: 192, txStepAttnDb: 17, paEnabled: true, psEnabled: true,
+            micControl: 0x33, lineInGain: 31, cw: ActiveCw(level: 64));
+        Assert.Equal(192, (p[14] << 8) | p[15]);  // sample rate intact
+        Assert.Equal((byte)0x33, p[50]);          // audio intact
+        Assert.Equal((byte)31, p[51]);
+        Assert.Equal((byte)0, p[57]);             // PS-on atten asymmetry intact
+        Assert.Equal((byte)31, p[58]);
+        Assert.Equal((byte)17, p[59]);
+    }
+
+    // ---- DEFAULT-UNSENT: CW inactive is byte-identical to the pre-feature wire ----
+
+    [Fact]
+    public void CmdTx_CwInactive_AllCwBytesAreZero()
+    {
+        var p = Compose(CwKeyerWireConfig.Inactive);
+        foreach (var i in new[] { 5, 6, 7, 8, 9, 10, 11, 12, 13, 17 })
+            Assert.Equal((byte)0, p[i]);
+    }
+
+    [Fact]
+    public void CmdTx_NotActive_SuppressesAllCwBytes_EvenWithConfigPopulated()
+    {
+        // The arm gate (RadioService: CW mode AND host-CW idle) lands here as
+        // Active=false. When disarmed, a fully-populated keyer config must
+        // still emit zero CW bytes — so a host-keyed CW send (MoxSource.Cwx)
+        // or a non-CW mode can never leave the FPGA keyer armed on the wire.
+        var p = Compose(new CwKeyerWireConfig
+        {
+            Active = false,
+            Mode = CwKeyerMode.IambicB,
+            SpeedWpm = 30,
+            SidetoneHz = 700,
+            SidetoneLevel = 64,
+        });
+        foreach (var i in new[] { 5, 6, 7, 8, 9, 10, 11, 12, 13, 17 })
+            Assert.Equal((byte)0, p[i]);
+    }
+
+    [Theory]
+    [InlineData(false, false)] // PS off
+    [InlineData(true,  true)]  // PS on + PA
+    public void CmdTx_CwInactive_Is_FullBuffer_ByteIdentical_To_PreFeatureEmission(
+        bool psEnabled, bool paEnabled)
+    {
+        // The pre-feature emission omits the cw arg entirely (default). An
+        // explicit Inactive config must reproduce the whole 60-byte buffer
+        // byte-for-byte — the regression guard that a non-CW transmit is
+        // unchanged on the wire.
+        var baseline = Protocol2Client.ComposeCmdTxBuffer(
+            seq: 7, sampleRateKhz: 48, txStepAttnDb: 19, paEnabled: paEnabled, psEnabled: psEnabled);
+        var cwInactive = Protocol2Client.ComposeCmdTxBuffer(
+            seq: 7, sampleRateKhz: 48, txStepAttnDb: 19, paEnabled: paEnabled, psEnabled: psEnabled,
+            micControl: 0, lineInGain: 0, cw: CwKeyerWireConfig.Inactive);
+
+        Assert.Equal(60, cwInactive.Length);
+        Assert.True(baseline.AsSpan().SequenceEqual(cwInactive),
+            "CW-inactive must reproduce the pre-feature CmdTx buffer byte-for-byte.");
+    }
+}


### PR DESCRIPTION
## What this does

Wires the **CW key jack for Protocol-2 radios** — closing #1032 (G2, front + back KEY jack dead). The jack was never wired on P2: Zeus built the TxSpecific packet (port 1026) but left the CW `mode_control` byte at `0`, so the radio's **internal (FPGA) iambic keyer** was never armed and a paddle/straight key did nothing.

Protocol-1 boards (Hermes, ANAN-10/100/200, Metis, HL2) **already key correctly** via C&C register `0x0B` — I verified that path end-to-end, it's untouched. This PR closes the gap for the **entire P2 family** (OrionMkII `0x0A`: G2 / G2-1K / 7000DLE / 8000DLE / OrionMkII / AnvelinaPro3 / RedPitaya) with one board-agnostic packet — **no per-board math**.

## How

On Protocol 2 the host does **not** key CW — once the keyer is armed, the gateware shapes the dits/dahs, keys the PA, and (with break-in) handles T/R itself. So the fix is to publish the keyer config in the TxSpecific packet:

| Byte | Field | Source |
|---|---|---|
| 5 | mode_control: CW-select `0x02`, iambic `0x08`, Mode-B `0x20`, sidetone `0x10`, break-in `0x80` | gated on CW mode |
| 6 | sidetone level (0-127) | CW sidetone gain |
| 7-8 | sidetone freq (Hz, BE) | CW pitch |
| 9 | keyer speed (WPM) | CW panel |
| 10 | weight (50) | pinned |
| 11-12 | hang (ms, BE) | pinned |
| 13 | RF delay (clamped to `900/WPM`) | pinned (FPGA keyer-bug workaround) |
| 17 | ramp (9 ms) | pinned |

Byte map verified against **pihpsdr `new_protocol_tx_specific`** (Zeus's cited reference) **and** the OpenHPSDR Ethernet Protocol v4.4 spec. `RadioService` pushes the config to the P2 client on connect, on a CW-settings change, and on every mode change (so the keyer arms/disarms as the operator enters/leaves CW).

Reuses the existing CW panel settings (WPM / keyer mode / sidetone). **No new UI, capability flag, or schema change.** Weight / spacing / reverse / break-in / hang / ramp follow Thetis/pihpsdr neutral defaults, mirroring how the P1 path already pins them.

## Safety: two T/R masters avoided

Zeus has its own host-side CW path (`CwEngine` → `MoxSource.Cwx`, keyboard/macros/TCI). Arming the FPGA keyer at the same time would put two transmit masters on the air — exactly what pihpsdr engineers around (`!CAT_cw && !MIDI_cw`). This PR **disarms the internal keyer while the host CW sender is keying** and re-arms when it stops, so host-keyed and paddle-keyed CW are mutually exclusive. (Caught by the self-review; gating on the host CW *source* rather than host MOX is deliberate — a paddle-driven TX can raise MOX via the opt-in PTT-IN→MOX setting, and gating on MOX would oscillate.)

Confirmed **zero PureSignal interaction** — no `PsEnabled` / persistence / arm path touched.

## Tests

Golden wire-format coverage for every CW byte, the mode-bit map, the `900/WPM` clamp, WPM clamp, disjointness from sample-rate/audio/attenuator bytes, and a **full-buffer regression guard** that a non-CW / disarmed transmit is byte-identical to the prior emission. Build clean (0 warnings); Protocol2 + Server suites green.

## 🚩 Bench validation before merge

This touches real-RF keying — confirm on the G2 before merging:

1. **Break-in defaults ON.** Load-bearing — without it the radio won't switch to TX on key-down, so the jack stays silent (the original bug). But "always full/semi break-in in CW" is an operator-felt TX default → **wants your/Brian's sign-off**, and a break-in mode control (off/semi/full + hang) is the natural follow-up (the hang field is already on the wire).
2. **Sidetone routing.** The radio generates its own CW sidetone (byte 6). Confirm it's audible/at a sane level through Zeus's host-audio path; if not, a host-side sidetone follow-up off the key-down status is the fix.
3. **Amp / SWR during internal CW.** Because the host never raises MOX for FPGA CW, Zeus's MOX-gated interlocks (auto-ATT, PS, SWR/RF2K-S protection) are blind during paddle TX (same as pihpsdr). Confirm the RF2K-S keys off its own RF sensing and protection behaves.
4. **Held-key + disconnect.** With break-in + a held key, pulling the network relies on the radio's P2 watchdog to drop TX — confirm it does.
5. **QSK RX-mute** during radio-side CW TX is not wired (out of scope; follow-up).

Closes #1032 on merge.
