### PR TITLE
DO NOT MERGE: FT8/FT4 + WSPR transmit — armed auto-sequencing keyer (#1012 #1013)

### DIFF
--- a/Zeus.Contracts/Ft8TxStatusFrame.cs
+++ b/Zeus.Contracts/Ft8TxStatusFrame.cs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Ft8TxStatusFrame (MsgType 0x3A) — server→client push of the FT8/FT4/WSPR TX
+// keyer state. JSON envelope, mirroring Ft8DecodeFrame (0x38): low rate (only on
+// arm/stage/transmit edges) and the shape is small. One DTO serves both the
+// FT8/FT4 auto-sequence keyer (Slot = "even"/"odd") and the WSPR beacon
+// (Slot = "", WatchdogSecsRemaining still meaningful). The workspace renders the
+// arm/transmit lamps from this so the UI tracks what the backend ACTUALLY keyed,
+// not just what the operator staged.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Zeus.Contracts;
+
+/// <summary>The live state of the digital-mode TX keyer for the wire/UI.</summary>
+public sealed record Ft8TxStatusDto(
+    bool Armed,                   // ENABLE-TX master; defaults false, never auto-set
+    bool Transmitting,            // true while a slot is being keyed on the air
+    string Mode,                  // "FT8" | "FT4" | "WSPR"
+    string? Message,              // currently staged / transmitting message, if any
+    int AudioHz,                  // TX audio offset of tone 0
+    string Slot,                  // "even" | "odd" (FT8/FT4); "" for WSPR
+    int WatchdogSecsRemaining,    // seconds until the unattended watchdog disarms (0 = disarmed)
+    long? LastTxSlotMs,           // unix-ms of the last slot the keyer transmitted, if any
+    bool NativeAvailable);        // encode/synth path present on this platform
+
+/// <summary>Wire codec for the digital TX-status frame (MsgType 0x3A).</summary>
+public static class Ft8TxStatusFrame
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
+    /// <summary>Serialise a status to a 0x3A frame ([type:1][UTF-8 JSON]).</summary>
+    public static byte[] Encode(Ft8TxStatusDto status)
+    {
+        var json = JsonSerializer.SerializeToUtf8Bytes(status, JsonOptions);
+        var frame = new byte[1 + json.Length];
+        frame[0] = (byte)MsgType.Ft8TxStatus;
+        json.CopyTo(frame, 1);
+        return frame;
+    }
+
+    /// <summary>Decode a 0x3A frame back to a status (for tests / the frontend mirror).</summary>
+    public static Ft8TxStatusDto Decode(ReadOnlySpan<byte> frame)
+    {
+        if (frame.Length < 1)
+            throw new InvalidDataException("Ft8TxStatus frame is empty");
+        if (frame[0] != (byte)MsgType.Ft8TxStatus)
+            throw new InvalidDataException(
+                $"expected Ft8TxStatus (0x{(byte)MsgType.Ft8TxStatus:X2}), got 0x{frame[0]:X2}");
+        var status = JsonSerializer.Deserialize<Ft8TxStatusDto>(frame[1..], JsonOptions);
+        return status ?? throw new InvalidDataException("Ft8TxStatus payload did not deserialise");
+    }
+}

--- a/Zeus.Contracts/MoxSource.cs
+++ b/Zeus.Contracts/MoxSource.cs
@@ -51,4 +51,14 @@ public enum MoxSource : byte
     /// <see cref="UI"/> remains the master override. CAT keying never arms
     /// PureSignal and never auto-keys on connect.</summary>
     Cat = 5,
+    /// <summary>The built-in FT8/FT4/WSPR armed auto-sequence keyer
+    /// (<c>Ft8TxService</c> / <c>WsprTxService</c>) driving keying from the
+    /// digital-mode slot clock. One shared wire value covers all three digital
+    /// modes (they never key simultaneously). Same release rule as
+    /// <see cref="Tci"/> / <see cref="Cat"/>: only this source releases what it
+    /// itself claimed, and <see cref="UI"/> remains the master override. The
+    /// keyer arms ONLY on an explicit operator ENABLE-TX action and a freshly
+    /// staged message — it never arms PureSignal and never auto-keys on connect
+    /// or startup.</summary>
+    Ft8 = 6,
 }

--- a/Zeus.Contracts/MsgType.cs
+++ b/Zeus.Contracts/MsgType.cs
@@ -262,4 +262,13 @@ public enum MsgType : byte
     // into its spot table. UI ignores unknown types so older builds tolerate it.
     // Payload: [type:1][UTF-8 JSON WsprSpotBatchDto]. See WsprSpotFrame.cs.
     WsprSpot = 0x39,
+
+    // Server → client (FT8/FT4/WSPR TX keyer status). Broadcast by Ft8TxService /
+    // WsprTxService on every armed/staged/transmitting edge so the UI reflects
+    // what the backend ACTUALLY keyed (authoritative), not just what the operator
+    // staged. Same low-rate JSON-envelope shape as Ft8Decode (0x38). One frame
+    // covers both the FT8/FT4 keyer (Slot = "even"/"odd") and the WSPR beacon
+    // (Slot = ""). UI ignores unknown types so older builds tolerate it.
+    // Payload: [type:1][UTF-8 JSON Ft8TxStatusDto]. See Ft8TxStatusFrame.cs.
+    Ft8TxStatus = 0x3A,
 }

--- a/Zeus.Dsp.Ft8/Ft8Synth.cs
+++ b/Zeus.Dsp.Ft8/Ft8Synth.cs
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Ft8Synth — pure managed FT8/FT4 GFSK/MFSK tone synthesizer (the TX-side
+// counterpart of Ft8Decoder.Encode). There is no native synth for FT8/FT4 (the
+// vendored zeus_ft8 ships encode + decode only), so this is C# — cross-platform
+// by construction, no P/Invoke, identical on macOS / Windows / Linux / Pi.
+//
+// Algorithm is faithful to WSJT-X gen_ft8wave.f90 / gen_ft4wave.f90 (the
+// authoritative reference for ANAN-class digital, the role Thetis plays for the
+// protocol/DSP path): build a smoothed instantaneous-frequency waveform by
+// summing per-symbol shaping pulses, integrate to phase, emit sin(phi). The
+// output is CONSTANT-ENVELOPE (a single clean tone at each instant) — this is
+// the audio fed into the WDSP TX chain, NOT RF power. `amplitude` sets the audio
+// level into TXA; drive/power are unchanged and owned elsewhere.
+//
+// FT8 uses an 8-GFSK Gaussian pulse (BT=2.0) spanning 3 symbols; FT4 uses a
+// 4-MFSK raised-cosine (partial-response) pulse spanning 2 symbols. Both use
+// modulation index hmod=1, so the tone spacing equals the baud rate
+// (FT8 6.25 Hz / 0.16 s; FT4 20.8333 Hz / 0.048 s).
+
+namespace Zeus.Dsp.Ft8;
+
+/// <summary>
+/// Pure-managed GFSK/MFSK synthesizer for FT8/FT4 transmit audio. Turns the FSK
+/// tone indices from <see cref="Ft8Decoder.Encode"/> into a continuous-phase
+/// mono waveform at any sample rate (48 kHz for the Zeus TX chain, 12 kHz for a
+/// round-trip decode test).
+/// </summary>
+public static class Ft8Synth
+{
+    /// <summary>The canonical TX-chain audio sample rate.</summary>
+    public const int TxSampleRate = 48000;
+
+    // Per-protocol modulation constants (WSJT-X). hmod = 1 for both.
+    private const double Ft8SymbolPeriodSec = 0.16;       // 79 symbols
+    private const double Ft4SymbolPeriodSec = 0.048;      // 105 symbols
+    private const int Ft8SymbolCount = 79;
+    private const int Ft4SymbolCount = 105;
+    private const double GaussianBt = 2.0;                // FT8 Gaussian pulse BT
+
+    /// <summary>
+    /// Synthesize the continuous-phase FT8/FT4 audio for a tone-index sequence.
+    /// <paramref name="tones"/> are 0..7 (FT8) / 0..3 (FT4) as produced by
+    /// <see cref="Ft8Decoder.Encode"/>. <paramref name="baseFreqHz"/> is the
+    /// audio offset of tone 0 (the operator TX offset, default 1500 Hz).
+    /// <paramref name="amplitude"/> is the peak audio level (RMS = amplitude/√2).
+    /// Returns exactly <c>tones.Length * nsps</c> samples, or null if the tone
+    /// count doesn't match the protocol.
+    /// </summary>
+    public static float[] Synth(
+        byte[] tones,
+        Ft8Protocol protocol = Ft8Protocol.Ft8,
+        float baseFreqHz = 1500f,
+        int sampleRate = TxSampleRate,
+        float amplitude = 0.5f)
+    {
+        ArgumentNullException.ThrowIfNull(tones);
+        if (sampleRate <= 0) throw new ArgumentOutOfRangeException(nameof(sampleRate));
+
+        bool ft4 = protocol == Ft8Protocol.Ft4;
+        int expectedSymbols = ft4 ? Ft4SymbolCount : Ft8SymbolCount;
+        if (tones.Length != expectedSymbols)
+            throw new ArgumentException(
+                $"expected {expectedSymbols} {protocol} tones, got {tones.Length}", nameof(tones));
+
+        double symbolPeriod = ft4 ? Ft4SymbolPeriodSec : Ft8SymbolPeriodSec;
+        int nsps = (int)Math.Round(symbolPeriod * sampleRate);
+        if (nsps <= 0) throw new ArgumentOutOfRangeException(nameof(sampleRate), "sample rate too low");
+        int nsym = tones.Length;
+        double dt = 1.0 / sampleRate;
+
+        // Shaping pulse, 3 symbols wide (the FT4 raised-cosine is zero in the
+        // outer thirds; the FT8 Gaussian tapers there).
+        int pulseLen = 3 * nsps;
+        var pulse = new double[pulseLen];
+        for (int i = 0; i < pulseLen; i++)
+        {
+            // tt centred on the middle symbol. WSJT-X gen_ft8wave uses a 1-based
+            // loop (Fortran i=1..3*nsps) with tt=(i-1.5*nsps)/nsps; our loop is
+            // 0-based, so Fortran's i == our (i+1). The (i+1) below is therefore the
+            // faithful translation — do NOT drop it (that would shift the pulse a
+            // sample early).
+            double tt = (i + 1 - 1.5 * nsps) / nsps;
+            pulse[i] = ft4 ? RaisedCosinePulse(tt) : GaussianPulse(GaussianBt, tt);
+        }
+
+        // Smoothed instantaneous frequency (radians/sample). Length (nsym+2)*nsps
+        // so the first and last symbols are fully shaped; trim the one-symbol
+        // lead/lag after integrating.
+        int dphiLen = (nsym + 2) * nsps;
+        var dphi = new double[dphiLen];
+        double carrier = 2.0 * Math.PI * baseFreqHz * dt;
+        for (int k = 0; k < dphiLen; k++) dphi[k] = carrier;
+
+        double dphiPeak = 2.0 * Math.PI / nsps; // hmod = 1
+        for (int j = 0; j < nsym; j++)
+        {
+            int tone = tones[j];
+            if (tone == 0) continue;
+            int ib = j * nsps;
+            double w = dphiPeak * tone;
+            for (int k = 0; k < pulseLen; k++)
+                dphi[ib + k] += w * pulse[k];
+        }
+
+        // Integrate to phase and emit. Keep the middle nsym*nsps samples
+        // (discard the one-symbol lead/lag introduced by the pulse padding).
+        var outAudio = new float[nsym * nsps];
+        double phi = 0.0;
+        for (int k = 0; k < nsps; k++) phi += dphi[k]; // advance through the lead symbol
+        for (int n = 0; n < outAudio.Length; n++)
+        {
+            outAudio[n] = (float)(amplitude * Math.Sin(phi));
+            phi += dphi[nsps + n];
+            // Keep phi bounded so float drift never accumulates over 600k samples.
+            if (phi > Math.PI) phi -= 2.0 * Math.PI;
+            else if (phi < -Math.PI) phi += 2.0 * Math.PI;
+        }
+
+        // Raised-cosine ramp at the very start/end to kill key clicks (half a
+        // symbol, WSJT-X uses nsps/8 — a half symbol is gentler and well inside
+        // the decoder's tolerance since the sync symbols sit away from the edges).
+        int nramp = Math.Max(1, nsps / 8);
+        for (int n = 0; n < nramp && n < outAudio.Length; n++)
+        {
+            double env = 0.5 * (1.0 - Math.Cos(Math.PI * n / nramp));
+            outAudio[n] *= (float)env;
+            outAudio[outAudio.Length - 1 - n] *= (float)env;
+        }
+
+        return outAudio;
+    }
+
+    // Gaussian GFSK shaping pulse (WSJT-X gfsk_pulse). Integrated Gaussian over
+    // one symbol, so a sequence of these sums to a smooth frequency trajectory.
+    private static double GaussianPulse(double bt, double t)
+    {
+        double c = Math.PI * Math.Sqrt(2.0 / Math.Log(2.0));
+        return 0.5 * (Erf(c * bt * (t + 0.5)) - Erf(c * bt * (t - 0.5)));
+    }
+
+    // FT4 raised-cosine (partial-response) shaping pulse spanning two symbols
+    // ([-1,1]); a Nyquist pulse so adjacent symbols sum to unity with no ISI.
+    private static double RaisedCosinePulse(double t)
+    {
+        if (t <= -1.0 || t >= 1.0) return 0.0;
+        return 0.5 * (1.0 + Math.Cos(Math.PI * t));
+    }
+
+    // Abramowitz & Stegun 7.1.26 error-function approximation (|error| < 1.5e-7),
+    // ample for shaping-pulse generation. .NET has no built-in Math.Erf.
+    private static double Erf(double x)
+    {
+        double sign = x < 0 ? -1.0 : 1.0;
+        double ax = Math.Abs(x);
+        double tt = 1.0 / (1.0 + 0.3275911 * ax);
+        double y = 1.0 - (((((1.061405429 * tt - 1.453152027) * tt) + 1.421413741) * tt
+                            - 0.284496736) * tt + 0.254829592) * tt * Math.Exp(-ax * ax);
+        return sign * y;
+    }
+}

--- a/Zeus.Server.Hosting/DigitalTxArbiter.cs
+++ b/Zeus.Server.Hosting/DigitalTxArbiter.cs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// DigitalTxArbiter — a single-owner interlock for the digital-mode keyers.
+// Ft8TxService and WsprTxService are BOTH always-running hosted services and BOTH
+// key the radio through the SAME MoxSource.Ft8. Nothing in the wire protocol
+// distinguishes them, so if both were armed at once one keyer's slot-end
+// `_keyer(false, Ft8)` would drop MOX out from under the other (same-source
+// release) and both would feed audio into TXA concurrently. The fix is a process
+// invariant enforced here: only ONE of {FT8/FT4, WSPR} may be armed at a time.
+// When a keyer arms, it Claim()s the arbiter, which force-disarms every sibling.
+
+namespace Zeus.Server;
+
+/// <summary>A digital keyer that the arbiter can force off when a sibling arms.</summary>
+public interface IDigitalTxKeyer
+{
+    /// <summary>Disarm immediately (and drop MOX if mid-slot). MUST NOT call back
+    /// into the arbiter — it is invoked from inside <see cref="DigitalTxArbiter.Claim"/>.</summary>
+    void ForceDisarm(string reason);
+}
+
+/// <summary>Process-wide single-owner gate for the digital keyers (DI singleton).</summary>
+public sealed class DigitalTxArbiter
+{
+    private readonly object _lock = new();
+    private readonly List<IDigitalTxKeyer> _keyers = new();
+
+    /// <summary>Register a keyer so a sibling's <see cref="Claim"/> can disarm it.</summary>
+    public void Register(IDigitalTxKeyer keyer)
+    {
+        ArgumentNullException.ThrowIfNull(keyer);
+        lock (_lock)
+        {
+            if (!_keyers.Contains(keyer)) _keyers.Add(keyer);
+        }
+    }
+
+    /// <summary>Called when <paramref name="claimant"/> arms: force-disarms every
+    /// other registered keyer so only the claimant holds MoxSource.Ft8.</summary>
+    public void Claim(IDigitalTxKeyer claimant)
+    {
+        ArgumentNullException.ThrowIfNull(claimant);
+        IDigitalTxKeyer[] others;
+        lock (_lock)
+        {
+            others = _keyers.Where(k => !ReferenceEquals(k, claimant)).ToArray();
+        }
+        foreach (var k in others) k.ForceDisarm("another digital keyer armed");
+    }
+}

--- a/Zeus.Server.Hosting/DigitalTxStreamer.cs
+++ b/Zeus.Server.Hosting/DigitalTxStreamer.cs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// DigitalTxStreamer — shared block-pacing helper for the FT8/FT4 and WSPR TX
+// keyers. Both render a 48 kHz mono float waveform, then must feed it to
+// TxAudioIngest in exactly 960-sample (3840-byte) f32le blocks at the 20 ms mic
+// cadence (anything else is silently dropped by the ingest). Real-time pacing is
+// Stopwatch-corrected, not a bare PeriodicTimer, so block delivery tracks
+// elapsed wall time and the TxIqRing neither underflows nor overflows —
+// identical parity with the live mic path on every platform.
+
+using System.Buffers.Binary;
+using System.Diagnostics;
+
+namespace Zeus.Server;
+
+internal static class DigitalTxStreamer
+{
+    /// <summary>Samples per ingest block (20 ms @ 48 kHz mono).</summary>
+    public const int BlockSamples = 960;
+    /// <summary>Bytes per ingest block (f32le).</summary>
+    public const int BlockBytes = BlockSamples * 4;
+    /// <summary>Block cadence in milliseconds.</summary>
+    public const int BlockMs = 20;
+
+    /// <summary>
+    /// Stream <paramref name="leadBlocks"/> silence blocks followed by the
+    /// <paramref name="audio"/> waveform as 960-sample f32le blocks into
+    /// <paramref name="sink"/>, paced one block every 20 ms of elapsed wall time.
+    /// The lead silence lets the T/R relay settle before real audio appears
+    /// (a digital MOX source has no UI pre-key mute window). Stops early — leaving
+    /// a clean block boundary — if <paramref name="ct"/> cancels or
+    /// <paramref name="stillArmed"/> returns false (operator Halt / disarm
+    /// mid-slot). <paramref name="delay"/> is injectable so tests run instantly.
+    /// </summary>
+    public static async Task StreamAsync(
+        float[] audio,
+        int leadBlocks,
+        Action<ReadOnlyMemory<byte>> sink,
+        Func<int, CancellationToken, Task> delay,
+        Func<bool> stillArmed,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(audio);
+        ArgumentNullException.ThrowIfNull(sink);
+
+        var block = new byte[BlockBytes];
+        var sw = Stopwatch.StartNew();
+        int blocksSent = 0;
+
+        // Lead-in silence (T/R settle). The block buffer starts all-zero.
+        for (int i = 0; i < leadBlocks; i++)
+        {
+            if (ct.IsCancellationRequested || !stillArmed()) return;
+            sink(block);
+            blocksSent++;
+            await PaceAsync(sw, blocksSent, delay, ct).ConfigureAwait(false);
+        }
+
+        // Real audio, padded to a whole final block with trailing zeros.
+        for (int offset = 0; offset < audio.Length; offset += BlockSamples)
+        {
+            if (ct.IsCancellationRequested || !stillArmed()) return;
+            int count = Math.Min(BlockSamples, audio.Length - offset);
+            for (int s = 0; s < BlockSamples; s++)
+            {
+                float v = s < count ? audio[offset + s] : 0f;
+                BinaryPrimitives.WriteSingleLittleEndian(block.AsSpan(s * 4, 4), v);
+            }
+            sink(block);
+            blocksSent++;
+            await PaceAsync(sw, blocksSent, delay, ct).ConfigureAwait(false);
+        }
+    }
+
+    // Wait until the wall clock reaches the deadline for the next block, so the
+    // average rate is exactly one block per 20 ms regardless of per-iteration
+    // jitter. Never waits negative time (a late block fires immediately).
+    private static Task PaceAsync(
+        Stopwatch sw, int blocksSent, Func<int, CancellationToken, Task> delay, CancellationToken ct)
+    {
+        long deadlineMs = (long)blocksSent * BlockMs;
+        long remaining = deadlineMs - sw.ElapsedMilliseconds;
+        return remaining > 0 ? delay((int)remaining, ct) : Task.CompletedTask;
+    }
+}

--- a/Zeus.Server.Hosting/Ft8TxEndpoints.cs
+++ b/Zeus.Server.Hosting/Ft8TxEndpoints.cs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Ft8TxEndpoints — the REST control surface for the FT8/FT4 + WSPR ARMED
+// auto-sequence keyers. Kept in its own extension file (called from
+// MapZeusEndpoints) so it doesn't pile onto the already-large ZeusEndpoints.cs.
+//
+// SAFETY: arming is ONLY via the explicit /arm endpoints (default false, no
+// auto-arm anywhere); staging a message never arms; /halt is the panic path. No
+// PureSignal, drive, or power state is read or written here.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Zeus.Server;
+
+/// <summary>POST /api/ft8/tx/arm — the FT8/FT4 ENABLE-TX master.</summary>
+public sealed record Ft8TxArmRequest(bool Enabled);
+
+/// <summary>POST /api/ft8/tx — stage the next FT8/FT4 transmission.</summary>
+public sealed record Ft8TxStageRequest(string Message, int? AudioHz, string? Slot, string? Mode);
+
+/// <summary>POST /api/wspr/tx/arm — the WSPR ENABLE-TX master.</summary>
+public sealed record WsprTxArmRequest(bool Enabled);
+
+/// <summary>POST /api/wspr/tx/settings — beacon content + cadence.</summary>
+public sealed record WsprTxSettingsRequest(
+    string Call, string Grid4, int? DBm, int? AudioHz, double? TxPercent);
+
+public static class Ft8TxEndpoints
+{
+    /// <summary>Maps the FT8/FT4 + WSPR keyer endpoints onto <paramref name="app"/>.</summary>
+    public static WebApplication MapFt8TxEndpoints(this WebApplication app)
+    {
+        var log = app.Services.GetRequiredService<ILogger<object>>();
+
+        // ---- FT8/FT4 keyer -------------------------------------------------
+
+        app.MapGet("/api/ft8/tx", (Ft8TxService svc) => Results.Ok(svc.Status()));
+
+        app.MapPost("/api/ft8/tx/arm", (Ft8TxArmRequest body, Ft8TxService svc) =>
+        {
+            svc.SetArmed(body.Enabled);
+            log.LogInformation("api.ft8.tx.arm enabled={Enabled}", body.Enabled);
+            return Results.Ok(svc.Status());
+        });
+
+        app.MapPost("/api/ft8/tx", (Ft8TxStageRequest body, Ft8TxService svc) =>
+        {
+            string? err = svc.Stage(
+                body.Message, body.AudioHz ?? 1500, body.Slot ?? "even", body.Mode ?? "FT8");
+            if (err is not null) return Results.BadRequest(new { error = err });
+            log.LogInformation("api.ft8.tx.stage msg='{Msg}' slot={Slot} mode={Mode}",
+                body.Message, body.Slot, body.Mode);
+            return Results.Ok(svc.Status());
+        });
+
+        app.MapPost("/api/ft8/tx/halt", (Ft8TxService svc) =>
+        {
+            svc.Halt();
+            log.LogInformation("api.ft8.tx.halt");
+            return Results.Ok(svc.Status());
+        });
+
+        // ---- WSPR beacon ---------------------------------------------------
+
+        app.MapGet("/api/wspr/tx", (WsprTxService svc) => Results.Ok(svc.Status()));
+
+        app.MapPost("/api/wspr/tx/arm", (WsprTxArmRequest body, WsprTxService svc) =>
+        {
+            svc.SetArmed(body.Enabled);
+            log.LogInformation("api.wspr.tx.arm enabled={Enabled}", body.Enabled);
+            return Results.Ok(svc.Status());
+        });
+
+        app.MapPost("/api/wspr/tx/settings", (WsprTxSettingsRequest body, WsprTxService svc) =>
+        {
+            string? err = svc.SetSettings(
+                body.Call, body.Grid4, body.DBm ?? 30, body.AudioHz ?? 1500, body.TxPercent ?? 0.2);
+            if (err is not null) return Results.BadRequest(new { error = err });
+            log.LogInformation("api.wspr.tx.settings call={Call} grid={Grid} pct={Pct}",
+                body.Call, body.Grid4, body.TxPercent);
+            return Results.Ok(svc.Status());
+        });
+
+        app.MapPost("/api/wspr/tx/halt", (WsprTxService svc) =>
+        {
+            svc.Halt();
+            log.LogInformation("api.wspr.tx.halt");
+            return Results.Ok(svc.Status());
+        });
+
+        return app;
+    }
+}

--- a/Zeus.Server.Hosting/Ft8TxService.cs
+++ b/Zeus.Server.Hosting/Ft8TxService.cs
@@ -1,0 +1,474 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Ft8TxService — the FT8/FT4 ARMED auto-sequence keyer (the TX half; the RX
+// decode pipeline lives in Ft8Service and is untouched). It owns the UTC slot
+// clock, keys MOX through TxService (MoxSource.Ft8), and streams the synthesized
+// tone audio into TxAudioIngest. The frontend QSO state machine decides WHAT to
+// say each window and STAGES it; this service decides WHEN to key and does the
+// keying.
+//
+// SAFETY (KB2UKA standing orders for digital auto-seq):
+//   * NEVER auto-arm. `_armed` defaults false and is only set by an explicit
+//     operator ENABLE-TX action (POST /api/ft8/tx/arm). No arm on startup,
+//     connect, or workspace entry.
+//   * NEVER transmit without a FRESH staged message whose slot parity matches
+//     the slot being entered. "No message staged ⇒ no transmission" is the
+//     structural guarantee — see ShouldKeyForSlot.
+//   * A backend WATCHDOG auto-disarms after WatchdogMinutes — a HARD MAXIMUM
+//     ARMED DURATION measured from the operator's arm action, independent of (and
+//     additional to) the frontend Halt / no-reply-stop / disable-after-73, which
+//     all arrive as arm/halt POSTs. It is intentionally a duration cap, not an
+//     idle detector: it always trips N minutes after arming so an abandoned rig
+//     can never beacon forever. (A future operator-activity keep-alive that
+//     refreshes the cap for an attended pileup run is tracked as a follow-up.)
+//   * PureSignal is never read or written here. Drive/power defaults are never
+//     touched — the keyer only keys MOX and feeds audio.
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Zeus.Contracts;
+using Zeus.Dsp.Ft8;
+
+namespace Zeus.Server;
+
+public sealed class Ft8TxService : IHostedService, IDisposable, IDigitalTxKeyer
+{
+    /// <summary>Keying delegate (production wraps <c>TxService.TrySetMox</c>).</summary>
+    internal delegate bool MoxKeyer(bool on, out string? error);
+
+    // Lead the slot boundary by this much (ms) so MOX/T-R settles before audio.
+    private const int LeadMs = 120;
+    // Hard maximum armed duration (minutes) measured from the arm action.
+    internal const int WatchdogMinutes = 10;
+
+    private readonly MoxKeyer _keyer;
+    private readonly Action<ReadOnlyMemory<byte>> _audioSink;
+    private readonly Action<byte[]> _broadcast;
+    private readonly Func<string, Ft8Protocol, int, float[]?> _renderer;
+    private readonly Func<DateTime> _clock;
+    private readonly Func<int, CancellationToken, Task> _delay;
+    private readonly ILogger _log;
+    private DigitalTxArbiter? _arbiter;        // single-owner interlock vs WSPR
+
+    private readonly object _lock = new();
+    private bool _armed;                       // ENABLE-TX master — defaults false
+    private Ft8Protocol _mode = Ft8Protocol.Ft8;
+    private string? _stagedMessage;
+    private int _stagedAudioHz = 1500;
+    private int _stagedParity;                 // 0 = even, 1 = odd
+    private DateTime _stagedAtUtc;
+    private DateTime _armedSinceUtc;
+    private bool _transmitting;
+    private long? _lastTxSlotMs;
+
+    private CancellationTokenSource? _cts;
+    private Task? _clockLoop;
+
+    /// <summary>Production constructor — wires the real keying / audio / broadcast seams.</summary>
+    public Ft8TxService(
+        TxService tx, TxAudioIngest ingest, StreamingHub hub,
+        DigitalTxArbiter arbiter, ILoggerFactory loggerFactory)
+        : this(
+            (bool on, out string? error) => tx.TrySetMox(on, MoxSource.Ft8, out error),
+            ingest.OnMicPcmBytesFromFt8,
+            hub.BroadcastFt8TxStatus,
+            DefaultRenderer,
+            static () => DateTime.UtcNow,
+            static (ms, ct) => Task.Delay(ms, ct),
+            loggerFactory.CreateLogger<Ft8TxService>())
+    {
+        SetArbiter(arbiter);
+    }
+
+    /// <summary>Test constructor — injects keying / audio / clock / pacing as
+    /// delegates so the scheduler can be driven deterministically with no native
+    /// dependency and no real-time waits.</summary>
+    internal Ft8TxService(
+        MoxKeyer keyer,
+        Action<ReadOnlyMemory<byte>> audioSink,
+        Action<byte[]> broadcast,
+        Func<string, Ft8Protocol, int, float[]?> renderer,
+        Func<DateTime> clock,
+        Func<int, CancellationToken, Task> delay,
+        ILogger logger)
+    {
+        _keyer = keyer;
+        _audioSink = audioSink;
+        _broadcast = broadcast;
+        _renderer = renderer;
+        _clock = clock;
+        _delay = delay;
+        _log = logger;
+    }
+
+    /// <summary>Attach (and register with) the cross-service arm interlock. Called
+    /// from the production ctor; tests opt in explicitly when exercising it.</summary>
+    internal void SetArbiter(DigitalTxArbiter arbiter)
+    {
+        _arbiter = arbiter;
+        arbiter.Register(this);
+    }
+
+    /// <summary>True if the FT8/FT4 encode + synth path is usable on this platform.</summary>
+    public bool NativeAvailable => Ft8Decoder.IsAvailable;
+
+    internal bool Armed { get { lock (_lock) return _armed; } }
+    internal bool Transmitting { get { lock (_lock) return _transmitting; } }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _cts = new CancellationTokenSource();
+        _clockLoop = Task.Run(() => ClockLoopAsync(_cts.Token));
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        _cts?.Cancel();
+        bool drop;
+        lock (_lock) { _armed = false; drop = _transmitting; }
+        if (drop) _keyer(false, out _);
+        if (_clockLoop is not null)
+        {
+            try { await _clockLoop.ConfigureAwait(false); }
+            catch (OperationCanceledException) { /* normal shutdown */ }
+        }
+    }
+
+    // ---- operator control surface (called by Ft8TxEndpoints) -----------------
+
+    /// <summary>The ENABLE-TX master. The ONLY way TX turns on. Stamps the
+    /// watchdog clock on a fresh arm; disarm clears any staged message.</summary>
+    public void SetArmed(bool enabled)
+    {
+        bool drop = false;
+        lock (_lock)
+        {
+            if (enabled)
+            {
+                if (!_armed) _armedSinceUtc = _clock();
+                _armed = true;
+            }
+            else
+            {
+                _armed = false;
+                _stagedMessage = null;
+                drop = _transmitting;
+            }
+        }
+        // Single-owner interlock: arming FT8/FT4 force-disarms a running WSPR
+        // beacon (and vice-versa) so only one digital keyer holds MoxSource.Ft8.
+        if (enabled) _arbiter?.Claim(this);
+        if (drop) _keyer(false, out _);
+        BroadcastStatus();
+    }
+
+    /// <summary>Arbiter-driven force-disarm (a sibling digital keyer armed). Like
+    /// <see cref="Halt"/> but does not re-enter the arbiter.</summary>
+    public void ForceDisarm(string reason)
+    {
+        bool drop;
+        lock (_lock)
+        {
+            if (!_armed) return;
+            _armed = false;
+            _stagedMessage = null;
+            drop = _transmitting;
+        }
+        if (drop) _keyer(false, out _);
+        _log.LogInformation("ft8.tx force-disarmed: {Reason}", reason);
+        BroadcastStatus();
+    }
+
+    /// <summary>Stage the next transmission (replaces any pending stage). Returns
+    /// an error string on bad input, or null on success.</summary>
+    public string? Stage(string message, int audioHz, string slot, string mode)
+    {
+        if (string.IsNullOrWhiteSpace(message)) return "message is required";
+        Ft8Protocol proto;
+        switch (mode?.Trim().ToUpperInvariant())
+        {
+            case null:
+            case "":
+            case "FT8": proto = Ft8Protocol.Ft8; break;
+            case "FT4": proto = Ft8Protocol.Ft4; break;
+            default: return "mode must be 'FT8' or 'FT4'";
+        }
+        int parity = slot?.Trim().ToLowerInvariant() switch
+        {
+            "even" => 0,
+            "odd" => 1,
+            _ => -1,
+        };
+        if (parity < 0) return "slot must be 'even' or 'odd'";
+
+        lock (_lock)
+        {
+            _mode = proto;
+            _stagedMessage = message.Trim().ToUpperInvariant();
+            _stagedAudioHz = Math.Clamp(audioHz, 0, 2500);
+            _stagedParity = parity;
+            _stagedAtUtc = _clock();
+        }
+        BroadcastStatus();
+        return null;
+    }
+
+    /// <summary>Panic / abort: clear the stage, disarm, and drop MOX if mid-slot.</summary>
+    public void Halt()
+    {
+        bool drop;
+        lock (_lock)
+        {
+            _armed = false;
+            _stagedMessage = null;
+            drop = _transmitting;
+        }
+        if (drop) _keyer(false, out _);
+        _log.LogInformation("ft8.tx halt");
+        BroadcastStatus();
+    }
+
+    /// <summary>Current keyer status DTO.</summary>
+    public Ft8TxStatusDto Status()
+    {
+        lock (_lock)
+        {
+            int watchdog = 0;
+            if (_armed)
+            {
+                double remaining = WatchdogMinutes * 60.0 - (_clock() - _armedSinceUtc).TotalSeconds;
+                watchdog = (int)Math.Max(0, Math.Ceiling(remaining));
+            }
+            return new Ft8TxStatusDto(
+                _armed,
+                _transmitting,
+                _mode == Ft8Protocol.Ft4 ? "FT4" : "FT8",
+                _stagedMessage,
+                _stagedAudioHz,
+                _stagedParity == 1 ? "odd" : "even",
+                watchdog,
+                _lastTxSlotMs,
+                NativeAvailable);
+        }
+    }
+
+    // ---- scheduler internals (also the test surface) -------------------------
+
+    private static double SlotSecondsFor(Ft8Protocol p) => p == Ft8Protocol.Ft4 ? 7.5 : 15.0;
+
+    // How late into a slot a fresh same-parity reply may still key it (positive DT,
+    // well inside the decoder's DT tolerance: FT8 ≈ ±2.5 s, FT4 ≈ ±1 s). The runner
+    // stages decode-driven replies a couple seconds into the slot, so without this
+    // the reply could only fire a FULL cycle later (next matching boundary). G2
+    // bench-tune.
+    private static double MaxLateStartSecondsFor(Ft8Protocol p) => p == Ft8Protocol.Ft4 ? 1.0 : 2.5;
+
+    private double SlotSeconds { get { lock (_lock) return SlotSecondsFor(_mode); } }
+
+    /// <summary>The only place RF is keyed. True iff the keyer should transmit in
+    /// the slot whose index is <paramref name="slotIndex"/>: armed, a message is
+    /// staged, the slot parity matches, the stage is fresh, and the watchdog has
+    /// not expired. The freshness window is ONE FULL TX CYCLE (two slots): a reply
+    /// staged in the "far" half of a cycle must survive to its next matching-parity
+    /// boundary, which is two slots after the slot it was staged in. Double-fire is
+    /// impossible because <see cref="_stagedMessage"/> is nulled after each
+    /// transmission and at most one matching-parity boundary falls inside the
+    /// window. No fresh matching stage ⇒ no transmission.</summary>
+    internal bool ShouldKeyForSlot(long slotIndex, DateTime nowUtc)
+    {
+        lock (_lock)
+        {
+            if (!_armed || _stagedMessage is null) return false;
+            if ((nowUtc - _armedSinceUtc).TotalMinutes >= WatchdogMinutes) return false;
+            long parity = ((slotIndex % 2) + 2) % 2;
+            if (parity != _stagedParity) return false;
+            double age = (nowUtc - _stagedAtUtc).TotalSeconds;
+            return age >= 0 && age < 2.0 * SlotSecondsFor(_mode);
+        }
+    }
+
+    /// <summary>Enforce the hard max-armed-duration cap: disarm (and drop MOX if
+    /// mid-slot) once the arm has been held longer than <see cref="WatchdogMinutes"/>.</summary>
+    internal void EnforceWatchdog(DateTime nowUtc)
+    {
+        bool fired = false, drop = false;
+        lock (_lock)
+        {
+            if (_armed && (nowUtc - _armedSinceUtc).TotalMinutes >= WatchdogMinutes)
+            {
+                _armed = false;
+                _stagedMessage = null;
+                fired = true;
+                drop = _transmitting;
+            }
+        }
+        if (!fired) return;
+        if (drop) _keyer(false, out _);
+        _log.LogWarning("ft8.tx watchdog disarmed after {Min} min max armed duration", WatchdogMinutes);
+        BroadcastStatus();
+    }
+
+    /// <summary>Key, render the staged message, stream it as 20 ms blocks, then
+    /// unkey and clear the stage (one stage = one transmission). Truncates cleanly
+    /// if disarmed / halted mid-slot.</summary>
+    internal async Task TransmitCurrentStageAsync(CancellationToken ct)
+    {
+        string message;
+        Ft8Protocol proto;
+        int audioHz;
+        lock (_lock)
+        {
+            if (!_armed || _stagedMessage is null) return;
+            message = _stagedMessage;
+            proto = _mode;
+            audioHz = _stagedAudioHz;
+        }
+
+        // Render BEFORE claiming the transmit and keying MOX. The synth of ~607k
+        // samples takes ~10-15 ms; if Halt() / SetArmed(false) / the watchdog fires
+        // during that window, the re-check below observes _armed == false and bails
+        // WITHOUT keying. Keying first (the old order) left MOX up after a panic with
+        // zero IQ fed → the documented "keyed-without-IQ → bare carrier" G2 footgun.
+        float[]? audio = _renderer(message, proto, audioHz);
+        if (audio is null || audio.Length == 0)
+        {
+            _log.LogWarning("ft8.tx render failed for '{Msg}' ({Proto})", message, proto);
+            lock (_lock) { if (ReferenceEquals(_stagedMessage, message)) _stagedMessage = null; }
+            return;
+        }
+
+        lock (_lock)
+        {
+            if (!_armed || _stagedMessage is null) return; // halted/disarmed during render
+            _transmitting = true;
+        }
+
+        bool keyed = false;
+        try
+        {
+            if (!_keyer(true, out string? err))
+            {
+                _log.LogWarning("ft8.tx key-up refused: {Err}", err);
+                return;
+            }
+            keyed = true;
+            BroadcastStatus();
+
+            int leadBlocks = Math.Max(1, LeadMs / DigitalTxStreamer.BlockMs);
+            await DigitalTxStreamer.StreamAsync(audio, leadBlocks, _audioSink, _delay, StillArmed, ct)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            if (keyed) _keyer(false, out _);
+            lock (_lock)
+            {
+                _transmitting = false;
+                _stagedMessage = null; // one stage = one transmission
+            }
+            BroadcastStatus();
+        }
+    }
+
+    private bool StillArmed() { lock (_lock) return _armed; }
+
+    private async Task ClockLoopAsync(CancellationToken ct)
+    {
+        long lastBoundarySlot = long.MinValue;   // boundary check already done for this nextSlot
+        long lastLaunchedSlot = long.MinValue;    // a transmission was launched for this slot
+        while (!ct.IsCancellationRequested)
+        {
+            DateTime now = _clock();
+            EnforceWatchdog(now);
+
+            double slotSec = SlotSeconds;
+            double totalSec = (now - DateTime.UnixEpoch).TotalSeconds;
+            long curSlot = (long)Math.Floor(totalSec / slotSec);
+            long nextSlot = curSlot + 1;
+            double msToBoundary = (nextSlot * slotSec - totalSec) * 1000.0;
+
+            if (msToBoundary <= LeadMs && nextSlot != lastBoundarySlot)
+            {
+                // Preferred path: key the UPCOMING slot at its boundary (audio at ~+0).
+                lastBoundarySlot = nextSlot;
+                if (!Transmitting && lastLaunchedSlot != nextSlot && ShouldKeyForSlot(nextSlot, now))
+                {
+                    lastLaunchedSlot = nextSlot;
+                    LaunchTransmit(nextSlot, slotSec, ct);
+                }
+            }
+            else if (!Transmitting && lastLaunchedSlot != curSlot && ShouldLateStartCurrentSlot(now))
+            {
+                // Late-start path: a decode-driven reply was staged a couple seconds
+                // into the CURRENT slot whose parity matches — key NOW (positive DT,
+                // inside decoder tolerance) instead of waiting a full cycle.
+                lastLaunchedSlot = curSlot;
+                LaunchTransmit(curSlot, slotSec, ct);
+            }
+
+            // Cap every sleep at 250 ms so arm/disarm/halt are honoured promptly
+            // and Windows' ~15 ms timer granularity is absorbed.
+            double waitMs = msToBoundary - LeadMs;
+            if (waitMs <= 0) waitMs = msToBoundary + 5; // settle just past the boundary
+            int sleep = (int)Math.Clamp(waitMs, 5, 250);
+            try { await _delay(sleep, ct).ConfigureAwait(false); }
+            catch (OperationCanceledException) { break; }
+        }
+    }
+
+    /// <summary>True iff the CURRENT slot should be keyed late: a fresh same-parity
+    /// stage exists, we are past the boundary lead window (which the boundary path
+    /// owns) but still within <see cref="MaxLateStartSecondsFor"/> of the slot start
+    /// (so the resulting positive DT stays inside the decoder's tolerance).</summary>
+    internal bool ShouldLateStartCurrentSlot(DateTime nowUtc)
+    {
+        Ft8Protocol mode;
+        lock (_lock) mode = _mode;
+        double slotSec = SlotSecondsFor(mode);
+        double totalSec = (nowUtc - DateTime.UnixEpoch).TotalSeconds;
+        long curSlot = (long)Math.Floor(totalSec / slotSec);
+        double secsIntoCur = totalSec - curSlot * slotSec;
+        if (secsIntoCur * 1000.0 <= LeadMs) return false;            // boundary path owns the lead window
+        if (secsIntoCur > MaxLateStartSecondsFor(mode)) return false; // too late — DT would exceed tolerance
+        return ShouldKeyForSlot(curSlot, nowUtc);
+    }
+
+    private void LaunchTransmit(long targetSlot, double slotSec, CancellationToken ct)
+    {
+        long slotStartMs = (long)(targetSlot * slotSec * 1000.0);
+        lock (_lock) _lastTxSlotMs = slotStartMs;
+        _ = Task.Run(() => SafeTransmitAsync(ct), ct);
+    }
+
+    private async Task SafeTransmitAsync(CancellationToken ct)
+    {
+        try { await TransmitCurrentStageAsync(ct).ConfigureAwait(false); }
+        catch (OperationCanceledException) { /* shutdown / halt */ }
+        catch (Exception ex) { _log.LogError(ex, "ft8.tx slot transmit failed"); }
+    }
+
+    private void BroadcastStatus()
+    {
+        try { _broadcast(Ft8TxStatusFrame.Encode(Status())); }
+        catch (Exception ex) { _log.LogDebug(ex, "ft8.tx status broadcast failed"); }
+    }
+
+    private static float[]? DefaultRenderer(string message, Ft8Protocol proto, int audioHz)
+    {
+        byte[]? tones = Ft8Decoder.Encode(message, proto);
+        if (tones is null) return null;
+        return Ft8Synth.Synth(tones, proto, audioHz, Ft8Synth.TxSampleRate);
+    }
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+        _cts?.Dispose();
+    }
+}

--- a/Zeus.Server.Hosting/StreamingHub.cs
+++ b/Zeus.Server.Hosting/StreamingHub.cs
@@ -892,6 +892,22 @@ public sealed class StreamingHub
     }
 
     /// <summary>
+    /// Broadcasts a pre-encoded Ft8TxStatus (0x3A) frame ([type][UTF-8 JSON of
+    /// <see cref="Zeus.Contracts.Ft8TxStatusDto"/>]) to every connected client.
+    /// One frame per FT8/FT4/WSPR keyer arm/stage/transmit edge — same fan-out
+    /// shape as <see cref="BroadcastFt8Decode"/>; called by Ft8TxService /
+    /// WsprTxService.
+    /// </summary>
+    public void BroadcastFt8TxStatus(byte[] payload)
+    {
+        if (_clients.IsEmpty) return;
+        foreach (var client in _clients.Values)
+        {
+            if (!client.TryEnqueue(payload)) System.Threading.Interlocked.Increment(ref _dropsOther);
+        }
+    }
+
+    /// <summary>
     /// Broadcasts a pre-encoded DiagnosticsHealth (0x36) frame
     /// ([type][UTF-8 JSON of <see cref="Zeus.Contracts.DiagnosticsHealthDto"/>]) to every
     /// connected client and caches it for push-on-attach. Same fan-out shape as

--- a/Zeus.Server.Hosting/TxAudioIngest.cs
+++ b/Zeus.Server.Hosting/TxAudioIngest.cs
@@ -70,6 +70,11 @@ internal enum MicBlockSource
     Tci,
     /// <summary>WAV-recording playback to the air. Operator-explicit override.</summary>
     Wav,
+    /// <summary>Built-in FT8/FT4/WSPR auto-sequence keyer audio (digital TX).
+    /// Operator-armed override — bypasses the host/radio single-select gate like
+    /// <see cref="Tci"/>/<see cref="Wav"/>, and suppresses the live mic for the
+    /// duration of a digital transmission so the two never double-feed TXA.</summary>
+    Ft8,
 }
 
 /// <summary>
@@ -143,6 +148,11 @@ public sealed class TxAudioIngest : IDisposable
     // concurrent native-mic frame within TciHysteresisMs is suppressed -- the
     // recording replaces the live mic on the air, they never mix.
     private long _lastWavTickMs;
+    // Digital-keyer-source recency: set on every OnMicPcmBytesFromFt8 call so a
+    // concurrent native/browser mic frame within TciHysteresisMs is suppressed --
+    // while the FT8/FT4/WSPR keyer is streaming its synthesized audio the live
+    // mic must never mix into TXA. Same hysteresis shape as TCI/WAV.
+    private long _lastFt8TickMs;
     // Browser/mobile mic recency: desktop mode has NativeMicCapture running
     // continuously, so remote WebSocket mic frames must temporarily own the
     // "live mic" source. Otherwise mobile PTT mixes phone audio with desktop
@@ -396,12 +406,30 @@ public sealed class TxAudioIngest : IDisposable
         OnMicPcmBytes(f32lePayload, MicBlockSource.RadioMic);
     }
 
+    /// <summary>
+    /// Source-tagged entry point for the built-in FT8/FT4/WSPR auto-sequence
+    /// keyer (from <see cref="Ft8TxService"/> / <see cref="WsprTxService"/>).
+    /// Mirrors <see cref="OnMicPcmBytesFromWav"/>: stamps the digital-keyer
+    /// recency marker so the live native/browser mic is suppressed for the
+    /// duration of the transmission, then feeds the synthesized block through the
+    /// normal TX chain. The block is tagged <see cref="MicBlockSource.Ft8"/>, an
+    /// operator-armed override that bypasses the host/radio single-select gate.
+    /// The caller keys MOX; this method does not touch MOX.
+    /// </summary>
+    internal void OnMicPcmBytesFromFt8(ReadOnlyMemory<byte> f32lePayload)
+    {
+        Volatile.Write(ref _lastFt8TickMs, Environment.TickCount64);
+        OnMicPcmBytes(f32lePayload, MicBlockSource.Ft8);
+    }
+
     private bool ShouldSuppressForAuthoritativeSource(long now)
     {
         long lastTci = Volatile.Read(ref _lastTciTickMs);
         if (lastTci != 0 && now - lastTci < TciHysteresisMs) return true;
         long lastWav = Volatile.Read(ref _lastWavTickMs);
-        return lastWav != 0 && now - lastWav < TciHysteresisMs;
+        if (lastWav != 0 && now - lastWav < TciHysteresisMs) return true;
+        long lastFt8 = Volatile.Read(ref _lastFt8TickMs);
+        return lastFt8 != 0 && now - lastFt8 < TciHysteresisMs;
     }
 
     /// <summary>Source-tagged entry point for WAV-recording playback to the

--- a/Zeus.Server.Hosting/WsprTxService.cs
+++ b/Zeus.Server.Hosting/WsprTxService.cs
@@ -1,0 +1,395 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// WsprTxService — the WSPR beacon keyer (the TX half; WSPR RX spotting lives in
+// WsprService and is untouched). WSPR is a beacon mode with no QSO sequencing,
+// so this is simpler than Ft8TxService: a 120 s UTC slot clock that, on each
+// even-minute boundary, keys MOX (MoxSource.Ft8 — the shared digital source) and
+// streams the K1JT/K9AN-synthesized beacon waveform, gated by a configurable
+// transmit fraction (txPercent, WSJT-X "fraction of slots") so two-minute
+// beacons don't run back-to-back unless asked.
+//
+// SAFETY: same standing orders as Ft8TxService — `_armed` defaults false and is
+// only set by an explicit POST /api/wspr/tx/arm; a backend watchdog auto-disarms
+// after WatchdogMinutes (a HARD MAXIMUM ARMED DURATION measured from the arm
+// action, not an idle detector); PureSignal is never touched; drive/power
+// defaults are never touched. Audio is the pure-native WSPR synth fed through the
+// existing TX-audio seam — no new native code. A shared DigitalTxArbiter ensures
+// WSPR and FT8/FT4 are never armed at the same time (they share MoxSource.Ft8).
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Zeus.Contracts;
+using Zeus.Dsp.Ft8;
+
+namespace Zeus.Server;
+
+public sealed class WsprTxService : IHostedService, IDisposable, IDigitalTxKeyer
+{
+    internal delegate bool MoxKeyer(bool on, out string? error);
+
+    private const double SlotSeconds = 120.0;   // WSPR 2-minute slots
+    private const int LeadMs = 120;             // key this far before the boundary (relay settle)
+    private const int WsprStartMs = 1000;       // WSPR audio starts ~1 s into the slot
+    // Hard maximum armed duration (minutes); beacons run longer so this is wider.
+    internal const int WatchdogMinutes = 30;
+
+    /// <summary>Canonical WSPR power-encoding steps (dBm). The protocol only encodes
+    /// values whose units digit is 0, 3 or 7; anything else makes WsprDecoder.Encode
+    /// return null and the beacon silently never transmits.</summary>
+    private static readonly int[] WsprDbmSteps =
+        { 0, 3, 7, 10, 13, 17, 20, 23, 27, 30, 33, 37, 40, 43, 47, 50, 53, 57, 60 };
+
+    private readonly MoxKeyer _keyer;
+    private readonly Action<ReadOnlyMemory<byte>> _audioSink;
+    private readonly Action<byte[]> _broadcast;
+    private readonly Func<string, int, float[]?> _renderer;
+    private readonly Func<DateTime> _clock;
+    private readonly Func<int, CancellationToken, Task> _delay;
+    private readonly Func<double> _random;
+    private readonly ILogger _log;
+    private DigitalTxArbiter? _arbiter;          // single-owner interlock vs FT8/FT4
+
+    private readonly object _lock = new();
+    private bool _armed;                         // ENABLE-TX master — defaults false
+    private string _call = "";
+    private string _grid4 = "";
+    private int _dBm = 30;
+    private int _audioHz = 1500;
+    private double _txPercent = 0.2;             // conservative default
+    private DateTime _armedSinceUtc;
+    private bool _transmitting;
+    private long? _lastTxSlotMs;
+
+    private CancellationTokenSource? _cts;
+    private Task? _clockLoop;
+
+    /// <summary>Production constructor — wires the real keying / audio / broadcast seams.</summary>
+    public WsprTxService(
+        TxService tx, TxAudioIngest ingest, StreamingHub hub,
+        DigitalTxArbiter arbiter, ILoggerFactory loggerFactory)
+        : this(
+            (bool on, out string? error) => tx.TrySetMox(on, MoxSource.Ft8, out error),
+            ingest.OnMicPcmBytesFromFt8,
+            hub.BroadcastFt8TxStatus,
+            DefaultRenderer,
+            static () => DateTime.UtcNow,
+            static (ms, ct) => Task.Delay(ms, ct),
+            static () => Random.Shared.NextDouble(),
+            loggerFactory.CreateLogger<WsprTxService>())
+    {
+        SetArbiter(arbiter);
+    }
+
+    /// <summary>Test constructor — injects keying / audio / clock / pacing / RNG as
+    /// delegates so the scheduler is deterministic with no native dependency.</summary>
+    internal WsprTxService(
+        MoxKeyer keyer,
+        Action<ReadOnlyMemory<byte>> audioSink,
+        Action<byte[]> broadcast,
+        Func<string, int, float[]?> renderer,
+        Func<DateTime> clock,
+        Func<int, CancellationToken, Task> delay,
+        Func<double> random,
+        ILogger logger)
+    {
+        _keyer = keyer;
+        _audioSink = audioSink;
+        _broadcast = broadcast;
+        _renderer = renderer;
+        _clock = clock;
+        _delay = delay;
+        _random = random;
+        _log = logger;
+    }
+
+    /// <summary>Attach (and register with) the cross-service arm interlock. Called
+    /// from the production ctor; tests opt in explicitly when exercising it.</summary>
+    internal void SetArbiter(DigitalTxArbiter arbiter)
+    {
+        _arbiter = arbiter;
+        arbiter.Register(this);
+    }
+
+    /// <summary>True if the WSPR encode + synth path is usable on this platform.</summary>
+    public bool NativeAvailable => WsprDecoder.IsAvailable;
+
+    internal bool Armed { get { lock (_lock) return _armed; } }
+    internal bool Transmitting { get { lock (_lock) return _transmitting; } }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _cts = new CancellationTokenSource();
+        _clockLoop = Task.Run(() => ClockLoopAsync(_cts.Token));
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        _cts?.Cancel();
+        bool drop;
+        lock (_lock) { _armed = false; drop = _transmitting; }
+        if (drop) _keyer(false, out _);
+        if (_clockLoop is not null)
+        {
+            try { await _clockLoop.ConfigureAwait(false); }
+            catch (OperationCanceledException) { /* normal shutdown */ }
+        }
+    }
+
+    // ---- operator control surface (called by Ft8TxEndpoints) -----------------
+
+    /// <summary>The ENABLE-TX master. The ONLY way the beacon turns on.</summary>
+    public void SetArmed(bool enabled)
+    {
+        bool drop = false;
+        lock (_lock)
+        {
+            if (enabled)
+            {
+                if (!_armed) _armedSinceUtc = _clock();
+                _armed = true;
+            }
+            else
+            {
+                _armed = false;
+                drop = _transmitting;
+            }
+        }
+        // Single-owner interlock: arming WSPR force-disarms a running FT8/FT4 keyer
+        // (and vice-versa) so only one digital keyer holds MoxSource.Ft8.
+        if (enabled) _arbiter?.Claim(this);
+        if (drop) _keyer(false, out _);
+        BroadcastStatus();
+    }
+
+    /// <summary>Arbiter-driven force-disarm (a sibling digital keyer armed). Like
+    /// <see cref="Halt"/> but does not re-enter the arbiter.</summary>
+    public void ForceDisarm(string reason)
+    {
+        bool drop;
+        lock (_lock)
+        {
+            if (!_armed) return;
+            _armed = false;
+            drop = _transmitting;
+        }
+        if (drop) _keyer(false, out _);
+        _log.LogInformation("wspr.tx force-disarmed: {Reason}", reason);
+        BroadcastStatus();
+    }
+
+    /// <summary>Update the beacon content / cadence. Returns an error string on
+    /// bad input, or null on success.</summary>
+    public string? SetSettings(string call, string grid4, int dBm, int audioHz, double txPercent)
+    {
+        if (string.IsNullOrWhiteSpace(call)) return "call is required";
+        if (string.IsNullOrWhiteSpace(grid4)) return "grid4 is required";
+        lock (_lock)
+        {
+            _call = call.Trim().ToUpperInvariant();
+            _grid4 = grid4.Trim().ToUpperInvariant();
+            _dBm = SnapWsprDbm(dBm);   // snap to a canonical step the encoder accepts
+            _audioHz = Math.Clamp(audioHz, 0, 2500);
+            _txPercent = Math.Clamp(txPercent, 0.0, 1.0);
+        }
+        BroadcastStatus();
+        return null;
+    }
+
+    /// <summary>Clamp to 0..60 dBm and snap to the nearest canonical WSPR power step
+    /// so the beacon never carries a value WsprDecoder.Encode would reject (which
+    /// would make it silently never transmit).</summary>
+    internal static int SnapWsprDbm(int dBm)
+    {
+        int v = Math.Clamp(dBm, WsprDbmSteps[0], WsprDbmSteps[^1]);
+        int best = WsprDbmSteps[0];
+        foreach (int step in WsprDbmSteps)
+            if (Math.Abs(step - v) < Math.Abs(best - v)) best = step;
+        return best;
+    }
+
+    /// <summary>Panic / abort: disarm and drop MOX if mid-slot.</summary>
+    public void Halt()
+    {
+        bool drop;
+        lock (_lock) { _armed = false; drop = _transmitting; }
+        if (drop) _keyer(false, out _);
+        _log.LogInformation("wspr.tx halt");
+        BroadcastStatus();
+    }
+
+    /// <summary>Current keyer status DTO (Mode = "WSPR", Slot = "").</summary>
+    public Ft8TxStatusDto Status()
+    {
+        lock (_lock)
+        {
+            int watchdog = 0;
+            if (_armed)
+            {
+                double remaining = WatchdogMinutes * 60.0 - (_clock() - _armedSinceUtc).TotalSeconds;
+                watchdog = (int)Math.Max(0, Math.Ceiling(remaining));
+            }
+            string? message = _call.Length == 0 ? null : BeaconMessage(_call, _grid4, _dBm);
+            return new Ft8TxStatusDto(
+                _armed, _transmitting, "WSPR", message, _audioHz, "", watchdog, _lastTxSlotMs, NativeAvailable);
+        }
+    }
+
+    // ---- scheduler internals (also the test surface) -------------------------
+
+    /// <summary>True iff the beacon should key this 120 s slot: armed, configured,
+    /// watchdog not expired, and the probabilistic txPercent gate passes. Draws
+    /// the RNG once (so a test can seed the sequence).</summary>
+    internal bool ShouldKeyForSlot(DateTime nowUtc)
+    {
+        double pct;
+        lock (_lock)
+        {
+            if (!_armed || _call.Length == 0) return false;
+            if ((nowUtc - _armedSinceUtc).TotalMinutes >= WatchdogMinutes) return false;
+            pct = _txPercent;
+        }
+        if (pct <= 0) return false;
+        if (pct >= 1) return true;
+        return _random() < pct;
+    }
+
+    /// <summary>Enforce the hard max-armed-duration cap: disarm (and drop MOX if
+    /// mid-slot) once the arm has been held longer than <see cref="WatchdogMinutes"/>.</summary>
+    internal void EnforceWatchdog(DateTime nowUtc)
+    {
+        bool fired = false, drop = false;
+        lock (_lock)
+        {
+            if (_armed && (nowUtc - _armedSinceUtc).TotalMinutes >= WatchdogMinutes)
+            {
+                _armed = false;
+                fired = true;
+                drop = _transmitting;
+            }
+        }
+        if (!fired) return;
+        if (drop) _keyer(false, out _);
+        _log.LogWarning("wspr.tx watchdog disarmed after {Min} min max armed duration", WatchdogMinutes);
+        BroadcastStatus();
+    }
+
+    /// <summary>Key, render the beacon, stream it (1 s lead silence + ~110.6 s of
+    /// audio) as 20 ms blocks, then unkey. Truncates cleanly if disarmed/halted.</summary>
+    internal async Task TransmitBeaconAsync(CancellationToken ct)
+    {
+        string message;
+        int audioHz;
+        lock (_lock)
+        {
+            if (!_armed || _call.Length == 0) return;
+            message = BeaconMessage(_call, _grid4, _dBm);
+            audioHz = _audioHz;
+        }
+
+        // Render BEFORE claiming the transmit and keying MOX: if Halt/disarm/the
+        // watchdog fires during render the re-check below bails without keying, so
+        // MOX is never left up with no IQ feeding it.
+        float[]? audio = _renderer(message, audioHz);
+        if (audio is null || audio.Length == 0)
+        {
+            _log.LogWarning("wspr.tx render failed for '{Msg}'", message);
+            return;
+        }
+
+        lock (_lock)
+        {
+            if (!_armed || _call.Length == 0) return; // halted/disarmed during render
+            _transmitting = true;
+        }
+
+        bool keyed = false;
+        try
+        {
+            if (!_keyer(true, out string? err))
+            {
+                _log.LogWarning("wspr.tx key-up refused: {Err}", err);
+                return;
+            }
+            keyed = true;
+            BroadcastStatus();
+
+            int leadBlocks = Math.Max(1, WsprStartMs / DigitalTxStreamer.BlockMs);
+            await DigitalTxStreamer.StreamAsync(audio, leadBlocks, _audioSink, _delay, StillArmed, ct)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            if (keyed) _keyer(false, out _);
+            lock (_lock) _transmitting = false;
+            BroadcastStatus();
+        }
+    }
+
+    private bool StillArmed() { lock (_lock) return _armed; }
+
+    private async Task ClockLoopAsync(CancellationToken ct)
+    {
+        long lastHandledSlot = long.MinValue;
+        while (!ct.IsCancellationRequested)
+        {
+            DateTime now = _clock();
+            EnforceWatchdog(now);
+
+            double totalSec = (now - DateTime.UnixEpoch).TotalSeconds;
+            long curSlot = (long)Math.Floor(totalSec / SlotSeconds);
+            long nextSlot = curSlot + 1;
+            double msToBoundary = (nextSlot * SlotSeconds - totalSec) * 1000.0;
+
+            if (msToBoundary <= LeadMs && nextSlot != lastHandledSlot)
+            {
+                lastHandledSlot = nextSlot;
+                if (!Transmitting && ShouldKeyForSlot(now))
+                {
+                    long slotStartMs = (long)(nextSlot * SlotSeconds * 1000.0);
+                    lock (_lock) _lastTxSlotMs = slotStartMs;
+                    _ = Task.Run(() => SafeTransmitAsync(ct), ct);
+                }
+            }
+
+            double waitMs = msToBoundary - LeadMs;
+            if (waitMs <= 0) waitMs = msToBoundary + 5;
+            int sleep = (int)Math.Clamp(waitMs, 5, 250);
+            try { await _delay(sleep, ct).ConfigureAwait(false); }
+            catch (OperationCanceledException) { break; }
+        }
+    }
+
+    private async Task SafeTransmitAsync(CancellationToken ct)
+    {
+        try { await TransmitBeaconAsync(ct).ConfigureAwait(false); }
+        catch (OperationCanceledException) { /* shutdown / halt */ }
+        catch (Exception ex) { _log.LogError(ex, "wspr.tx slot transmit failed"); }
+    }
+
+    private void BroadcastStatus()
+    {
+        try { _broadcast(Ft8TxStatusFrame.Encode(Status())); }
+        catch (Exception ex) { _log.LogDebug(ex, "wspr.tx status broadcast failed"); }
+    }
+
+    private static string BeaconMessage(string call, string grid4, int dBm) => $"{call} {grid4} {dBm}";
+
+    private static float[]? DefaultRenderer(string message, int audioHz)
+    {
+        byte[]? symbols = WsprDecoder.Encode(message);
+        if (symbols is null) return null;
+        return WsprDecoder.Synth(symbols, audioHz, 48000);
+    }
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+        _cts?.Dispose();
+    }
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -108,6 +108,11 @@ public static class ZeusEndpoints
                     : Results.Ok(new { enabled = false, nativeAvailable = ft8.NativeAvailable });
             });
 
+        // FT8/FT4 + WSPR ARMED auto-sequence TX keyer control surface (arm /
+        // stage / halt / status). Kept in its own extension file so this one
+        // stays manageable.
+        app.MapFt8TxEndpoints();
+
         app.MapPost("/api/ft8/disable", (Ft8Service ft8) =>
         {
             ft8.Disable();

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -469,6 +469,20 @@ public static class ZeusHost
         builder.Services.AddSingleton<FreeDvNativeInstaller>();
         builder.Services.AddSingleton<TxService>();
         builder.Services.AddSingleton<TxAudioIngest>();
+        // Ft8TxService / WsprTxService — the ARMED FT8/FT4 + WSPR auto-sequence
+        // keyers (TX half; the RX decode/spot services above are untouched). They
+        // own the UTC slot clock, key MOX via TxService (MoxSource.Ft8) and stream
+        // synthesized tone audio through TxAudioIngest. They NEVER auto-arm (armed
+        // defaults false, operator-only) and a backend watchdog auto-disarms an
+        // unattended arm. No PureSignal / drive / power state is touched. A shared
+        // DigitalTxArbiter enforces that only ONE of FT8/FT4/WSPR is armed at a
+        // time (they share MoxSource.Ft8), so neither can drop MOX out from under
+        // the other or double-feed TXA.
+        builder.Services.AddSingleton<DigitalTxArbiter>();
+        builder.Services.AddSingleton<Ft8TxService>();
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<Ft8TxService>());
+        builder.Services.AddSingleton<WsprTxService>();
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<WsprTxService>());
         // Resolve at startup so the MicPcmReceived subscription attaches before the
         // first client connects (lazy resolution would leave early frames unhandled).
         builder.Services.AddHostedService<TxAudioIngestStartup>();

--- a/docs/designs/ft8-ui.md
+++ b/docs/designs/ft8-ui.md
@@ -141,6 +141,51 @@ visuals before that global flip. The **FT8-scoped** theme is approved now.
 The layout/IA above is unaffected; build components theme-agnostic and apply
 the HUD token layer as the skin.
 
+## Layout refinement — KB2UKA 2026-06-26 (build to THIS)
+
+KB2UKA re-confirmed `ft8-target-mockup.png` as **the** target layout ("I like
+this layout a little better than ours"). Build the workspace to match it, with
+these hard adaptations:
+
+### Hard rules
+- **NO closable panels.** The mockup draws an `×` on every panel header —
+  **ignore those.** Zeus has zero close/collapse/move/resize affordances in this
+  workspace. Every panel is **fixed in its slot**, always visible. Do not render
+  a close button anywhere. (Reinforces "no moveable panels" above.)
+- **Controls map to OUR feature set, not WSJT-X's.** The mockup is a visual
+  reference; its labels are illustrative. Concretely:
+  - **MODE** tiles = `FT8 · FT4 · WSPR` (NOT JT65/JT9 — Zeus does not implement
+    those). WSPR swaps the QSO-oriented panels for spot-oriented ones (see WSPR
+    note above).
+  - **DECODE** tiles = Zeus's actual decode depths (`NORMAL · DEEP · MULTI`
+    maps to our single-pass / multi-pass / deep multi-pass `time_osr` ladder).
+  - **Power / TX controls** mirror Zeus's existing rig controls (Drive %, Tune
+    power, MOX/TUNE) — same backing endpoints/state as the main app, NOT new
+    parallel power logic. See "TX control + power" below.
+  - **Meters** (SWR / ALC / COMP) reuse Zeus's existing meter sources; only show
+    meters the connected board actually provides (board-capability gated).
+  - Chrome text in the mock (`CAT: IC-7300`, `WSJT-X v2.6.1`) is mockup-only —
+    Zeus shows its own connected-radio / version info.
+
+### Waterfall ("RECEIVE" panel) — KB2UKA 2026-06-26
+- **Beautiful, and reuse our existing waterfall.** Borrowing the current Zeus
+  panadapter/waterfall WebGL panel and injecting it into the workspace is the
+  approved approach — do not write a second waterfall renderer from scratch.
+- **Click-a-slice to tune.** Operator clicks a slice/column in the waterfall to
+  set their RX/TX audio frequency (the in-passband offset, 0–2.5 kHz), with a
+  visible RX cursor and TX marker as in the mock. Honor `HOLD TX FREQ`.
+- Controls: **WF SPEED · WF ZOOM · WF OFFSET** as shown.
+
+### TX control + power — KB2UKA 2026-06-26
+- **TX CONTROL** cluster: `TX ENABLE` arm (explicit, never auto-arms),
+  `HOLD TX FREQ`, `TX EVEN/ODD` slot selector, **TX POWER** slider, **TUNE**
+  button.
+- **Power controls live in the workspace and mimic what we already have** so the
+  operator adjusts drive/tune power without leaving the workspace. Wire them to
+  the **same** drive/tune endpoints and state the main rig uses — do not fork a
+  second power model. (Safety: FT8 is 100 % duty; do not change power defaults,
+  and do not auto-key.)
+
 ## Build sequencing
 
 UI is a later phase. Backend decode engine, `Zeus.Dsp.Ft8`, `Ft8Service`, and

--- a/tests/Zeus.Dsp.Ft8.Tests/Ft8SynthTests.cs
+++ b/tests/Zeus.Dsp.Ft8.Tests/Ft8SynthTests.cs
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Ft8SynthTests — the pure (always-run) tests assert the waveform shape with no
+// native dependency: exact length, phase continuity (no key clicks), RMS, the
+// start/end ramp, and a single-tone spectral check. The round-trip tests
+// (Encode → Synth → Decode) SkippableFact-skip when the zeus_ft8 native lib
+// isn't staged for the current RID, mirroring WsprDecoderTests.
+
+using Zeus.Dsp.Ft8;
+
+namespace Zeus.Dsp.Ft8.Tests;
+
+public class Ft8SynthTests
+{
+    // ---- pure, always-run -----------------------------------------------------
+
+    [Theory]
+    [InlineData(48000, 79 * 7680)]   // FT8 @ 48 kHz (nsps = 7680) — matches the brief
+    [InlineData(12000, 79 * 1920)]   // FT8 @ 12 kHz (nsps = 1920)
+    public void Ft8_Output_HasExactLength(int sampleRate, int expected)
+    {
+        var tones = new byte[79];          // all tone 0 — pure carrier
+        var audio = Ft8Synth.Synth(tones, Ft8Protocol.Ft8, 1500f, sampleRate);
+        Assert.Equal(expected, audio.Length);
+    }
+
+    [Theory]
+    [InlineData(48000, 105 * 2304)]  // FT4 @ 48 kHz (nsps = 2304)
+    [InlineData(12000, 105 * 576)]   // FT4 @ 12 kHz (nsps = 576)
+    public void Ft4_Output_HasExactLength(int sampleRate, int expected)
+    {
+        var tones = new byte[105];
+        var audio = Ft8Synth.Synth(tones, Ft8Protocol.Ft4, 1500f, sampleRate);
+        Assert.Equal(expected, audio.Length);
+    }
+
+    [Fact]
+    public void WrongToneCount_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => Ft8Synth.Synth(new byte[10], Ft8Protocol.Ft8));
+        Assert.Throws<ArgumentException>(() => Ft8Synth.Synth(new byte[79], Ft8Protocol.Ft4));
+    }
+
+    [Fact]
+    public void PhaseIsContinuous_NoKeyClicks()
+    {
+        // A constant-envelope GFSK waveform changes slowly sample-to-sample: the
+        // max step is bounded by 2*pi*fmax/fs * amplitude. The highest tone is
+        // baseFreq + 7*6.25 ≈ 1544 Hz at 48 kHz → ~0.101 per sample at A=0.5.
+        var tones = RampTones(79, 8);
+        var audio = Ft8Synth.Synth(tones, Ft8Protocol.Ft8, 1500f, 48000, 0.5f);
+        float maxStep = 0f;
+        for (int i = 1; i < audio.Length; i++)
+            maxStep = MathF.Max(maxStep, MathF.Abs(audio[i] - audio[i - 1]));
+        Assert.True(maxStep < 0.15f, $"max sample step {maxStep} suggests a discontinuity/click");
+    }
+
+    [Fact]
+    public void Rms_IsApproximatelyAmplitudeOverRootTwo()
+    {
+        var tones = RampTones(79, 8);
+        const float amp = 0.5f;
+        var audio = Ft8Synth.Synth(tones, Ft8Protocol.Ft8, 1500f, 48000, amp);
+        double sumSq = 0;
+        foreach (var s in audio) sumSq += (double)s * s;
+        double rms = Math.Sqrt(sumSq / audio.Length);
+        double expected = amp / Math.Sqrt(2.0);
+        Assert.True(Math.Abs(rms - expected) < 0.02, $"RMS {rms:F4} vs expected {expected:F4}");
+    }
+
+    [Fact]
+    public void StartAndEnd_AreRampedToZero()
+    {
+        var tones = RampTones(79, 8);
+        var audio = Ft8Synth.Synth(tones, Ft8Protocol.Ft8, 1500f, 48000, 0.5f);
+        // The raised-cosine envelope is exactly 0 at the very first/last sample.
+        Assert.True(MathF.Abs(audio[0]) < 1e-6f);
+        Assert.True(MathF.Abs(audio[^1]) < 1e-6f);
+    }
+
+    [Fact]
+    public void SingleTone_ConcentratesEnergyAtExpectedFrequency()
+    {
+        // All tone 4 ⇒ a steady tone at baseFreq + 4*6.25 = 1525 Hz. Goertzel
+        // power there must dominate an off-tone bin.
+        const int fs = 48000;
+        const float baseHz = 1500f;
+        var tones = new byte[79];
+        for (int i = 0; i < tones.Length; i++) tones[i] = 4;
+        var audio = Ft8Synth.Synth(tones, Ft8Protocol.Ft8, baseHz, fs, 0.5f);
+
+        // Use the steady middle (skip the ramp + first/last symbol shaping).
+        int start = audio.Length / 4, len = audio.Length / 2;
+        double onTone = GoertzelPower(audio, start, len, 1525.0, fs);
+        double offTone = GoertzelPower(audio, start, len, 1000.0, fs);
+        Assert.True(onTone > offTone * 50, $"on-tone {onTone:E2} not dominant over off-tone {offTone:E2}");
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(3)]
+    [InlineData(6)]
+    [InlineData(7)]
+    public void SteadyTone_LandsEnergyInTheExpectedFskBin(int tone)
+    {
+        // Each FT8 tone index n maps to baseFreq + n*6.25 Hz. Synthesizing a steady
+        // tone must land its energy in THAT bin (not just "some single bin"), so a
+        // tone→frequency mapping regression is caught even when native is absent.
+        const int fs = 48000;
+        const float baseHz = 1500f;
+        var tones = new byte[79];
+        for (int i = 0; i < tones.Length; i++) tones[i] = (byte)tone;
+        var audio = Ft8Synth.Synth(tones, Ft8Protocol.Ft8, baseHz, fs, 0.5f);
+
+        double expectedHz = baseHz + tone * 6.25;
+        int start = audio.Length / 4, len = audio.Length / 2;
+        double onTone = GoertzelPower(audio, start, len, expectedHz, fs);
+        double neighbor = GoertzelPower(audio, start, len, expectedHz + 6.25, fs);
+        double offTone = GoertzelPower(audio, start, len, 1000.0, fs);
+        Assert.True(onTone > neighbor * 5, $"tone {tone}: on {onTone:E2} vs neighbor {neighbor:E2}");
+        Assert.True(onTone > offTone * 50, $"tone {tone}: on {onTone:E2} vs off {offTone:E2}");
+    }
+
+    // ---- round-trip (native-gated) -------------------------------------------
+
+    [SkippableFact]
+    public void RoundTrip_Ft8_EncodeSynthDecode_RecoversMessage()
+    {
+        Skip.IfNot(Ft8Decoder.IsAvailable, "zeus_ft8 native library not staged for this RID");
+        AssertRoundTrip("CQ KB2UKA FN12", Ft8Protocol.Ft8, 15.0);
+    }
+
+    [SkippableFact]
+    public void RoundTrip_Ft4_EncodeSynthDecode_RecoversMessage()
+    {
+        Skip.IfNot(Ft8Decoder.IsAvailable, "zeus_ft8 native library not staged for this RID");
+        AssertRoundTrip("CQ KB2UKA FN12", Ft8Protocol.Ft4, 7.5);
+    }
+
+    private static void AssertRoundTrip(string message, Ft8Protocol proto, double slotSeconds)
+    {
+        byte[]? tones = Ft8Decoder.Encode(message, proto);
+        Assert.NotNull(tones);
+
+        int fs = Ft8Decoder.SampleRate;                       // 12 kHz
+        float[] wave = Ft8Synth.Synth(tones!, proto, 1500f, fs);
+
+        // Place the waveform 0.5 s into a full UTC slot, the rest silence. FT4's
+        // sync is far more DT-sensitive than FT8 (tolerance ~±1 s vs ±2.5 s), so
+        // keep the offset modest; both protocols decode cleanly at 0.5 s.
+        int slot = (int)(slotSeconds * fs);
+        int lead = fs / 2;                                     // 0.5 s lead
+        var buf = new float[slot];
+        Array.Copy(wave, 0, buf, lead, Math.Min(wave.Length, slot - lead));
+
+        using var decoder = new Ft8Decoder();
+        var decodes = decoder.Decode(buf, proto, passes: 1);
+        Assert.Contains(decodes, d => d.Text.Trim() == message);
+    }
+
+    // ---- helpers -------------------------------------------------------------
+
+    private static byte[] RampTones(int n, int modulo)
+    {
+        var t = new byte[n];
+        for (int i = 0; i < n; i++) t[i] = (byte)(i % modulo);
+        return t;
+    }
+
+    private static double GoertzelPower(float[] x, int start, int len, double freq, int fs)
+    {
+        double w = 2.0 * Math.PI * freq / fs;
+        double cw = Math.Cos(w), coeff = 2.0 * cw;
+        double s0 = 0, s1 = 0, s2 = 0;
+        for (int i = 0; i < len; i++)
+        {
+            s0 = x[start + i] + coeff * s1 - s2;
+            s2 = s1;
+            s1 = s0;
+        }
+        return s1 * s1 + s2 * s2 - coeff * s1 * s2;
+    }
+}

--- a/tests/Zeus.Server.Tests/DigitalTxArbiterTests.cs
+++ b/tests/Zeus.Server.Tests/DigitalTxArbiterTests.cs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// DigitalTxArbiterTests — the single-owner interlock guarantee: FT8/FT4 and WSPR
+// share MoxSource.Ft8, so only ONE may be armed at a time. Arming one MUST
+// force-disarm the other (otherwise a slot-end MOX drop on the shared source
+// truncates the sibling's live transmission, and both feed audio into TXA).
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Dsp.Ft8;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class DigitalTxArbiterTests
+{
+    private static bool NoKey(bool on, out string? error) { error = null; return true; }
+
+    private static Ft8TxService NewFt8(DigitalTxArbiter arb)
+    {
+        var svc = new Ft8TxService(
+            NoKey, _ => { }, _ => { }, (_, _, _) => new float[960],
+            () => DateTime.UtcNow, static (_, _) => Task.CompletedTask, NullLogger.Instance);
+        svc.SetArbiter(arb);
+        return svc;
+    }
+
+    private static WsprTxService NewWspr(DigitalTxArbiter arb)
+    {
+        var svc = new WsprTxService(
+            NoKey, _ => { }, _ => { }, (_, _) => new float[960],
+            () => DateTime.UtcNow, static (_, _) => Task.CompletedTask, () => 0.0, NullLogger.Instance);
+        svc.SetArbiter(arb);
+        return svc;
+    }
+
+    [Fact]
+    public void ArmingWspr_ForceDisarmsFt8()
+    {
+        var arb = new DigitalTxArbiter();
+        var ft8 = NewFt8(arb);
+        var wspr = NewWspr(arb);
+
+        ft8.SetArmed(true);
+        Assert.True(ft8.Armed);
+
+        wspr.SetSettings("KB2UKA", "FN12", 30, 1500, 1.0);
+        wspr.SetArmed(true);
+
+        Assert.True(wspr.Armed);
+        Assert.False(ft8.Armed);   // FT8 force-disarmed by the arbiter
+    }
+
+    [Fact]
+    public void ArmingFt8_ForceDisarmsWspr()
+    {
+        var arb = new DigitalTxArbiter();
+        var ft8 = NewFt8(arb);
+        var wspr = NewWspr(arb);
+
+        wspr.SetSettings("KB2UKA", "FN12", 30, 1500, 1.0);
+        wspr.SetArmed(true);
+        Assert.True(wspr.Armed);
+
+        ft8.SetArmed(true);
+
+        Assert.True(ft8.Armed);
+        Assert.False(wspr.Armed);  // WSPR force-disarmed by the arbiter
+    }
+}

--- a/tests/Zeus.Server.Tests/Ft8TxServiceTests.cs
+++ b/tests/Zeus.Server.Tests/Ft8TxServiceTests.cs
@@ -1,0 +1,350 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Ft8TxServiceTests — drive the keyer directly through its internal test
+// constructor (no native, no real-time waits, an injected clock + no-op delay).
+// The safety invariants are the point: never key disarmed, never key without a
+// fresh matching-parity stage, watchdog auto-disarm, halt drops MOX + clears
+// stage, and every audio block is exactly 3840 bytes.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Dsp.Ft8;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class Ft8TxServiceTests
+{
+    // Records keying + audio so the tests can assert against the wire effect.
+    private sealed class Recorder
+    {
+        public int KeyUps;
+        public int KeyDowns;
+        public bool Keyed;
+        public int Blocks;
+        public int LastBlockBytes = -1;
+        public int StatusBroadcasts;
+
+        public bool Key(bool on, out string? error)
+        {
+            error = null;
+            if (on) { KeyUps++; Keyed = true; } else { KeyDowns++; Keyed = false; }
+            return true;
+        }
+
+        public void Audio(ReadOnlyMemory<byte> block)
+        {
+            Blocks++;
+            LastBlockBytes = block.Length;
+        }
+
+        public void Broadcast(byte[] _) => StatusBroadcasts++;
+    }
+
+    // 12 960-sample blocks of synthetic "audio" so the streamer has something to
+    // pace without needing the native encoder.
+    private static float[] FakeAudio() => new float[960 * 3];
+
+    private static Ft8TxService NewService(Recorder rec, DateTime now,
+        Func<string, Ft8Protocol, int, float[]?>? renderer = null)
+    {
+        return new Ft8TxService(
+            rec.Key,
+            rec.Audio,
+            rec.Broadcast,
+            renderer ?? ((_, _, _) => FakeAudio()),
+            () => now,
+            static (_, _) => Task.CompletedTask,   // no-op delay
+            NullLogger.Instance);
+    }
+
+    // SlotIndexOf — the same epoch math the service uses, for picking even/odd.
+    private static long SlotIndexOf(DateTime utc, double slotSeconds)
+        => (long)Math.Floor((utc - DateTime.UnixEpoch).TotalSeconds / slotSeconds);
+
+    private static DateTime EvenSlotInstant()
+    {
+        // Pick a UTC instant whose 15 s slot index is even.
+        var t = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        if (SlotIndexOf(t, 15.0) % 2 != 0) t = t.AddSeconds(15);
+        return t;
+    }
+
+    [Fact]
+    public void Disarmed_NeverKeys()
+    {
+        var rec = new Recorder();
+        var now = EvenSlotInstant();
+        var svc = NewService(rec, now);
+        svc.Stage("CQ KB2UKA FN12", 1500, "even", "FT8");   // staged but NOT armed
+        Assert.False(svc.ShouldKeyForSlot(SlotIndexOf(now, 15.0), now));
+    }
+
+    [Fact]
+    public void Armed_NoStage_NeverKeys()
+    {
+        var rec = new Recorder();
+        var now = EvenSlotInstant();
+        var svc = NewService(rec, now);
+        svc.SetArmed(true);
+        Assert.False(svc.ShouldKeyForSlot(SlotIndexOf(now, 15.0), now));
+    }
+
+    [Fact]
+    public void Armed_FreshStage_MatchingParity_Keys()
+    {
+        var rec = new Recorder();
+        var now = EvenSlotInstant();
+        var svc = NewService(rec, now);
+        svc.SetArmed(true);
+        svc.Stage("CQ KB2UKA FN12", 1500, "even", "FT8");
+        long evenSlot = SlotIndexOf(now, 15.0);                  // even index
+        Assert.True(svc.ShouldKeyForSlot(evenSlot, now));
+        Assert.False(svc.ShouldKeyForSlot(evenSlot + 1, now));   // odd slot — no key
+    }
+
+    [Fact]
+    public void StagedButStale_NeverKeys()
+    {
+        var rec = new Recorder();
+        var staged = EvenSlotInstant();
+        var clock = staged;
+        var svc = new Ft8TxService(
+            rec.Key, rec.Audio, rec.Broadcast, (_, _, _) => FakeAudio(),
+            () => clock, static (_, _) => Task.CompletedTask, NullLogger.Instance);
+        svc.SetArmed(true);
+        svc.Stage("CQ KB2UKA FN12", 1500, "even", "FT8");
+        // Advance two full cycles to the SAME-parity slot → age >= 2*slot → stale.
+        // (The freshness window is one full TX cycle, so this exercises staleness,
+        // not parity: the slot below is even, matching the staged even parity.)
+        clock = staged.AddSeconds(2 * 15.0);
+        long sameParity = SlotIndexOf(clock, 15.0);
+        Assert.Equal(0, ((sameParity % 2) + 2) % 2);            // confirm same (even) parity
+        Assert.False(svc.ShouldKeyForSlot(sameParity, clock));  // age == 2*slot → rejected
+    }
+
+    [Fact]
+    public void FreshStage_SurvivesToNextMatchingBoundary()
+    {
+        // A decode-driven reply staged in the "far" half of a cycle must still key
+        // at its NEXT matching-parity boundary, two slots later. The boundary check
+        // fires ~LeadMs before that boundary, so age is just under 2*slot.
+        var rec = new Recorder();
+        var staged = EvenSlotInstant();
+        var clock = staged;
+        var svc = new Ft8TxService(
+            rec.Key, rec.Audio, rec.Broadcast, (_, _, _) => FakeAudio(),
+            () => clock, static (_, _) => Task.CompletedTask, NullLogger.Instance);
+        svc.SetArmed(true);
+        svc.Stage("KB2UKA K1ABC -12", 1500, "even", "FT8");
+        long evenSlot = SlotIndexOf(staged, 15.0);
+
+        var atLead = staged.AddSeconds(2 * 15.0).AddMilliseconds(-120); // just before S+2 boundary
+        Assert.True(svc.ShouldKeyForSlot(evenSlot + 2, atLead));
+    }
+
+    [Fact]
+    public void LateStart_FreshReplyInCurrentSlot_Keys()
+    {
+        // Hear a CQ in the even slot, settle ~2 s into the (matching even) reply
+        // slot, stage the reply: the late-start gate keys it THIS slot rather than a
+        // full cycle later. This is the path the boundary-only keyer silently missed.
+        var rec = new Recorder();
+        var slotStart = EvenSlotInstant();
+        var clock = slotStart;
+        var svc = new Ft8TxService(
+            rec.Key, rec.Audio, rec.Broadcast, (_, _, _) => FakeAudio(),
+            () => clock, static (_, _) => Task.CompletedTask, NullLogger.Instance);
+        svc.SetArmed(true);
+        clock = slotStart.AddSeconds(2.0);
+        svc.Stage("KB2UKA K1ABC FN12", 1500, "even", "FT8");
+        Assert.True(svc.ShouldLateStartCurrentSlot(clock));
+    }
+
+    [Fact]
+    public void LateStart_PastWindow_DefersToNextBoundary()
+    {
+        var rec = new Recorder();
+        var slotStart = EvenSlotInstant();
+        var clock = slotStart;
+        var svc = new Ft8TxService(
+            rec.Key, rec.Audio, rec.Broadcast, (_, _, _) => FakeAudio(),
+            () => clock, static (_, _) => Task.CompletedTask, NullLogger.Instance);
+        svc.SetArmed(true);
+        clock = slotStart.AddSeconds(5.0);                  // 5 s in > 2.5 s FT8 window
+        svc.Stage("KB2UKA K1ABC FN12", 1500, "even", "FT8");
+        Assert.False(svc.ShouldLateStartCurrentSlot(clock));
+    }
+
+    [Fact]
+    public void LateStart_WithinLeadWindow_DefersToBoundaryPath()
+    {
+        var rec = new Recorder();
+        var slotStart = EvenSlotInstant();
+        var clock = slotStart;
+        var svc = new Ft8TxService(
+            rec.Key, rec.Audio, rec.Broadcast, (_, _, _) => FakeAudio(),
+            () => clock, static (_, _) => Task.CompletedTask, NullLogger.Instance);
+        svc.SetArmed(true);
+        clock = slotStart.AddMilliseconds(50);              // inside the boundary lead window
+        svc.Stage("CQ KB2UKA FN12", 1500, "even", "FT8");
+        Assert.False(svc.ShouldLateStartCurrentSlot(clock));
+    }
+
+    [Fact]
+    public async Task HaltDuringRender_NeverKeys()
+    {
+        // The panic path must win even if Halt() fires while the synth is running.
+        // Render happens BEFORE keying, so a mid-render Halt makes the post-render
+        // re-check bail and MOX is never keyed (no keyed-without-IQ carrier).
+        var rec = new Recorder();
+        var now = EvenSlotInstant();
+        Ft8TxService? svc = null;
+        Func<string, Ft8Protocol, int, float[]?> renderer = (_, _, _) =>
+        {
+            svc!.Halt();          // operator panic mid-render
+            return FakeAudio();
+        };
+        svc = NewService(rec, now, renderer);
+        svc.SetArmed(true);
+        svc.Stage("CQ KB2UKA FN12", 1500, "even", "FT8");
+
+        await svc.TransmitCurrentStageAsync(CancellationToken.None);
+
+        Assert.Equal(0, rec.KeyUps);   // never keyed after the panic
+        Assert.Equal(0, rec.Blocks);
+        Assert.False(rec.Keyed);
+    }
+
+    [Fact]
+    public async Task Transmit_KeysThenUnkeys_AndEmits3840ByteBlocks()
+    {
+        var rec = new Recorder();
+        var now = EvenSlotInstant();
+        var svc = NewService(rec, now);
+        svc.SetArmed(true);
+        svc.Stage("CQ KB2UKA FN12", 1500, "even", "FT8");
+
+        await svc.TransmitCurrentStageAsync(CancellationToken.None);
+
+        Assert.Equal(1, rec.KeyUps);
+        Assert.Equal(1, rec.KeyDowns);
+        Assert.False(rec.Keyed);                 // ended un-keyed
+        Assert.True(rec.Blocks > 0);
+        Assert.Equal(3840, rec.LastBlockBytes);  // exactly one 20 ms f32le block
+        Assert.False(svc.Transmitting);
+        // One stage = one transmission: the stage is cleared after sending.
+        Assert.Null(svc.Status().Message);
+    }
+
+    [Fact]
+    public async Task RenderFailure_DoesNotKey()
+    {
+        var rec = new Recorder();
+        var now = EvenSlotInstant();
+        var svc = NewService(rec, now, renderer: (_, _, _) => null);  // encode/synth failed
+        svc.SetArmed(true);
+        svc.Stage("garbage", 1500, "even", "FT8");
+
+        await svc.TransmitCurrentStageAsync(CancellationToken.None);
+
+        Assert.Equal(0, rec.KeyUps);
+        Assert.Equal(0, rec.Blocks);
+    }
+
+    [Fact]
+    public void Watchdog_DisarmsAfterWindow()
+    {
+        var rec = new Recorder();
+        var armed = EvenSlotInstant();
+        var clock = armed;
+        var svc = new Ft8TxService(
+            rec.Key, rec.Audio, rec.Broadcast, (_, _, _) => FakeAudio(),
+            () => clock, static (_, _) => Task.CompletedTask, NullLogger.Instance);
+        svc.SetArmed(true);
+        Assert.True(svc.Armed);
+
+        clock = armed.AddMinutes(Ft8TxService.WatchdogMinutes + 1);
+        svc.EnforceWatchdog(clock);
+        Assert.False(svc.Armed);
+    }
+
+    [Fact]
+    public void Halt_Disarms_AndClearsStage()
+    {
+        var rec = new Recorder();
+        var now = EvenSlotInstant();
+        var svc = NewService(rec, now);
+        svc.SetArmed(true);
+        svc.Stage("CQ KB2UKA FN12", 1500, "even", "FT8");
+        Assert.True(svc.Armed);
+
+        svc.Halt();
+
+        Assert.False(svc.Armed);
+        Assert.Null(svc.Status().Message);
+        Assert.False(svc.ShouldKeyForSlot(SlotIndexOf(now, 15.0), now));
+    }
+
+    [Fact]
+    public async Task DisarmMidStream_TruncatesAndUnkeys()
+    {
+        // With a delay that disarms partway through, the streamer's stillArmed
+        // check stops feeding and the finally unkeys — a clean mid-slot abort.
+        var rec = new Recorder();
+        var now = EvenSlotInstant();
+        Ft8TxService? svc = null;
+        int ticks = 0;
+        Func<int, CancellationToken, Task> delay = (_, _) =>
+        {
+            if (++ticks == 2) svc!.SetArmed(false);   // disarm after the 2nd block
+            return Task.CompletedTask;
+        };
+        svc = new Ft8TxService(
+            rec.Key, rec.Audio, rec.Broadcast, (_, _, _) => new float[960 * 10],
+            () => now, delay, NullLogger.Instance);
+        svc.SetArmed(true);
+        svc.Stage("CQ KB2UKA FN12", 1500, "even", "FT8");
+
+        await svc.TransmitCurrentStageAsync(CancellationToken.None);
+
+        Assert.True(rec.Blocks < 13);   // did NOT stream the full 6 lead + 10 audio blocks
+        Assert.False(rec.Keyed);        // unkeyed on truncation
+    }
+
+    [Fact]
+    public void Stage_RejectsBadSlotAndMode()
+    {
+        var rec = new Recorder();
+        var svc = NewService(rec, EvenSlotInstant());
+        Assert.NotNull(svc.Stage("CQ K1ABC", 1500, "sideways", "FT8"));
+        Assert.NotNull(svc.Stage("CQ K1ABC", 1500, "even", "RTTY"));
+        Assert.NotNull(svc.Stage("   ", 1500, "even", "FT8"));
+        Assert.Null(svc.Stage("CQ K1ABC", 1500, "odd", "FT4"));
+    }
+
+    [Fact]
+    public void Status_ReportsArmAndStage()
+    {
+        var rec = new Recorder();
+        var now = EvenSlotInstant();
+        var svc = NewService(rec, now);
+        var s0 = svc.Status();
+        Assert.False(s0.Armed);
+        Assert.False(s0.Transmitting);
+
+        svc.SetArmed(true);
+        svc.Stage("CQ KB2UKA FN12", 1200, "odd", "FT4");
+        var s1 = svc.Status();
+        Assert.True(s1.Armed);
+        Assert.Equal("FT4", s1.Mode);
+        Assert.Equal("odd", s1.Slot);
+        Assert.Equal(1200, s1.AudioHz);
+        Assert.Equal("CQ KB2UKA FN12", s1.Message);
+        Assert.True(s1.WatchdogSecsRemaining > 0);
+    }
+}

--- a/tests/Zeus.Server.Tests/WsprTxServiceTests.cs
+++ b/tests/Zeus.Server.Tests/WsprTxServiceTests.cs
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// WsprTxServiceTests — drive the beacon keyer through its internal test
+// constructor (no native, no real-time waits, injected clock + RNG). Asserts the
+// safety invariants: never key disarmed / unconfigured, txPercent gating with a
+// seeded RNG, watchdog auto-disarm, and 3840-byte audio blocks.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class WsprTxServiceTests
+{
+    private sealed class Recorder
+    {
+        public int KeyUps;
+        public int KeyDowns;
+        public bool Keyed;
+        public int Blocks;
+        public int LastBlockBytes = -1;
+
+        public bool Key(bool on, out string? error)
+        {
+            error = null;
+            if (on) { KeyUps++; Keyed = true; } else { KeyDowns++; Keyed = false; }
+            return true;
+        }
+
+        public void Audio(ReadOnlyMemory<byte> block) { Blocks++; LastBlockBytes = block.Length; }
+        public void Broadcast(byte[] _) { }
+    }
+
+    private static float[] FakeAudio() => new float[960 * 4];
+
+    // A deterministic RNG that replays a fixed sequence, then repeats the last.
+    private static Func<double> SeededRandom(params double[] values)
+    {
+        int i = 0;
+        return () => values[Math.Min(i++, values.Length - 1)];
+    }
+
+    private static WsprTxService NewService(
+        Recorder rec, DateTime now, Func<double> random,
+        Func<string, int, float[]?>? renderer = null)
+    {
+        return new WsprTxService(
+            rec.Key,
+            rec.Audio,
+            rec.Broadcast,
+            renderer ?? ((_, _) => FakeAudio()),
+            () => now,
+            static (_, _) => Task.CompletedTask,
+            random,
+            NullLogger.Instance);
+    }
+
+    private static DateTime AnInstant() => new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void Disarmed_NeverKeys()
+    {
+        var rec = new Recorder();
+        var svc = NewService(rec, AnInstant(), SeededRandom(0.0));
+        svc.SetSettings("KB2UKA", "FN12", 30, 1500, 1.0);
+        Assert.False(svc.ShouldKeyForSlot(AnInstant()));
+    }
+
+    [Fact]
+    public void Armed_NoSettings_NeverKeys()
+    {
+        var rec = new Recorder();
+        var svc = NewService(rec, AnInstant(), SeededRandom(0.0));
+        svc.SetArmed(true);
+        Assert.False(svc.ShouldKeyForSlot(AnInstant()));
+    }
+
+    [Fact]
+    public void Armed_FullDuty_AlwaysKeys()
+    {
+        var rec = new Recorder();
+        var svc = NewService(rec, AnInstant(), SeededRandom(0.99));
+        svc.SetArmed(true);
+        svc.SetSettings("KB2UKA", "FN12", 30, 1500, 1.0);   // txPercent 1.0 → no RNG draw
+        Assert.True(svc.ShouldKeyForSlot(AnInstant()));
+    }
+
+    [Fact]
+    public void Armed_ZeroDuty_NeverKeys()
+    {
+        var rec = new Recorder();
+        var svc = NewService(rec, AnInstant(), SeededRandom(0.0));
+        svc.SetArmed(true);
+        svc.SetSettings("KB2UKA", "FN12", 30, 1500, 0.0);
+        Assert.False(svc.ShouldKeyForSlot(AnInstant()));
+    }
+
+    [Fact]
+    public void TxPercentGate_HonoursSeededRng()
+    {
+        var rec = new Recorder();
+        // pct 0.5: draw 0.3 (<0.5 → key), then 0.7 (≥0.5 → skip).
+        var svc = NewService(rec, AnInstant(), SeededRandom(0.3, 0.7));
+        svc.SetArmed(true);
+        svc.SetSettings("KB2UKA", "FN12", 30, 1500, 0.5);
+        Assert.True(svc.ShouldKeyForSlot(AnInstant()));
+        Assert.False(svc.ShouldKeyForSlot(AnInstant()));
+    }
+
+    [Fact]
+    public void Watchdog_DisarmsAfterWindow()
+    {
+        var rec = new Recorder();
+        var armed = AnInstant();
+        var clock = armed;
+        var svc = new WsprTxService(
+            rec.Key, rec.Audio, rec.Broadcast, (_, _) => FakeAudio(),
+            () => clock, static (_, _) => Task.CompletedTask, SeededRandom(0.0), NullLogger.Instance);
+        svc.SetArmed(true);
+        Assert.True(svc.Armed);
+
+        clock = armed.AddMinutes(WsprTxService.WatchdogMinutes + 1);
+        svc.EnforceWatchdog(clock);
+        Assert.False(svc.Armed);
+    }
+
+    [Fact]
+    public async Task Transmit_KeysThenUnkeys_AndEmits3840ByteBlocks()
+    {
+        var rec = new Recorder();
+        var svc = NewService(rec, AnInstant(), SeededRandom(0.0));
+        svc.SetArmed(true);
+        svc.SetSettings("KB2UKA", "FN12", 30, 1500, 1.0);
+
+        await svc.TransmitBeaconAsync(CancellationToken.None);
+
+        Assert.Equal(1, rec.KeyUps);
+        Assert.Equal(1, rec.KeyDowns);
+        Assert.False(rec.Keyed);
+        Assert.True(rec.Blocks > 0);
+        Assert.Equal(3840, rec.LastBlockBytes);
+        Assert.False(svc.Transmitting);
+    }
+
+    [Fact]
+    public async Task RenderFailure_DoesNotKey()
+    {
+        var rec = new Recorder();
+        var svc = NewService(rec, AnInstant(), SeededRandom(0.0), renderer: (_, _) => null);
+        svc.SetArmed(true);
+        svc.SetSettings("KB2UKA", "FN12", 30, 1500, 1.0);
+
+        await svc.TransmitBeaconAsync(CancellationToken.None);
+
+        Assert.Equal(0, rec.KeyUps);
+        Assert.Equal(0, rec.Blocks);
+    }
+
+    [Fact]
+    public void SetSettings_RejectsEmptyCallOrGrid()
+    {
+        var rec = new Recorder();
+        var svc = NewService(rec, AnInstant(), SeededRandom(0.0));
+        Assert.NotNull(svc.SetSettings("", "FN12", 30, 1500, 0.2));
+        Assert.NotNull(svc.SetSettings("KB2UKA", "  ", 30, 1500, 0.2));
+        Assert.Null(svc.SetSettings("KB2UKA", "FN12", 30, 1500, 0.2));
+    }
+
+    [Fact]
+    public void SnapWsprDbm_SnapsToNearestCanonicalStep()
+    {
+        Assert.Equal(0, WsprTxService.SnapWsprDbm(-5));    // clamp low
+        Assert.Equal(60, WsprTxService.SnapWsprDbm(100));  // clamp high
+        Assert.Equal(30, WsprTxService.SnapWsprDbm(30));   // already canonical
+        Assert.Equal(30, WsprTxService.SnapWsprDbm(31));   // 31 -> 30
+        Assert.Equal(33, WsprTxService.SnapWsprDbm(32));   // 32 -> 33
+        Assert.Equal(3, WsprTxService.SnapWsprDbm(5));     // tie 3/7 -> lower (3)
+    }
+
+    [Fact]
+    public void SetSettings_SnapsNonCanonicalDbm()
+    {
+        var rec = new Recorder();
+        var svc = NewService(rec, AnInstant(), SeededRandom(0.0));
+        // 31 dBm is NOT a valid WSPR power step; the encoder would reject it and the
+        // beacon would silently never key. SetSettings must snap it to 30.
+        Assert.Null(svc.SetSettings("KB2UKA", "FN12", 31, 1500, 0.2));
+        Assert.Equal("KB2UKA FN12 30", svc.Status().Message);
+    }
+
+    [Fact]
+    public void Status_ReportsWsprModeAndBeaconMessage()
+    {
+        var rec = new Recorder();
+        var svc = NewService(rec, AnInstant(), SeededRandom(0.0));
+        svc.SetArmed(true);
+        svc.SetSettings("KB2UKA", "FN12", 30, 1400, 0.2);
+        var s = svc.Status();
+        Assert.Equal("WSPR", s.Mode);
+        Assert.Equal("", s.Slot);
+        Assert.Equal("KB2UKA FN12 30", s.Message);
+        Assert.Equal(1400, s.AudioHz);
+        Assert.True(s.Armed);
+    }
+}

--- a/zeus-web/src/dsp/ft8-tx-controller.test.ts
+++ b/zeus-web/src/dsp/ft8-tx-controller.test.ts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+import { describe, expect, it, vi } from 'vitest';
+import { Ft8TxController } from './ft8-tx-controller';
+
+interface PostCall {
+  url: string;
+  body: Record<string, unknown>;
+}
+
+function makeFetch(): { fn: typeof fetch; calls: PostCall[] } {
+  const calls: PostCall[] = [];
+  const fn = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+    calls.push({ url: String(url), body });
+    return {} as Response;
+  }) as unknown as typeof fetch;
+  return { fn, calls };
+}
+
+const tx = (calls: PostCall[]) => calls.filter((c) => c.url === '/api/ft8/tx');
+const arm = (calls: PostCall[]) => calls.filter((c) => c.url === '/api/ft8/tx/arm');
+const halt = (calls: PostCall[]) => calls.filter((c) => c.url === '/api/ft8/tx/halt');
+
+describe('Ft8TxController', () => {
+  it('never POSTs /tx while disarmed', () => {
+    const { fn, calls } = makeFetch();
+    const ctrl = new Ft8TxController({ myCall: 'KB2UKA', myGrid4: 'FN12', fetchFn: fn });
+    // Not enabled: a decode window must not stage anything.
+    ctrl.onWindow(['CQ K1ABC FN42']);
+    ctrl.onWindow([]);
+    expect(tx(calls)).toHaveLength(0);
+  });
+
+  it('arms on enableTx and stages the answerer sequence', () => {
+    const { fn, calls } = makeFetch();
+    const logged: string[] = [];
+    const ctrl = new Ft8TxController({
+      myCall: 'KB2UKA',
+      myGrid4: 'FN12',
+      fetchFn: fn,
+      onLogQso: (s) => logged.push(s.dxCall ?? ''),
+    });
+
+    // Double-click a CQ heard in an even slot → we answer in the odd slot.
+    expect(ctrl.answerCq('CQ K1ABC FN42', 'even')).toBe(true);
+    expect(ctrl.getState().txSlot).toBe('odd');
+
+    ctrl.enableTx();
+    expect(arm(calls).at(-1)?.body).toEqual({ enabled: true });
+
+    // DX sends us a signal report → we stage R-report.
+    ctrl.onWindow(['KB2UKA K1ABC -12']);
+    const stage1 = tx(calls).at(-1);
+    expect(stage1).toBeDefined();
+    expect(String(stage1?.body.message)).toContain('K1ABC KB2UKA R');
+    expect(stage1?.body.slot).toBe('odd');
+    expect(stage1?.body.mode).toBe('FT8');
+
+    // DX rogers with RR73 → we stage 73 and the QSO logs exactly once.
+    ctrl.onWindow(['KB2UKA K1ABC RR73']);
+    expect(String(tx(calls).at(-1)?.body.message)).toContain('73');
+    expect(logged).toEqual(['K1ABC']);
+
+    // Next window: signoff complete → disarm (disable-after-73).
+    ctrl.onWindow([]);
+    expect(arm(calls).at(-1)?.body).toEqual({ enabled: false });
+  });
+
+  it('stages the current message immediately on enableTx (CQ caller)', () => {
+    const { fn, calls } = makeFetch();
+    const ctrl = new Ft8TxController({ myCall: 'KB2UKA', myGrid4: 'FN12', fetchFn: fn });
+    // CQ caller in 'calling': arming should both arm AND stage the CQ so the
+    // keyer has something to key at the next slot.
+    ctrl.enableTx();
+    expect(arm(calls).at(-1)?.body).toEqual({ enabled: true });
+    const stage = tx(calls).at(-1);
+    expect(stage).toBeDefined();
+    expect(String(stage?.body.message)).toBe('CQ KB2UKA FN12');
+  });
+
+  it('callStation() opens a QSO against any clicked decode', () => {
+    const { fn } = makeFetch();
+    const ctrl = new Ft8TxController({ myCall: 'KB2UKA', myGrid4: 'FN12', fetchFn: fn });
+    // Click a station heard in an even slot → call the SENDER (W9ZZZ), reply in
+    // the odd slot with our grid.
+    expect(ctrl.callStation('K1ABC W9ZZZ -05', 'even')).toBe(true);
+    expect(ctrl.getState().dxCall).toBe('W9ZZZ');
+    expect(ctrl.getState().txSlot).toBe('odd');
+    expect(ctrl.getOutgoing()).toBe('W9ZZZ KB2UKA FN12');
+    // A decode with no parseable callsign is rejected.
+    expect(ctrl.callStation('   ', 'even')).toBe(false);
+  });
+
+  it('CALL 1ST auto-answers the first decoded CQ while armed', () => {
+    const { fn, calls } = makeFetch();
+    const ctrl = new Ft8TxController({ myCall: 'KB2UKA', myGrid4: 'FN12', fetchFn: fn });
+    ctrl.setCallFirst(true);
+    ctrl.enableTx(); // arm + stage CQ
+    // A window with a CQ heard in an even slot → auto-answer in odd with grid.
+    ctrl.onWindow(['CQ DL1XYZ JO31'], undefined, 'even');
+    expect(ctrl.getState().dxCall).toBe('DL1XYZ');
+    expect(ctrl.getState().txSlot).toBe('odd');
+    const stage = tx(calls).at(-1);
+    expect(String(stage?.body.message)).toBe('DL1XYZ KB2UKA FN12');
+  });
+
+  it('CALL 1ST is inert when disarmed', () => {
+    const { fn, calls } = makeFetch();
+    const ctrl = new Ft8TxController({ myCall: 'KB2UKA', myGrid4: 'FN12', fetchFn: fn });
+    ctrl.setCallFirst(true);
+    // Not armed: a heard CQ must not stage anything.
+    ctrl.onWindow(['CQ DL1XYZ JO31'], undefined, 'even');
+    expect(tx(calls)).toHaveLength(0);
+    expect(ctrl.getState().dxCall).toBeNull();
+  });
+
+  it('posts /halt on operator Halt', () => {
+    const { fn, calls } = makeFetch();
+    const ctrl = new Ft8TxController({ myCall: 'KB2UKA', fetchFn: fn });
+    ctrl.enableTx();
+    ctrl.halt();
+    expect(halt(calls)).toHaveLength(1);
+    expect(ctrl.getState().enableTx).toBe(false);
+  });
+
+  it('respects HOLD TX FREQ for waterfall clicks', () => {
+    const { fn } = makeFetch();
+    const ctrl = new Ft8TxController({ myCall: 'KB2UKA', audioHz: 1500, fetchFn: fn });
+    ctrl.setHoldTxFreq(true);
+    ctrl.setTxFreq(2000);
+    expect(ctrl.getAudioHz()).toBe(1500); // held — click ignored
+    ctrl.setHoldTxFreq(false);
+    ctrl.setTxFreq(2000);
+    expect(ctrl.getAudioHz()).toBe(2000);
+  });
+});

--- a/zeus-web/src/dsp/ft8-tx-controller.ts
+++ b/zeus-web/src/dsp/ft8-tx-controller.ts
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// ft8-tx-controller — the QSO runner that bridges the PURE ft8-sequencer state
+// machine to the backend keyer (Ft8TxService). ft8-sequencer stays pure (no I/O,
+// no keying); this drives it: once per RX→TX window it gathers the just-ended
+// slot's decodes, calls step(), and turns the StepResult into the backend POSTs
+// (stage / arm / halt). The backend then keys at the next matching slot boundary.
+//
+// SAFETY: arming is EXPLICIT ONLY — enableTx() is the single path that sets
+// state.enableTx and POSTs /arm {enabled:true}. Nothing here auto-arms on mount
+// or workspace entry. disarmTx (signoff / no-reply-stop) and halt map straight
+// to /arm {enabled:false} and /halt. A message is only staged when enableTx is
+// true, so a disarmed controller never POSTs /tx.
+
+import { parseFt8Message } from './ft8-message';
+import {
+  answerCq as seqAnswerCq,
+  currentOutgoing,
+  halt as seqHalt,
+  startCq as seqStartCq,
+  slotOf,
+  step,
+  type DigitalQsoMode,
+  type NewQsoOpts,
+  type QsoState,
+  type Slot,
+} from './ft8-sequencer';
+
+export interface Ft8TxControllerOpts {
+  myCall: string;
+  myGrid4?: string | null;
+  mode?: DigitalQsoMode;
+  /** Initial TX audio offset (Hz). */
+  audioHz?: number;
+  /** Override fetch (tests). Defaults to global fetch. */
+  fetchFn?: typeof fetch;
+  /** Called once when a QSO should be logged (Team C's log endpoint). */
+  onLogQso?: (state: QsoState) => void;
+}
+
+/** The QSO runner. Owns the live QsoState and the TX audio offset, and issues
+ *  the backend stage/arm/halt POSTs as the sequencer advances. */
+export class Ft8TxController {
+  private state: QsoState;
+  private audioHz: number;
+  /** CALL 1ST: when armed and idle, auto-answer the first CQ heard. Off by
+   *  default — auto-answer is an explicit operator opt-in. */
+  private callFirst = false;
+  private readonly doFetch: typeof fetch;
+  private readonly onLogQso?: (state: QsoState) => void;
+
+  constructor(opts: Ft8TxControllerOpts) {
+    this.state = seqStartCq({
+      myCall: opts.myCall,
+      myGrid4: opts.myGrid4 ?? null,
+      mode: opts.mode ?? 'FT8',
+    });
+    this.audioHz = opts.audioHz ?? 1500;
+    this.doFetch = opts.fetchFn ?? ((...a: Parameters<typeof fetch>) => fetch(...a));
+    this.onLogQso = opts.onLogQso;
+  }
+
+  /** Snapshot of the current logical QSO state (read-only view for the UI). */
+  getState(): QsoState {
+    return this.state;
+  }
+
+  getAudioHz(): number {
+    return this.audioHz;
+  }
+
+  getCallFirst(): boolean {
+    return this.callFirst;
+  }
+
+  /** The message the machine would transmit next (UI preview). */
+  getOutgoing(): string | null {
+    return currentOutgoing(this.state);
+  }
+
+  // ---- per-window driver --------------------------------------------------
+
+  /**
+   * Advance one RX→TX window. `decoded` are the raw decoded message texts heard
+   * in the just-ended slot; `senderSlot` is the parity of that slot (so a
+   * CALL-1ST auto-answer can reply in the opposite slot). Applies the
+   * sequencer's decision: stages the next message (only while armed), logs once,
+   * and disarms/halts as the machine dictates. Pure decision in, POSTs out.
+   */
+  onWindow(decoded: string[], measuredSnrOfDx?: number, senderSlot?: Slot): void {
+    // CALL 1ST: while armed and idle (calling CQ, no DX latched yet), pounce on
+    // the first decoded CQ. Requires the just-ended slot's parity so we answer
+    // in the opposite slot. Explicit opt-in — never auto-engages.
+    if (
+      this.callFirst &&
+      this.state.enableTx &&
+      this.state.progress === 'calling' &&
+      !this.state.dxCall &&
+      senderSlot
+    ) {
+      const cqText = decoded.find((t) => {
+        const m = parseFt8Message(t, this.state.myCall);
+        return m.kind === 'cq' && !!m.deCall;
+      });
+      if (cqText && this.answerCq(cqText, senderSlot)) {
+        const msg = currentOutgoing(this.state);
+        if (msg != null) void this.postStage(msg);
+        return;
+      }
+    }
+
+    const res =
+      measuredSnrOfDx === undefined
+        ? step(this.state, decoded)
+        : step(this.state, decoded, { measuredSnrOfDx });
+    this.state = res.next;
+
+    if (res.outgoing != null && this.state.enableTx) {
+      void this.postStage(res.outgoing);
+    }
+    if (res.logQso) {
+      this.onLogQso?.(this.state);
+    }
+    if (res.halt) {
+      void this.postHalt();
+    } else if (res.disarmTx) {
+      void this.postArm(false);
+    }
+  }
+
+  // ---- operator actions ---------------------------------------------------
+
+  /** ENABLE-TX: the only path that arms. Sets enableTx, POSTs /arm, and stages
+   *  the current message so the keyer has something to key at the next matching
+   *  slot (CQ when calling, the QSO reply when answering). */
+  enableTx(): void {
+    this.state = { ...this.state, enableTx: true };
+    void this.postArm(true);
+    const msg = currentOutgoing(this.state);
+    if (msg != null) void this.postStage(msg);
+  }
+
+  /** CALL 1ST toggle: auto-answer the first CQ while armed and idle. */
+  setCallFirst(on: boolean): void {
+    this.callFirst = on;
+  }
+
+  /** Operator disable (disable-after-73 also routes here). */
+  disableTx(): void {
+    this.state = { ...this.state, enableTx: false };
+    void this.postArm(false);
+  }
+
+  /** Operator Halt: abort, disarm, reset the machine, POST /halt. */
+  halt(): void {
+    const res = seqHalt(this.state);
+    this.state = res.next;
+    void this.postHalt();
+  }
+
+  /** TX EVEN / ODD. */
+  setTxSlot(slot: Slot): void {
+    this.state = { ...this.state, txSlot: slot };
+  }
+
+  /** FT8 ↔ FT4 (slot timing differs; sequencer text is identical). */
+  setMode(mode: DigitalQsoMode): void {
+    this.state = { ...this.state, mode };
+  }
+
+  /** Operator identity (call / grid) — kept current so message generation uses
+   *  the latest values even if the operator fills them in after opening. */
+  setIdentity(myCall: string, myGrid4: string | null): void {
+    this.state = {
+      ...this.state,
+      myCall: myCall.toUpperCase().trim(),
+      myGrid4: myGrid4 ? myGrid4.toUpperCase().trim() : null,
+    };
+  }
+
+  /** HOLD TX FREQ toggle. */
+  setHoldTxFreq(hold: boolean): void {
+    this.state = { ...this.state, holdTxFreq: hold };
+  }
+
+  /** Waterfall click → TX offset. Ignored while HOLD TX FREQ is engaged. */
+  setTxFreq(hz: number): void {
+    if (this.state.holdTxFreq) return;
+    this.audioHz = hz;
+  }
+
+  /** Start calling CQ (CALL 1ST). */
+  startCq(opts?: Partial<NewQsoOpts>): void {
+    this.state = seqStartCq({
+      myCall: this.state.myCall,
+      myGrid4: this.state.myGrid4,
+      mode: this.state.mode,
+      ...opts,
+    });
+  }
+
+  /** Call an arbitrary decoded station (click a decode row). Treats any decode
+   *  with an identifiable callsign as a station to call — we open with our grid
+   *  reply (Tx1) in the slot opposite the one it was heard in. Returns false if
+   *  no callsign could be parsed. */
+  callStation(decodeText: string, senderSlot: Slot): boolean {
+    const parsed = parseFt8Message(decodeText, this.state.myCall);
+    if (!parsed.deCall) return false;
+    const next = seqAnswerCq(
+      { myCall: this.state.myCall, myGrid4: this.state.myGrid4, mode: this.state.mode },
+      { ...parsed, kind: 'cq' },
+      senderSlot,
+    );
+    if (!next) return false;
+    this.state = next;
+    return true;
+  }
+
+  /** Answer a decoded CQ (double-click a decode). Returns true if it was a CQ. */
+  answerCq(decodeText: string, cqSenderSlot: Slot): boolean {
+    const msg = parseFt8Message(decodeText, this.state.myCall);
+    const next = seqAnswerCq(
+      {
+        myCall: this.state.myCall,
+        myGrid4: this.state.myGrid4,
+        mode: this.state.mode,
+      },
+      msg,
+      cqSenderSlot,
+    );
+    if (!next) return false;
+    this.state = next;
+    return true;
+  }
+
+  /** Stage an arbitrary macro message (CQ / CQ DX / grid / RR73 / 73 buttons).
+   *  The backend will only key it if armed. */
+  stageMacro(message: string): void {
+    void this.postStage(message);
+  }
+
+  /** Slot helper for the caller's window ticker (UTC seconds-into-minute). */
+  slotForSecond(secondsIntoMinute: number): Slot {
+    return slotOf(secondsIntoMinute, this.state.mode);
+  }
+
+  // ---- backend POSTs ------------------------------------------------------
+
+  private postStage(message: string): Promise<unknown> {
+    return this.post('/api/ft8/tx', {
+      message,
+      audioHz: this.audioHz,
+      slot: this.state.txSlot,
+      mode: this.state.mode,
+    });
+  }
+
+  private postArm(enabled: boolean): Promise<unknown> {
+    return this.post('/api/ft8/tx/arm', { enabled });
+  }
+
+  private postHalt(): Promise<unknown> {
+    return this.post('/api/ft8/tx/halt', {});
+  }
+
+  private async post(url: string, body: unknown): Promise<unknown> {
+    try {
+      await this.doFetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+    } catch {
+      // The keyer's own watchdog + arm-state is authoritative; a dropped POST
+      // just means this window doesn't change the backend. Swallow.
+    }
+    return undefined;
+  }
+}

--- a/zeus-web/src/dsp/ft8-tx-runner.test.ts
+++ b/zeus-web/src/dsp/ft8-tx-runner.test.ts
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  beaconDisarm,
+  decodesForSlot,
+  slotIndexOf,
+  slotMsFor,
+  slotParity,
+  startFt8SlotDriver,
+} from './ft8-tx-runner';
+import { Ft8TxController } from './ft8-tx-controller';
+import type { Slot } from './ft8-sequencer';
+import type { Ft8Row } from '../state/ft8-store';
+
+function row(slotStartUnixMs: number, text: string, i = 0): Ft8Row {
+  return {
+    id: `0:${slotStartUnixMs}:${i}`,
+    receiver: 0,
+    protocol: 'FT8',
+    slotStartUnixMs,
+    snrDb: -10,
+    dtSec: 0.1,
+    freqHz: 1000,
+    score: 20,
+    text,
+  };
+}
+
+describe('ft8-tx-runner slot helpers', () => {
+  it('slotMsFor: FT8 = 15 s, FT4 = 7.5 s', () => {
+    expect(slotMsFor('FT8')).toBe(15_000);
+    expect(slotMsFor('FT4')).toBe(7_500);
+  });
+
+  it('slotIndexOf floors epoch to the slot grid', () => {
+    expect(slotIndexOf(0, 15_000)).toBe(0);
+    expect(slotIndexOf(14_999, 15_000)).toBe(0);
+    expect(slotIndexOf(15_000, 15_000)).toBe(1);
+    expect(slotIndexOf(30_001, 15_000)).toBe(2);
+  });
+
+  it('slotParity alternates even/odd', () => {
+    expect(slotParity(0)).toBe('even');
+    expect(slotParity(1)).toBe('odd');
+    expect(slotParity(2)).toBe('even');
+  });
+
+  it('decodesForSlot returns only the texts in the requested slot index', () => {
+    const slotMs = 15_000;
+    const rows = [
+      row(30_000, 'CQ K1ABC FN42', 0), // slot 2
+      row(30_000, 'CQ W2XYZ EM10', 1), // slot 2
+      row(15_000, 'CQ N0OLD AA00', 0), // slot 1 (older)
+    ];
+    expect(decodesForSlot(rows, 2, slotMs)).toEqual(['CQ K1ABC FN42', 'CQ W2XYZ EM10']);
+    expect(decodesForSlot(rows, 1, slotMs)).toEqual(['CQ N0OLD AA00']);
+    expect(decodesForSlot(rows, 0, slotMs)).toEqual([]);
+  });
+});
+
+describe('startFt8SlotDriver (boundary → settle → decodes pipeline)', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('hands the just-ended slot decodes + parity to onWindow after settle', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0); // epoch — slot 0 (even)
+    const slotMs = 15_000;
+    const settleMs = 2_000;
+    const rows = [row(0, 'CQ K1ABC FN42')]; // a decode in slot 0
+    const windows: Array<{ texts: string[]; senderSlot: Slot }> = [];
+
+    const stop = startFt8SlotDriver({
+      slotMs,
+      settleMs,
+      getRows: () => rows,
+      onWindow: (texts, senderSlot) => windows.push({ texts, senderSlot }),
+    });
+
+    // Cross into slot 1 (odd): a boundary tick fires and schedules the settle.
+    vi.advanceTimersByTime(slotMs);
+    expect(windows).toHaveLength(0); // settle hasn't elapsed yet
+
+    vi.advanceTimersByTime(settleMs);
+    expect(windows).toHaveLength(1);
+    expect(windows[0]?.texts).toEqual(['CQ K1ABC FN42']);
+    expect(windows[0]?.senderSlot).toBe('even'); // slot 0 parity
+
+    stop();
+  });
+
+  it('drives an armed controller to stage the reply in the opposite slot', () => {
+    // End-to-end frontend half: a CQ heard in an even slot, fed through the driver
+    // after settle, makes the armed controller stage a reply with ODD parity — the
+    // parity the backend keyer requires for the answer slot.
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const slotMs = 15_000;
+    const settleMs = 2_000;
+    const rows = [row(0, 'CQ K1ABC FN42')];
+
+    const posts: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const fetchFn = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      posts.push({
+        url: String(url),
+        body: init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {},
+      });
+      return {} as Response;
+    }) as unknown as typeof fetch;
+
+    const ctrl = new Ft8TxController({ myCall: 'KB2UKA', myGrid4: 'FN12', fetchFn });
+    ctrl.setCallFirst(true); // auto-answer the first CQ while armed + idle
+    ctrl.enableTx();
+
+    const stop = startFt8SlotDriver({
+      slotMs,
+      settleMs,
+      getRows: () => rows,
+      onWindow: (texts, senderSlot) => ctrl.onWindow(texts, undefined, senderSlot),
+    });
+
+    vi.advanceTimersByTime(slotMs + settleMs);
+
+    const stage = posts.filter((p) => p.url === '/api/ft8/tx').at(-1);
+    expect(stage).toBeDefined();
+    expect(stage?.body.slot).toBe('odd'); // reply goes in the slot opposite the CQ
+    expect(String(stage?.body.message)).toContain('K1ABC');
+
+    stop();
+  });
+});
+
+describe('beaconDisarm', () => {
+  it('disarms the FT8 keyer via sendBeacon on the arm endpoint', () => {
+    const calls: Array<{ url: string; body: string }> = [];
+    const orig = navigator.sendBeacon;
+    // jsdom has no sendBeacon; install a spy.
+    (navigator as unknown as { sendBeacon: (u: string, d?: BodyInit) => boolean }).sendBeacon = (
+      url: string,
+      data?: BodyInit,
+    ) => {
+      calls.push({ url: String(url), body: String(data) });
+      return true;
+    };
+    try {
+      beaconDisarm();
+    } finally {
+      (navigator as unknown as { sendBeacon?: unknown }).sendBeacon = orig;
+    }
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe('/api/ft8/tx/arm');
+  });
+});

--- a/zeus-web/src/dsp/ft8-tx-runner.ts
+++ b/zeus-web/src/dsp/ft8-tx-runner.ts
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// ft8-tx-runner — the React glue that turns the pure ft8-sequencer + the
+// Ft8TxController into a LIVE keyer: it owns one controller per workspace and,
+// once per UTC slot, hands the just-completed slot's decodes to the controller
+// so the sequencer can stage the next message for the backend keyer.
+//
+// The BACKEND owns precise slot-boundary keying (its own UTC slot clock keys
+// ~120 ms before the boundary if a fresh matching stage exists). This runner's
+// only timing job is to POST a fresh stage every slot while armed — it processes
+// the window a few seconds after each boundary, once the decoder has produced
+// that slot's decodes, which leaves the stage fresh for the upcoming slot.
+//
+// SAFETY: the controller gates everything on enableTx, so running the slot timer
+// unconditionally is safe — a disarmed controller's onWindow is a no-op and
+// never POSTs /tx. Arming is still EXPLICIT ONLY (controller.enableTx()).
+
+import { useEffect, useRef, useState } from 'react';
+import { useFt8Store, type Ft8Row } from '../state/ft8-store';
+import { Ft8TxController } from './ft8-tx-controller';
+import type { DigitalQsoMode, QsoState, Slot } from './ft8-sequencer';
+
+/** Slot length (ms) for a digital mode. FT8 = 15 s, FT4 = 7.5 s. */
+export function slotMsFor(mode: DigitalQsoMode): number {
+  return mode === 'FT4' ? 7_500 : 15_000;
+}
+
+/**
+ * Decoder settle time (ms) after a slot boundary before its decodes are in. Kept
+ * inside the backend's late-start window (FT8 ≤2.5 s / FT4 ≤1.0 s into the slot,
+ * see Ft8TxService.MaxLateStartSecondsFor) so a decode-driven reply staged here
+ * keys in the SAME slot rather than a full cycle later. If a stage lands after the
+ * window (decoder/POST jitter) the backend's one-cycle freshness window still
+ * keys it at the next matching boundary — graceful degradation, never a stall.
+ * G2 bench-tune.
+ */
+function settleMsFor(mode: DigitalQsoMode): number {
+  return mode === 'FT4' ? 800 : 2_000;
+}
+
+/** The UTC slot index a given epoch-ms falls in, for a slot length. */
+export function slotIndexOf(epochMs: number, slotMs: number): number {
+  return Math.floor(epochMs / slotMs);
+}
+
+/** Even/odd parity of a slot index (even = the 0th/2nd/… slot of the minute). */
+export function slotParity(slotIndex: number): Slot {
+  return slotIndex % 2 === 0 ? 'even' : 'odd';
+}
+
+/**
+ * Texts of the decode rows that belong to a given UTC slot index. Pure — the
+ * runner's per-window input. Rows carry the backend's exact slot-start ms, so
+ * membership is `floor(slotStartUnixMs / slotMs) === slotIndex`.
+ */
+export function decodesForSlot(rows: readonly Ft8Row[], slotIndex: number, slotMs: number): string[] {
+  return rows.filter((r) => slotIndexOf(r.slotStartUnixMs, slotMs) === slotIndex).map((r) => r.text);
+}
+
+export interface Ft8TxRunnerView {
+  /** Live QSO state snapshot (drives the TX-control UI). */
+  qso: QsoState;
+  /** Current TX audio offset (Hz). */
+  audioHz: number;
+  /** CALL 1ST auto-answer enabled. */
+  callFirst: boolean;
+  /** The message the machine would key next (preview). */
+  outgoing: string | null;
+
+  // Operator actions (each mirrors a controller method, then re-syncs the view).
+  enableTx: () => void;
+  disableTx: () => void;
+  halt: () => void;
+  setTxSlot: (slot: Slot) => void;
+  setHoldTxFreq: (hold: boolean) => void;
+  setTxFreq: (hz: number) => void;
+  setCallFirst: (on: boolean) => void;
+  startCq: () => void;
+  answerCq: (decodeText: string, senderSlot: Slot) => boolean;
+  callStation: (decodeText: string, senderSlot: Slot) => boolean;
+  stageMacro: (message: string) => void;
+}
+
+export interface UseFt8TxRunnerOpts {
+  myCall: string;
+  myGrid?: string | null;
+  mode: DigitalQsoMode;
+  /** Workspace open / decoder live — gates the slot timer. */
+  active: boolean;
+  /** Current band — a change while armed force-disarms (never TX on a new band). */
+  band?: string;
+  onLogQso?: (state: QsoState) => void;
+}
+
+/**
+ * Owns the per-slot RX→TX window timing: polls for each UTC slot boundary and,
+ * `settleMs` after one is crossed, hands the just-ended slot's decodes (and its
+ * parity) to `onWindow`. Extracted from the hook so the
+ * boundary→settle→decodes→stage pipeline is unit-testable with fake timers (no
+ * React renderer / extra test dep needed). Returns a disposer that clears every
+ * timer it created.
+ */
+export function startFt8SlotDriver(opts: {
+  slotMs: number;
+  settleMs: number;
+  getRows: () => readonly Ft8Row[];
+  onWindow: (texts: string[], senderSlot: Slot) => void;
+}): () => void {
+  const { slotMs, settleMs, getRows, onWindow } = opts;
+  let lastSlot = slotIndexOf(Date.now(), slotMs);
+  const pending: ReturnType<typeof setTimeout>[] = [];
+
+  const tick = () => {
+    const cur = slotIndexOf(Date.now(), slotMs);
+    if (cur === lastSlot) return;
+    const endedSlot = lastSlot; // the slot that just closed
+    lastSlot = cur;
+    const id = setTimeout(() => {
+      onWindow(decodesForSlot(getRows(), endedSlot, slotMs), slotParity(endedSlot));
+    }, settleMs);
+    pending.push(id);
+  };
+
+  const interval = setInterval(tick, 250);
+  return () => {
+    clearInterval(interval);
+    for (const id of pending) clearTimeout(id);
+  };
+}
+
+/** Best-effort disarm of the backend keyer. Uses sendBeacon so it survives a tab
+ *  close / page unload where an in-flight fetch would be killed. */
+export function beaconDisarm(): void {
+  try {
+    const body = new Blob([JSON.stringify({ enabled: false })], { type: 'application/json' });
+    navigator.sendBeacon?.('/api/ft8/tx/arm', body);
+  } catch {
+    // sendBeacon unavailable / blocked — the backend watchdog is the backstop.
+  }
+}
+
+/**
+ * Owns a single Ft8TxController for the open FT8/FT4 workspace and drives it once
+ * per slot. Returns a reactive view + bound actions for the TX-control cluster.
+ */
+export function useFt8TxRunner(opts: UseFt8TxRunnerOpts): Ft8TxRunnerView {
+  const { myCall, myGrid, mode, active, band, onLogQso } = opts;
+
+  // One controller for the lifetime of the workspace. Identity (call/grid) and
+  // mode are pushed in via setters so an in-flight QSO survives a re-render.
+  const ctrlRef = useRef<Ft8TxController | null>(null);
+  if (ctrlRef.current === null) {
+    ctrlRef.current = new Ft8TxController({ myCall, myGrid4: myGrid, mode, onLogQso });
+  }
+  const ctrl = ctrlRef.current;
+
+  const [view, setView] = useState(() => snapshot(ctrl));
+  const sync = () => setView(snapshot(ctrl));
+
+  // Keep identity + mode current without resetting the live QSO.
+  useEffect(() => {
+    ctrl.setMode(mode);
+    ctrl.setIdentity(myCall, myGrid ?? null);
+    sync();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode, myCall, myGrid]);
+
+  // Slot timer: detect each UTC slot boundary, then after the decoder settles,
+  // feed the just-completed slot's decodes to the controller.
+  useEffect(() => {
+    if (!active) return;
+    return startFt8SlotDriver({
+      slotMs: slotMsFor(mode),
+      settleMs: settleMsFor(mode),
+      getRows: () => useFt8Store.getState().rows,
+      onWindow: (texts, senderSlot) => {
+        ctrl.onWindow(texts, undefined, senderSlot);
+        sync();
+      },
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, mode]);
+
+  // Safety: force-disarm the backend keyer when the workspace unmounts or the tab
+  // closes. Without this, navigating away while armed leaves the radio auto-
+  // sequencing until only the watchdog (minutes later) catches it.
+  useEffect(() => {
+    window.addEventListener('pagehide', beaconDisarm);
+    return () => {
+      window.removeEventListener('pagehide', beaconDisarm);
+      if (ctrl.getState().enableTx) ctrl.disableTx();
+      beaconDisarm();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Safety: a band change while armed force-disarms — never keep auto-keying a
+  // QSO sequence onto whatever band the operator just switched to.
+  const prevBand = useRef(band);
+  useEffect(() => {
+    if (prevBand.current === band) return;
+    prevBand.current = band;
+    if (ctrl.getState().enableTx) {
+      ctrl.disableTx();
+      sync();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [band]);
+
+  return {
+    ...view,
+    enableTx: () => {
+      ctrl.enableTx();
+      sync();
+    },
+    disableTx: () => {
+      ctrl.disableTx();
+      sync();
+    },
+    halt: () => {
+      ctrl.halt();
+      sync();
+    },
+    setTxSlot: (slot) => {
+      ctrl.setTxSlot(slot);
+      sync();
+    },
+    setHoldTxFreq: (hold) => {
+      ctrl.setHoldTxFreq(hold);
+      sync();
+    },
+    setTxFreq: (hz) => {
+      ctrl.setTxFreq(hz);
+      sync();
+    },
+    setCallFirst: (on) => {
+      ctrl.setCallFirst(on);
+      sync();
+    },
+    startCq: () => {
+      ctrl.startCq();
+      sync();
+    },
+    answerCq: (text, senderSlot) => {
+      const ok = ctrl.answerCq(text, senderSlot);
+      sync();
+      return ok;
+    },
+    callStation: (text, senderSlot) => {
+      const ok = ctrl.callStation(text, senderSlot);
+      sync();
+      return ok;
+    },
+    stageMacro: (message) => {
+      ctrl.stageMacro(message);
+      sync();
+    },
+  };
+}
+
+function snapshot(ctrl: Ft8TxController): {
+  qso: QsoState;
+  audioHz: number;
+  callFirst: boolean;
+  outgoing: string | null;
+} {
+  return {
+    qso: ctrl.getState(),
+    audioHz: ctrl.getAudioHz(),
+    callFirst: ctrl.getCallFirst(),
+    outgoing: ctrl.getOutgoing(),
+  };
+}

--- a/zeus-web/src/layout/ft8/Ft8TxControl.tsx
+++ b/zeus-web/src/layout/ft8/Ft8TxControl.tsx
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Ft8TxControl — the TX control cluster for the FT8/FT4 workspace. Renders the
+// arm/transmit lamps (from the backend's 0x3A status, NOT local optimism), the
+// ENABLE-TX master, HOLD-TX-FREQ, TX EVEN/ODD selector, the message + macro row,
+// the TX audio-offset field, and TUNE. All keying flows through the runner
+// (sequencer → Ft8TxController → backend keyer); arming is explicit only.
+//
+// Power (Drive %, Tune %) is owned by the main app's TX controls (Team B) and is
+// intentionally not duplicated here — this cluster only arms, sequences, and
+// keys. TUNE reuses the same /api/tx/tun carrier the main rig uses.
+
+import { useState } from 'react';
+import { setTun } from '../../api/client';
+import { genCq, genTx4, genTx5 } from '../../dsp/ft8-sequencer';
+import type { Ft8TxRunnerView } from '../../dsp/ft8-tx-runner';
+import { useFt8TxStore } from '../../state/ft8-tx-store';
+
+export interface Ft8TxControlProps {
+  runner: Ft8TxRunnerView;
+  myCall: string;
+  myGrid: string;
+}
+
+export function Ft8TxControl({ runner, myCall, myGrid }: Ft8TxControlProps) {
+  const status = useFt8TxStore((s) => s.status);
+  const [custom, setCustom] = useState('');
+  const [tunOn, setTunOn] = useState(false);
+
+  const qso = runner.qso;
+  const dx = qso.dxCall;
+  const armed = qso.enableTx;
+  const liveArmed = status?.armed ?? false;
+  const transmitting = status?.transmitting ?? false;
+  const canCall = myCall.trim().length > 0;
+
+  const toggleTune = () => {
+    const next = !tunOn;
+    setTunOn(next);
+    void setTun(next).catch(() => setTunOn(!next));
+  };
+
+  return (
+    <div className="ft8-tx" aria-label="TX control">
+      {/* Status lamps — driven by the backend keyer, not local state. */}
+      <div className="ft8-tx__lamps">
+        <span className={`ft8-tx__lamp${liveArmed ? ' is-armed' : ''}`} title="Backend armed">
+          ARMED
+        </span>
+        <span className={`ft8-tx__lamp${transmitting ? ' is-tx' : ''}`} title="On air">
+          TX
+        </span>
+        {liveArmed && status && status.watchdogSecsRemaining > 0 && (
+          <span className="ft8-tx__wdt" title="Watchdog auto-disarm">
+            WDT {Math.ceil(status.watchdogSecsRemaining)}s
+          </span>
+        )}
+      </div>
+
+      {/* ENABLE-TX master + HOLD TX FREQ. */}
+      <div className="ft8-tx__row">
+        <button
+          type="button"
+          className={`ft8-tx__enable${armed ? ' is-on' : ''}`}
+          disabled={!canCall}
+          title={canCall ? 'Arm the keyer (explicit)' : 'Set your Call to enable TX'}
+          onClick={() => (armed ? runner.disableTx() : runner.enableTx())}
+        >
+          {armed ? 'TX ENABLED · DISABLE' : 'TX ENABLE'}
+        </button>
+        <button
+          type="button"
+          className={`ft8-tx__toggle${qso.holdTxFreq ? ' is-on' : ''}`}
+          onClick={() => runner.setHoldTxFreq(!qso.holdTxFreq)}
+          title="Lock the TX audio offset against waterfall clicks"
+        >
+          HOLD TX FREQ
+        </button>
+      </div>
+
+      {/* TX slot (even/odd) + audio offset. */}
+      <div className="ft8-tx__row">
+        <div className="ft8-tx__seg" role="group" aria-label="TX slot">
+          <span className="ft8-tx__seg-label">TX</span>
+          {(['even', 'odd'] as const).map((s) => (
+            <button
+              key={s}
+              type="button"
+              className={`ft8-tx__seg-btn${qso.txSlot === s ? ' is-on' : ''}`}
+              onClick={() => runner.setTxSlot(s)}
+            >
+              {s === 'even' ? '1ST' : '2ND'}
+            </button>
+          ))}
+        </div>
+        <label className="ft8-tx__offset">
+          <span>OFFSET</span>
+          <input
+            type="number"
+            min={0}
+            max={2500}
+            step={1}
+            value={Math.round(runner.audioHz)}
+            disabled={qso.holdTxFreq}
+            onChange={(e) => runner.setTxFreq(Number(e.target.value))}
+          />
+          <span>Hz</span>
+        </label>
+      </div>
+
+      {/* Next / staged message preview. */}
+      <div className="ft8-tx__next">
+        <span className="ft8-tx__next-label">NEXT</span>
+        <span className="ft8-tx__next-msg">{runner.outgoing ?? '—'}</span>
+      </div>
+      {dx && (
+        <div className="ft8-tx__dx">
+          QSO with <strong>{dx}</strong>
+          {qso.dxGrid4 ? ` · ${qso.dxGrid4}` : ''} · {qso.progress}
+        </div>
+      )}
+
+      {/* Macro row — operator overrides. */}
+      <div className="ft8-tx__macros" role="group" aria-label="TX macros">
+        <button
+          type="button"
+          className="ft8-tx__macro"
+          disabled={!canCall}
+          onClick={() => {
+            runner.startCq();
+            runner.stageMacro(genCq(myCall, myGrid || null));
+          }}
+        >
+          CQ
+        </button>
+        <button
+          type="button"
+          className="ft8-tx__macro"
+          disabled={!canCall}
+          onClick={() => {
+            runner.startCq();
+            runner.stageMacro(genCq(myCall, myGrid || null, 'DX'));
+          }}
+        >
+          CQ DX
+        </button>
+        <button
+          type="button"
+          className="ft8-tx__macro"
+          disabled={!runner.outgoing}
+          title="Re-send the standard next message (grid / report)"
+          onClick={() => runner.outgoing && runner.stageMacro(runner.outgoing)}
+        >
+          GRID/RPT
+        </button>
+        <button
+          type="button"
+          className="ft8-tx__macro"
+          disabled={!dx || !canCall}
+          onClick={() => dx && runner.stageMacro(genTx4(dx, myCall, 'RR73'))}
+        >
+          RR73
+        </button>
+        <button
+          type="button"
+          className="ft8-tx__macro"
+          disabled={!dx || !canCall}
+          onClick={() => dx && runner.stageMacro(genTx5(dx, myCall))}
+        >
+          73
+        </button>
+        <button
+          type="button"
+          className={`ft8-tx__macro${runner.callFirst ? ' is-on' : ''}`}
+          title="Auto-answer the first decoded CQ while armed"
+          onClick={() => runner.setCallFirst(!runner.callFirst)}
+        >
+          CALL 1ST
+        </button>
+      </div>
+
+      {/* Free-form message stage. */}
+      <div className="ft8-tx__custom">
+        <input
+          value={custom}
+          onChange={(e) => setCustom(e.target.value.toUpperCase())}
+          placeholder="free-form message"
+          spellCheck={false}
+          maxLength={13}
+        />
+        <button
+          type="button"
+          className="ft8-tx__macro"
+          disabled={!custom.trim()}
+          onClick={() => {
+            runner.stageMacro(custom.trim());
+            setCustom('');
+          }}
+        >
+          STAGE
+        </button>
+      </div>
+
+      {/* TUNE + HALT. */}
+      <div className="ft8-tx__row">
+        <button
+          type="button"
+          className={`ft8-tx__tune${tunOn ? ' is-on' : ''}`}
+          onClick={toggleTune}
+          title="Key a single-tone carrier (antenna tune)"
+        >
+          {tunOn ? 'TUNE ON' : 'TUNE'}
+        </button>
+        <button
+          type="button"
+          className="ft8-tx__halt"
+          onClick={() => runner.halt()}
+          title="Abort: disarm and drop the keyer immediately"
+        >
+          HALT
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/zeus-web/src/layout/ft8/Ft8Workspace.tsx
+++ b/zeus-web/src/layout/ft8/Ft8Workspace.tsx
@@ -15,18 +15,10 @@ import { useFt8Store, type Ft8Row } from '../../state/ft8-store';
 import { useConnectionStore } from '../../state/connection-store';
 import { useOperatorStore } from '../../state/operator-store';
 import { DIGITAL_BANDS } from '../../dsp/digital-segments';
-import { parseFt8Message, type Ft8Message } from '../../dsp/ft8-message';
-import {
-  answerCq,
-  currentOutgoing,
-  genTx2,
-  genTx3,
-  genTx4,
-  genTx5,
-  slotOf,
-  type QsoState,
-} from '../../dsp/ft8-sequencer';
+import { slotOf } from '../../dsp/ft8-sequencer';
+import { useFt8TxRunner } from '../../dsp/ft8-tx-runner';
 import { Ft8DecodeTable } from './Ft8DecodeTable';
+import { Ft8TxControl } from './Ft8TxControl';
 import '../../styles/ft8-theme.css';
 
 export interface Ft8WorkspaceProps {
@@ -66,7 +58,14 @@ export function Ft8Workspace({ onClose }: Ft8WorkspaceProps) {
   const setCall = useOperatorStore((s) => s.setCall);
   const setGrid = useOperatorStore((s) => s.setGrid);
 
-  const [staged, setStaged] = useState<QsoState | null>(null);
+  // Live TX runner: owns the QSO sequencer + backend keyer, driven once per slot.
+  const tx = useFt8TxRunner({
+    myCall,
+    myGrid: myGrid || null,
+    mode: protocol,
+    active: true,
+    band,
+  });
 
   // Esc closes the workspace.
   useEffect(() => {
@@ -81,19 +80,12 @@ export function Ft8Workspace({ onClose }: Ft8WorkspaceProps) {
     return () => window.removeEventListener('keydown', h);
   }, [onClose]);
 
-  // Click a decode → stage a QSO answering that station.
+  // Click a decode → start calling that station (we reply in the opposite slot).
   const onRowClick = (row: Ft8Row) => {
     if (!myCall) return; // need an operator call to generate Tx messages
-    const parsed = parseFt8Message(row.text, myCall);
-    if (!parsed.deCall) return;
-    // The slot the heard station transmitted in (FT8 15 s / FT4 7.5 s) — we
-    // answer in the opposite slot.
     const secs = new Date(row.slotStartUnixMs).getUTCSeconds();
     const senderSlot = slotOf(secs, protocol);
-    // Treat any clicked station as a CQ to answer (start with our grid reply).
-    const asCq: Ft8Message = { ...parsed, kind: 'cq' };
-    const next = answerCq({ myCall, myGrid4: myGrid || null, mode: protocol }, asCq, senderSlot);
-    if (next) setStaged(next);
+    tx.callStation(row.text, senderSlot);
   };
 
   const bandsForProtocol = useMemo(
@@ -205,7 +197,7 @@ export function Ft8Workspace({ onClose }: Ft8WorkspaceProps) {
           <section className="ft8-region ft8-region--grow">
             <div className="ft8-region__head">TX control · QSO</div>
             <div className="ft8-region__body">
-              <QsoPanel staged={staged} onClear={() => setStaged(null)} />
+              <Ft8TxControl runner={tx} myCall={myCall} myGrid={myGrid} />
             </div>
           </section>
           <section className="ft8-region">
@@ -225,55 +217,6 @@ export function Ft8Workspace({ onClose }: Ft8WorkspaceProps) {
           {protocol} native · {band}
         </span>
       </footer>
-    </div>
-  );
-}
-
-/** Staged-QSO preview: the message ladder we WOULD transmit. Keying is
- *  bench-gated — Enable Tx is intentionally inert until verified on the G2. */
-function QsoPanel({ staged, onClear }: { staged: QsoState | null; onClear: () => void }) {
-  if (!staged || !staged.dxCall) {
-    return (
-      <div className="ft8-qso ft8-qso--empty">
-        Click a decoded station to stage a QSO. The auto-sequence preview appears here.
-      </div>
-    );
-  }
-  const his = staged.dxCall;
-  const mine = staged.myCall;
-  const ladder: { label: string; msg: string }[] = [
-    { label: 'Tx1', msg: currentOutgoing(staged) ?? '' },
-    { label: 'Tx2', msg: genTx2(his, mine, -10) },
-    { label: 'Tx3', msg: genTx3(his, mine, -10) },
-    { label: 'Tx4', msg: genTx4(his, mine, staged.txAck) },
-    { label: 'Tx5', msg: genTx5(his, mine) },
-  ];
-  return (
-    <div className="ft8-qso">
-      <div className="ft8-qso__dx">
-        Calling <strong>{his}</strong>
-        {staged.dxGrid4 ? ` · ${staged.dxGrid4}` : ''} · slot {staged.txSlot}
-      </div>
-      <ol className="ft8-qso__ladder">
-        {ladder.map((l) => (
-          <li key={l.label}>
-            <span className="ft8-qso__slot">{l.label}</span>
-            <span className="ft8-qso__msg">{l.msg}</span>
-          </li>
-        ))}
-      </ol>
-      <div className="ft8-qso__bench" role="note">
-        ⚠ TX keying is bench-gated — Enable Tx is disabled until verified on the G2. This panel
-        previews the sequence only.
-      </div>
-      <div className="ft8-qso__actions">
-        <button type="button" className="ft8-qso__btn" disabled title="Bench-gated">
-          Enable Tx
-        </button>
-        <button type="button" className="ft8-qso__btn" onClick={onClear}>
-          Clear
-        </button>
-      </div>
     </div>
   );
 }

--- a/zeus-web/src/layout/ft8/WsprTxControl.tsx
+++ b/zeus-web/src/layout/ft8/WsprTxControl.tsx
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// WsprTxControl — the beacon TX cluster for the WSPR workspace. WSPR has no QSO
+// state machine: it is a fire-and-forget beacon keyed by the backend WsprTxService
+// on even-minute 120 s slots, gated by a tx-percent probability. This cluster
+// only sets the beacon content/cadence, arms (explicit), and offers TUNE/HALT.
+//
+// Arm + transmit lamps come from the shared 0x3A status (mode === "WSPR"); the
+// backend is authoritative. No power model is duplicated here.
+
+import { useEffect } from 'react';
+import { useState } from 'react';
+import { setTun } from '../../api/client';
+import { useFt8TxStore } from '../../state/ft8-tx-store';
+import { useWsprStore } from '../../state/wspr-store';
+
+export interface WsprTxControlProps {
+  myCall: string;
+  myGrid: string;
+}
+
+async function postJson(url: string, body: unknown): Promise<void> {
+  try {
+    await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  } catch {
+    // Backend arm-state + watchdog are authoritative; a dropped POST is benign.
+  }
+}
+
+/** Best-effort disarm of the WSPR beacon that survives a tab close / page unload
+ *  (where an in-flight fetch would be killed). */
+function beaconDisarm(): void {
+  try {
+    const body = new Blob([JSON.stringify({ enabled: false })], { type: 'application/json' });
+    navigator.sendBeacon?.('/api/wspr/tx/arm', body);
+  } catch {
+    // sendBeacon unavailable / blocked — the backend watchdog is the backstop.
+  }
+}
+
+export function WsprTxControl({ myCall, myGrid }: WsprTxControlProps) {
+  const status = useFt8TxStore((s) => s.status);
+  const band = useWsprStore((s) => s.band);
+  const [dBm, setDBm] = useState(30);
+  const [audioHz, setAudioHz] = useState(1500);
+  const [txPercent, setTxPercent] = useState(20);
+  const [tunOn, setTunOn] = useState(false);
+
+  // Safety: disarm the beacon when the WSPR control unmounts (workspace close) or
+  // the tab closes. WSPR is fully backend-autonomous once armed (no per-slot
+  // frontend interaction), so without this it would beacon every 120 s slot on a
+  // real amp until the 30-min watchdog — the watchdog must not be the SOLE backstop.
+  useEffect(() => {
+    window.addEventListener('pagehide', beaconDisarm);
+    return () => {
+      window.removeEventListener('pagehide', beaconDisarm);
+      beaconDisarm();
+    };
+  }, []);
+
+  // Safety: a band change force-disarms the beacon (never auto-beacon onto a band
+  // the operator just switched to).
+  useEffect(() => {
+    beaconDisarm();
+  }, [band]);
+
+  const wsprStatus = status?.mode === 'WSPR' ? status : null;
+  const armed = wsprStatus?.armed ?? false;
+  const transmitting = wsprStatus?.transmitting ?? false;
+  const canBeacon = myCall.trim().length > 0 && myGrid.trim().length >= 4;
+
+  const pushSettings = () =>
+    void postJson('/api/wspr/tx/settings', {
+      call: myCall,
+      grid4: myGrid.slice(0, 4),
+      dBm,
+      audioHz,
+      txPercent: txPercent / 100,
+    });
+
+  const toggleArm = () => {
+    if (!armed) pushSettings(); // sync content before arming
+    void postJson('/api/wspr/tx/arm', { enabled: !armed });
+  };
+
+  const toggleTune = () => {
+    const next = !tunOn;
+    setTunOn(next);
+    void setTun(next).catch(() => setTunOn(!next));
+  };
+
+  return (
+    <div className="ft8-tx" aria-label="WSPR TX control">
+      <div className="ft8-tx__lamps">
+        <span className={`ft8-tx__lamp${armed ? ' is-armed' : ''}`} title="Backend armed">
+          ARMED
+        </span>
+        <span className={`ft8-tx__lamp${transmitting ? ' is-tx' : ''}`} title="On air">
+          TX
+        </span>
+        {armed && wsprStatus && wsprStatus.watchdogSecsRemaining > 0 && (
+          <span className="ft8-tx__wdt" title="Watchdog auto-disarm">
+            WDT {Math.ceil(wsprStatus.watchdogSecsRemaining / 60)}m
+          </span>
+        )}
+      </div>
+
+      <label className="ft8-tx__field">
+        <span>POWER (dBm)</span>
+        <input
+          type="number"
+          min={0}
+          max={43}
+          value={dBm}
+          onChange={(e) => setDBm(Number(e.target.value))}
+          onBlur={() => armed && pushSettings()}
+        />
+      </label>
+      <label className="ft8-tx__field">
+        <span>OFFSET (Hz)</span>
+        <input
+          type="number"
+          min={1400}
+          max={1600}
+          value={audioHz}
+          onChange={(e) => setAudioHz(Number(e.target.value))}
+          onBlur={() => armed && pushSettings()}
+        />
+      </label>
+      <label className="ft8-tx__field">
+        <span>TX % (slots beaconed)</span>
+        <input
+          type="number"
+          min={0}
+          max={100}
+          step={5}
+          value={txPercent}
+          onChange={(e) => setTxPercent(Number(e.target.value))}
+          onBlur={() => armed && pushSettings()}
+        />
+      </label>
+
+      <div className="ft8-tx__row">
+        <button
+          type="button"
+          className={`ft8-tx__enable${armed ? ' is-on' : ''}`}
+          disabled={!canBeacon}
+          title={canBeacon ? 'Arm the WSPR beacon (explicit)' : 'Set Call + Grid to beacon'}
+          onClick={toggleArm}
+        >
+          {armed ? 'BEACON ON · DISABLE' : 'ENABLE BEACON'}
+        </button>
+      </div>
+
+      <div className="ft8-tx__row">
+        <button
+          type="button"
+          className={`ft8-tx__tune${tunOn ? ' is-on' : ''}`}
+          onClick={toggleTune}
+          title="Key a single-tone carrier (antenna tune)"
+        >
+          {tunOn ? 'TUNE ON' : 'TUNE'}
+        </button>
+        <button
+          type="button"
+          className="ft8-tx__halt"
+          onClick={() => void postJson('/api/wspr/tx/halt', {})}
+          title="Abort: disarm and drop the beacon immediately"
+        >
+          HALT
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/zeus-web/src/layout/ft8/WsprWorkspace.tsx
+++ b/zeus-web/src/layout/ft8/WsprWorkspace.tsx
@@ -8,7 +8,9 @@
 import { useEffect, useState } from 'react';
 import { useWsprStore, type WsprRow } from '../../state/wspr-store';
 import { useConnectionStore } from '../../state/connection-store';
+import { useOperatorStore } from '../../state/operator-store';
 import { DIGITAL_BANDS } from '../../dsp/digital-segments';
+import { WsprTxControl } from './WsprTxControl';
 import '../../styles/ft8-theme.css';
 
 function useUtcClock(): string {
@@ -36,6 +38,10 @@ export function WsprWorkspace({ onClose }: { onClose?: () => void }) {
   const error = useWsprStore((s) => s.error);
   const qsyBand = useWsprStore((s) => s.qsyBand);
   const vfoHz = useConnectionStore((s) => s.vfoHz);
+  const myCall = useOperatorStore((s) => s.call);
+  const myGrid = useOperatorStore((s) => s.grid);
+  const setCall = useOperatorStore((s) => s.setCall);
+  const setGrid = useOperatorStore((s) => s.setGrid);
 
   useEffect(() => {
     if (!onClose) return;
@@ -55,6 +61,26 @@ export function WsprWorkspace({ onClose }: { onClose?: () => void }) {
     <div className="ft8-workspace" role="region" aria-label="WSPR workspace">
       <header className="ft8-ws-header">
         <span className="ft8-ws-title">WSPR · BEACON MONITOR</span>
+        <label className="ft8-ws-id">
+          <span>Call</span>
+          <input
+            value={myCall}
+            onChange={(e) => setCall(e.target.value)}
+            placeholder="MYCALL"
+            spellCheck={false}
+            size={8}
+          />
+        </label>
+        <label className="ft8-ws-id">
+          <span>Grid</span>
+          <input
+            value={myGrid}
+            onChange={(e) => setGrid(e.target.value)}
+            placeholder="FN42"
+            spellCheck={false}
+            size={6}
+          />
+        </label>
         <span className="ft8-ws-clock">{clock}</span>
         {onClose && (
           <button type="button" className="ft8-ws-close" onClick={onClose}>
@@ -84,11 +110,16 @@ export function WsprWorkspace({ onClose }: { onClose?: () => void }) {
               ))}
             </div>
           </section>
+          <section className="ft8-region">
+            <div className="ft8-region__head">TX control · beacon</div>
+            <div className="ft8-region__body">
+              <WsprTxControl myCall={myCall} myGrid={myGrid} />
+            </div>
+          </section>
           <section className="ft8-region ft8-region--grow">
             <div className="ft8-region__head">About</div>
             <div className="ft8-placeholder">
-              WSPR beacon spots received here. WSPRnet upload + WSPR TX are
-              follow-ups.
+              WSPR is a 2-minute beacon mode. WSPRnet upload is a follow-up.
             </div>
           </section>
         </div>

--- a/zeus-web/src/realtime/ws-client.ts
+++ b/zeus-web/src/realtime/ws-client.ts
@@ -65,6 +65,7 @@ import { useSpotStore } from '../state/spot-store';
 import { useChatStore, type ChatEnvelope } from '../state/chat-store';
 import { useFt8Store, type Ft8DecodeBatch } from '../state/ft8-store';
 import { useWsprStore, type WsprSpotBatch } from '../state/wspr-store';
+import { useFt8TxStore, type Ft8TxStatus } from '../state/ft8-tx-store';
 import { usePttStore } from '../state/ptt-store';
 import { warnOnce } from '../util/logger';
 import { clampFinite } from '../util/number';
@@ -218,6 +219,10 @@ export const MSG_TYPE_FT8_DECODE = 0x38;
 // byte, one per completed 120 s WSPR slot; dispatched into wspr-store's
 // ingest(). Contract: Zeus.Contracts/WsprSpotFrame.cs.
 export const MSG_TYPE_WSPR_SPOT = 0x39;
+// 0x3A Ft8TxStatus: variable-length UTF-8 JSON Ft8TxStatusDto after the type
+// byte, pushed on every FT8/FT4/WSPR keyer arm/stage/transmit edge; dispatched
+// into ft8-tx-store's ingest(). Contract: Zeus.Contracts/Ft8TxStatusFrame.cs.
+export const MSG_TYPE_FT8_TX_STATUS = 0x3a;
 
 // CW engine status — broadcast on every state edge of the host-side CW
 // keyer so the macro pad can render in-flight text + queue depth without
@@ -537,6 +542,18 @@ export function dispatchServerFrame(data: ArrayBuffer): void {
         useWsprStore.getState().ingest(batch);
       } catch (err) {
         warnOnce('ws-wspr-spot-parse', 'wspr spot frame parse failed', err);
+      }
+      return;
+    }
+    if (peekType === MSG_TYPE_FT8_TX_STATUS) {
+      // Variable-length UTF-8 JSON Ft8TxStatusDto after the type byte.
+      const bytes = new Uint8Array(ev.data, 1);
+      const json = new TextDecoder('utf-8').decode(bytes);
+      try {
+        const status = JSON.parse(json) as Ft8TxStatus;
+        useFt8TxStore.getState().ingest(status);
+      } catch (err) {
+        warnOnce('ws-ft8-tx-status-parse', 'ft8 tx status frame parse failed', err);
       }
       return;
     }

--- a/zeus-web/src/state/ft8-tx-store.test.ts
+++ b/zeus-web/src/state/ft8-tx-store.test.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useFt8TxStore, type Ft8TxStatus } from './ft8-tx-store';
+
+function status(over: Partial<Ft8TxStatus> = {}): Ft8TxStatus {
+  return {
+    armed: false,
+    transmitting: false,
+    mode: 'FT8',
+    message: null,
+    audioHz: 1500,
+    slot: '',
+    watchdogSecsRemaining: 0,
+    lastTxSlotMs: null,
+    nativeAvailable: true,
+    ...over,
+  };
+}
+
+describe('ft8-tx-store (0x3A status frames)', () => {
+  beforeEach(() => {
+    useFt8TxStore.setState({ status: null });
+  });
+
+  it('starts with no status', () => {
+    expect(useFt8TxStore.getState().status).toBeNull();
+  });
+
+  it('ingest() replaces the status snapshot', () => {
+    useFt8TxStore.getState().ingest(status({ armed: true, mode: 'FT8' }));
+    expect(useFt8TxStore.getState().status?.armed).toBe(true);
+
+    useFt8TxStore
+      .getState()
+      .ingest(status({ armed: true, transmitting: true, message: 'CQ KB2UKA FN12', slot: 'even' }));
+    const s = useFt8TxStore.getState().status;
+    expect(s?.transmitting).toBe(true);
+    expect(s?.message).toBe('CQ KB2UKA FN12');
+    expect(s?.slot).toBe('even');
+  });
+
+  it('carries a WSPR status through unchanged (shared frame)', () => {
+    useFt8TxStore.getState().ingest(status({ mode: 'WSPR', armed: true, watchdogSecsRemaining: 1800 }));
+    const s = useFt8TxStore.getState().status;
+    expect(s?.mode).toBe('WSPR');
+    expect(s?.watchdogSecsRemaining).toBe(1800);
+  });
+});

--- a/zeus-web/src/state/ft8-tx-store.ts
+++ b/zeus-web/src/state/ft8-tx-store.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// FT8/FT4/WSPR TX keyer status store. Holds the authoritative keyer state pushed
+// by the backend as 0x3A Ft8TxStatus WS frames (one per arm/stage/transmit
+// edge). The TX HUD renders the arm/transmit lamps from THIS — what the backend
+// actually keyed — not from what the operator staged locally. Mirrors the
+// ft8-store / ptt-store split: WS push for live state.
+
+import { create } from 'zustand';
+
+/** The 0x3A Ft8TxStatusDto payload (camelCase JSON off the wire). */
+export interface Ft8TxStatus {
+  armed: boolean;
+  transmitting: boolean;
+  mode: string; // "FT8" | "FT4" | "WSPR"
+  message: string | null;
+  audioHz: number;
+  slot: string; // "even" | "odd" | ""
+  watchdogSecsRemaining: number;
+  lastTxSlotMs: number | null;
+  nativeAvailable: boolean;
+}
+
+interface Ft8TxState {
+  status: Ft8TxStatus | null;
+  ingest: (status: Ft8TxStatus) => void;
+}
+
+export const useFt8TxStore = create<Ft8TxState>((set) => ({
+  status: null,
+  ingest: (status) => set({ status }),
+}));

--- a/zeus-web/src/styles/ft8-theme.css
+++ b/zeus-web/src/styles/ft8-theme.css
@@ -227,33 +227,103 @@
 .ft8-band-btn:hover { border-color: var(--hud-cyan-line); }
 .ft8-band-btn.is-active { background: var(--hud-cyan); color: #06121a; font-weight: 700; }
 
-/* QSO / TX-control panel. */
-.ft8-qso { display: flex; flex-direction: column; gap: 8px; font-size: 12px; }
-.ft8-qso--empty { color: var(--hud-text-dim); font-style: italic; }
-.ft8-qso__dx { color: var(--hud-text); }
-.ft8-qso__dx strong { color: var(--hud-cyan); }
-.ft8-qso__ladder { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 3px; }
-.ft8-qso__ladder li { display: flex; gap: 8px; align-items: baseline; }
-.ft8-qso__slot { color: var(--hud-text-dim); font-size: 10px; width: 26px; flex: none; }
-.ft8-qso__msg { font-variant-numeric: tabular-nums; color: var(--hud-text); }
-.ft8-qso__bench {
-  color: var(--hud-power, #ffc93a);
-  background: rgba(255, 201, 58, 0.08);
-  border: 1px solid rgba(255, 201, 58, 0.3);
+/* ---- TX control cluster ---- */
+.ft8-tx { display: flex; flex-direction: column; gap: 8px; font-size: 12px; }
+.ft8-tx__row { display: flex; gap: 6px; align-items: center; }
+
+/* Arm / transmit lamps — dim by default, lit by backend status. */
+.ft8-tx__lamps { display: flex; gap: 6px; align-items: center; }
+.ft8-tx__lamp {
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  padding: 2px 8px;
   border-radius: 3px;
-  padding: 6px 8px;
-  font-size: 11px;
-  line-height: 1.35;
+  border: 1px solid var(--hud-line);
+  color: var(--hud-text-dim);
+  background: var(--hud-inset);
 }
-.ft8-qso__actions { display: flex; gap: 6px; }
-.ft8-qso__btn {
+.ft8-tx__lamp.is-armed { color: #06121a; background: var(--hud-me); border-color: var(--hud-me); font-weight: 700; }
+.ft8-tx__lamp.is-tx { color: #1a0604; background: var(--tx); border-color: var(--tx); font-weight: 700; }
+.ft8-tx__wdt { font-size: 10px; color: var(--hud-text-dim); font-variant-numeric: tabular-nums; }
+
+/* ENABLE-TX master. */
+.ft8-tx__enable {
+  flex: 1;
+  background: var(--hud-panel-2);
+  border: 1px solid var(--hud-cyan-line);
+  color: var(--hud-cyan);
+  border-radius: 3px;
+  padding: 6px 10px;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+.ft8-tx__enable.is-on { background: var(--hud-me); color: #06121a; border-color: var(--hud-me); }
+.ft8-tx__enable:disabled { opacity: 0.4; cursor: not-allowed; }
+
+/* Generic toggle / segmented / macro buttons. */
+.ft8-tx__toggle,
+.ft8-tx__seg-btn,
+.ft8-tx__macro,
+.ft8-tx__tune,
+.ft8-tx__halt {
   background: var(--hud-panel-2);
   border: 1px solid var(--hud-line);
   color: var(--hud-text);
   border-radius: 3px;
-  padding: 4px 12px;
+  padding: 4px 10px;
   cursor: pointer;
   font: inherit;
+  font-size: 11px;
 }
-.ft8-qso__btn:disabled { opacity: 0.45; cursor: not-allowed; }
-.ft8-qso__btn:not(:disabled):hover { border-color: var(--hud-cyan-line); }
+.ft8-tx__toggle:not(:disabled):hover,
+.ft8-tx__macro:not(:disabled):hover,
+.ft8-tx__tune:hover { border-color: var(--hud-cyan-line); }
+.ft8-tx__toggle.is-on,
+.ft8-tx__seg-btn.is-on,
+.ft8-tx__macro.is-on { background: var(--hud-cyan); color: #06121a; border-color: var(--hud-cyan); font-weight: 700; }
+.ft8-tx__macro:disabled,
+.ft8-tx__toggle:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.ft8-tx__seg { display: flex; align-items: center; gap: 4px; }
+.ft8-tx__seg-label { font-size: 10px; color: var(--hud-text-dim); }
+.ft8-tx__seg-btn { padding: 4px 8px; }
+
+.ft8-tx__offset,
+.ft8-tx__field { display: flex; align-items: center; gap: 6px; font-size: 10px; color: var(--hud-text-dim); }
+.ft8-tx__field { justify-content: space-between; }
+.ft8-tx__offset input,
+.ft8-tx__field input,
+.ft8-tx__custom input {
+  background: var(--hud-panel);
+  border: 1px solid var(--hud-line);
+  color: var(--hud-cyan);
+  border-radius: 3px;
+  padding: 3px 6px;
+  font: inherit;
+  width: 5.5em;
+  text-align: right;
+}
+.ft8-tx__offset input:disabled { opacity: 0.5; }
+
+.ft8-tx__next { display: flex; align-items: baseline; gap: 8px; }
+.ft8-tx__next-label { font-size: 10px; color: var(--hud-text-dim); }
+.ft8-tx__next-msg { font-variant-numeric: tabular-nums; color: var(--hud-cyan); font-size: 13px; }
+.ft8-tx__dx { font-size: 11px; color: var(--hud-text); }
+.ft8-tx__dx strong { color: var(--hud-cyan); }
+
+.ft8-tx__macros { display: grid; grid-template-columns: repeat(3, 1fr); gap: 4px; }
+
+.ft8-tx__custom { display: flex; gap: 6px; }
+.ft8-tx__custom input { flex: 1; width: auto; text-align: left; text-transform: uppercase; }
+
+.ft8-tx__tune { flex: 1; }
+.ft8-tx__tune.is-on { background: var(--power); color: #06121a; border-color: var(--power); font-weight: 700; }
+.ft8-tx__halt {
+  flex: 1;
+  border-color: var(--tx);
+  color: var(--tx);
+  font-weight: 700;
+}
+.ft8-tx__halt:hover { background: var(--tx); color: #1a0604; }


### PR DESCRIPTION
## ⛔ DO NOT MERGE — bench sign-off required (real RF / TX)

**Stack 1 of 4.** Base: `feat/ft8-wspr-native` (PR #997). This is the TRANSMIT foundation the other three FT8 PRs stack on.

Closes the TX half of the native digital client: **FT8/FT4 + WSPR transmit with armed auto-sequencing.** Once the operator arms TX (ENABLE-TX — never auto-armed), the keyer transmits automatically at each UTC slot and the sequencer walks the QSO hands-free (CQ → answer → report → RR73 → 73 → log; Call-1st auto-answers).

### What's in it
- `Ft8Synth.cs` — pure-C# 8-GFSK FT8/FT4 audio at 48 kHz (no new native; encode is the committed lib). Round-trip encode→synth→decode tested.
- `Ft8TxService`/`WsprTxService` — UTC slot clock, MOX key/unkey via new `MoxSource.Ft8`, 20 ms block streaming into the existing TX audio path (`MicBlockSource.Ft8`), watchdog max-armed cap, Halt, late-start so QSO replies key the current slot.
- `DigitalTxArbiter` — single-owner interlock so FT8/FT4 and WSPR can never both key.
- Frontend TX CONTROL cluster (ENABLE-TX, HOLD TX FREQ, TX EVEN/ODD, message + macros, TUNE); sequencer wired to air; disarm on unmount/pagehide/band-change.

### Refs
#1012 (FT8/FT4 transmit), #1013 (WSPR beacon).

### Safety / bench
- No auto-arm; PureSignal untouched; no power/drive default changes; cross-platform-pure.
- **Bench-untested on the G2** — this is why it's DO NOT MERGE. Verify on the G2: actual decode of our TX by WSJT-X/another rig; T/R timing; PA thermal at FT8 100% duty.
- **Deferred for bench:** FT8 audio currently goes through the SSB TX DSP chain (compressor/leveler/EQ) which can distort the single tone — a flat/bypassed digital TX path wants a bench decision; +0.5 s cadence tune; idle-reset watchdog (needs a FE heartbeat).
