### PR TITLE
fix(kiwi): squelch, zoom/pan re-centering, TX mute, waterfall floor normalization

### DIFF
--- a/Zeus.Server.Hosting/Kiwi/KiwiSdrService.cs
+++ b/Zeus.Server.Hosting/Kiwi/KiwiSdrService.cs
@@ -126,6 +126,51 @@ public sealed class KiwiSdrService : BackgroundService, IKiwiReceiverProvider, I
     private bool _muted;
     private int _zoomLevel = 1; // 1..32, shared zoom level (see /api/rx/zoom)
 
+    // True while the radio is transmitting (MOX or TUN). The Kiwi is a remote RX
+    // monitoring the same band the operator transmits on, so during TX it would
+    // play back the operator's own signal (delayed, off-frequency, often loud) —
+    // exactly the monitor-feedback we don't want. Mirror the local RX: drop the
+    // Kiwi out of the mix while keyed. _txActive = _moxActive || _tunActive, fed
+    // by RadioService.MoxChanged / TunActiveChanged; all guarded by _sync.
+    private bool _moxActive;
+    private bool _tunActive;
+    private bool _txActive;
+
+    // RX squelch. The Kiwi demodulates server-side and rides the mix bus (no
+    // WDSP), so Zeus's WDSP / adaptive squelch in DspPipelineService never
+    // reaches it — the global SQL control was a no-op on the Kiwi. We gate the
+    // Kiwi audio HERE instead, using the Kiwi's own per-SND-frame S-meter (dBm),
+    // so the same global squelch config drives the Kiwi too. Config is mirrored
+    // from RadioService.StateChanged (guarded by _sync). The gate runtime state
+    // (_sqlSignalDbm/_sqlNoiseFloorDbm/_sqlGain/_sqlOpen) is touched only on the
+    // SND receive-loop thread (OnSignalLevel + OnAudio run there), so it needs
+    // no lock.
+    private bool _sqlEnabled;            // guarded by _sync
+    private bool _sqlAdaptive = true;    // guarded by _sync
+    private int _sqlLevel;               // 0..100, higher = tighter; guarded by _sync
+    private double _sqlSignalDbm = double.NaN;     // latest Kiwi S-meter (SND thread)
+    private double _sqlNoiseFloorDbm = double.NaN; // adaptive floor estimate (SND thread)
+    private double _sqlGain = 1.0;       // smoothed gate gain 0..1 (SND thread)
+    private bool _sqlOpen = true;        // current gate state w/ hysteresis (SND thread)
+
+    // Fixed-mode threshold maps Level 0..100 linearly onto the Kiwi S-meter dBm
+    // range (~-120 dBm noise floor .. ~-20 dBm strong signal): higher Level =
+    // higher (tighter) threshold. Adaptive mode tracks a slow noise floor and
+    // opens a fixed margin above it. Hysteresis avoids chatter on signals
+    // hovering at the threshold.
+    private const double SqlFixedFloorDbm = -120.0;
+    private const double SqlFixedSpanDb = 100.0; // dBm at Level 100 = floor + span
+    private const double SqlOpenMarginDb = 6.0;
+    private const double SqlHysteresisDb = 3.0;
+    // Per-SND-frame slew (frames arrive ~20-40/s): the floor follows the signal
+    // down quickly but creeps up slowly so a brief carrier doesn't raise it.
+    private const double SqlFloorFallDbPerFrame = 3.0;
+    private const double SqlFloorRiseDbPerFrame = 0.2;
+    // Per-sample gain ramp (native ~12 kHz): fast attack (~5 ms) so signal
+    // onset isn't clipped, slower release (~50 ms) so tails fade without a click.
+    private const double SqlAttackPerSample = 1.0 / 60.0;
+    private const double SqlReleasePerSample = 1.0 / 600.0;
+
     // Waterfall span for the current zoom level. Caller need not hold _sync.
     private double CurrentSpanHz()
     {
@@ -212,7 +257,7 @@ public sealed class KiwiSdrService : BackgroundService, IKiwiReceiverProvider, I
     // -------------------------------------------------------------------------
     public bool AudioActive
     {
-        get { lock (_sync) return _enabled && !_muted && _client is not null; }
+        get { lock (_sync) return _enabled && !_muted && !_txActive && _client is not null; }
     }
 
     public int ReadAudio(Span<float> dst)
@@ -240,6 +285,11 @@ public sealed class KiwiSdrService : BackgroundService, IKiwiReceiverProvider, I
     internal int EnqueueAudioForTest(ReadOnlySpan<float> samples) => _audioBus.Write(samples);
     internal int AudioBusDepthForTest => _audioBus.Count;
 
+    // Test seams for the TX-mute path: drive the keyed flag and the audio-ingest
+    // entry point so "Kiwi mutes on TX" is unit-testable without a live client.
+    internal void SetTxActiveForTest(bool active) { lock (_sync) _txActive = active; }
+    internal void OnAudioForTest(float[] samples, int inRateHz) => OnAudio(samples, inRateHz);
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         // Hydrate the persisted enable flag. Unlike PureSignal there is no
@@ -257,13 +307,23 @@ public sealed class KiwiSdrService : BackgroundService, IKiwiReceiverProvider, I
         Action<Zeus.Protocol1.IProtocol1Client> onP1Connect = _ => OnRadioConnected();
         Action<Zeus.Protocol2.Protocol2Client> onP2Connect = _ => OnRadioConnected();
         Action onDisconnect = OnRadioDisconnected;
+        // Mirror the global RX squelch config so the Kiwi audio gate (ApplySquelchGate)
+        // honours the same SQL control as the hardware RXs.
+        Action<StateDto> onState = s => ApplySquelchConfig(s.Squelch);
+        // Track TX (MOX/TUN) so the Kiwi mutes while the operator is keyed.
+        Action<bool> onMox = on => { lock (_sync) { _moxActive = on; _txActive = _moxActive || _tunActive; } };
+        Action<bool> onTun = on => { lock (_sync) { _tunActive = on; _txActive = _moxActive || _tunActive; } };
         if (radio is not null)
         {
             radio.Connected += onP1Connect;
             radio.P2Connected += onP2Connect;
             radio.Disconnected += onDisconnect;
             radio.P2Disconnected += onDisconnect;
+            radio.StateChanged += onState;
+            radio.MoxChanged += onMox;
+            radio.TunActiveChanged += onTun;
             lock (_sync) { _radioConnected = radio.IsConnected; }
+            ApplySquelchConfig(radio.Snapshot().Squelch);
         }
         else
         {
@@ -286,6 +346,9 @@ public sealed class KiwiSdrService : BackgroundService, IKiwiReceiverProvider, I
             radio.P2Connected -= onP2Connect;
             radio.Disconnected -= onDisconnect;
             radio.P2Disconnected -= onDisconnect;
+            radio.StateChanged -= onState;
+            radio.MoxChanged -= onMox;
+            radio.TunActiveChanged -= onTun;
         }
         await StopClientAsync().ConfigureAwait(false);
     }
@@ -551,9 +614,12 @@ public sealed class KiwiSdrService : BackgroundService, IKiwiReceiverProvider, I
         client.AudioReceived = OnAudio;
         client.WaterfallReceived = OnWaterfall;
         client.StatusChanged = OnClientStatus;
-        // SignalLevel is intentionally not wired: RxMeterFrame carries no RxId,
-        // so a Kiwi S-meter broadcast would overwrite RX1's meter. The
-        // panadapter/waterfall convey the Kiwi signal level visually.
+        // The Kiwi S-meter is NOT broadcast (RxMeterFrame carries no RxId, so it
+        // would overwrite RX1's meter — the panadapter/waterfall convey the Kiwi
+        // level visually). It IS consumed internally to drive the audio squelch
+        // gate (ApplySquelchGate), since the Kiwi rides the mix bus and never
+        // sees Zeus's WDSP/adaptive squelch.
+        client.SignalLevel = dbm => _sqlSignalDbm = dbm;
 
         lock (_sync)
         {
@@ -599,6 +665,7 @@ public sealed class KiwiSdrService : BackgroundService, IKiwiReceiverProvider, I
         // the new width so the frequency mapping is unchanged.
         Interlocked.Increment(ref _wfFramesWindow);
         double span = binsDb.Length * hzPerBin;
+        LogWfDbRangeIfDue(binsDb);
         var db = ResampleBins(binsDb, DisplayWidth);
         var frame = new DisplayFrame(
             Seq: unchecked(++_displaySeq),
@@ -613,6 +680,33 @@ public sealed class KiwiSdrService : BackgroundService, IKiwiReceiverProvider, I
             PanDb: db,
             WfDb: db);
         _hub.Broadcast(frame);
+    }
+
+    // 1 Hz diagnostic of the incoming Kiwi waterfall dB span. The Kiwi sends raw
+    // dBm (byte-255) on a different absolute scale than the hardware RX's dBFS,
+    // and an operator reported the Kiwi pane washing out bright (noise floor not
+    // dark like RX1). The frontend cross-band floor-normalisation
+    // (floor-normalization.ts) is supposed to align it, but to calibrate that we
+    // need to SEE the real distribution rather than guess — log min / robust
+    // floor (10th pct) / median / max once per second. Cheap: one pass + a tiny
+    // partial sort over ~1k bins.
+    private long _wfDbLogMs;
+    private void LogWfDbRangeIfDue(float[] binsDb)
+    {
+        if (!_log.IsEnabled(LogLevel.Debug)) return;
+        long now = Environment.TickCount64;
+        long last = Interlocked.Read(ref _wfDbLogMs);
+        if (now - last < 1000) return;
+        if (Interlocked.CompareExchange(ref _wfDbLogMs, now, last) != last) return;
+
+        float mn = float.MaxValue, mx = float.MinValue;
+        foreach (var v in binsDb) { if (v < mn) mn = v; if (v > mx) mx = v; }
+        var sorted = (float[])binsDb.Clone();
+        Array.Sort(sorted);
+        float floor = sorted[(int)(sorted.Length * 0.10)];
+        float median = sorted[sorted.Length / 2];
+        _log.LogDebug("kiwi.wf.db min={Min:F1} floor10={Floor:F1} median={Median:F1} max={Max:F1} bins={N}",
+            mn, floor, median, mx, binsDb.Length);
     }
 
     // Linear-interpolate a per-bin dB array to a fixed destination length.
@@ -641,8 +735,12 @@ public sealed class KiwiSdrService : BackgroundService, IKiwiReceiverProvider, I
         // the Kiwi is muted we simply stop publishing its frames so it drops out
         // of the client-side mix.
         bool muted;
-        lock (_sync) muted = _muted;
+        lock (_sync) muted = _muted || _txActive;
         if (muted) return;
+        // Squelch the native-rate audio (ties to the per-frame S-meter) before
+        // resampling, so the gate's attack/release constants match the ~12 kHz
+        // native cadence.
+        ApplySquelchGate(samples);
         var output = Resample(samples, inRateHz);
         if (output.Length == 0) return;
 
@@ -711,6 +809,86 @@ public sealed class KiwiSdrService : BackgroundService, IKiwiReceiverProvider, I
         _resamplePrev = prev;
         return outList.ToArray();
     }
+
+    // -------------------------------------------------------------------------
+    // Squelch — the Kiwi rides the mix bus, so Zeus's WDSP/adaptive squelch can't
+    // reach it. Gate the audio here off the Kiwi's own S-meter (dBm) so the
+    // global SQL control works on the Kiwi too. Mirrors the spirit of
+    // DspPipelineService's adaptive squelch (noise-floor tracking + margin +
+    // hysteresis) but operates on the Kiwi's server-side-demodulated stream.
+    // -------------------------------------------------------------------------
+    internal void ApplySquelchConfig(SquelchConfig? cfg)
+    {
+        cfg ??= new SquelchConfig();
+        lock (_sync)
+        {
+            _sqlEnabled = cfg.Enabled;
+            _sqlAdaptive = cfg.Adaptive;
+            _sqlLevel = Math.Clamp(cfg.Level, 0, 100);
+        }
+    }
+
+    // SND-thread only. Updates the gate state from the latest S-meter and applies
+    // a smoothed gain ramp to the native-rate samples in place.
+    internal void ApplySquelchGate(float[] samples)
+    {
+        bool enabled, adaptive; int level;
+        lock (_sync) { enabled = _sqlEnabled; adaptive = _sqlAdaptive; level = _sqlLevel; }
+        if (!enabled)
+        {
+            // Off: pass through and reset the gate so a later enable doesn't open
+            // muted or replay a stale floor estimate.
+            _sqlGain = 1.0; _sqlOpen = true; _sqlNoiseFloorDbm = double.NaN;
+            return;
+        }
+
+        double sig = _sqlSignalDbm;
+        bool open;
+        if (!double.IsFinite(sig))
+        {
+            // No S-meter yet (just connected): never mute on missing data.
+            open = true;
+        }
+        else if (adaptive)
+        {
+            if (!double.IsFinite(_sqlNoiseFloorDbm)) _sqlNoiseFloorDbm = sig;
+            else if (sig < _sqlNoiseFloorDbm)
+                _sqlNoiseFloorDbm = Math.Max(sig, _sqlNoiseFloorDbm - SqlFloorFallDbPerFrame);
+            else
+                _sqlNoiseFloorDbm = Math.Min(sig, _sqlNoiseFloorDbm + SqlFloorRiseDbPerFrame);
+
+            double openThresh = _sqlNoiseFloorDbm + SqlOpenMarginDb;
+            double closeThresh = openThresh - SqlHysteresisDb;
+            open = _sqlOpen ? sig >= closeThresh : sig >= openThresh;
+        }
+        else
+        {
+            double thresh = SqlFixedFloorDbm + (level / 100.0) * SqlFixedSpanDb;
+            double closeThresh = thresh - SqlHysteresisDb;
+            open = _sqlOpen ? sig >= closeThresh : sig >= thresh;
+        }
+        _sqlOpen = open;
+
+        double target = open ? 1.0 : 0.0;
+        double g = _sqlGain;
+        if (g == target)
+        {
+            if (g != 1.0)
+                for (int i = 0; i < samples.Length; i++) samples[i] *= (float)g;
+            return;
+        }
+        for (int i = 0; i < samples.Length; i++)
+        {
+            if (g < target) g = Math.Min(target, g + SqlAttackPerSample);
+            else if (g > target) g = Math.Max(target, g - SqlReleasePerSample);
+            samples[i] *= (float)g;
+        }
+        _sqlGain = g;
+    }
+
+    // Test seam: feed an S-meter reading so the gate is unit-testable without a
+    // live KiwiSdrClient.
+    internal void SetSignalDbmForTest(double dbm) => _sqlSignalDbm = dbm;
 
     // -------------------------------------------------------------------------
     // Helpers.

--- a/tests/Zeus.Server.Tests/KiwiSdrTests.cs
+++ b/tests/Zeus.Server.Tests/KiwiSdrTests.cs
@@ -224,6 +224,93 @@ public sealed class KiwiSdrTests : IDisposable
             $"expected freshest samples, got {dst[0]}");
     }
 
+    // ---- TX mute: the Kiwi drops out of the mix while the radio is keyed -------
+
+    [Fact]
+    public void OnAudio_writes_to_the_bus_when_not_keyed()
+    {
+        using var svc = NewService();
+        svc.OnAudioForTest(new float[] { 0.2f, 0.2f, 0.2f, 0.2f }, 48_000);
+        Assert.True(svc.AudioBusDepthForTest > 0);
+    }
+
+    [Fact]
+    public void OnAudio_is_muted_while_transmitting()
+    {
+        using var svc = NewService();
+        svc.SetTxActiveForTest(true);
+        svc.OnAudioForTest(new float[] { 0.2f, 0.2f, 0.2f, 0.2f }, 48_000);
+        Assert.Equal(0, svc.AudioBusDepthForTest);
+
+        // Un-key: audio flows again.
+        svc.SetTxActiveForTest(false);
+        svc.OnAudioForTest(new float[] { 0.2f, 0.2f, 0.2f, 0.2f }, 48_000);
+        Assert.True(svc.AudioBusDepthForTest > 0);
+    }
+
+    // ---- Squelch: the Kiwi rides the mix bus, so it gets its own S-meter gate --
+
+    private static float[] Tone(int n)
+    {
+        var b = new float[n];
+        Array.Fill(b, 1.0f);
+        return b;
+    }
+
+    [Fact]
+    public void SquelchGate_off_passes_audio_through_untouched()
+    {
+        using var svc = NewService();
+        svc.ApplySquelchConfig(new SquelchConfig(Enabled: false));
+        svc.SetSignalDbmForTest(-130); // dead-quiet would mute if squelch were on
+        var buf = Tone(256);
+        svc.ApplySquelchGate(buf);
+        Assert.All(buf, s => Assert.Equal(1.0f, s));
+    }
+
+    [Fact]
+    public void SquelchGate_fixed_mutes_weak_then_opens_on_strong()
+    {
+        using var svc = NewService();
+        // Fixed, Level 100 → threshold = -120 + 100% * 100 = -20 dBm.
+        svc.ApplySquelchConfig(new SquelchConfig(Enabled: true, Level: 100, Adaptive: false));
+
+        // Weak signal well below the threshold: the gate closes, ramping audio to
+        // silence (release ~50 ms @ 12 kHz, so a ~1 k buffer fully settles).
+        svc.SetSignalDbmForTest(-100);
+        var weak = Tone(1500);
+        svc.ApplySquelchGate(weak);
+        Assert.True(weak[^1] < 0.01f, $"expected muted tail, got {weak[^1]}");
+
+        // Strong signal above the threshold: the gate re-opens (attack ~5 ms), so
+        // a couple hundred samples restore full gain.
+        svc.SetSignalDbmForTest(-10);
+        var strong = Tone(600);
+        svc.ApplySquelchGate(strong);
+        Assert.True(strong[^1] > 0.99f, $"expected open tail, got {strong[^1]}");
+    }
+
+    [Fact]
+    public void SquelchGate_adaptive_tracks_floor_and_opens_above_margin()
+    {
+        using var svc = NewService();
+        svc.ApplySquelchConfig(new SquelchConfig(Enabled: true, Level: 0, Adaptive: true));
+
+        // Sit at the noise floor for a while: the gate stays closed (signal is
+        // below floor + open-margin), muting the audio.
+        svc.SetSignalDbmForTest(-120);
+        for (int i = 0; i < 4; i++) svc.ApplySquelchGate(Tone(1500));
+        var quiet = Tone(1500);
+        svc.ApplySquelchGate(quiet);
+        Assert.True(quiet[^1] < 0.01f, $"expected muted floor, got {quiet[^1]}");
+
+        // A signal well above the tracked floor opens the gate.
+        svc.SetSignalDbmForTest(-80);
+        var sig = Tone(600);
+        svc.ApplySquelchGate(sig);
+        Assert.True(sig[^1] > 0.99f, $"expected open on strong signal, got {sig[^1]}");
+    }
+
     // ---- KiwiDirectoryService: parse the public receiver list ---------------
 
     [Theory]

--- a/zeus-web/src/components/ZoomControl.tsx
+++ b/zeus-web/src/components/ZoomControl.tsx
@@ -47,7 +47,7 @@ import { useCallback, useRef } from 'react';
 import { setZoom, ZOOM_MAX, ZOOM_MIN, type ZoomLevel } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
 import { useLiveSlider } from '../hooks/useLiveSlider';
-import { applyCtunZoomCenterAfterState, centerCtunForZoomIn } from '../util/ctun-zoom-center';
+import { applyCtunZoomCenterAfterState, centerCtunForZoomIn, centerKiwiForZoomIn } from '../util/ctun-zoom-center';
 
 // Compact zoom slider styled as a panel-head chip. Lives in the hero
 // tile header (above the panadapter) so the operator always sees the
@@ -94,6 +94,9 @@ export function ZoomControl() {
       const centeredLoHz = centerCtunForZoomIn(cur, v);
       if (centeredLoHz != null) centeredLoHzRef.current = centeredLoHz;
       else if (v <= cur) centeredLoHzRef.current = null;
+      // Zoom is global: the Kiwi slice re-centres on its own dial too (the RX1
+      // path above doesn't touch it).
+      centerKiwiForZoomIn(cur, v);
       setLocalZoom(v);
       liveSlider.push(v);
     },

--- a/zeus-web/src/dsp/floor-normalization.test.ts
+++ b/zeus-web/src/dsp/floor-normalization.test.ts
@@ -98,6 +98,34 @@ describe('floorNormalizationOffsetDb', () => {
   });
 });
 
+describe('Kiwi slice (index 7) is a foreign RX — aligns to, but never defines, the anchor', () => {
+  it('is excluded from the reference median', () => {
+    reportReceiverFloorDb(0, -135); // hardware RX1
+    reportReceiverFloorDb(7, -100); // Kiwi — must not move the anchor
+    expect(referenceFloorDb()).toBe(-135);
+  });
+
+  it('aligns the Kiwi fully to the hardware anchor (not half-way)', () => {
+    reportReceiverFloorDb(0, -140); // quiet hardware RX
+    reportReceiverFloorDb(7, -100); // noisier remote Kiwi
+    // Kiwi shifts its whole window up by the full floor delta so its floor lands
+    // at the hardware floor's colour — NOT the half-shift a shared median gives.
+    expect(floorNormalizationOffsetDb(7)).toBeCloseTo(40, 1);
+  });
+
+  it('does not pull the hardware panes (RX1 offset stays 0 with only the Kiwi alongside)', () => {
+    reportReceiverFloorDb(0, -140);
+    reportReceiverFloorDb(7, -100);
+    expect(floorNormalizationOffsetDb(0)).toBe(0);
+  });
+
+  it('falls back to no shift when no hardware floor has reported yet', () => {
+    reportReceiverFloorDb(7, -100); // Kiwi alone → anchor null → raw window
+    expect(referenceFloorDb()).toBeNull();
+    expect(floorNormalizationOffsetDb(7)).toBe(0);
+  });
+});
+
 describe('reportReceiverFloorDb EMA', () => {
   it('seeds on first report then smooths', () => {
     reportReceiverFloorDb(3, -100);

--- a/zeus-web/src/dsp/floor-normalization.ts
+++ b/zeus-web/src/dsp/floor-normalization.ts
@@ -36,6 +36,17 @@
 
 const floorByRx = new Map<number, number>();
 
+// The KiwiSDR slice receiver (reserved index — mirrors receiver-state
+// KIWI_RECEIVER_INDEX) is a FOREIGN remote receiver: a different site, antenna
+// and ADC calibration than the local hardware DDCs, so its absolute dB scale is
+// unrelated to theirs. It must normalise TO the hardware noise-floor anchor, but
+// must NOT help DEFINE it — co-anchoring drags the hardware panes toward the
+// Kiwi's (often very different) floor and, with just RX1 + Kiwi, leaves BOTH only
+// half-aligned, so the Kiwi pane washes out bright instead of matching RX1's dark
+// floor (operator report). Held as a local literal to avoid a dsp→state import
+// cycle.
+const KIWI_RX_INDEX = 7;
+
 // EMA smoothing for the per-receiver floor — fast enough to settle on a band
 // change within a couple of seconds, slow enough that the colours don't jitter
 // frame to frame as the instantaneous floor estimate wobbles.
@@ -85,14 +96,17 @@ export function resetReceiverFloors(): void {
 }
 
 /**
- * Median of all reported receiver floors (dB) — the common normalization
- * anchor and the "0 dB" reference the master scale reads against. Median, not
- * mean, so one dead or carrier-stuffed band can't drag the anchor. Returns null
- * until at least one floor has been reported. Allocation-free.
+ * Median of the reported HARDWARE receiver floors (dB) — the common
+ * normalization anchor and the "0 dB" reference the master scale reads against.
+ * Median, not mean, so one dead or carrier-stuffed band can't drag the anchor.
+ * The foreign Kiwi slice ({@link KIWI_RX_INDEX}) is excluded so it aligns to the
+ * hardware anchor without redefining it. Returns null until at least one
+ * hardware floor has been reported. Allocation-free.
  */
 export function referenceFloorDb(): number | null {
   let n = 0;
-  for (const v of floorByRx.values()) {
+  for (const [idx, v] of floorByRx) {
+    if (idx === KIWI_RX_INDEX) continue;
     if (n >= refScratch.length) break;
     refScratch[n++] = v;
   }

--- a/zeus-web/src/util/ctun-zoom-center.ts
+++ b/zeus-web/src/util/ctun-zoom-center.ts
@@ -20,7 +20,7 @@
 import { setRadioLo, setReceiverLo, type ZoomLevel } from '../api/client';
 import { selectDisplaySlice, useDisplayStore } from '../state/display-store';
 import { useConnectionStore } from '../state/connection-store';
-import { rxIndexOf, type ReceiverKey } from '../state/receiver-state';
+import { getReceiverVfoHz, KIWI_RECEIVER_INDEX, rxIndexOf, type ReceiverKey } from '../state/receiver-state';
 import * as viewCenter from '../state/view-center';
 
 const MAX_HZ = 60_000_000;
@@ -72,6 +72,21 @@ export function centerCtunForZoomIn(
       .catch(() => {});
   }
   return targetLoHz;
+}
+
+// On zoom-IN under CTUN, re-centre the Kiwi slice on its own dial. The global
+// ZoomControl only re-centres RX1 (centerCtunForZoomIn above), so without this
+// the Kiwi's frozen CTUN waterfall centre stays put while the span shrinks — its
+// dial (and the passband overlay that hangs off it) drift to the pane edge as
+// you zoom in (operator report: "zoom breaks the Kiwi filter + waterfall").
+// No-op when zooming out, CTUN off, or the Kiwi slice isn't enabled. Mirrors the
+// RX1 path but targets the Kiwi's independent waterfall centre via SetCenter.
+export function centerKiwiForZoomIn(currentZoom: ZoomLevel, nextZoom: ZoomLevel): void {
+  if (nextZoom <= currentZoom) return;
+  const s = useConnectionStore.getState();
+  if (!s.ctunEnabled) return;
+  if (!s.receivers.some((r) => r.index === KIWI_RECEIVER_INDEX)) return;
+  panReceiverCenterTo(KIWI_RECEIVER_INDEX, getReceiverVfoHz(s, KIWI_RECEIVER_INDEX));
 }
 
 // Coalesce overlapping autopan POSTs — a fast tune burst can queue several

--- a/zeus-web/src/util/use-keyboard-shortcuts.ts
+++ b/zeus-web/src/util/use-keyboard-shortcuts.ts
@@ -57,7 +57,7 @@ import * as viewCenter from '../state/view-center';
 import { useToolbarFavoritesStore } from '../state/toolbar-favorites-store';
 import { useTxStore } from '../state/tx-store';
 import { ACTIVE_MAP_REF } from '../state/active-map-ref';
-import { applyCtunZoomCenterAfterState, centerCtunForZoomIn } from './ctun-zoom-center';
+import { applyCtunZoomCenterAfterState, centerCtunForZoomIn, centerKiwiForZoomIn } from './ctun-zoom-center';
 
 // The arrow-key tune step follows the operator's TuningStepWidget choice
 // (toolbar-favorites-store.stepHz). Read at event time inside bumpTune so
@@ -147,6 +147,8 @@ export function useKeyboardShortcuts() {
       const ctrl = new AbortController();
       zoomAbort = ctrl;
       const centeredLoHz = centerCtunForZoomIn(store.zoomLevel, next, ctrl.signal);
+      // Zoom is global — re-centre the Kiwi slice on its dial too (self-guards).
+      centerKiwiForZoomIn(store.zoomLevel, next);
       setZoom(next, ctrl.signal)
         .then((s) => {
           if (!ctrl.signal.aborted) {

--- a/zeus-web/src/util/use-pan-tune-gesture.ts
+++ b/zeus-web/src/util/use-pan-tune-gesture.ts
@@ -44,13 +44,14 @@
 // License for details.
 
 import { createContext, useContext, useEffect, type RefObject } from 'react';
-import { setRadioLo, setZoom, ZOOM_MAX, ZOOM_MIN, type RadioStateDto, type ZoomLevel } from '../api/client';
+import { setRadioLo, setReceiverLo, setZoom, ZOOM_MAX, ZOOM_MIN, type RadioStateDto, type ZoomLevel } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
 import { selectDisplaySlice, useDisplayStore } from '../state/display-store';
 import {
   getReceiverVfoFromState,
   getReceiverVfoHz,
   isSecondaryReceiver,
+  KIWI_RECEIVER_INDEX,
   optimisticSetReceiverVfo,
   postReceiverVfo,
   rxIndexOf,
@@ -62,7 +63,7 @@ import { useNotchStore } from '../state/notch-store';
 import * as viewCenter from '../state/view-center';
 import { useToolbarFavoritesStore } from '../state/toolbar-favorites-store';
 import { roundToStep } from './number';
-import { applyCtunZoomCenterAfterState, centerCtunForZoomIn } from './ctun-zoom-center';
+import { applyCtunZoomCenterAfterState, centerCtunForZoomIn, centerKiwiForZoomIn } from './ctun-zoom-center';
 import { rulerDragTargetHz } from './use-ruler-pan-gesture';
 
 const MAX_HZ = 60_000_000;
@@ -357,6 +358,17 @@ export function usePanTuneGesture(
     const tuneReceiver = options.tuneReceiver ?? receiver;
     const dragMode = options.dragMode ?? 'tune';
     const panIsSecondary = isSecondaryReceiver(receiver);
+    // The Kiwi slice has an INDEPENDENT waterfall centre (SetCenter / the per-RX
+    // /lo endpoint) that is decoupled from its demod dial — exactly like RX1's
+    // CTUN-frozen NCO, and unlike a hardware secondary DDC whose centre IS its
+    // VFO. So a ruler-pan must move the Kiwi's centre, NOT retune its dial:
+    // posting the VFO under CTUN only roams the dial inside the frozen window and
+    // never streams the panned-to band (operator report: "drag pan doesn't load
+    // the rest of the waterfall"). Route the Kiwi pan-centre through SetCenter.
+    const panIsKiwi = rxIndexOf(receiver) === KIWI_RECEIVER_INDEX;
+    // RX1 and the Kiwi pan an independent centre; true hardware secondaries pan
+    // by retuning their VFO (the DDC follows it).
+    const panUsesCenter = panIsKiwi || !panIsSecondary;
     const touchPinchOnly = options.touchMode === 'pinch-only';
 
     type Drag = {
@@ -457,17 +469,31 @@ export function usePanTuneGesture(
     // follows their VFO, so a ruler/pan drag retunes the VFO. RX1 (index 0)
     // repositions the hardware radio LO.
     const fallbackPanCenterHz = () =>
-      panIsSecondary
-        ? getReceiverVfoHz(useConnectionStore.getState(), receiver)
-        : Number(selectDisplaySlice(useDisplayStore.getState(), receiver).centerHz);
+      panUsesCenter
+        ? Number(selectDisplaySlice(useDisplayStore.getState(), receiver).centerHz)
+        : getReceiverVfoHz(useConnectionStore.getState(), receiver);
     const writePanCenter = (hz: number) => {
+      // The Kiwi centre lives server-side (no connection-store field); the pan
+      // view-centre tween carries the optimistic motion until frames reconcile.
+      if (panIsKiwi) return;
       if (panIsSecondary) optimisticSetReceiverVfo(receiver, hz);
       else useConnectionStore.setState({ radioLoHz: hz });
     };
     const postPanCenter = (hz: number, signal?: AbortSignal) =>
-      panIsSecondary ? postReceiverVfo(receiver, hz, signal) : setRadioLo(hz, signal);
+      panIsKiwi
+        ? setReceiverLo(rxIndexOf(receiver), hz, signal)
+        : panIsSecondary
+          ? postReceiverVfo(receiver, hz, signal)
+          : setRadioLo(hz, signal);
     const appliedPanCenterFromState = (state: RadioStateDto) =>
-      panIsSecondary ? getReceiverVfoFromState(state, receiver) : state.radioLoHz;
+      // The Kiwi's centre isn't carried in the StateDto — the next DisplayFrame
+      // reconciles it (view-center.reconcileFrame), so report the commanded value
+      // here to leave the tween untouched on the POST round-trip.
+      panIsKiwi
+        ? commandedPanHz()
+        : panIsSecondary
+          ? getReceiverVfoFromState(state, receiver)
+          : state.radioLoHz;
     const commandedPanHz = () =>
       pendingPanHz ?? (panVc.isInitialized() ? panVc.getTargetCenterHz() : fallbackPanCenterHz());
     const readPanViewport = (): { centerHz: number; spanHz: number } | null => {
@@ -604,6 +630,9 @@ export function usePanTuneGesture(
         rxIndexOf(receiver) === 0 && rxIndexOf(tuneReceiver) === 0
           ? centerCtunForZoomIn(cur, next, ctrl.signal)
           : null;
+      // Zoom is global — re-centre the Kiwi slice on its dial too (self-guards on
+      // CTUN + Kiwi-enabled + zoom-in), whichever panel the wheel is over.
+      centerKiwiForZoomIn(cur, next);
       setZoom(next, ctrl.signal)
         .then((s) => {
           if (!ctrl.signal.aborted) {


### PR DESCRIPTION
The KiwiSDR slice receiver demodulates **server-side** and rides the shared RX mix bus, so several controls that work on the hardware RXs were no-ops or broken on the Kiwi. This bundles the fixes.

## Changes

**Squelch** — the global `SQL` control never reached the Kiwi (WDSP/adaptive squelch in `DspPipelineService` only touches the hardware path). Now the Kiwi audio is gated on its own per-SND-frame S-meter: fixed-threshold mapped from the SQL level, plus an adaptive noise-floor-tracking mode, with a smoothed attack/release so there's no click on open/close.

**Zoom re-centering (CTUN)** — zoom-in re-centering was hardcoded to RX1, so zooming the Kiwi left its CTUN-frozen centre put while the span shrank: the dial (and the passband overlay that hangs off it) drifted to the pane edge. Now the Kiwi re-centres on its own dial on every zoom-in path (slider / keyboard / wheel).

**Drag-pan** — a ruler-pan posted the Kiwi *VFO* (`postReceiverVfo`), which under CTUN only roams the dial inside a frozen window — nothing new streamed in. The Kiwi has an independent waterfall centre like RX1, so pan now routes through `SetCenter` (`/api/receivers/{kiwi}/lo`) and the panned-to band actually loads.

**TX mute** — the Kiwi now drops out of the mix while keyed (MOX/TUN) so the operator doesn't monitor their own delayed/off-frequency signal feeding back through the remote RX.

**Waterfall floor normalization** — the cross-band floor anchor medianed *all* receivers including the Kiwi. The Kiwi is a *foreign* receiver (different site/antenna/calibration), so co-anchoring left RX1 and the Kiwi each only half-aligned and the Kiwi pane washed out bright. It's now excluded from the anchor so it normalises *to* the hardware floor without dragging it.

Also adds a 1 Hz `kiwi.wf.db` diagnostic log of the real waterfall dB span (min/floor/median/max) to calibrate normalization from on-wire data.

## Tests
- Backend: Kiwi squelch-gate (off/fixed/adaptive) + TX-mute (`KiwiSdrTests`).
- Frontend: floor-normalization Kiwi-exclusion (`floor-normalization.test.ts`).
- Backend builds clean on `develop`; full suites pass locally (56 backend Kiwi, 1039 frontend, typecheck clean).

## Verification note
The Kiwi paths can't be browser/bench-verified from here (need a connected radio to clock the mix bus + a live remote KiwiSDR). The drag-pan and the floor-normalization *visual* result are worth a quick on-hardware confirmation.