### PR TITLE
DO NOT MERGE: FT8 workspace waterfall + click-to-tune + in-workspace power (#1016)

### DIFF
--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -50,6 +50,7 @@ import { FlexWorkspace } from './layout/FlexWorkspace';
 import { Ft8WorkspaceMount } from './layout/ft8/Ft8Workspace';
 import { WsprWorkspaceMount } from './layout/ft8/WsprWorkspace';
 import { useFt8Store } from './state/ft8-store';
+import { useWsprStore } from './state/wspr-store';
 import { WorkspaceErrorBoundary } from './layout/WorkspaceErrorBoundary';
 import { AppErrorBoundary } from './layout/AppErrorBoundary';
 import {
@@ -176,6 +177,16 @@ export default function App() {
   const preampOn = useConnectionStore((s) => s.preampOn);
   const moxOn = useTxStore((s) => s.moxOn);
   const tunOn = useTxStore((s) => s.tunOn);
+  // A digital workspace (FT8/FT4 or WSPR) is a fully-opaque full-screen overlay
+  // that mounts its OWN spectrum surfaces. While it is open, unmount the main
+  // console's FlexWorkspace so its (now-occluded) panadapter/waterfall WebGL
+  // contexts are released instead of drawing behind the overlay and competing
+  // for the browser's limited WebGL-context budget (which can evict and force a
+  // context-loss/restore on the main panadapter). Open/close is an explicit,
+  // infrequent operator action, so the remount cost is irrelevant.
+  const ft8WorkspaceOpen = useFt8Store((s) => s.open);
+  const wsprWorkspaceOpen = useWsprStore((s) => s.open);
+  const digitalWorkspaceOpen = ft8WorkspaceOpen || wsprWorkspaceOpen;
   const endpoint = useConnectionStore((s) => s.endpoint);
   const connected = status === 'Connected';
   // Brand sub label reflects what discovery actually saw on the wire
@@ -1121,7 +1132,7 @@ export default function App() {
               />
             </Suspense>
           </AppErrorBoundary>
-        ) : (
+        ) : digitalWorkspaceOpen ? null : (
           <WorkspaceErrorBoundary
             key={activeLayoutId}
             onReset={resetActiveWorkspaceLayout}

--- a/zeus-web/src/dsp/ft8-passband.test.ts
+++ b/zeus-web/src/dsp/ft8-passband.test.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+import { describe, expect, it } from 'vitest';
+import {
+  absHzForClientX,
+  clampOffsetHz,
+  isOffsetVisible,
+  offsetHzForClientX,
+  pixelForOffsetHz,
+  resolveWaterfallClick,
+  snapOffsetToDecode,
+  spanHzOf,
+  type PassbandView,
+} from './ft8-passband';
+
+// CTUN-centred framing geometry: the panel centres at dial + 1400 Hz, so the
+// audio passband (0..3000) straddles the centre line. span = width*hzPerPixel.
+const DIAL = 14_074_000;
+const VIEW: PassbandView = { centerHz: DIAL + 1400, hzPerPixel: 2, width: 2000 }; // 4 kHz span
+
+describe('ft8-passband geometry', () => {
+  it('span is width * hzPerPixel, 0 when geometry absent', () => {
+    expect(spanHzOf(VIEW)).toBe(4000);
+    expect(spanHzOf({ centerHz: 0, hzPerPixel: 0, width: 0 })).toBe(0);
+  });
+
+  it('maps a click X to the absolute RF frequency at the slice centre', () => {
+    // Centre of a 1000px element → the slice centre frequency.
+    expect(absHzForClientX(500, 0, 1000, VIEW)).toBe(DIAL + 1400);
+    // Left edge → centre − span/2; right edge → centre + span/2.
+    expect(absHzForClientX(0, 0, 1000, VIEW)).toBe(DIAL + 1400 - 2000);
+    expect(absHzForClientX(1000, 0, 1000, VIEW)).toBe(DIAL + 1400 + 2000);
+  });
+
+  it('converts a click X to a clamped audio offset', () => {
+    // Centre → dial + 1400.
+    expect(offsetHzForClientX(500, 0, 1000, VIEW, DIAL)).toBe(1400);
+    // Far left maps below 0 → clamped to 0; far right above 3000 → clamped.
+    expect(offsetHzForClientX(0, 0, 1000, VIEW, DIAL)).toBe(0);
+    expect(offsetHzForClientX(1000, 0, 1000, VIEW, DIAL)).toBe(3000);
+  });
+
+  it('round-trips offset ↔ pixel', () => {
+    for (const offset of [0, 800, 1400, 2000, 3000]) {
+      const px = pixelForOffsetHz(offset, 1000, VIEW, DIAL);
+      const back = offsetHzForClientX(px, 0, 1000, VIEW, DIAL);
+      expect(back).toBeCloseTo(offset, 6);
+    }
+  });
+
+  it('pixelForOffsetHz(_, 100, …) yields a left-percentage', () => {
+    // Centre offset (1400) → 50%.
+    expect(pixelForOffsetHz(1400, 100, VIEW, DIAL)).toBeCloseTo(50, 6);
+  });
+
+  it('reports off-screen offsets as not visible', () => {
+    // dial+1400 visible; a far-out RF offset (beyond the 4 kHz window) is not.
+    expect(isOffsetVisible(1400, VIEW, DIAL)).toBe(true);
+    // Offset whose absolute Hz lands outside the window.
+    const narrow: PassbandView = { centerHz: DIAL + 1400, hzPerPixel: 0.5, width: 200 }; // 100 Hz span
+    expect(isOffsetVisible(0, narrow, DIAL)).toBe(false);
+  });
+});
+
+describe('clampOffsetHz', () => {
+  it('clamps to the FT8 passband', () => {
+    expect(clampOffsetHz(-50)).toBe(0);
+    expect(clampOffsetHz(3500)).toBe(3000);
+    expect(clampOffsetHz(1500)).toBe(1500);
+    expect(clampOffsetHz(Number.NaN)).toBe(0);
+  });
+});
+
+describe('snapOffsetToDecode', () => {
+  // span 4000 over 1000px → 4 Hz/px; 30px radius → 120 Hz.
+  const decodes = [1500, 2400];
+  it('snaps to a decode within the pixel radius', () => {
+    expect(snapOffsetToDecode(1450, decodes, 1000, VIEW)).toBe(1500);
+  });
+  it('leaves the click alone past the radius', () => {
+    expect(snapOffsetToDecode(1700, decodes, 1000, VIEW)).toBe(1700);
+  });
+  it('is a no-op with no decodes', () => {
+    expect(snapOffsetToDecode(1700, [], 1000, VIEW)).toBe(1700);
+  });
+});
+
+describe('resolveWaterfallClick — HOLD TX FREQ', () => {
+  it('moves both RX and TX when not held', () => {
+    expect(resolveWaterfallClick(1500, false)).toEqual({ rxFocusHz: 1500, txOffsetHz: 1500 });
+  });
+  it('moves only RX when HOLD TX FREQ is engaged', () => {
+    expect(resolveWaterfallClick(1500, true)).toEqual({ rxFocusHz: 1500, txOffsetHz: null });
+  });
+});

--- a/zeus-web/src/dsp/ft8-passband.ts
+++ b/zeus-web/src/dsp/ft8-passband.ts
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// ft8-passband — PURE pixel <-> audio-offset geometry for the FT8/FT4 receive
+// waterfall. The FT8 workspace reuses the shipping RF panadapter/waterfall
+// surfaces (display-store frames). FT8 is USB, so the audio offset `o` Hz maps
+// to RF `dial + o`. A click on the waterfall therefore resolves to an absolute
+// RF frequency through the live slice geometry (centerHz/hzPerPixel/width), and
+// the audio offset is `absHz - dialHz`, clamped to the 0..3000 Hz passband.
+//
+// These helpers are intentionally framework-free so the mapping can be unit
+// tested without a renderer, and so the overlay and the marker math share ONE
+// source of truth (they must never disagree — a click and the cursor it draws
+// have to land on the same pixel). Mirrors readView()/SpotOverlay in the main
+// app, scoped to the FT8 audio passband.
+
+/** The FT8/FT4 audio passband. The decoder searches ~0..3000 Hz of USB audio. */
+export const FT8_MIN_OFFSET_HZ = 0;
+export const FT8_MAX_OFFSET_HZ = 3000;
+
+/** Snap a waterfall click to a nearby decode when the cursor lands within this
+ *  many screen pixels of a decoded signal's audio offset. Light, ham-friendly. */
+export const DECODE_SNAP_RADIUS_PX = 30;
+
+/** Live spectrum-slice geometry, read from the display-store slice that drives
+ *  the panadapter/waterfall. `width` is the bin count and `hzPerPixel` the Hz
+ *  per bin, so the total visible span is `width * hzPerPixel`. */
+export interface PassbandView {
+  centerHz: number;
+  hzPerPixel: number;
+  width: number;
+}
+
+/** Total visible span in Hz for a slice geometry (0 when geometry is absent). */
+export function spanHzOf(view: PassbandView): number {
+  const span = view.width * view.hzPerPixel;
+  return Number.isFinite(span) && span > 0 ? span : 0;
+}
+
+/** Clamp an audio offset to the FT8/FT4 passband. */
+export function clampOffsetHz(
+  hz: number,
+  min: number = FT8_MIN_OFFSET_HZ,
+  max: number = FT8_MAX_OFFSET_HZ,
+): number {
+  if (!Number.isFinite(hz)) return min;
+  return Math.min(max, Math.max(min, hz));
+}
+
+/** Absolute RF frequency under a client X coordinate, using the slice geometry.
+ *  `rectLeft`/`rectWidth` describe the on-screen element the click landed on
+ *  (its CSS pixel box), which is independent of the slice's bin `width`. */
+export function absHzForClientX(
+  clientX: number,
+  rectLeft: number,
+  rectWidth: number,
+  view: PassbandView,
+): number {
+  const span = spanHzOf(view);
+  if (span <= 0 || rectWidth <= 0) return view.centerHz;
+  const frac = (clientX - rectLeft) / rectWidth;
+  return view.centerHz + (frac - 0.5) * span;
+}
+
+/** Audio offset (Hz, clamped to the passband) under a client X coordinate. */
+export function offsetHzForClientX(
+  clientX: number,
+  rectLeft: number,
+  rectWidth: number,
+  view: PassbandView,
+  dialHz: number,
+): number {
+  const absHz = absHzForClientX(clientX, rectLeft, rectWidth, view);
+  return clampOffsetHz(absHz - dialHz);
+}
+
+/** Inverse mapping: the pixel X (relative to the element's left edge, in the
+ *  same `rectWidth` units passed in) for an audio offset. Pass `rectWidth=100`
+ *  to get a left-percentage directly. Returns a value that may fall outside
+ *  `[0, rectWidth]` when the offset is off-screen — callers gate visibility. */
+export function pixelForOffsetHz(
+  offsetHz: number,
+  rectWidth: number,
+  view: PassbandView,
+  dialHz: number,
+): number {
+  const span = spanHzOf(view);
+  if (span <= 0) return 0;
+  const absHz = dialHz + offsetHz;
+  const frac = 0.5 + (absHz - view.centerHz) / span;
+  return frac * rectWidth;
+}
+
+/** True when an offset's marker would be visible in the current window. */
+export function isOffsetVisible(
+  offsetHz: number,
+  view: PassbandView,
+  dialHz: number,
+): boolean {
+  if (spanHzOf(view) <= 0) return false;
+  const frac = pixelForOffsetHz(offsetHz, 1, view, dialHz);
+  return frac >= 0 && frac <= 1;
+}
+
+/** Snap a clicked audio offset to the nearest decoded signal offset, when one
+ *  sits within `radiusPx` screen pixels of the click. Past the radius the click
+ *  stands (so clicking empty water tunes where you clicked). Pure: the caller
+ *  supplies the decode offsets + the on-screen element width. */
+export function snapOffsetToDecode(
+  offsetHz: number,
+  decodeOffsetsHz: readonly number[],
+  rectWidth: number,
+  view: PassbandView,
+  radiusPx: number = DECODE_SNAP_RADIUS_PX,
+): number {
+  const span = spanHzOf(view);
+  if (span <= 0 || rectWidth <= 0 || decodeOffsetsHz.length === 0) return offsetHz;
+  const hzPerScreenPx = span / rectWidth;
+  const radiusHz = radiusPx * hzPerScreenPx;
+  let best = offsetHz;
+  let bestDist = radiusHz;
+  for (const d of decodeOffsetsHz) {
+    const dist = Math.abs(d - offsetHz);
+    if (dist <= bestDist) {
+      bestDist = dist;
+      best = d;
+    }
+  }
+  return best;
+}
+
+/** The outcome of a waterfall click: the RX focus cursor ALWAYS moves; the TX
+ *  audio offset moves UNLESS HOLD TX FREQ is engaged (then only RX moves). The
+ *  controller double-guards `setTxFreq` when held, so `txOffsetHz` being null is
+ *  belt-and-suspenders, not the sole guard. */
+export interface WaterfallClickResult {
+  rxFocusHz: number;
+  txOffsetHz: number | null;
+}
+
+export function resolveWaterfallClick(
+  offsetHz: number,
+  holdTxFreq: boolean,
+): WaterfallClickResult {
+  return { rxFocusHz: offsetHz, txOffsetHz: holdTxFreq ? null : offsetHz };
+}

--- a/zeus-web/src/layout/ft8/Ft8ReceivePanel.tsx
+++ b/zeus-web/src/layout/ft8/Ft8ReceivePanel.tsx
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Ft8ReceivePanel — the RECEIVE region of the FT8/FT4 workspace. It REUSES the
+// shipping spectrum surfaces: a short Panadapter header strip + the full
+// WaterfallSurface (WebGPU heightfield, WebGL2 fallback), both on receiver A,
+// exactly as HeroPanel mounts them. A transparent Ft8WaterfallOverlay sits on
+// top for FT8 click-to-offset, the RX/TX cursors, and decode ticks; the WF
+// SPEED / ZOOM / OFFSET strip sits beneath. No new renderer.
+//
+// The display is framed onto the FT8 passband by ft8-framing (called from
+// digital-mode entry), so the panel just composes — it reads the live geometry,
+// it does not configure the radio.
+
+import { Panadapter } from '../../components/Panadapter';
+import { WaterfallSurface } from '../../components/WaterfallSurface';
+import { useConnectionStore } from '../../state/connection-store';
+import type { Ft8TxRunnerView } from '../../dsp/ft8-tx-runner';
+import { Ft8WaterfallOverlay } from './Ft8WaterfallOverlay';
+import { Ft8WaterfallControls } from './Ft8WaterfallControls';
+
+export interface Ft8ReceivePanelProps {
+  runner: Ft8TxRunnerView;
+  rxFocusHz: number;
+  setRxFocusHz: (hz: number) => void;
+  myCall?: string;
+}
+
+export function Ft8ReceivePanel({ runner, rxFocusHz, setRxFocusHz, myCall }: Ft8ReceivePanelProps) {
+  const connected = useConnectionStore((s) => s.status === 'Connected');
+
+  return (
+    <section className="ft8-region ft8-region--grow ft8-receive">
+      <div className="ft8-region__head">
+        Receive · waterfall
+        {/* HOLD TX FREQ defaults on (ft8-sequencer), so a click moves only the
+            RX focus until the operator releases HOLD to also move TX. */}
+        <small> · click to set RX (release HOLD to move TX)</small>
+      </div>
+      <div className="ft8-receive__stack">
+        {connected ? (
+          <>
+            <div className="ft8-receive__pan">
+              <Panadapter receiver="A" />
+            </div>
+            <div className="ft8-receive__wf">
+              <WaterfallSurface receiver="A" />
+            </div>
+            <Ft8WaterfallOverlay
+              runner={runner}
+              rxFocusHz={rxFocusHz}
+              setRxFocusHz={setRxFocusHz}
+              myCall={myCall}
+            />
+          </>
+        ) : (
+          <div className="ft8-placeholder">connect a radio to see the waterfall</div>
+        )}
+      </div>
+      <Ft8WaterfallControls />
+    </section>
+  );
+}

--- a/zeus-web/src/layout/ft8/Ft8TxControl.tsx
+++ b/zeus-web/src/layout/ft8/Ft8TxControl.tsx
@@ -3,18 +3,25 @@
 // Ft8TxControl — the TX control cluster for the FT8/FT4 workspace. Renders the
 // arm/transmit lamps (from the backend's 0x3A status, NOT local optimism), the
 // ENABLE-TX master, HOLD-TX-FREQ, TX EVEN/ODD selector, the message + macro row,
-// the TX audio-offset field, and TUNE. All keying flows through the runner
-// (sequencer → Ft8TxController → backend keyer); arming is explicit only.
+// the TX audio-offset field, the TX POWER / TUNE PWR sliders, and TUNE. All
+// keying flows through the runner (sequencer → Ft8TxController → backend keyer);
+// arming is explicit only.
 //
-// Power (Drive %, Tune %) is owned by the main app's TX controls (Team B) and is
-// intentionally not duplicated here — this cluster only arms, sequences, and
-// keys. TUNE reuses the same /api/tx/tun carrier the main rig uses.
+// Power lives in this cluster per the approved design (docs/designs/ft8-ui.md:
+// "TX CONTROL cluster … TX POWER slider, TUNE button"). NO forked power model:
+// TX POWER / TUNE PWR are the SAME DriveSlider / TunePowerSlider the main rig
+// uses (→ /api/tx/drive, /api/tx/tune-drive), and TUNE reuses /api/tx/tun. TUNE
+// reads server-authoritative tunOn from tx-store (not local optimism), and toggles
+// via setTunOn so the MOX/TUN mutual-exclusion invariant holds.
 
 import { useState } from 'react';
 import { setTun } from '../../api/client';
+import { DriveSlider } from '../../components/DriveSlider';
+import { TunePowerSlider } from '../../components/TunePowerSlider';
 import { genCq, genTx4, genTx5 } from '../../dsp/ft8-sequencer';
 import type { Ft8TxRunnerView } from '../../dsp/ft8-tx-runner';
 import { useFt8TxStore } from '../../state/ft8-tx-store';
+import { useTxStore } from '../../state/tx-store';
 
 export interface Ft8TxControlProps {
   runner: Ft8TxRunnerView;
@@ -25,7 +32,10 @@ export interface Ft8TxControlProps {
 export function Ft8TxControl({ runner, myCall, myGrid }: Ft8TxControlProps) {
   const status = useFt8TxStore((s) => s.status);
   const [custom, setCustom] = useState('');
-  const [tunOn, setTunOn] = useState(false);
+  // Server-authoritative TUN state + the action that keeps MOX/TUN mutually
+  // exclusive (setTunOn(true) clears moxOn) — identical to the main TunButton.
+  const tunOn = useTxStore((s) => s.tunOn);
+  const setTunOn = useTxStore((s) => s.setTunOn);
 
   const qso = runner.qso;
   const dx = qso.dxCall;
@@ -36,6 +46,8 @@ export function Ft8TxControl({ runner, myCall, myGrid }: Ft8TxControlProps) {
 
   const toggleTune = () => {
     const next = !tunOn;
+    // Optimistic via the store action so the button reacts immediately and the
+    // moxOn=false invariant holds; the keyer status frame reconciles.
     setTunOn(next);
     void setTun(next).catch(() => setTunOn(!next));
   };
@@ -199,6 +211,19 @@ export function Ft8TxControl({ runner, myCall, myGrid }: Ft8TxControlProps) {
         >
           STAGE
         </button>
+      </div>
+
+      {/* TX power — the SAME drive/tune sliders the main rig uses (server-
+          authoritative, no forked power model). Placed here per the design doc. */}
+      <div className="ft8-power" aria-label="TX power">
+        <div className="ft8-power__row">
+          <span className="ft8-power__label">TX POWER</span>
+          <DriveSlider />
+        </div>
+        <div className="ft8-power__row">
+          <span className="ft8-power__label">TUNE PWR</span>
+          <TunePowerSlider />
+        </div>
       </div>
 
       {/* TUNE + HALT. */}

--- a/zeus-web/src/layout/ft8/Ft8WaterfallControls.tsx
+++ b/zeus-web/src/layout/ft8/Ft8WaterfallControls.tsx
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Ft8WaterfallControls — the control strip under the FT8 receive waterfall.
+// WF SPEED and WF ZOOM reuse the shipping main-app controls verbatim (they drive
+// the same display-settings / zoom state the heightfield honours). WF OFFSET is
+// a tiny stepper that pans the visible window WITHOUT moving the dial, by nudging
+// the hardware LO via the same setRadioLo lever use-pan-tune-gesture uses for
+// RX1 pan. Under the CTUN passband framing this slides the window while the dial
+// (the decoder's reference) stays put — the natural "WF OFFSET" semantics.
+
+import { setRadioLo } from '../../api/client';
+import { useConnectionStore } from '../../state/connection-store';
+import { viewCenterFor } from '../../state/view-center';
+import { ZoomControl } from '../../components/ZoomControl';
+import { WaterfallSpeedControl } from '../../components/WaterfallSpeedControl';
+
+const OFFSET_STEPS_HZ = [-500, -100, 100, 500] as const;
+
+export function Ft8WaterfallControls() {
+  const connected = useConnectionStore((s) => s.status === 'Connected');
+
+  const nudgeOffset = (deltaHz: number) => {
+    const cur = useConnectionStore.getState().radioLoHz;
+    const next = Math.max(0, cur + deltaHz);
+    const applied = next - cur;
+    // The renderers anchor on the ANIMATED view-center tween, not radioLoHz, so
+    // the window only slides when the tween moves. Drive it the same way the pan
+    // gesture does: stamp the optimistic-tune clock (suppresses poll rubber-band)
+    // and glide by the delta — that is what makes the slide immediate. Then POST
+    // setRadioLo; its echo reconciles the store to the server-clamped value.
+    const vc = viewCenterFor('A');
+    vc.markOptimisticTune();
+    if (applied !== 0) vc.nudgeTargetHz(applied);
+    useConnectionStore.setState({ radioLoHz: next });
+    setRadioLo(next)
+      .then((s) => useConnectionStore.getState().applyState(s))
+      .catch(() => {
+        /* next state poll reconciles */
+      });
+  };
+
+  return (
+    <div className="ft8-wf-controls" role="group" aria-label="Waterfall controls">
+      <WaterfallSpeedControl />
+      <ZoomControl />
+      <div className="ft8-wf-offset" role="group" aria-label="Waterfall offset">
+        <span className="ft8-wf-offset__label">WF OFFSET</span>
+        {OFFSET_STEPS_HZ.map((d) => (
+          <button
+            key={d}
+            type="button"
+            className="ft8-wf-offset__btn"
+            disabled={!connected}
+            onClick={() => nudgeOffset(d)}
+            title={`Pan the waterfall window ${d > 0 ? '+' : ''}${d} Hz (dial unchanged)`}
+          >
+            {d > 0 ? `+${d}` : d}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/zeus-web/src/layout/ft8/Ft8WaterfallOverlay.tsx
+++ b/zeus-web/src/layout/ft8/Ft8WaterfallOverlay.tsx
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Ft8WaterfallOverlay — a transparent capture layer laid over the FT8 receive
+// panadapter/waterfall. It does three things, all reading the LIVE display-store
+// slice geometry + the dial so they line up with the rendered spectrum:
+//
+//   1. Click-to-offset. The built-in canvas gesture (usePanTuneGesture) moves
+//      the RF DIAL — wrong for FT8, which keeps the dial fixed and moves the
+//      AUDIO OFFSET. Because pointer events go to the topmost element, this
+//      overlay cleanly suppresses that gesture WITHOUT editing the shared
+//      component. A click always moves the RX focus cursor; it also moves the TX
+//      audio offset UNLESS HOLD TX FREQ is engaged (then only RX moves).
+//   2. RX cursor (cyan) + TX marker (red) verticals.
+//   3. Decode-marker ticks from useFt8Store, coloured to match the decode-table
+//      row classes (CQ / directed-at-me / worked / new).
+//
+// Pure render from store state; the heavy spectrum render is the existing
+// panadapter/waterfall underneath. No new subscriptions beyond the stores the
+// table + VFO already use.
+
+import { useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
+import { setZoom, ZOOM_MAX, ZOOM_MIN, type ZoomLevel } from '../../api/client';
+import { selectDisplaySlice, useDisplayStore } from '../../state/display-store';
+import { useConnectionStore } from '../../state/connection-store';
+import { viewCenterFor } from '../../state/view-center';
+import { useFt8Store } from '../../state/ft8-store';
+import type { Ft8TxRunnerView } from '../../dsp/ft8-tx-runner';
+import { classifyDecode, type Ft8RowClass } from './Ft8DecodeTable';
+import {
+  clampOffsetHz,
+  offsetHzForClientX,
+  pixelForOffsetHz,
+  resolveWaterfallClick,
+  snapOffsetToDecode,
+  spanHzOf,
+  type PassbandView,
+} from '../../dsp/ft8-passband';
+
+export interface Ft8WaterfallOverlayProps {
+  runner: Ft8TxRunnerView;
+  rxFocusHz: number;
+  setRxFocusHz: (hz: number) => void;
+  /** Operator call — enables the "directed at me" tick colour. */
+  myCall?: string;
+}
+
+const TICK_VAR: Record<Ft8RowClass, string> = {
+  cq: 'var(--hud-cq)',
+  me: 'var(--hud-me)',
+  worked: 'var(--hud-worked)',
+  new: 'var(--hud-new)',
+  normal: 'var(--hud-text-dim)',
+};
+
+export function Ft8WaterfallOverlay({
+  runner,
+  rxFocusHz,
+  setRxFocusHz,
+  myCall,
+}: Ft8WaterfallOverlayProps) {
+  // Live slice geometry (receiver A) as primitives so the selectors stay
+  // referentially stable — selectDisplaySlice allocates a fresh object.
+  const sliceCenterHz = useDisplayStore((s) => Number(selectDisplaySlice(s, 'A').centerHz));
+  const hzPerPixel = useDisplayStore((s) => selectDisplaySlice(s, 'A').hzPerPixel);
+  const width = useDisplayStore((s) => selectDisplaySlice(s, 'A').width);
+
+  // CRITICAL: the panadapter and waterfall render the spectrum against the
+  // ANIMATED view-center tween (view-center.ts, issue #597), not the raw frame
+  // centerHz. Reading the raw center here would make the markers snap while the
+  // trace glides on every reframe (entry / band QSY / WF OFFSET). Subscribe to
+  // the same tween so the markers ease in lock-step with the spectrum; fall back
+  // to the slice center until the tween is initialised. Object.is(NaN, NaN) is
+  // true, so the parked-and-uninitialised snapshot is stable (no render loop).
+  const vc = useMemo(() => viewCenterFor('A'), []);
+  const tweenCenterHz = useSyncExternalStore(vc.subscribe, () =>
+    vc.isInitialized() ? vc.getViewCenterHz() : NaN,
+  );
+  const centerHz = Number.isFinite(tweenCenterHz) ? tweenCenterHz : sliceCenterHz;
+  const dialHz = useConnectionStore((s) => s.vfoHz);
+  const rows = useFt8Store((s) => s.rows);
+
+  const view: PassbandView = { centerHz, hzPerPixel, width };
+  const haveGeometry = spanHzOf(view) > 0;
+
+  const holdTxFreq = runner.qso.holdTxFreq;
+
+  // Decodes worth marking: the two most-recent slots present. FT8 churns the
+  // band every slot, so older ticks would clutter without adding information.
+  const recent = useMemo(() => {
+    if (rows.length === 0) return [];
+    const slots = Array.from(new Set(rows.map((r) => r.slotStartUnixMs)))
+      .sort((a, b) => b - a)
+      .slice(0, 2);
+    const keep = new Set(slots);
+    return rows.filter((r) => keep.has(r.slotStartUnixMs));
+  }, [rows]);
+
+  const recentOffsets = useMemo(() => recent.map((r) => clampOffsetHz(r.freqHz)), [recent]);
+
+  // Wheel-to-zoom parity. The overlay is the topmost element over the canvases,
+  // so the panadapter's own wheel-to-zoom never fires and the page would scroll.
+  // Take over: step the zoom the same lever ZoomControl uses (scroll up = zoom
+  // in). A native non-passive listener is required because React's delegated
+  // onWheel is passive, so preventDefault() there is a no-op.
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const el = overlayRef.current;
+    if (!el) return;
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      const cur = useConnectionStore.getState().zoomLevel;
+      const next = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, cur + (e.deltaY < 0 ? 1 : -1))) as ZoomLevel;
+      if (next === cur) return;
+      useConnectionStore.getState().setZoomLevel(next);
+      setZoom(next)
+        .then((s) => useConnectionStore.getState().applyState(s))
+        .catch(() => {
+          /* next state poll reconciles */
+        });
+    };
+    el.addEventListener('wheel', onWheel, { passive: false });
+    return () => el.removeEventListener('wheel', onWheel);
+  }, []);
+
+  const onClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!haveGeometry) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    if (rect.width <= 0) return;
+    const raw = offsetHzForClientX(e.clientX, rect.left, rect.width, view, dialHz);
+    const offset = snapOffsetToDecode(raw, recentOffsets, rect.width, view);
+    const result = resolveWaterfallClick(offset, holdTxFreq);
+    setRxFocusHz(result.rxFocusHz);
+    // Double-guarded: setTxFreq itself no-ops while HOLD TX FREQ is engaged.
+    if (result.txOffsetHz != null) runner.setTxFreq(result.txOffsetHz);
+  };
+
+  // Marker left-position as a percentage of the element width (pixelForOffsetHz
+  // scales linearly, so passing 100 yields a percent directly — no rect read at
+  // render time).
+  const pct = (offsetHz: number): number => pixelForOffsetHz(offsetHz, 100, view, dialHz);
+  const visible = (p: number): boolean => p >= 0 && p <= 100;
+
+  const rxPct = pct(rxFocusHz);
+  const txPct = pct(runner.audioHz);
+
+  return (
+    <div
+      ref={overlayRef}
+      className="ft8-wf-overlay"
+      // Suppress the canvas dial-tune gesture underneath: as the topmost element
+      // the overlay receives the pointer events the gesture would otherwise see.
+      onPointerDown={(e) => e.stopPropagation()}
+      onClick={onClick}
+      role="presentation"
+    >
+      {haveGeometry && (
+        <>
+          {recent.map((r) => {
+            const p = pct(clampOffsetHz(r.freqHz));
+            if (!visible(p)) return null;
+            const cls = classifyDecode(r, myCall);
+            return (
+              <span
+                key={r.id}
+                className="ft8-wf-decode-tick"
+                style={{ left: `${p}%`, background: TICK_VAR[cls] }}
+                title={`${r.text}  ·  ${Math.round(r.freqHz)} Hz  ·  ${
+                  r.snrDb >= 0 ? `+${r.snrDb.toFixed(0)}` : r.snrDb.toFixed(0)
+                } dB`}
+              />
+            );
+          })}
+          {visible(rxPct) && (
+            <span
+              className="ft8-wf-rx-cursor"
+              style={{ left: `${rxPct}%` }}
+              title={`RX focus ${Math.round(rxFocusHz)} Hz`}
+            />
+          )}
+          {visible(txPct) && (
+            <span
+              className="ft8-wf-tx-marker"
+              style={{ left: `${txPct}%` }}
+              title={`TX ${Math.round(runner.audioHz)} Hz${holdTxFreq ? ' · HOLD' : ''}`}
+            />
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/zeus-web/src/layout/ft8/Ft8Workspace.tsx
+++ b/zeus-web/src/layout/ft8/Ft8Workspace.tsx
@@ -19,6 +19,7 @@ import { slotOf } from '../../dsp/ft8-sequencer';
 import { useFt8TxRunner } from '../../dsp/ft8-tx-runner';
 import { Ft8DecodeTable } from './Ft8DecodeTable';
 import { Ft8TxControl } from './Ft8TxControl';
+import { Ft8ReceivePanel } from './Ft8ReceivePanel';
 import '../../styles/ft8-theme.css';
 
 export interface Ft8WorkspaceProps {
@@ -53,6 +54,8 @@ export function Ft8Workspace({ onClose }: Ft8WorkspaceProps) {
   const qsyBand = useFt8Store((s) => s.qsyBand);
 
   const vfoHz = useConnectionStore((s) => s.vfoHz);
+  const rxFocusHz = useFt8Store((s) => s.rxFocusHz);
+  const setRxFocusHz = useFt8Store((s) => s.setRxFocusHz);
   const myCall = useOperatorStore((s) => s.call);
   const myGrid = useOperatorStore((s) => s.grid);
   const setCall = useOperatorStore((s) => s.setCall);
@@ -161,14 +164,12 @@ export function Ft8Workspace({ onClose }: Ft8WorkspaceProps) {
               ))}
             </div>
           </section>
-          <section className="ft8-region">
-            <div className="ft8-region__head">Band activity</div>
-            <div className="ft8-placeholder">spectrum — reuses panadapter WebGL (follow-up)</div>
-          </section>
-          <section className="ft8-region ft8-region--grow">
-            <div className="ft8-region__head">Receive · waterfall</div>
-            <div className="ft8-placeholder">waterfall + decode markers (follow-up)</div>
-          </section>
+          <Ft8ReceivePanel
+            runner={tx}
+            rxFocusHz={rxFocusHz}
+            setRxFocusHz={setRxFocusHz}
+            myCall={myCall || undefined}
+          />
         </div>
 
         {/* Center — decode table (live) + activity log */}

--- a/zeus-web/src/layout/ft8/ft8-power-controls.test.ts
+++ b/zeus-web/src/layout/ft8/ft8-power-controls.test.ts
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Power-control + HOLD-TX-FREQ WIRING tests. The FT8 power cluster reuses the
+// EXISTING /api/tx/drive, /api/tx/tune-drive and /api/tx/tun endpoints (no
+// forked power model). These assert the workspace controls POST to those exact
+// endpoints with the expected bodies (fetch + localStorage stubbed), and that a
+// waterfall click respects HOLD TX FREQ end-to-end (RX always moves; TX only
+// when not held).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setDrive, setTun, setTuneDrive } from '../../api/client';
+import { Ft8TxController } from '../../dsp/ft8-tx-controller';
+import { resolveWaterfallClick } from '../../dsp/ft8-passband';
+
+interface Call {
+  url: string;
+  body: Record<string, unknown>;
+}
+
+let calls: Call[];
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => body,
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  calls = [];
+  // Deterministic localStorage so importing api/client + stores never touches a
+  // real (or absent) browser store.
+  const store = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, String(v)),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+    key: () => null,
+    length: 0,
+  });
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const u = String(url);
+      const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+      calls.push({ url: u, body });
+      if (u === '/api/tx/drive') return jsonResponse({ drivePercent: body.percent });
+      if (u === '/api/tx/tune-drive') return jsonResponse({ tunePercent: body.percent });
+      if (u === '/api/tx/tun') return jsonResponse({ tunOn: body.on });
+      return jsonResponse({});
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('FT8 power controls reuse the existing TX endpoints', () => {
+  it('TX POWER posts to /api/tx/drive with the percent', async () => {
+    const r = await setDrive(35);
+    expect(calls).toContainEqual({ url: '/api/tx/drive', body: { percent: 35 } });
+    expect(r.drivePercent).toBe(35);
+  });
+
+  it('TUNE PWR posts to /api/tx/tune-drive with the percent', async () => {
+    const r = await setTuneDrive(40);
+    expect(calls).toContainEqual({ url: '/api/tx/tune-drive', body: { percent: 40 } });
+    expect(r.tunePercent).toBe(40);
+  });
+
+  it('TUNE posts to /api/tx/tun', async () => {
+    const r = await setTun(true);
+    expect(calls).toContainEqual({ url: '/api/tx/tun', body: { on: true } });
+    expect(r.tunOn).toBe(true);
+  });
+});
+
+describe('waterfall click honours HOLD TX FREQ end-to-end', () => {
+  it('moves the TX audio offset when not held', () => {
+    const ctrl = new Ft8TxController({ myCall: 'KB2UKA', myGrid4: 'FN12', fetchFn: globalThis.fetch });
+    // HOLD TX FREQ defaults ON; release it so a click can move the TX offset.
+    ctrl.setHoldTxFreq(false);
+    const click = resolveWaterfallClick(1800, ctrl.getState().holdTxFreq);
+    if (click.txOffsetHz != null) ctrl.setTxFreq(click.txOffsetHz);
+    expect(ctrl.getAudioHz()).toBe(1800);
+    // RX focus always moves regardless of hold.
+    expect(click.rxFocusHz).toBe(1800);
+  });
+
+  it('does NOT move the TX audio offset when HOLD TX FREQ is engaged', () => {
+    const ctrl = new Ft8TxController({ myCall: 'KB2UKA', myGrid4: 'FN12', fetchFn: globalThis.fetch });
+    ctrl.setHoldTxFreq(false);
+    ctrl.setTxFreq(1500); // baseline while unheld
+    ctrl.setHoldTxFreq(true);
+    const click = resolveWaterfallClick(2300, ctrl.getState().holdTxFreq);
+    // Overlay guard: no TX update offered.
+    expect(click.txOffsetHz).toBeNull();
+    // Controller guard (belt-and-suspenders): setTxFreq is a no-op when held.
+    ctrl.setTxFreq(2300);
+    expect(ctrl.getAudioHz()).toBe(1500);
+    // RX focus still moves.
+    expect(click.rxFocusHz).toBe(2300);
+  });
+});

--- a/zeus-web/src/state/digital-mode.test.ts
+++ b/zeus-web/src/state/digital-mode.test.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// digital-mode orchestration tests. The shared configureRadioForDigital /
+// qsyToDigitalBand drive BOTH FT8/FT4 and WSPR. FT8 frames the waterfall onto
+// its audio passband (CTUN / LO / zoom); WSPR renders no passband overlay and
+// must NOT inherit that framing. These assert the protocol gate so opening or
+// QSYing the WSPR workspace never silently enables CTUN or zooms the display.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { setCtun, setMode, setRadioLo, setVfo, setZoom } from '../api/client';
+import { useConnectionStore } from './connection-store';
+import { useTxStore } from './tx-store';
+import { configureRadioForDigital, qsyToDigitalBand } from './digital-mode';
+
+vi.mock('../api/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/client')>();
+  const ok = vi.fn(async () => ({}) as never);
+  return {
+    ...actual,
+    setMode: vi.fn(async () => ({}) as never),
+    setFilter: vi.fn(async () => ({}) as never),
+    setVfo: vi.fn(async () => ({}) as never),
+    setCtun: ok,
+    setRadioLo: ok,
+    setZoom: ok,
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Park on the 20 m FT8 sub-band; stub applyState so the framing's server-echo
+  // plumbing is inert (its real reducer needs a full RadioStateDto we don't
+  // build here). tx-store defaults to moxOn/tunOn=false (not transmitting), so
+  // we don't setState it — that would trip the persist/localStorage quirk local
+  // vitest has (see feedback memory), and the defaults are exactly what we want.
+  useConnectionStore.setState({ vfoHz: 14_074_000, applyState: vi.fn() as never });
+  expect(useTxStore.getState().moxOn || useTxStore.getState().tunOn).toBe(false);
+});
+
+describe('digital-mode framing gate', () => {
+  it('FT8 entry frames the waterfall (CTUN + LO + zoom)', async () => {
+    await configureRadioForDigital('FT8', '20m');
+    expect(setMode).toHaveBeenCalledWith('DIGU');
+    expect(setCtun).toHaveBeenCalled();
+    expect(setZoom).toHaveBeenCalled();
+    expect(setRadioLo).toHaveBeenCalled();
+  });
+
+  it('WSPR entry does NOT post CTUN / zoom / LO framing', async () => {
+    await configureRadioForDigital('WSPR', '20m');
+    // Still configured for digital (mode/QSY happen)…
+    expect(setMode).toHaveBeenCalledWith('DIGU');
+    expect(setVfo).toHaveBeenCalled();
+    // …but the FT8-only passband framing must be skipped.
+    expect(setCtun).not.toHaveBeenCalled();
+    expect(setZoom).not.toHaveBeenCalled();
+    expect(setRadioLo).not.toHaveBeenCalled();
+  });
+
+  it('WSPR QSY does NOT reframe the passband', async () => {
+    await qsyToDigitalBand('WSPR', '40m');
+    expect(setVfo).toHaveBeenCalled();
+    expect(setCtun).not.toHaveBeenCalled();
+    expect(setZoom).not.toHaveBeenCalled();
+    expect(setRadioLo).not.toHaveBeenCalled();
+  });
+
+  it('FT8 QSY reframes the passband', async () => {
+    await qsyToDigitalBand('FT8', '40m');
+    expect(setVfo).toHaveBeenCalled();
+    expect(setCtun).toHaveBeenCalled();
+    expect(setZoom).toHaveBeenCalled();
+  });
+});

--- a/zeus-web/src/state/digital-mode.ts
+++ b/zeus-web/src/state/digital-mode.ts
@@ -27,13 +27,19 @@ import {
   nearestDigitalBand,
   type DigitalProtocol,
 } from '../dsp/digital-segments';
+import { applyFt8Framing, restoreFt8Framing } from './ft8-framing';
 
-/** The RX config captured at digital-mode entry so exit can restore it. */
+/** The RX config captured at digital-mode entry so exit can restore it.
+ *  Includes the display framing (CTUN / LO / zoom) the FT8 waterfall applies, so
+ *  exit reverses the framing alongside mode/filter/VFO. */
 export interface RadioModeSnapshot {
   mode: RxMode;
   filterLowHz: number;
   filterHighHz: number;
   vfoHz: number;
+  ctunEnabled: boolean;
+  radioLoHz: number;
+  zoomLevel: number;
 }
 
 /** True while the radio is keyed or tuning — radio reconfig is suppressed. */
@@ -50,6 +56,9 @@ export function snapshotRadio(): RadioModeSnapshot {
     filterLowHz: s.filterLowHz,
     filterHighHz: s.filterHighHz,
     vfoHz: s.vfoHz,
+    ctunEnabled: s.ctunEnabled,
+    radioLoHz: s.radioLoHz,
+    zoomLevel: s.zoomLevel,
   };
 }
 
@@ -75,6 +84,11 @@ export async function configureRadioForDigital(
     await setMode('DIGU');
     await setFilter(DIGITAL_RX_FILTER_LOW_HZ, DIGITAL_RX_FILTER_HIGH_HZ);
     if (dial && Math.abs(dial - vfoHz) > 1) await setVfo(dial);
+    // Frame the waterfall onto the FT8 passband (CTUN / LO / zoom). Uses the
+    // post-QSY dial so the passband centres on the sub-band we just moved to.
+    // FT8-specific: WSPR shares this orchestration but renders no passband
+    // overlay and never requested CTUN/LO/zoom framing, so it is excluded.
+    if (protocol !== 'WSPR') await applyFt8Framing(dial ?? vfoHz);
   } catch {
     // Best-effort: the decoder still runs on whatever audio is present, and the
     // operator can tune manually. Don't let a transient radio error block entry.
@@ -95,6 +109,11 @@ export async function qsyToDigitalBand(
   if (!dial) return null;
   try {
     await setVfo(dial);
+    // Re-frame the passband around the new dial (under CTUN the frozen LO offset
+    // would otherwise stay anchored to the previous band's dial). FT8-specific —
+    // WSPR has no passband overlay and never framed on entry, so it never
+    // reframes on QSY either.
+    if (protocol !== 'WSPR') await applyFt8Framing(dial);
     return dial;
   } catch {
     return null;
@@ -105,6 +124,14 @@ export async function qsyToDigitalBand(
 export async function restoreRadio(snap: RadioModeSnapshot | null): Promise<void> {
   if (!snap || txActive()) return;
   try {
+    // Reverse the FT8 waterfall framing (CTUN / LO / zoom) FIRST, then restore
+    // mode/filter/VFO, so the dial lands on the operator's pre-FT8 frequency
+    // rather than the CTUN-frozen LO offset.
+    await restoreFt8Framing({
+      ctunEnabled: snap.ctunEnabled,
+      radioLoHz: snap.radioLoHz,
+      zoomLevel: snap.zoomLevel,
+    });
     await setMode(snap.mode);
     await setFilter(snap.filterLowHz, snap.filterHighHz);
     await setVfo(snap.vfoHz);

--- a/zeus-web/src/state/ft8-framing.test.ts
+++ b/zeus-web/src/state/ft8-framing.test.ts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { setCtun, setRadioLo, setZoom } from '../api/client';
+import { useConnectionStore } from './connection-store';
+import { useTxStore } from './tx-store';
+
+// tx-store persists via zustand persist, whose storage is bound at import; local
+// vitest's jsdom localStorage trips setItem (see feedback memory), so a setState
+// throws AFTER updating state. Wrap the one place we must flip MOX so the state
+// change still lands and the (local-only) persist error is swallowed; defaults
+// are already moxOn/tunOn=false so the non-TX tests need no setState at all.
+function setTransmitting(on: boolean): void {
+  try {
+    useTxStore.setState({ moxOn: on, tunOn: false });
+  } catch {
+    /* local-only persist/localStorage quirk — state already updated */
+  }
+}
+import {
+  FT8_FRAMING_ZOOM,
+  FT8_PASSBAND_CENTER_HZ,
+  USE_CTUN_CENTERING,
+  applyFt8Framing,
+  framingTargets,
+  restoreFt8Framing,
+} from './ft8-framing';
+
+const DIAL = 14_074_000;
+
+describe('framingTargets', () => {
+  it('applies the entry zoom regardless of centring mode', () => {
+    expect(framingTargets(DIAL).zoomLevel).toBe(FT8_FRAMING_ZOOM);
+  });
+
+  it('frames the passband per the active centring mode', () => {
+    const t = framingTargets(DIAL);
+    if (USE_CTUN_CENTERING) {
+      // CTUN: enable CTUN and freeze the LO at dial + passband centre so the
+      // band sits centred while the dial (decode reference) stays put.
+      expect(t.ctunEnabled).toBe(true);
+      expect(t.radioLoHz).toBe(DIAL + FT8_PASSBAND_CENTER_HZ);
+    } else {
+      // Fallback: dial-centred, CTUN untouched.
+      expect(t.ctunEnabled).toBe(false);
+      expect(t.radioLoHz).toBe(DIAL);
+    }
+  });
+
+  it('rounds the LO to an integer Hz', () => {
+    const t = framingTargets(DIAL + 0.4);
+    expect(Number.isInteger(t.radioLoHz)).toBe(true);
+  });
+});
+
+// Reversibility — the load-bearing entry/exit sequencing. These mock the radio
+// POSTs and assert order/skip/re-freeze, the tricky part that, if wrong, strands
+// the operator's dial under CTUN on exit.
+vi.mock('../api/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/client')>();
+  return {
+    ...actual,
+    setCtun: vi.fn(async (on: boolean) => ({ ctunEnabled: on }) as never),
+    setRadioLo: vi.fn(async (hz: number) => ({ radioLoHz: hz }) as never),
+    setZoom: vi.fn(async (z: number) => ({ zoomLevel: z }) as never),
+  };
+});
+
+describe('applyFt8Framing / restoreFt8Framing reversibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setTransmitting(false);
+    // Stub applyState so the framing's server-echo plumbing is inert in the test
+    // (its real reducer needs a full RadioStateDto we are not constructing here).
+    useConnectionStore.setState({ applyState: vi.fn() as never });
+  });
+
+  it('applies CTUN, then the frozen LO, then zoom (order matters)', async () => {
+    if (!USE_CTUN_CENTERING) return;
+    await applyFt8Framing(DIAL);
+    expect(setCtun).toHaveBeenCalledWith(true);
+    expect(setRadioLo).toHaveBeenCalledWith(DIAL + FT8_PASSBAND_CENTER_HZ);
+    expect(setZoom).toHaveBeenCalledWith(FT8_FRAMING_ZOOM);
+    const ctunOrder = (setCtun as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0]!;
+    const loOrder = (setRadioLo as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0]!;
+    const zoomOrder = (setZoom as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0]!;
+    expect(ctunOrder).toBeLessThan(loOrder);
+    expect(loOrder).toBeLessThan(zoomOrder);
+  });
+
+  it('restore with CTUN-off zooms back and disables CTUN, NOT setRadioLo', async () => {
+    await restoreFt8Framing({ ctunEnabled: false, radioLoHz: 0, zoomLevel: 3 });
+    expect(setZoom).toHaveBeenCalledWith(3);
+    expect(setCtun).toHaveBeenCalledWith(false);
+    expect(setRadioLo).not.toHaveBeenCalled();
+  });
+
+  it('restore with CTUN-on re-freezes the saved LO', async () => {
+    await restoreFt8Framing({ ctunEnabled: true, radioLoHz: 14_075_400, zoomLevel: 5 });
+    expect(setZoom).toHaveBeenCalledWith(5);
+    expect(setCtun).toHaveBeenCalledWith(true);
+    expect(setRadioLo).toHaveBeenCalledWith(14_075_400);
+  });
+
+  it('both are no-ops while transmitting', async () => {
+    setTransmitting(true);
+    await applyFt8Framing(DIAL);
+    await restoreFt8Framing({ ctunEnabled: true, radioLoHz: 1, zoomLevel: 1 });
+    expect(setCtun).not.toHaveBeenCalled();
+    expect(setRadioLo).not.toHaveBeenCalled();
+    expect(setZoom).not.toHaveBeenCalled();
+  });
+});

--- a/zeus-web/src/state/ft8-framing.ts
+++ b/zeus-web/src/state/ft8-framing.ts
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// ft8-framing — frames the shipping RF panadapter/waterfall onto the FT8/FT4
+// audio passband on entry, and is fully reversible on exit. NO new renderer and
+// NO audio-baseband FFT: an RF display zoomed tight onto [dial .. dial+~3 kHz]
+// IS the 0..3000 Hz audio cascade WSJT-X shows (FT8 is USB).
+//
+// Two framings, behind one switch:
+//   • CTUN-centred (USE_CTUN_CENTERING=true): enable CTUN and freeze the
+//     hardware LO at dial + ~1.4 kHz so the passband sits centred in the panel
+//     while the VFO/dial (the decoder's reference) stays put. This is the
+//     recommended framing — but it exercises CTUN x DIGU, which is the ONE thing
+//     worth verifying on the G2. If it misbehaves at the bench, flip the switch.
+//   • Dial-centred fallback (false): leave CTUN alone; just apply a tight zoom.
+//     The band fills the right ~75% of the panel — still perfectly usable, zero
+//     risk. "dial ±~1.5 kHz".
+//
+// Either way the overlay/click math reads the LIVE slice geometry + the dial, so
+// it is correct regardless of which framing is active.
+//
+// SAFETY: every mutation is gated on !txActive() (never reconfigure a keyed
+// radio) and is display-only — it touches CTUN / LO / zoom, never power,
+// PureSignal, mode, or filter. Exit restores the captured snapshot.
+
+import { setCtun, setRadioLo, setZoom, type RadioStateDto } from '../api/client';
+import { useConnectionStore } from './connection-store';
+import { useTxStore } from './tx-store';
+
+/**
+ * CTUN-centred framing is the recommended primary (see header). Default ON per
+ * the design; this is the single one-line switch to the zero-risk dial-centred
+ * fallback if CTUN x DIGU misbehaves on the G2. Flagged for bench verification.
+ */
+export const USE_CTUN_CENTERING = true;
+
+/** Where in the audio passband to centre the panel under CTUN framing (Hz).
+ *  ~1.4 kHz puts 0 Hz left-of-centre and 3 kHz right-of-centre. */
+export const FT8_PASSBAND_CENTER_HZ = 1400;
+
+/** Entry zoom level so the visible span is ~3.5 kHz around the passband.
+ *  Bench-tune on the G2; reversible via the entry snapshot. */
+export const FT8_FRAMING_ZOOM = 8;
+
+/** The reversible display state framing touches. Captured at entry, restored on
+ *  exit. (digital-mode.ts folds these into its RadioModeSnapshot.) */
+export interface FramingSnapshot {
+  ctunEnabled: boolean;
+  radioLoHz: number;
+  zoomLevel: number;
+}
+
+/** The display targets framing wants for a given dial. PURE — unit tested. */
+export interface FramingTargets {
+  ctunEnabled: boolean;
+  radioLoHz: number;
+  zoomLevel: number;
+}
+
+/** True while the radio is keyed or tuning — display reconfig is suppressed. */
+function txActive(): boolean {
+  const tx = useTxStore.getState();
+  return tx.moxOn || tx.tunOn;
+}
+
+/** The framing display targets for a dial frequency. CTUN-centred freezes the
+ *  LO at dial + FT8_PASSBAND_CENTER_HZ; the fallback leaves the LO on the dial.
+ *  Both apply the entry zoom. */
+export function framingTargets(dialHz: number): FramingTargets {
+  if (USE_CTUN_CENTERING) {
+    return {
+      ctunEnabled: true,
+      radioLoHz: Math.round(dialHz + FT8_PASSBAND_CENTER_HZ),
+      zoomLevel: FT8_FRAMING_ZOOM,
+    };
+  }
+  return { ctunEnabled: false, radioLoHz: Math.round(dialHz), zoomLevel: FT8_FRAMING_ZOOM };
+}
+
+function applyServerState(s: RadioStateDto): void {
+  useConnectionStore.getState().applyState(s);
+}
+
+/**
+ * Apply the FT8 passband framing for `dialHz`. Best-effort: the decoder still
+ * runs on whatever audio is present even if a framing POST fails, so a transient
+ * radio error must never block workspace entry. No-op while transmitting.
+ */
+export async function applyFt8Framing(dialHz: number): Promise<void> {
+  if (txActive()) return;
+  const t = framingTargets(dialHz);
+  try {
+    if (t.ctunEnabled) {
+      applyServerState(await setCtun(true));
+      applyServerState(await setRadioLo(t.radioLoHz));
+    }
+    applyServerState(await setZoom(t.zoomLevel));
+  } catch {
+    // Best-effort — see header SAFETY note.
+  }
+}
+
+/**
+ * Restore the display state captured before framing was applied (CTUN, LO,
+ * zoom). No-op while transmitting / with no snapshot. Order: zoom first, then
+ * CTUN — disabling CTUN snaps the LO back to the dial, so when CTUN was off we
+ * skip the explicit LO write; when it was on we re-freeze it at the saved LO.
+ */
+export async function restoreFt8Framing(snap: FramingSnapshot | null): Promise<void> {
+  if (!snap || txActive()) return;
+  try {
+    applyServerState(await setZoom(snap.zoomLevel));
+    if (snap.ctunEnabled) {
+      applyServerState(await setCtun(true));
+      applyServerState(await setRadioLo(snap.radioLoHz));
+    } else {
+      applyServerState(await setCtun(false));
+    }
+  } catch {
+    // Best-effort restore.
+  }
+}

--- a/zeus-web/src/state/ft8-store.ts
+++ b/zeus-web/src/state/ft8-store.ts
@@ -10,6 +10,7 @@
 
 import { create } from 'zustand';
 import { nearestDigitalBand } from '../dsp/digital-segments';
+import { FT8_MAX_OFFSET_HZ, FT8_MIN_OFFSET_HZ } from '../dsp/ft8-passband';
 import {
   configureRadioForDigital,
   qsyToDigitalBand,
@@ -64,6 +65,11 @@ interface Ft8State {
   band: string;
   /** RX config captured at entry so exit restores the radio. */
   priorRadio: RadioModeSnapshot | null;
+  /** RX focus cursor — the audio offset (Hz) the waterfall click last set. FT8
+   *  decodes the whole passband, so this is purely a UI cursor: where a reply
+   *  defaults and which decode the operator is eyeing. Shared by the waterfall
+   *  RX-cursor marker (and, later, decode-row highlighting). */
+  rxFocusHz: number;
 
   /** Open the FT8 workspace: configure the radio (DIGU + wide filter + QSY to
    *  the band dial) and start decoding. */
@@ -84,6 +90,8 @@ interface Ft8State {
   disable: () => Promise<void>;
   /** Clear the decode table. */
   clear: () => void;
+  /** Move the RX focus cursor to an audio offset (clamped to the passband). */
+  setRxFocusHz: (hz: number) => void;
 }
 
 export const useFt8Store = create<Ft8State>((set, get) => ({
@@ -97,6 +105,7 @@ export const useFt8Store = create<Ft8State>((set, get) => ({
   error: null,
   band: '20m',
   priorRadio: null,
+  rxFocusHz: 1500,
 
   openWorkspace: (opts) => {
     const protocol = opts?.protocol ?? get().protocol;
@@ -205,4 +214,7 @@ export const useFt8Store = create<Ft8State>((set, get) => ({
   },
 
   clear: () => set({ rows: [] }),
+
+  setRxFocusHz: (hz) =>
+    set({ rxFocusHz: Math.min(FT8_MAX_OFFSET_HZ, Math.max(FT8_MIN_OFFSET_HZ, hz)) }),
 }));

--- a/zeus-web/src/styles/ft8-theme.css
+++ b/zeus-web/src/styles/ft8-theme.css
@@ -326,4 +326,100 @@
   color: var(--tx);
   font-weight: 700;
 }
+
+/* ---- Receive · waterfall ---- */
+.ft8-receive { overflow: hidden; }
+/* The spectrum stack: short panadapter strip over the growing waterfall, with
+   the click-capture overlay laid on top (position:relative is its containing
+   block). */
+.ft8-receive__stack {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--hud-inset);
+}
+.ft8-receive__pan { flex: 0 0 34%; min-height: 0; position: relative; }
+.ft8-receive__wf { flex: 1; min-height: 0; position: relative; }
+
+/* Transparent capture layer — sits above the canvases so a click resolves to an
+   FT8 audio offset instead of moving the dial. */
+.ft8-wf-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 30;
+  cursor: crosshair;
+}
+/* Markers span the full height; left is set inline as a percent. */
+.ft8-wf-decode-tick,
+.ft8-wf-rx-cursor,
+.ft8-wf-tx-marker {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  pointer-events: none;
+  transform: translateX(-50%);
+}
+.ft8-wf-decode-tick { width: 2px; opacity: 0.75; }
+.ft8-wf-rx-cursor {
+  width: 2px;
+  background: var(--hud-cyan);
+  box-shadow: 0 0 6px var(--hud-cyan-soft);
+}
+.ft8-wf-tx-marker {
+  width: 2px;
+  background: var(--tx);
+  box-shadow: 0 0 6px color-mix(in srgb, var(--tx) 40%, transparent);
+}
+
+/* WF SPEED / ZOOM / OFFSET control strip. */
+.ft8-wf-controls {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 5px 8px;
+  border-top: 1px solid var(--hud-line);
+  background: var(--hud-panel-2);
+}
+.ft8-wf-offset { display: inline-flex; align-items: center; gap: 4px; }
+.ft8-wf-offset__label {
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--hud-text-dim);
+  font-weight: 600;
+}
+.ft8-wf-offset__btn {
+  background: var(--hud-panel);
+  border: 1px solid var(--hud-line);
+  color: var(--hud-text);
+  border-radius: 3px;
+  padding: 2px 6px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+}
+.ft8-wf-offset__btn:hover:not(:disabled) { border-color: var(--hud-cyan-line); }
+.ft8-wf-offset__btn:disabled { opacity: 0.5; cursor: default; }
+
+/* ---- TX power (TX CONTROL cluster) ---- */
+.ft8-power { display: flex; flex-direction: column; gap: 6px; padding: 6px 8px 8px; }
+.ft8-power__row { display: flex; align-items: center; gap: 8px; }
+.ft8-power__label {
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--hud-text-dim);
+  font-weight: 600;
+  width: 64px;
+  flex: 0 0 auto;
+}
+/* The reused DriveSlider/TunePowerSlider fill the remaining row width. The
+   .ft8-power block now lives inside the TX CONTROL cluster (Ft8TxControl); TUNE
+   is the cluster's own .ft8-tx__tune button, so there is no .ft8-power__tune. */
+.ft8-power__row .knob-group { flex: 1; min-width: 0; }
 .ft8-tx__halt:hover { background: var(--tx); color: #1a0604; }


### PR DESCRIPTION
## ⛔ DO NOT MERGE — bench sign-off required

**Stack 2 of 4.** Base: `ft8/tx-keying` (PR for #1012/#1013). Review that one first.

Adds the workspace **RECEIVE waterfall with click-to-tune** and **in-workspace power controls**, per the approved `ft8-target-mockup.png` layout.

### What's in it
- Reuses the existing panadapter/waterfall WebGL (no second renderer, no new wire frame): the RECEIVE panel mounts the shipping spectrum surface framed onto the FT8 sub-band, reversible on exit (WSPR excluded).
- **Click a slice** → sets RX focus + TX audio offset (honoring HOLD TX FREQ); cyan RX cursor, red TX marker, decode-class ticks; WF SPEED/ZOOM/OFFSET.
- **Power in the workspace** (Drive + Tune + TUNE) wired to the SAME `/api/tx/drive` + `/api/tx/tune-drive` + server `tunOn` — no forked power model, no default changes. Occluded main-console GL contexts released while open.

### Refs
#1016 (workspace waterfall).

### Safety / bench
- Fixed-slot layout, no closable panels, tokens only. No power-default changes.
- **Bench note:** the CTUN × DIGU passband-centering default wants G2 verification (zero-risk dial-centered fallback already wired if it misbehaves).
