### PR TITLE
feat: wire RX speaker audio to Protocol-1 radio codecs

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -2013,6 +2013,19 @@ public sealed record AudioFrontEndSetRequest(
     bool MicBias,
     int LineInGain);
 
+// Radio-side speaker output (Protocol-1 codec radios). Whether to send
+// demodulated RX audio down the EP2 frame's L/R slots so the radio's onboard
+// codec drives its speaker/headphone/line-out jacks. <c>Available</c> is true
+// only while a P1 codec radio (not the codec-less HL2) is connected; the toggle
+// is otherwise inert. The Protocol-2 Saturn/G2 appliance speaker path is
+// separate and is NOT governed by this setting.
+public sealed record RadioSpeakerOutputDto(
+    bool Enabled,
+    bool Available);
+
+public sealed record RadioSpeakerOutputSetRequest(
+    bool Enabled);
+
 // HL2-specific optional toggles surfaced via /api/radio/hl2-options.
 // Shape is an object (not a bare bool) so future mi0bot HL2 toggles can
 // slot in without breaking the contract. Currently carries Band Volts

--- a/Zeus.Protocol1/ControlFrame.cs
+++ b/Zeus.Protocol1/ControlFrame.cs
@@ -732,7 +732,8 @@ internal static class ControlFrame
         CcRegister evenRegister,
         CcRegister oddRegister,
         in CcState state,
-        ITxIqSource? iqSource = null)
+        ITxIqSource? iqSource = null,
+        IRxAudioSource? rxAudioSource = null)
     {
         if (packet.Length != PacketLength)
             throw new ArgumentException("packet span must be 1032 bytes", nameof(packet));
@@ -746,8 +747,8 @@ internal static class ControlFrame
         packet[3] = 0x02;
         BinaryPrimitives.WriteUInt32BigEndian(packet[4..8], sendSequence);
 
-        WriteUsbFrame(packet.Slice(8, UsbFrameLength), evenRegister, in state, iqSource);
-        WriteUsbFrame(packet.Slice(8 + UsbFrameLength, UsbFrameLength), oddRegister, in state, iqSource);
+        WriteUsbFrame(packet.Slice(8, UsbFrameLength), evenRegister, in state, iqSource, rxAudioSource);
+        WriteUsbFrame(packet.Slice(8 + UsbFrameLength, UsbFrameLength), oddRegister, in state, iqSource, rxAudioSource);
     }
 
     /// <summary>
@@ -766,7 +767,7 @@ internal static class ControlFrame
     /// <summary>Number of IQ samples per 504-byte EP2 USB-frame payload (63 × 8 bytes).</summary>
     internal const int IqSamplesPerUsbFrame = 63;
 
-    private static void WriteUsbFrame(Span<byte> frame, CcRegister register, in CcState state, ITxIqSource? source)
+    private static void WriteUsbFrame(Span<byte> frame, CcRegister register, in CcState state, ITxIqSource? source, IRxAudioSource? rxAudioSource = null)
     {
         frame[0] = 0x7F;
         frame[1] = 0x7F;
@@ -793,11 +794,22 @@ internal static class ControlFrame
         // is identical across all Protocol-1 boards (HL2, Hermes, ANAN-class,
         // Orion-MkII). PA enable is driven by the C0 MOX bit + board-specific
         // DriveFilter C2 bits in WriteCcBytes — see issue #294.
-        if (source is null || !state.Mox)
+        if (!state.Mox)
         {
-            // frame[8..] was cleared by BuildDataPacket; leave zero.
+            // RX: the radio is not transmitting, so the EP2 I/Q slots stay zero
+            // (no carrier) and the L/R slots may carry demodulated RX audio so
+            // the radio's onboard codec drives its speaker/headphone/line-out
+            // jacks (faithful to Thetis, which sends RX audio inline on EP2).
+            // When no RX-audio source is plumbed, or the ring is empty, the L/R
+            // slots stay zero — byte-identical to a radio that carries no audio.
+            // HL2 has no codec and ignores L/R; the host simply never feeds the
+            // ring for it, so this branch leaves the frame all-zero there too.
+            if (rxAudioSource is not null) WriteRxAudioLr(frame[8..], rxAudioSource);
             return;
         }
+
+        // From here MOX is engaged; the TX I/Q path needs a real source.
+        if (source is null) return;
 
         // The HL2's TXG stage (DriveFilter C1 = DriveLevel byte) scales the
         // transmit path by drive%. Scaling IQ here on top would double-multiply
@@ -836,6 +848,32 @@ internal static class ControlFrame
         LastMeanAbs = (int)(sumAbs / (2 * IqSamplesPerUsbFrame));
         LastFirstI = firstI;
         LastFirstQ = firstQ;
+    }
+
+    /// <summary>
+    /// Fill the L/R audio slots (bytes 0..3 of each 8-byte group) of one EP2
+    /// USB-frame payload from the RX-audio source, leaving the I/Q slots (4..7)
+    /// untouched. The mono sample is written to BOTH the left and right channels
+    /// as big-endian s16: duplicating mono sidesteps the per-board hardware L/R
+    /// swap entirely (both channels carry identical audio), exactly as the
+    /// Saturn/G2 P2 speaker sink already does. On underrun the source returns
+    /// fewer samples than requested and the remaining groups keep their cleared
+    /// (zero) L/R, which is silence rather than wrap noise.
+    /// </summary>
+    private static void WriteRxAudioLr(Span<byte> payload, IRxAudioSource rxAudioSource)
+    {
+        Span<short> mono = stackalloc short[IqSamplesPerUsbFrame];
+        int n = rxAudioSource.Read(mono);
+        for (int s = 0; s < n; s++)
+        {
+            int off = s * 8;
+            byte hi = (byte)((mono[s] >> 8) & 0xFF);
+            byte lo = (byte)(mono[s] & 0xFF);
+            payload[off + 0] = hi;   // L high byte
+            payload[off + 1] = lo;   // L low byte
+            payload[off + 2] = hi;   // R high byte
+            payload[off + 3] = lo;   // R low byte
+        }
     }
 
     // Diagnostic tap — read by Protocol1Client.TxLoopAsync to log what's

--- a/Zeus.Protocol1/IRxAudioSource.cs
+++ b/Zeus.Protocol1/IRxAudioSource.cs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+namespace Zeus.Protocol1;
+
+/// <summary>
+/// Supplies demodulated RX audio (mono, 48 kHz, s16) for the L/R slots of the
+/// EP2 TX frame so a Protocol-1 radio's onboard codec drives its
+/// speaker/headphone/line-out jacks. The same EP2 frame carries TX I/Q (via
+/// <see cref="ITxIqSource"/>) in its other four bytes; this seam only owns the
+/// two RX-audio channels.
+///
+/// The single concrete source is <see cref="RxAudioRing"/>, fed by the DSP RX
+/// path host-side. Implementations must be safe for a single reader (the
+/// Protocol-1 TX loop); the ring variant handles cross-thread writes from the
+/// audio-publish side.
+/// </summary>
+public interface IRxAudioSource
+{
+    /// <summary>
+    /// Fill <paramref name="dest"/> with up to <c>dest.Length</c> mono s16
+    /// samples and return the count actually written. When the source is empty
+    /// the return value is 0 and <paramref name="dest"/> is left untouched — the
+    /// caller then leaves the L/R slots zero, byte-identical to a radio that
+    /// carries no RX audio at all.
+    /// </summary>
+    int Read(Span<short> dest);
+}

--- a/Zeus.Protocol1/Protocol1Client.cs
+++ b/Zeus.Protocol1/Protocol1Client.cs
@@ -170,11 +170,16 @@ public sealed class Protocol1Client : IProtocol1Client
     // the built-in test-tone when caller wants a bring-up carrier. Default is
     // the tone so legacy callers (tests, tools/zeus-dump) keep working.
     private readonly ITxIqSource _txIqSource;
+    // Optional RX-audio source for the EP2 L/R slots. Null = never carry RX audio
+    // to the radio codec (legacy behaviour). Drained only during RX in
+    // ControlFrame.WriteUsbFrame; see RxAudioRing.
+    private readonly IRxAudioSource? _rxAudioSource;
 
-    public Protocol1Client(ILogger<Protocol1Client>? logger = null, ITxIqSource? iqSource = null)
+    public Protocol1Client(ILogger<Protocol1Client>? logger = null, ITxIqSource? iqSource = null, IRxAudioSource? rxAudioSource = null)
     {
         _log = logger ?? NullLogger<Protocol1Client>.Instance;
         _txIqSource = iqSource ?? new TestToneGenerator();
+        _rxAudioSource = rxAudioSource;
         _channel = Channel.CreateBounded<IqFrame>(new BoundedChannelOptions(DefaultFrameChannelCapacity)
         {
             FullMode = BoundedChannelFullMode.DropOldest,
@@ -1300,7 +1305,7 @@ public sealed class Protocol1Client : IProtocol1Client
                 bool psArmed = state.PsEnabled && state.Board == HpsdrBoardKind.HermesLite2;
                 var (first, second) = PhaseRegisters(phase, state.Mox, psArmed);
                 phase = psArmed ? ((phase + 1) & 0xF) : ((phase + 1) % 5);
-                ControlFrame.BuildDataPacket(buf, sendSeq++, first, second, in state, _txIqSource);
+                ControlFrame.BuildDataPacket(buf, sendSeq++, first, second, in state, _txIqSource, _rxAudioSource);
                 rateWindowPkts++;
                 var nowUtc = DateTime.UtcNow;
                 var elapsed = nowUtc - rateWindowStart;

--- a/Zeus.Protocol1/RxAudioRing.cs
+++ b/Zeus.Protocol1/RxAudioRing.cs
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+namespace Zeus.Protocol1;
+
+/// <summary>
+/// SPSC-ish ring of mono s16 audio samples linking the host-side RX audio
+/// publisher (<c>RadioSpeakerAudioSink</c>, pushes one demodulated 48 kHz
+/// AudioFrame at a time) to the P1 EP2 packer consumer (<see cref="ControlFrame"/>,
+/// pulls 63 samples per USB frame every ~1.5 ms). The mirror image of
+/// <see cref="TxIqRing"/> on the RX-audio half of the same EP2 frame.
+///
+/// Rate shape (both ends nominally 48 kHz):
+///   producer:  one AudioFrame block (typically 512–2048 samples) per DSP tick
+///   consumer:  63 samples per USB frame, 2 frames per EP2 packet, ~381 pkt/s
+/// Producer and consumer are rate-matched at 48 kHz; the ring absorbs the block
+/// vs per-frame granularity mismatch and any scheduler jitter. Drop-oldest on
+/// overflow keeps latency bounded — staleness on the order of the ring depth is
+/// the worst case, and the sink stops feeding on MOX so a transmission never
+/// leaves a stale RX tail to play on unkey.
+///
+/// Reading an empty ring writes nothing and returns 0, so the caller leaves the
+/// L/R slots zero — byte-identical to today's behaviour where Zeus never carried
+/// RX audio. That makes enabling/disabling the feature a strict superset: when
+/// nobody feeds the ring, the wire is unchanged.
+///
+/// Implemented with a plain lock, like <see cref="TxIqRing"/>: the enqueue path
+/// runs a few hundred times a second and the dequeue ~760 times a second, so
+/// contention is negligible and a lock is far simpler to reason about than a
+/// lock-free variant.
+/// </summary>
+public sealed class RxAudioRing : IRxAudioSource
+{
+    // 16384 samples ≈ 340 ms at 48 kHz — matches TxIqRing's depth. Deep enough
+    // to ride out a GC pause or a bursty DSP tick without dropping, shallow
+    // enough that a steady-state backlog never adds audible latency to the
+    // radio-side monitor.
+    public const int DefaultCapacitySamples = 16384;
+
+    private readonly short[] _buf;
+    private readonly int _capacity;
+    private readonly object _gate = new();
+    private int _head;   // write index
+    private int _count;  // number of valid samples
+    private long _totalWritten;
+    private long _totalRead;
+    private long _dropped;
+
+    public RxAudioRing(int capacitySamples = DefaultCapacitySamples)
+    {
+        if (capacitySamples <= 0) throw new ArgumentOutOfRangeException(nameof(capacitySamples));
+        _capacity = capacitySamples;
+        _buf = new short[capacitySamples];
+    }
+
+    public int Capacity => _capacity;
+    public int Count { get { lock (_gate) return _count; } }
+    public long TotalWritten { get { lock (_gate) return _totalWritten; } }
+    public long TotalRead { get { lock (_gate) return _totalRead; } }
+    public long Dropped { get { lock (_gate) return _dropped; } }
+
+    /// <summary>
+    /// Push one block of mono float samples (−1..+1) into the ring, saturating
+    /// to s16. Overflow overwrites the oldest samples (drop-oldest).
+    /// </summary>
+    public void Write(ReadOnlySpan<float> mono)
+    {
+        if (mono.IsEmpty) return;
+
+        lock (_gate)
+        {
+            foreach (float f in mono)
+            {
+                _buf[_head] = ToS16(f);
+                _head = (_head + 1) % _capacity;
+                if (_count < _capacity) _count++;
+                else _dropped++;   // overwrote the oldest
+            }
+            _totalWritten += mono.Length;
+        }
+    }
+
+    /// <summary>
+    /// Drain up to <c>dest.Length</c> oldest samples into <paramref name="dest"/>.
+    /// Returns the count written; the remainder of <paramref name="dest"/> is
+    /// left untouched. Returns 0 when empty.
+    /// </summary>
+    public int Read(Span<short> dest)
+    {
+        if (dest.IsEmpty) return 0;
+
+        lock (_gate)
+        {
+            int n = Math.Min(dest.Length, _count);
+            int tail = (_head - _count + _capacity) % _capacity;
+            for (int k = 0; k < n; k++)
+            {
+                dest[k] = _buf[tail];
+                tail = (tail + 1) % _capacity;
+            }
+            _count -= n;
+            _totalRead += n;
+            return n;
+        }
+    }
+
+    /// <summary>
+    /// Drop all buffered samples. Called when a P1 session ends or the feature
+    /// is toggled off so a later RX never replays a stale tail.
+    /// </summary>
+    public void Clear()
+    {
+        lock (_gate)
+        {
+            _count = 0;
+            _head = 0;
+        }
+    }
+
+    private static short ToS16(float v)
+    {
+        if (!float.IsFinite(v)) return 0;
+        float clamped = v;
+        if (clamped > 1.0f) clamped = 1.0f;
+        else if (clamped < -1.0f) clamped = -1.0f;
+        return (short)Math.Round(clamped * short.MaxValue);
+    }
+}

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -356,13 +356,19 @@ public sealed class RadioService : IDisposable
     // to its internal test-tone generator (dev / tests without a hub).
     private readonly Zeus.Protocol1.ITxIqSource? _txIqSource;
 
+    // Optional RX-audio source for the Protocol-1 EP2 L/R slots (radio-codec
+    // speaker output). Drained by Protocol1Client during RX; fed host-side by
+    // RadioSpeakerAudioSink. Null in tests / hosts without the feature wired,
+    // in which case P1 frames carry no RX audio (legacy behaviour).
+    private readonly Zeus.Protocol1.IRxAudioSource? _rxAudioSource;
+
     // Optional non-hardware KiwiSDR slice receiver. When present its entry is
     // appended to the projected receiver list (reserved index
     // WireContract.KiwiReceiverIndex) and a change re-broadcasts state. Null in
     // tests / hosts without the Kiwi feature wired.
     private readonly IKiwiReceiverProvider? _kiwiReceiverProvider;
 
-    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, FilterPresetStore? filterPresetStore = null, Zeus.Protocol1.ITxIqSource? txIqSource = null, PreferredRadioStore? preferredRadioStore = null, PsSettingsStore? psStore = null, RadioStateStore? radioStateStore = null, CwSettingsStore? cwSettingsStore = null, TxAudioProfileStore? txAudioProfileStore = null, AntennaSettingsStore? antennaStore = null, AudioSettingsStore? audioStore = null, Nr3ModelStore? nr3ModelStore = null, Hl2GpioSettingsStore? hl2GpioStore = null, BandMemoryStore? bandMemoryStore = null, IKiwiReceiverProvider? kiwiReceiverProvider = null)
+    public RadioService(ILoggerFactory loggerFactory, DspSettingsStore dspSettingsStore, PaSettingsStore paStore, FilterPresetStore? filterPresetStore = null, Zeus.Protocol1.ITxIqSource? txIqSource = null, PreferredRadioStore? preferredRadioStore = null, PsSettingsStore? psStore = null, RadioStateStore? radioStateStore = null, CwSettingsStore? cwSettingsStore = null, TxAudioProfileStore? txAudioProfileStore = null, AntennaSettingsStore? antennaStore = null, AudioSettingsStore? audioStore = null, Nr3ModelStore? nr3ModelStore = null, Hl2GpioSettingsStore? hl2GpioStore = null, BandMemoryStore? bandMemoryStore = null, IKiwiReceiverProvider? kiwiReceiverProvider = null, Zeus.Protocol1.IRxAudioSource? rxAudioSource = null)
     {
         _loggerFactory = loggerFactory;
         _log = loggerFactory.CreateLogger<RadioService>();
@@ -403,6 +409,7 @@ public sealed class RadioService : IDisposable
         if (_kiwiReceiverProvider is not null)
             _kiwiReceiverProvider.KiwiReceiverChanged += () => StateChanged?.Invoke(Snapshot());
         _txIqSource = txIqSource;
+        _rxAudioSource = rxAudioSource;
         // Seed the on-board CW keyer config from persisted settings so a
         // reconnect after restart re-applies the operator's mode/speed
         // before they touch the panel — otherwise a paddle op who saved
@@ -800,6 +807,23 @@ public sealed class RadioService : IDisposable
         get { lock (_sync) return _activeClient is not null || _p2Active; }
     }
 
+    /// <summary>True while a Protocol-1 client owns the connection — i.e. the
+    /// EP2 TX loop (and its RX-audio L/R slots) is live. RadioSpeakerAudioSink
+    /// gates on this so it only feeds the P1 RxAudioRing when something will
+    /// actually drain it.</summary>
+    internal bool IsProtocol1Active
+    {
+        get { lock (_sync) return _activeClient is not null; }
+    }
+
+    /// <summary>Cheap MOX accessor (no Receivers projection, unlike Snapshot).
+    /// Used on the per-AudioFrame path to skip feeding RX audio to the radio
+    /// codec while transmitting.</summary>
+    internal bool IsMox
+    {
+        get { lock (_sync) return _mox; }
+    }
+
     public StateDto Snapshot() { lock (_sync) return _state with { Receivers = ProjectReceivers(_state), MaxReceivers = EffectiveMaxReceivers }; }
 
     /// <summary>Current operator preamp toggle. PreampOn isn't on the
@@ -904,9 +928,13 @@ public sealed class RadioService : IDisposable
             if (_activeClient is not null)
                 throw new InvalidOperationException("Already connected. Disconnect first.");
 
+            // Drop any RX-audio buffered from a previous session so a fresh
+            // P1 connect starts from silence rather than replaying a stale tail.
+            (_rxAudioSource as Zeus.Protocol1.RxAudioRing)?.Clear();
             client = new Protocol1Client(
                 _loggerFactory.CreateLogger<Protocol1Client>(),
-                _txIqSource);
+                _txIqSource,
+                _rxAudioSource);
             client.AdcOverloadObserved += OnAdcOverload;
             client.Disconnected += OnClientDisconnected;
             _activeClient = client;

--- a/Zeus.Server.Hosting/RadioSpeakerAudioSink.cs
+++ b/Zeus.Server.Hosting/RadioSpeakerAudioSink.cs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Zeus.Contracts;
+using Zeus.Protocol1;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Feeds demodulated RX audio into the Protocol-1 <see cref="RxAudioRing"/> so a
+/// connected P1 radio's onboard codec drives its speaker / headphone / line-out
+/// jacks. The ring is drained by <c>Protocol1Client</c>'s EP2 TX loop and packed
+/// into the L/R slots of the frame it already sends continuously — no extra
+/// socket, no platform gate. Works in every host mode and on every OS.
+///
+/// This is the Protocol-1 counterpart to <see cref="SaturnSpeakerAudioSink"/>,
+/// which owns the Protocol-2 (Saturn/G2 appliance) speaker path. The two are
+/// mutually exclusive at runtime: a P1 radio has no Saturn endpoint, and a P2
+/// radio has no <c>RxAudioRing</c> consumer. This sink never touches P2.
+///
+/// Gating (all must hold, re-checked per frame so a mid-session toggle or MOX
+/// transition takes effect immediately):
+///   • operator opted in (RadioSpeakerSettingsStore.Enabled, default off)
+///   • a Protocol-1 client is connected (so the ring is actually drained)
+///   • the board has an onboard codec and is not the codec-less HL2
+///   • not transmitting (don't push TX-monitor audio to the radio speaker)
+///   • the frame is the expected 48 kHz mono RX audio
+/// When any check fails the frame is dropped and the ring is left to drain to
+/// silence, so the wire reverts to byte-identical "no RX audio" behaviour.
+/// </summary>
+public sealed class RadioSpeakerAudioSink : IRxAudioSink, IDisposable
+{
+    private const uint ExpectedSampleRateHz = 48_000;
+
+    private readonly RadioService _radio;
+    private readonly RxAudioRing _ring;
+    private readonly RadioSpeakerSettingsStore _settings;
+
+    public RadioSpeakerAudioSink(RadioService radio, RxAudioRing ring, RadioSpeakerSettingsStore settings)
+    {
+        _radio = radio;
+        _ring = ring;
+        _settings = settings;
+        // Drop any buffered tail when the operator turns the feature off so a
+        // later re-enable starts clean rather than replaying stale audio.
+        _settings.Changed += OnSettingsChanged;
+    }
+
+    /// <summary>True when this sink would currently forward RX audio to the
+    /// radio codec for the connected board. Surfaced via /api/radio/speaker-output
+    /// so the UI can show the toggle only where it does something.</summary>
+    public bool AvailableForConnectedBoard()
+    {
+        if (!_radio.IsProtocol1Active) return false;
+        var board = _radio.ConnectedBoardKind;
+        if (board == HpsdrBoardKind.HermesLite2) return false;
+        return BoardCapabilitiesTable.For(board, _radio.EffectiveOrionMkIIVariant).HasOnboardCodec;
+    }
+
+    public void Publish(in AudioFrame frame)
+    {
+        if (frame.Channels != 1 || frame.SampleRateHz != ExpectedSampleRateHz) return;
+        if (!_settings.Enabled) return;
+        if (_radio.IsMox)
+        {
+            // While transmitting, the EP2 L/R slots carry no audio (WriteUsbFrame
+            // only fills them during RX) and the TX-monitor frames arriving here
+            // are not for the radio speaker. Drop the buffer so unkey resumes from
+            // live RX rather than replaying the pre-key tail still in the ring.
+            _ring.Clear();
+            return;
+        }
+        if (!AvailableForConnectedBoard()) return;
+
+        _ring.Write(frame.Samples.Span);
+    }
+
+    private void OnSettingsChanged()
+    {
+        if (!_settings.Enabled) _ring.Clear();
+    }
+
+    public void Dispose() => _settings.Changed -= OnSettingsChanged;
+}

--- a/Zeus.Server.Hosting/RadioSpeakerSettingsStore.cs
+++ b/Zeus.Server.Hosting/RadioSpeakerSettingsStore.cs
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using LiteDB;
+
+namespace Zeus.Server;
+
+// Persists the single "send RX audio to the radio's onboard speaker/headphone
+// jacks" toggle for Protocol-1 codec radios (Hermes, ANAN-10/10E/100/100B,
+// ANAN-100D/200D, Orion). The Saturn/G2 appliance speaker path (Protocol-2,
+// SaturnSpeakerAudioSink) is independent and is NOT governed by this setting.
+//
+// Default is OFF (opt-in). Zeus already plays RX audio host-side (browser /
+// native sink); auto-enabling the radio-side codec output would make every P1
+// operator hear doubled audio on connect. Operators who want the radio's own
+// speaker turn it on explicitly, and the choice survives a backend restart.
+// Lives in the same zeus-prefs.db as the other settings stores.
+public sealed class RadioSpeakerSettingsStore : IDisposable
+{
+    public const bool DefaultEnabled = false;
+
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<RadioSpeakerSettingsEntry> _docs;
+    private readonly ILogger<RadioSpeakerSettingsStore> _log;
+    private readonly object _sync = new();
+    private bool _cacheLoaded;
+    private bool _cachedEnabled = DefaultEnabled;
+
+    /// <summary>Raised after <see cref="Set"/> changes the stored value.</summary>
+    public event Action? Changed;
+
+    public RadioSpeakerSettingsStore(ILogger<RadioSpeakerSettingsStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _docs = _db.GetCollection<RadioSpeakerSettingsEntry>("radio_speaker_settings");
+
+        _log.LogInformation("RadioSpeakerSettingsStore initialized at {Path}", dbPath);
+    }
+
+    /// <summary>Current toggle state. Cheap (in-memory cache after first read).</summary>
+    public bool Enabled
+    {
+        get
+        {
+            lock (_sync)
+            {
+                EnsureCacheLocked();
+                return _cachedEnabled;
+            }
+        }
+    }
+
+    public void Set(bool enabled)
+    {
+        bool changed;
+        lock (_sync)
+        {
+            EnsureCacheLocked();
+            changed = _cachedEnabled != enabled;
+
+            var e = _docs.FindAll().FirstOrDefault() ?? new RadioSpeakerSettingsEntry();
+            e.Enabled = enabled;
+            e.UpdatedUtc = DateTime.UtcNow;
+            if (e.Id == 0) _docs.Insert(e);
+            else _docs.Update(e);
+
+            _cachedEnabled = enabled;
+            _cacheLoaded = true;
+        }
+
+        if (changed) Changed?.Invoke();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private void EnsureCacheLocked()
+    {
+        if (_cacheLoaded) return;
+        // A fresh / pre-feature DB has no row — fall back to the safe default OFF.
+        _cachedEnabled = _docs.FindAll().FirstOrDefault()?.Enabled ?? DefaultEnabled;
+        _cacheLoaded = true;
+    }
+}
+
+public sealed class RadioSpeakerSettingsEntry
+{
+    public int Id { get; set; }
+    public bool Enabled { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -2826,6 +2826,32 @@ public static class ZeusEndpoints
                 resolved.LineInGain));
         });
 
+        // Radio-side speaker output (Protocol-1 codec radios). GET reports the
+        // persisted opt-in plus whether it's currently effective for the connected
+        // board (a P1 codec radio, not the codec-less HL2, and not a P2 board —
+        // the Saturn/G2 appliance speaker path is independent). The frontend
+        // refetches this on connect to hydrate the toggle without touching the
+        // StateDto wire format.
+        app.MapGet("/api/radio/speaker-output", (RadioSpeakerSettingsStore store, RadioSpeakerAudioSink sink) =>
+            Results.Ok(new RadioSpeakerOutputDto(
+                Enabled: store.Enabled,
+                Available: sink.AvailableForConnectedBoard())));
+
+        // PUT the opt-in. Persisted globally; the store's Changed event clears the
+        // RX-audio ring when turned off so a later RX never replays a stale tail.
+        // The sink self-gates per frame (board + MOX + mono/48k), so the toggle is
+        // safe to flip at any time, including mid-session.
+        app.MapPut("/api/radio/speaker-output", (RadioSpeakerOutputSetRequest req, RadioSpeakerSettingsStore store, RadioSpeakerAudioSink sink) =>
+        {
+            if (req is null)
+                return Results.BadRequest(new { error = "body required" });
+
+            store.Set(req.Enabled);
+            return Results.Ok(new RadioSpeakerOutputDto(
+                Enabled: store.Enabled,
+                Available: sink.AvailableForConnectedBoard()));
+        });
+
         app.MapGet("/api/radio/power-calibration", (HardwareDiagnosticsService diag) =>
         {
             return Results.Ok(diag.PowerCalibrationSnapshot());

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -300,6 +300,22 @@ public static class ZeusHost
         builder.Services.AddSingleton<Zeus.Protocol1.TxIqRing>();
         builder.Services.AddSingleton<Zeus.Protocol1.ITxIqSource>(sp =>
             sp.GetRequiredService<Zeus.Protocol1.TxIqRing>());
+        // RX-audio → radio codec speaker path (Protocol-1). RxAudioRing is the RX
+        // counterpart of TxIqRing on the same EP2 frame: RadioSpeakerAudioSink
+        // writes demodulated RX audio into it and Protocol1Client (constructed
+        // inside RadioService) drains it into the frame's L/R slots so the radio's
+        // onboard codec drives its speaker/headphone/line-out jacks. Registered
+        // before RadioService so the latter's optional IRxAudioSource? ctor param
+        // resolves. The IRxAudioSink mapping is added unconditionally (both host
+        // modes) and self-gates per frame; the Protocol-2 Saturn/G2 appliance
+        // speaker path is separate (SaturnSpeakerAudioSink) and untouched here.
+        builder.Services.AddSingleton<Zeus.Protocol1.RxAudioRing>();
+        builder.Services.AddSingleton<Zeus.Protocol1.IRxAudioSource>(sp =>
+            sp.GetRequiredService<Zeus.Protocol1.RxAudioRing>());
+        builder.Services.AddSingleton<RadioSpeakerSettingsStore>();
+        builder.Services.AddSingleton<RadioSpeakerAudioSink>();
+        builder.Services.AddSingleton<IRxAudioSink>(sp =>
+            sp.GetRequiredService<RadioSpeakerAudioSink>());
         // Global (per-radio) TX-audio source store (external-audio-jacks
         // re-port). Registered before RadioService so the latter's optional
         // AudioSettingsStore? ctor param resolves it and wires the Changed →

--- a/tests/Zeus.Protocol1.Tests/ControlFrameTests.cs
+++ b/tests/Zeus.Protocol1.Tests/ControlFrameTests.cs
@@ -561,6 +561,102 @@ public class ControlFrameTests
         return (peak, firstI, firstQ);
     }
 
+    private static (int peak, int firstL, int firstR) FirstFrameAudioStats(ReadOnlySpan<byte> packet)
+    {
+        const int payloadStart = 16;
+        int peak = 0;
+        int firstL = (short)((packet[payloadStart + 0] << 8) | packet[payloadStart + 1]);
+        int firstR = (short)((packet[payloadStart + 2] << 8) | packet[payloadStart + 3]);
+        for (int s = 0; s < 63; s++)
+        {
+            int off = payloadStart + s * 8;
+            int l = (short)((packet[off + 0] << 8) | packet[off + 1]);
+            int r = (short)((packet[off + 2] << 8) | packet[off + 3]);
+            peak = Math.Max(peak, Math.Max(Math.Abs(l), Math.Abs(r)));
+        }
+        return (peak, firstL, firstR);
+    }
+
+    // Fills every requested slot with a constant s16, returning the full count —
+    // the steady-state "ring has plenty of audio" case.
+    private sealed class ConstRxAudioSource : IRxAudioSource
+    {
+        private readonly short _v;
+        public ConstRxAudioSource(short v) { _v = v; }
+        public int Read(Span<short> dest) { dest.Fill(_v); return dest.Length; }
+    }
+
+    // Always empty — models a ring that has nothing buffered (feature off / HL2 /
+    // underrun). Must leave the L/R slots zero, byte-identical to legacy behaviour.
+    private sealed class EmptyRxAudioSource : IRxAudioSource
+    {
+        public int Read(Span<short> dest) => 0;
+    }
+
+    [Fact]
+    public void BuildDataPacket_MoxOff_WithRxAudio_FillsLrAndLeavesIqZero()
+    {
+        // RX (not transmitting): demodulated audio rides the EP2 L/R slots so the
+        // radio codec drives its speaker jacks; the I/Q slots carry no carrier.
+        var buf = new byte[1032];
+        var state = BaseState() with { Board = HpsdrBoardKind.Hermes, Mox = false };
+        var rx = new ConstRxAudioSource(0x1234);
+
+        ControlFrame.BuildDataPacket(
+            buf, 1,
+            ControlFrame.CcRegister.Config,
+            ControlFrame.CcRegister.RxFreq,
+            state, iqSource: null, rxAudioSource: rx);
+
+        var (audioPeak, firstL, firstR) = FirstFrameAudioStats(buf);
+        var (iqPeak, _, _) = FirstFrameIqStats(buf);
+        Assert.Equal(0x1234, firstL);
+        Assert.Equal(0x1234, firstR);   // mono duplicated to both channels
+        Assert.Equal(0x1234, audioPeak);
+        Assert.Equal(0, iqPeak);        // no carrier while receiving
+    }
+
+    [Fact]
+    public void BuildDataPacket_MoxOff_EmptyRxAudio_KeepsPayloadZero()
+    {
+        // Empty ring (feature off / HL2 / underrun) → L/R stay zero, byte-identical
+        // to a radio that carries no RX audio at all.
+        var buf = new byte[1032];
+        var state = BaseState() with { Board = HpsdrBoardKind.Hermes, Mox = false };
+
+        ControlFrame.BuildDataPacket(
+            buf, 1,
+            ControlFrame.CcRegister.Config,
+            ControlFrame.CcRegister.RxFreq,
+            state, iqSource: null, rxAudioSource: new EmptyRxAudioSource());
+
+        var (audioPeak, _, _) = FirstFrameAudioStats(buf);
+        Assert.Equal(0, audioPeak);
+    }
+
+    [Fact]
+    public void BuildDataPacket_MoxOn_IgnoresRxAudio_LeavesLrZero()
+    {
+        // While transmitting, the L/R slots stay zero even if an RX-audio source
+        // is plumbed — the radio is keyed, not monitoring, and the I/Q path owns
+        // the frame. Guards against feeding TX-monitor audio to the radio speaker.
+        var buf = new byte[1032];
+        var state = BaseState() with { Board = HpsdrBoardKind.Hermes, Mox = true, DriveLevel = 0x80 };
+        var iq = new ConstIqSource(0x2000, -0x2000);
+        var rx = new ConstRxAudioSource(0x7FFF);
+
+        ControlFrame.BuildDataPacket(
+            buf, 1,
+            ControlFrame.CcRegister.Config,
+            ControlFrame.CcRegister.RxFreq,
+            state, iqSource: iq, rxAudioSource: rx);
+
+        var (audioPeak, _, _) = FirstFrameAudioStats(buf);
+        var (iqPeak, _, _) = FirstFrameIqStats(buf);
+        Assert.Equal(0, audioPeak);   // no RX audio on the wire during TX
+        Assert.True(iqPeak > 0);      // IQ path unchanged
+    }
+
     [Theory]
     [InlineData(HpsdrBoardKind.Hermes)]        // ANAN-10E reports here (issue #294)
     [InlineData(HpsdrBoardKind.HermesII)]      // ANAN-10E w/ HermesII firmware

--- a/tests/Zeus.Protocol1.Tests/RxAudioRingTests.cs
+++ b/tests/Zeus.Protocol1.Tests/RxAudioRingTests.cs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// Coverage for the RX-audio ring that carries demodulated RX audio into the
+// Protocol-1 EP2 L/R slots (radio-codec speaker output). The RX-half mirror of
+// TxIqRing: rate-matched 48 kHz producer/consumer, drop-oldest on overflow,
+// silence (zero count) on underrun so the wire reverts to "no RX audio".
+
+using Zeus.Protocol1;
+
+namespace Zeus.Protocol1.Tests;
+
+public class RxAudioRingTests
+{
+    [Fact]
+    public void Read_EmptyRing_ReturnsZeroAndLeavesDestUntouched()
+    {
+        var ring = new RxAudioRing(64);
+        Span<short> dest = stackalloc short[8];
+        dest.Fill(0x55);
+
+        int n = ring.Read(dest);
+
+        Assert.Equal(0, n);
+        // Untouched: caller relies on this to keep the cleared (zero) L/R slots.
+        foreach (var s in dest) Assert.Equal((short)0x55, s);
+    }
+
+    [Fact]
+    public void WriteThenRead_RoundTripsSamplesInOrder()
+    {
+        var ring = new RxAudioRing(64);
+        // 0.5f -> +16384 with round(0.5 * 32767) = 16384 (16383.5 rounds to even? no:
+        // MidpointRounding default is ToEven for Math.Round(double) -> 16384).
+        ring.Write(new float[] { 0.0f, 0.5f, -0.5f, 1.0f });
+
+        Span<short> dest = stackalloc short[4];
+        int n = ring.Read(dest);
+
+        Assert.Equal(4, n);
+        Assert.Equal(0, dest[0]);
+        Assert.Equal((short)Math.Round(0.5f * short.MaxValue), dest[1]);
+        Assert.Equal((short)Math.Round(-0.5f * short.MaxValue), dest[2]);
+        Assert.Equal(short.MaxValue, dest[3]);
+    }
+
+    [Fact]
+    public void Write_SaturatesOutOfRangeAndNonFinite()
+    {
+        var ring = new RxAudioRing(64);
+        ring.Write(new float[] { 2.0f, -2.0f, float.NaN, float.PositiveInfinity });
+
+        Span<short> dest = stackalloc short[4];
+        ring.Read(dest);
+
+        // Out-of-range floats clamp; non-finite (NaN/±inf) map to 0 — matches
+        // TxIqRing. Symmetric scale by short.MaxValue: ±1.0 -> ±32767.
+        Assert.Equal(short.MaxValue, dest[0]);
+        Assert.Equal((short)-short.MaxValue, dest[1]);
+        Assert.Equal((short)0, dest[2]);   // NaN -> 0
+        Assert.Equal((short)0, dest[3]);   // +inf non-finite -> 0
+    }
+
+    [Fact]
+    public void Read_Underrun_ReturnsPartialCount()
+    {
+        var ring = new RxAudioRing(64);
+        ring.Write(new float[] { 0.1f, 0.2f });
+
+        Span<short> dest = stackalloc short[8];
+        int n = ring.Read(dest);
+
+        Assert.Equal(2, n);   // only 2 available; rest of dest left to the caller
+    }
+
+    [Fact]
+    public void Write_Overflow_DropsOldest()
+    {
+        var ring = new RxAudioRing(4);
+        // Write 6 into a depth-4 ring: oldest two (1,2) are overwritten.
+        ring.Write(new float[] { 1f / 32767, 2f / 32767, 3f / 32767, 4f / 32767, 5f / 32767, 6f / 32767 });
+
+        Assert.Equal(4, ring.Count);
+        Assert.Equal(2, ring.Dropped);
+
+        Span<short> dest = stackalloc short[4];
+        int n = ring.Read(dest);
+
+        Assert.Equal(4, n);
+        Assert.Equal((short)3, dest[0]);   // 1 and 2 dropped
+        Assert.Equal((short)4, dest[1]);
+        Assert.Equal((short)5, dest[2]);
+        Assert.Equal((short)6, dest[3]);
+    }
+
+    [Fact]
+    public void Clear_DropsBufferedSamples()
+    {
+        var ring = new RxAudioRing(64);
+        ring.Write(new float[] { 0.5f, 0.5f, 0.5f });
+
+        ring.Clear();
+
+        Assert.Equal(0, ring.Count);
+        Span<short> dest = stackalloc short[4];
+        Assert.Equal(0, ring.Read(dest));
+    }
+
+    [Fact]
+    public void WrapAround_PreservesOrder()
+    {
+        // Exercise the modular index path: fill, drain, refill past the end.
+        var ring = new RxAudioRing(4);
+        ring.Write(new float[] { 1f / 32767, 2f / 32767, 3f / 32767 });
+        Span<short> d1 = stackalloc short[3];
+        ring.Read(d1);   // head/tail now mid-buffer
+        ring.Write(new float[] { 4f / 32767, 5f / 32767, 6f / 32767 });
+
+        Span<short> d2 = stackalloc short[3];
+        int n = ring.Read(d2);
+
+        Assert.Equal(3, n);
+        Assert.Equal((short)4, d2[0]);
+        Assert.Equal((short)5, d2[1]);
+        Assert.Equal((short)6, d2[2]);
+    }
+}

--- a/tests/Zeus.Server.Tests/NativeAudioSinkRegistrationTests.cs
+++ b/tests/Zeus.Server.Tests/NativeAudioSinkRegistrationTests.cs
@@ -34,15 +34,24 @@ public class NativeAudioSinkRegistrationTests
         var app = ZeusHost.Build(Array.Empty<string>(), opts);
 
         var sinks = app.Services.GetServices<IRxAudioSink>().ToArray();
-        Assert.Single(sinks);
         // Server mode keeps the WS sink — bit-for-bit equivalent of the
         // pre-seam direct hub broadcast.
-        Assert.Equal("WebSocketAudioSink", sinks[0].GetType().Name);
+        Assert.Contains(sinks, s => s.GetType().Name == "WebSocketAudioSink");
+        // Plus the Protocol-1 radio-speaker sink, registered in BOTH host modes
+        // (a headless Zeus next to a P1 radio can drive its codec speaker). It's
+        // a managed ring-feeder, not a native audio device, and self-gates to
+        // off-by-default, so it never opens hardware on its own.
+        Assert.Contains(sinks, s => s.GetType().Name == "RadioSpeakerAudioSink");
+        Assert.DoesNotContain(sinks, s => s.GetType().Name == "NativeAudioSink");
+        Assert.DoesNotContain(sinks, s => s.GetType().Name == "SaturnSpeakerAudioSink");
 
-        // Native capture must never be registered in server mode.
+        // Native capture / device-owning services must never be registered in
+        // server mode. RadioSpeakerAudioSink is NOT among them — it owns no
+        // device and is not a hosted service.
         var hosted = app.Services.GetServices<IHostedService>().ToArray();
         Assert.DoesNotContain(hosted, h => h.GetType().Name == "NativeAudioSink");
         Assert.DoesNotContain(hosted, h => h.GetType().Name == "SaturnSpeakerAudioSink");
+        Assert.DoesNotContain(hosted, h => h.GetType().Name == "RadioSpeakerAudioSink");
         Assert.DoesNotContain(hosted, h => h.GetType().Name == "NativeMicCapture");
 
         await app.DisposeAsync();
@@ -67,6 +76,8 @@ public class NativeAudioSinkRegistrationTests
         Assert.Contains(sinks, sink => sink.GetType().Name == "NativeAudioSink");
         Assert.Contains(sinks, sink => sink.GetType().Name == "SaturnSpeakerAudioSink");
         Assert.Contains(sinks, sink => sink.GetType().Name == "GatedWebSocketAudioSink");
+        // P1 radio-speaker sink is present in desktop mode too (both modes).
+        Assert.Contains(sinks, sink => sink.GetType().Name == "RadioSpeakerAudioSink");
         Assert.DoesNotContain(sinks, sink => sink.GetType().Name == "WebSocketAudioSink");
 
         // Same NativeAudioSink instance must also be wired as a hosted

--- a/tests/Zeus.Server.Tests/RadioSpeakerAudioSinkTests.cs
+++ b/tests/Zeus.Server.Tests/RadioSpeakerAudioSinkTests.cs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// Gating coverage for the Protocol-1 radio-speaker sink. The sink only feeds
+// the RxAudioRing when ALL hold: opted in, a P1 client is connected (so the
+// ring is drained), the board has a codec (not HL2), not transmitting, and the
+// frame is 48 kHz mono. The positive "writes to a connected G2/Hermes" path is
+// integration/bench (needs a live P1 connection); these unit tests pin the
+// negative gates that must never leak audio onto the wire by mistake.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Protocol1;
+
+namespace Zeus.Server.Tests;
+
+public class RadioSpeakerAudioSinkTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-spksink-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+        try { if (File.Exists(_dbPath + ".pa")) File.Delete(_dbPath + ".pa"); } catch { }
+        try { if (File.Exists(_dbPath + ".dsp")) File.Delete(_dbPath + ".dsp"); } catch { }
+        try { if (File.Exists(_dbPath + ".spk")) File.Delete(_dbPath + ".spk"); } catch { }
+    }
+
+    private RadioService NewDisconnectedRadio() =>
+        new RadioService(
+            NullLoggerFactory.Instance,
+            new DspSettingsStore(NullLogger<DspSettingsStore>.Instance, _dbPath + ".dsp"),
+            new PaSettingsStore(NullLogger<PaSettingsStore>.Instance, _dbPath + ".pa"));
+
+    private RadioSpeakerSettingsStore NewSettings() =>
+        new(NullLogger<RadioSpeakerSettingsStore>.Instance, _dbPath + ".spk");
+
+    private static AudioFrame MonoFrame(int samples = 64, byte channels = 1, uint rateHz = 48_000)
+    {
+        var buf = new float[samples * channels];
+        for (int i = 0; i < buf.Length; i++) buf[i] = 0.5f;
+        return new AudioFrame(
+            Seq: 1, TsUnixMs: 0, RxId: 0,
+            Channels: channels, SampleRateHz: rateHz,
+            SampleCount: (ushort)samples, Samples: buf);
+    }
+
+    [Fact]
+    public void Disabled_ByDefault_DoesNotWrite()
+    {
+        using var radio = NewDisconnectedRadio();
+        using var settings = NewSettings();
+        var ring = new RxAudioRing();
+        var sink = new RadioSpeakerAudioSink(radio, ring, settings);
+
+        sink.Publish(MonoFrame());
+
+        Assert.Equal(0, ring.Count);   // default off — nothing forwarded
+    }
+
+    [Fact]
+    public void Enabled_ButNoProtocol1Connection_DoesNotWrite()
+    {
+        using var radio = NewDisconnectedRadio();
+        using var settings = NewSettings();
+        settings.Set(true);
+        var ring = new RxAudioRing();
+        var sink = new RadioSpeakerAudioSink(radio, ring, settings);
+
+        sink.Publish(MonoFrame());
+
+        // No P1 client → ring would never be drained → must not feed it.
+        Assert.Equal(0, ring.Count);
+        Assert.False(sink.AvailableForConnectedBoard());
+    }
+
+    [Theory]
+    [InlineData((byte)2, 48_000u)]   // stereo — not the RX mono frame
+    [InlineData((byte)1, 44_100u)]   // wrong sample rate
+    public void WrongFormat_DoesNotWrite(byte channels, uint rateHz)
+    {
+        using var radio = NewDisconnectedRadio();
+        using var settings = NewSettings();
+        settings.Set(true);
+        var ring = new RxAudioRing();
+        var sink = new RadioSpeakerAudioSink(radio, ring, settings);
+
+        sink.Publish(MonoFrame(channels: channels, rateHz: rateHz));
+
+        Assert.Equal(0, ring.Count);
+    }
+
+    [Fact]
+    public void DisablingSettings_ClearsBufferedAudio()
+    {
+        using var radio = NewDisconnectedRadio();
+        using var settings = NewSettings();
+        var ring = new RxAudioRing();
+        // Sink subscribes to settings.Changed and clears the ring on disable.
+        _ = new RadioSpeakerAudioSink(radio, ring, settings);
+
+        // Simulate a buffered tail (e.g. from a prior session) then flip off.
+        ring.Write(new float[] { 0.5f, 0.5f, 0.5f });
+        settings.Set(true);
+        settings.Set(false);
+
+        Assert.Equal(0, ring.Count);
+    }
+}

--- a/tests/Zeus.Server.Tests/RadioSpeakerSettingsStoreTests.cs
+++ b/tests/Zeus.Server.Tests/RadioSpeakerSettingsStoreTests.cs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+//
+// Persistence coverage for the radio-side speaker output opt-in (Protocol-1
+// codec radios). Default is OFF (safe, opt-in); the choice survives a backend
+// restart; the Changed event fires only on an actual transition.
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Zeus.Server.Tests;
+
+public class RadioSpeakerSettingsStoreTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-spk-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+    }
+
+    private RadioSpeakerSettingsStore BuildStore() =>
+        new(NullLogger<RadioSpeakerSettingsStore>.Instance, _dbPath);
+
+    [Fact]
+    public void FreshDb_DefaultsToOff()
+    {
+        using var store = BuildStore();
+        Assert.False(store.Enabled);
+        Assert.False(RadioSpeakerSettingsStore.DefaultEnabled);
+    }
+
+    [Fact]
+    public void Set_RoundTripsThroughDb()
+    {
+        using (var store = BuildStore())
+        {
+            store.Set(true);
+            Assert.True(store.Enabled);
+        }
+        // New instance, same file — value survives a "restart".
+        using (var reopened = BuildStore())
+        {
+            Assert.True(reopened.Enabled);
+        }
+    }
+
+    [Fact]
+    public void Set_BackToOff_RoundTrips()
+    {
+        using var store = BuildStore();
+        store.Set(true);
+        store.Set(false);
+        Assert.False(store.Enabled);
+    }
+
+    [Fact]
+    public void Changed_FiresOnlyOnActualTransition()
+    {
+        using var store = BuildStore();
+        int fires = 0;
+        store.Changed += () => fires++;
+
+        store.Set(false);   // no change (already off) — no fire
+        Assert.Equal(0, fires);
+
+        store.Set(true);    // off -> on
+        Assert.Equal(1, fires);
+
+        store.Set(true);    // no change (already on) — no fire
+        Assert.Equal(1, fires);
+
+        store.Set(false);   // on -> off
+        Assert.Equal(2, fires);
+    }
+}

--- a/zeus-web/src/components/RadioSettingsPanel.tsx
+++ b/zeus-web/src/components/RadioSettingsPanel.tsx
@@ -28,6 +28,7 @@ import { useEffect, useState } from 'react';
 import { usePttStore } from '../state/ptt-store';
 import { useG2PanelStore } from '../state/g2panel-store';
 import { useAudioStore, type TxAudioSource } from '../state/audio-store';
+import { useRadioSpeakerStore } from '../state/radio-speaker-store';
 import {
   useAntennaStore,
   type AntennaName,
@@ -85,6 +86,11 @@ export function RadioSettingsPanel() {
   const loadAudio = useAudioStore((s) => s.load);
   const updateAudio = useAudioStore((s) => s.update);
 
+  const speaker = useRadioSpeakerStore((s) => s.settings);
+  const speakerInflight = useRadioSpeakerStore((s) => s.inflight);
+  const loadSpeaker = useRadioSpeakerStore((s) => s.load);
+  const setSpeakerEnabled = useRadioSpeakerStore((s) => s.setEnabled);
+
   const antSettings = useAntennaStore((s) => s.settings);
   const antInflight = useAntennaStore((s) => s.inflight);
   const loadAntenna = useAntennaStore((s) => s.load);
@@ -99,9 +105,10 @@ export function RadioSettingsPanel() {
     void loadPtt();
     void loadG2();
     void loadAudio();
+    void loadSpeaker();
     void loadAntenna();
     void loadGpio();
-  }, [loadPtt, loadG2, loadAudio, loadAntenna, loadGpio]);
+  }, [loadPtt, loadG2, loadAudio, loadSpeaker, loadAntenna, loadGpio]);
 
   // Poll the front-panel bridge status while this tab is mounted so the
   // connected lamp reflects plug/unplug without a manual reload.
@@ -476,6 +483,44 @@ export function RadioSettingsPanel() {
           )}
         </div>
       ) : null}
+
+      {/* Audio Output — radio-side speaker/headphone/line-out (Protocol-1 codec
+          radios). Only shown when a P1 codec board is connected (server reports
+          `available`); the codec-less HL2 and the Protocol-2 Saturn/G2 appliance
+          path never surface here. Default OFF so an operator already hearing RX
+          audio host-side isn't surprised by doubled audio. */}
+      {speaker.available ? (
+        <div className="ps-card">
+          <h4>
+            <svg className="ps-ic-sm" viewBox="0 0 12 12">
+              <path d="M2 4.5h2L6.5 2v8L4 7.5H2zM8.5 4a3 3 0 0 1 0 4M10 2.5a5 5 0 0 1 0 7" />
+            </svg>
+            Audio Output
+            <span className="ps-card-hint">radio speaker</span>
+          </h4>
+          <div className="ps-field">
+            <div className="ps-name">
+              Radio Speaker / Headphone
+              <em>
+                Send RX audio to the radio&apos;s own speaker / headphone /
+                line-out jacks. Leave off if you only listen through this
+                computer — turning it on plays audio from both at once.
+              </em>
+            </div>
+            <label className="ps-check">
+              <input
+                type="checkbox"
+                checked={speaker.enabled}
+                disabled={speakerInflight}
+                onChange={(e) => void setSpeakerEnabled(e.target.checked)}
+              />
+              <span className="ps-check-box" />
+              <span>{speaker.enabled ? 'On' : 'Off (default)'}</span>
+            </label>
+          </div>
+        </div>
+      ) : null}
+
       {showAntenna && (
         <div className="ps-card">
           <h4>

--- a/zeus-web/src/state/radio-speaker-store.test.ts
+++ b/zeus-web/src/state/radio-speaker-store.test.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Radio-side speaker output store — parse robustness + optimistic toggle
+// round-trip. Mirrors audio-store.test.ts.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  fetchRadioSpeakerOutput,
+  updateRadioSpeakerOutput,
+  useRadioSpeakerStore,
+} from './radio-speaker-store';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  useRadioSpeakerStore.setState({
+    settings: { enabled: false, available: false },
+    loaded: false,
+    inflight: false,
+    error: null,
+  });
+});
+
+function stubFetch(body: unknown, status = 200) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  );
+}
+
+describe('radio-speaker-store parsing', () => {
+  it('parses enabled + available', async () => {
+    stubFetch({ enabled: true, available: true });
+    const s = await fetchRadioSpeakerOutput();
+    expect(s.enabled).toBe(true);
+    expect(s.available).toBe(true);
+  });
+
+  it('defaults both false on garbage', async () => {
+    stubFetch(42);
+    const s = await fetchRadioSpeakerOutput();
+    expect(s.enabled).toBe(false);
+    expect(s.available).toBe(false);
+  });
+
+  it('throws on a non-OK PUT', async () => {
+    stubFetch({ error: 'nope' }, 500);
+    await expect(updateRadioSpeakerOutput(true)).rejects.toThrow();
+  });
+});
+
+describe('radio-speaker-store toggle', () => {
+  it('optimistically toggles then adopts the server response', async () => {
+    stubFetch({ enabled: true, available: true });
+    await useRadioSpeakerStore.getState().setEnabled(true);
+    const s = useRadioSpeakerStore.getState().settings;
+    expect(s.enabled).toBe(true);
+    expect(s.available).toBe(true);
+  });
+
+  it('rolls back on PUT failure', async () => {
+    useRadioSpeakerStore.setState({
+      settings: { enabled: false, available: true },
+    });
+    stubFetch({ error: 'boom' }, 500);
+    await useRadioSpeakerStore.getState().setEnabled(true);
+    const s = useRadioSpeakerStore.getState().settings;
+    expect(s.enabled).toBe(false); // rolled back
+    expect(useRadioSpeakerStore.getState().error).toBeTruthy();
+  });
+});

--- a/zeus-web/src/state/radio-speaker-store.ts
+++ b/zeus-web/src/state/radio-speaker-store.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Radio-side speaker output (Protocol-1 codec radios). Mirrors
+// /api/radio/speaker-output: when ON, the backend sends demodulated RX audio
+// down the EP2 frame's L/R slots so the radio's onboard codec drives its
+// speaker / headphone / line-out jacks. `available` is true only while a P1
+// codec radio (not the codec-less HL2) is connected; the toggle is otherwise
+// inert. The Protocol-2 Saturn/G2 appliance speaker path is independent and is
+// NOT governed by this setting. Default is OFF (opt-in) so an operator who
+// already hears RX audio host-side isn't surprised by doubled audio.
+
+import { create } from 'zustand';
+
+export interface RadioSpeakerOutput {
+  enabled: boolean;
+  available: boolean;
+}
+
+const DEFAULT: RadioSpeakerOutput = { enabled: false, available: false };
+
+function parseBool(v: unknown, fallback: boolean): boolean {
+  return typeof v === 'boolean' ? v : fallback;
+}
+
+function parse(raw: unknown): RadioSpeakerOutput {
+  if (!raw || typeof raw !== 'object') return DEFAULT;
+  const r = raw as Record<string, unknown>;
+  return {
+    enabled: parseBool(r.enabled, false),
+    available: parseBool(r.available, false),
+  };
+}
+
+export async function fetchRadioSpeakerOutput(
+  signal?: AbortSignal,
+): Promise<RadioSpeakerOutput> {
+  const res = await fetch('/api/radio/speaker-output', { signal });
+  if (!res.ok) throw new Error(`GET /api/radio/speaker-output → ${res.status}`);
+  return parse(await res.json());
+}
+
+export async function updateRadioSpeakerOutput(
+  enabled: boolean,
+  signal?: AbortSignal,
+): Promise<RadioSpeakerOutput> {
+  const res = await fetch('/api/radio/speaker-output', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ enabled }),
+    signal,
+  });
+  if (!res.ok) throw new Error(`PUT /api/radio/speaker-output → ${res.status}`);
+  return parse(await res.json());
+}
+
+type RadioSpeakerStore = {
+  settings: RadioSpeakerOutput;
+  loaded: boolean;
+  inflight: boolean;
+  error: string | null;
+  load: () => Promise<void>;
+  setEnabled: (enabled: boolean) => Promise<void>;
+};
+
+export const useRadioSpeakerStore = create<RadioSpeakerStore>((set, get) => ({
+  settings: DEFAULT,
+  loaded: false,
+  inflight: false,
+  error: null,
+
+  load: async () => {
+    set({ inflight: true, error: null });
+    try {
+      const s = await fetchRadioSpeakerOutput();
+      set({ settings: s, loaded: true, inflight: false });
+    } catch (err) {
+      set({
+        error: err instanceof Error ? err.message : String(err),
+        inflight: false,
+      });
+    }
+  },
+
+  setEnabled: async (enabled) => {
+    // Optimistic local update, rollback on error — same idiom as the audio
+    // store. The PUT returns the canonical {enabled, available}.
+    const prev = get().settings;
+    set({ settings: { ...prev, enabled }, inflight: true, error: null });
+    try {
+      const s = await updateRadioSpeakerOutput(enabled);
+      set({ settings: s, inflight: false });
+    } catch (err) {
+      set({
+        settings: prev,
+        error: err instanceof Error ? err.message : String(err),
+        inflight: false,
+      });
+    }
+  },
+}));


### PR DESCRIPTION
## What & why

Zeus wired the radio's audio **input** jacks (mic / line-in / XLR) but never its **speaker** jacks. On every Protocol-1 radio, `ControlFrame` zeroed the EP2 frame's L/R audio slots (`// Audio L/R stay zero`), so the radio's onboard codec drove its **speaker / headphone / line-out** with silence. Thetis sends RX audio inline on EP2 always-on; Zeus sent nothing.

This wires it: demodulated 48 kHz mono RX audio now rides the EP2 L/R slots into the radio codec, so the rig's own speaker/headphone/line-out work — for **Hermes, ANAN-10/10E/100/100B/100D/200D, and Orion**.

## Scope (deliberate)

- ✅ **Protocol-1 codec radios** — the real gap; this PR fixes it.
- ⛔ **G2 / Saturn (Protocol-2)** — **untouched.** `SaturnSpeakerAudioSink` (the Linux + co-located "Zeus on the G2's internal Pi" path from #1027) is left exactly as shipped. The new path is Protocol-1 only and shares no code with it.
- ⛔ **Hermes-Lite 2** — correctly excluded: the HL2 has **no audio codec** (confirmed against mi0bot Thetis and `docs/references/protocol-1/hermes-lite2-protocol.md` — "no use for the audio data sent"). The host never feeds its ring.
- ↪️ **Other P2 boards from a remote/non-Linux host** (7000DLE/8000DLE/Anvelina/RedPitaya/OrionMkII/HermesC10 not co-located): not addressed here, to avoid touching the G2 path. Noted as a follow-up.

## How it works

Mirrors the existing `TxIqRing` pattern on the RX half of the same EP2 frame:

- **`RxAudioRing` / `IRxAudioSource`** (`Zeus.Protocol1`) — mono s16 ring, drop-oldest, **silence-on-empty** so an unfed ring is byte-identical to today's wire.
- **`ControlFrame.WriteUsbFrame`** — fills L/R **during RX only** (`!Mox`); mono is duplicated to both channels, which sidesteps the per-board hardware L/R swap entirely. The IQ/TX path is unchanged.
- **`RadioSpeakerAudioSink`** (host, both modes) — feeds the ring from the demod `AudioFrame`, gated on `enabled + P1 codec board + not-MOX + 48 kHz mono`. Clears the ring while keyed so unkey never replays a stale tail.
- **`RadioSpeakerSettingsStore`** + `GET/PUT /api/radio/speaker-output` + a **"Radio Speaker / Headphone"** toggle in Radio Settings (shown only for connected P1 codec boards).

## 🚩 Red-light decision — needs sign-off

**Default is OFF (opt-in).** Zeus already plays RX audio host-side (browser / native sink); auto-enabling the radio codec output would make every P1 operator hear **doubled audio** on connect. If you'd rather it default ON ("always on when plugged in"), it's a one-line flip in `RadioSpeakerSettingsStore.DefaultEnabled` — your call.

## Testing

- `dotnet build Zeus.slnx` ✅ · `npm --prefix zeus-web run build` ✅ · typecheck ✅
- **Backend:** Protocol1.Tests **274** ✅, Server.Tests **2035** ✅ (0 failed)
- **Frontend:** new store + panel tests ✅
- New coverage: `RxAudioRing` (round-trip / drop-oldest / underrun / clear), `ControlFrame` L/R wire fill + empty-ring byte-identity + MOX ignores RX audio, sink gating, settings persistence, audio-sink registration contract.
- ⚠️ **Not bench-tested on hardware.** The wire fill is unit-tested but the actual codec output should be verified on a P1 radio (G2 is P2, so it can't validate this path — needs a Hermes/ANAN P1 rig). Flagging per the cross-board "correct by construction" rule.

Research: behavior verified against ramdor/Thetis (P1 EP2 L/R, always-on), mi0bot Thetis (HL2 no codec), and the in-repo protocol docs.
