### PR TITLE
feat(web): add Exit button to login dialog to close the app

### DIFF
--- a/Zeus.Server.Hosting/AppRestartService.cs
+++ b/Zeus.Server.Hosting/AppRestartService.cs
@@ -30,6 +30,29 @@ public sealed class AppRestartService
     // or stop a sidecar). Best-effort — failures are swallowed.
     public Action? OnRestartRequested { get; set; }
 
+    // Exit the running Zeus process without relaunching. Used by the login
+    // dialog's Exit button to close the app. Same clean teardown as the restart
+    // path (Environment.Exit unwinds the Photino window without re-entering a
+    // torn-down WebView2 apartment), minus the detached relauncher helper.
+    public void RequestQuit()
+    {
+        try
+        {
+            OnRestartRequested?.Invoke();
+        }
+        catch
+        {
+            // Never block the exit on a best-effort hook.
+        }
+
+        // Let the in-flight HTTP response flush before the process dies.
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(300).ConfigureAwait(false);
+            Environment.Exit(0);
+        });
+    }
+
     public void RequestRestart()
     {
         var exe = Environment.ProcessPath

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -3293,6 +3293,12 @@ public static class ZeusEndpoints
             return Results.Ok(new { restarting = true });
         });
 
+        app.MapPost("/api/app/quit", (AppRestartService restart) =>
+        {
+            restart.RequestQuit();
+            return Results.Ok(new { quitting = true });
+        });
+
         app.MapGet("/api/qrz/status", (QrzService qrz) => qrz.GetStatus());
 
         app.MapPost("/api/qrz/login", async (QrzLoginRequest req, QrzService qrz, HttpContext ctx) =>

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -5156,6 +5156,26 @@ export function restartApp(
   );
 }
 
+/** Ask the backend to exit (close the app). Used by the login dialog's Exit
+ *  button — the desktop Photino window tears down cleanly when the process
+ *  exits. The response may not arrive before the process dies. */
+export function quitApp(
+  signal?: AbortSignal,
+): Promise<{ quitting: boolean }> {
+  return jsonFetch(
+    '/api/app/quit',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      signal,
+    },
+    (raw) => {
+      const o = (raw ?? {}) as Record<string, unknown>;
+      return { quitting: o.quitting === true };
+    },
+  );
+}
+
 export type UpdateAction = 'none' | 'download' | 'openRelease';
 
 /** Status of the local install vs the latest production build on the download

--- a/zeus-web/src/components/ConnectPanel.tsx
+++ b/zeus-web/src/components/ConnectPanel.tsx
@@ -58,6 +58,7 @@ import {
   uploadPrefsDatabase,
   exportPrefsDatabase,
   restartApp,
+  quitApp,
   ApiError,
   type PrefsDatabaseInfo,
   type RadioInfoDto,
@@ -548,6 +549,9 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
   const [pendingManualTakeover, setPendingManualTakeover] =
     useState<Required<Pick<SavedEndpoint, 'ip' | 'port' | 'protocol' | 'sampleRate' | 'board'>> & { label?: string } | null>(null);
 
+  // Pending "Exit Zeus?" confirmation for the login-dialog Exit button.
+  const [pendingQuit, setPendingQuit] = useState(false);
+
   const [manualIp, setManualIp] = useState(manualFormDefaults.ip);
   const [manualPort, setManualPort] = useState(manualFormDefaults.port);
   const [manualProtocol, setManualProtocol] = useState<ProtocolChoice>(manualFormDefaults.protocol);
@@ -869,6 +873,13 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
 
   const onSavePromptCancel = useCallback(() => setSavePrompt(null), []);
 
+  const handleQuit = useCallback(() => {
+    setPendingQuit(false);
+    // The process exits ~300 ms after acking, so the response may never land —
+    // fire and forget, swallowing the inevitable network error on teardown.
+    void quitApp().catch(() => {});
+  }, []);
+
   const handleRetry = useCallback(() => {
     setError(null);
     setFailureCount(0);
@@ -1013,6 +1024,15 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
             OpenHPSDR · Protocol 1 / 2
           </span>
         </div>
+        <button
+          type="button"
+          onClick={() => setPendingQuit(true)}
+          className="btn sm"
+          style={{ marginLeft: 'auto' }}
+          title="Close Zeus"
+        >
+          Exit
+        </button>
       </div>
       <div style={{ height: 180 }} />
 
@@ -1262,6 +1282,21 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
             is in use by another controller. Taking it over sends a stop command
             that disconnects whoever is currently using it — including an active
             transmission — and then connects Zeus.
+          </p>
+        </ConfirmDialog>
+      )}
+      {pendingQuit && (
+        <ConfirmDialog
+          title="Exit Zeus?"
+          confirmLabel="Exit"
+          cancelLabel="Cancel"
+          intent="danger"
+          onConfirm={handleQuit}
+          onCancel={() => setPendingQuit(false)}
+        >
+          <p style={{ margin: 0 }}>
+            This closes Zeus and stops the backend. Any active radio connection
+            will be dropped.
           </p>
         </ConfirmDialog>
       )}


### PR DESCRIPTION
## What

Adds an **Exit** button to the connect/login dialog that closes Zeus when pressed, with an in-app confirmation.

## Why

There was no in-app way to quit Zeus from the login screen — you had to use the OS window controls. This adds a first-class Exit affordance.

## How

- **`AppRestartService.RequestQuit()`** — exits the running process without relaunching. Reuses the same clean-teardown approach as the existing restart path (`Environment.Exit(0)` after a ~300 ms response-flush delay, which unwinds the Photino desktop window without re-entering a torn-down WebView2 apartment), minus the detached relauncher helper.
- **`POST /api/app/quit`** — new endpoint that calls `RequestQuit()`.
- **`quitApp()`** — client helper in `api/client.ts`.
- **`ConnectPanel`** — an **Exit** button in the dialog header (right-aligned next to the ZEUS logo). It opens an in-app `ConfirmDialog` ("Exit Zeus?") rather than a browser dialog, per project convention. Confirming fires `quitApp()` fire-and-forget (the process dies before the response lands, so the network error is swallowed).

## Testing

- `dotnet build Zeus.Server.Hosting` — clean (0 warnings, 0 errors)
- `tsc --noEmit` — clean
- The Exit button + confirm flow reuse patterns already proven in this file (e.g. the takeover `ConfirmDialog` with `intent="danger"`).

## Note for reviewers

The Exit button currently shows for any client reaching the connect screen, including a LAN browser pointed at this backend. If it should be limited to the local desktop shell only, that can be gated behind a desktop-mode check — happy to follow up.