### PR TITLE
DO NOT MERGE: FT8 native logbook + opt-in WSJT-X UDP push (#1015)

### DIFF
--- a/Zeus.Contracts/WsjtxDtos.cs
+++ b/Zeus.Contracts/WsjtxDtos.cs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+namespace Zeus.Contracts;
+
+/// <summary>
+/// Persisted config for the outbound WSJT-X "logged QSO" UDP broadcaster. When
+/// enabled, every QSO logged through /api/log/entry (auto-logged or manual — NOT
+/// ADIF import) is emitted as a WSJT-X NetworkMessage type 12 (LoggedADIF) to
+/// <c>Host:Port</c>, which JTAlert / Log4OM / GridTracker / N1MM already
+/// understand. NEW network egress — DISABLED by default, loopback target. This
+/// is QSO-record push only; CAT/TCI already provide rig control.
+/// </summary>
+public sealed record WsjtxRuntimeConfig(
+    bool Enabled = false,
+    string Host = "127.0.0.1",
+    int Port = 2237,
+    string InstanceId = "WSJT-X");
+
+/// <summary>Status/config view for the WSJT-X broadcaster. UDP has no listener,
+/// so config applies live — there is no RequiresRestart, unlike CAT/TCI.</summary>
+public sealed record WsjtxStatus(
+    bool Enabled,
+    string Host,
+    int Port,
+    string InstanceId);

--- a/Zeus.Server.Hosting/LogService.cs
+++ b/Zeus.Server.Hosting/LogService.cs
@@ -88,7 +88,10 @@ public sealed class LogService : IDisposable
                 QsoDateTimeUtc = request.QsoDateTimeUtc ?? DateTime.UtcNow,
                 Callsign = request.Callsign.ToUpperInvariant(),
                 Name = request.Name,
-                FrequencyMhz = request.FrequencyMhz,
+                // 0/negative MHz means "dial unknown" (e.g. a manual log while
+                // disconnected) — store null so ADIF omits FREQ and falls back to
+                // BAND, rather than exporting a junk FREQ:0.000000.
+                FrequencyMhz = request.FrequencyMhz > 0 ? request.FrequencyMhz : null,
                 Band = request.Band,
                 Mode = request.Mode,
                 RstSent = request.RstSent,
@@ -528,7 +531,22 @@ public sealed class LogService : IDisposable
         if (doc.FrequencyMhz.HasValue)
             AppendAdifField(sb, "FREQ", doc.FrequencyMhz.Value.ToString("F6", CultureInfo.InvariantCulture));
         AppendAdifField(sb, "BAND", doc.Band);
-        AppendAdifField(sb, "MODE", doc.Mode);
+        // FT4 is an MFSK SUBMODE in ADIF (3.1.x), not a top-level MODE enum value;
+        // strict parsers (LoTW / Club Log / QRZ) reject MODE=FT4. Emit it the
+        // canonical way. FT8 is a valid MODE and passes through unchanged.
+        if (string.Equals(doc.Mode, "FT4", StringComparison.OrdinalIgnoreCase))
+        {
+            AppendAdifField(sb, "MODE", "MFSK");
+            // Don't duplicate a SUBMODE already carried in the imported fields
+            // (those are re-emitted verbatim by AppendAdditionalAdifFields).
+            var hasSubmode = doc.AdifFields is not null && doc.AdifFields.ContainsKey("SUBMODE");
+            if (!hasSubmode)
+                AppendAdifField(sb, "SUBMODE", "FT4");
+        }
+        else
+        {
+            AppendAdifField(sb, "MODE", doc.Mode);
+        }
         AppendAdifField(sb, "RST_SENT", doc.RstSent);
         AppendAdifField(sb, "RST_RCVD", doc.RstRcvd);
 

--- a/Zeus.Server.Hosting/Wsjtx/WsjtxMessage.cs
+++ b/Zeus.Server.Hosting/Wsjtx/WsjtxMessage.cs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using System.Buffers.Binary;
+using System.Text;
+
+namespace Zeus.Server.Wsjtx;
+
+/// <summary>
+/// Encoder for the WSJT-X UDP "NetworkMessage" wire format — the de-facto
+/// protocol that JTAlert / Log4OM / GridTracker / N1MM consume. We emit ONE
+/// message type: 12 (LoggedADIF). The wire format is a Qt QDataStream: all
+/// integers big-endian, and each string is a UTF-8 QByteArray written as a
+/// 4-byte big-endian length followed by the bytes (length 0xFFFFFFFF = null).
+///
+/// Common header (every message): magic uint32 0xADBCCBDA, schema uint32,
+/// message-type uint32, then the instance id (utf8). LoggedADIF appends a single
+/// utf8 string: the ADIF record text.
+///
+/// Pure + allocation-light so it is trivially unit-testable; no I/O lives here
+/// (see WsjtxUdpBroadcaster for the send).
+/// </summary>
+public static class WsjtxMessage
+{
+    /// <summary>WSJT-X NetworkMessage magic number.</summary>
+    public const uint Magic = 0xADBCCBDA;
+
+    /// <summary>LoggedADIF message type id.</summary>
+    public const uint LoggedAdifType = 12;
+
+    /// <summary>
+    /// Schema number written into the header. WSJT-X has used schema 2 across the
+    /// long-lived 2.x series and downstream tools accept it broadly; bumping is a
+    /// one-line change if a future client demands 3. G2 bench: confirm JTAlert /
+    /// GridTracker ingest before relying on this.
+    /// </summary>
+    public const uint DefaultSchema = 2;
+
+    /// <summary>Encode a LoggedADIF (type 12) datagram for the given ADIF text.</summary>
+    public static byte[] EncodeLoggedAdif(string instanceId, string adif, uint schema = DefaultSchema)
+    {
+        using var ms = new MemoryStream(64 + (adif?.Length ?? 0));
+        WriteUInt32(ms, Magic);
+        WriteUInt32(ms, schema);
+        WriteUInt32(ms, LoggedAdifType);
+        WriteUtf8(ms, instanceId);
+        WriteUtf8(ms, adif);
+        return ms.ToArray();
+    }
+
+    private static void WriteUInt32(Stream s, uint value)
+    {
+        Span<byte> b = stackalloc byte[4];
+        BinaryPrimitives.WriteUInt32BigEndian(b, value);
+        s.Write(b);
+    }
+
+    private static void WriteUtf8(Stream s, string? value)
+    {
+        if (value is null)
+        {
+            // Qt encodes a null QByteArray as length 0xFFFFFFFF.
+            WriteUInt32(s, 0xFFFFFFFF);
+            return;
+        }
+
+        var bytes = Encoding.UTF8.GetBytes(value);
+        WriteUInt32(s, (uint)bytes.Length);
+        s.Write(bytes);
+    }
+}

--- a/Zeus.Server.Hosting/Wsjtx/WsjtxUdpBroadcaster.cs
+++ b/Zeus.Server.Hosting/Wsjtx/WsjtxUdpBroadcaster.cs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using System.Net.Sockets;
+using Zeus.Contracts;
+
+namespace Zeus.Server.Wsjtx;
+
+/// <summary>
+/// Emits a single WSJT-X NetworkMessage type 12 (LoggedADIF) datagram when a QSO
+/// is logged, so third-party loggers (JTAlert / Log4OM / GridTracker / N1MM)
+/// pick up Zeus's native FT8/FT4 QSOs. The ADIF for the single entry is reused
+/// from <see cref="LogService.ExportToAdifAsync"/>.
+///
+/// Wired ONLY at /api/log/entry (live + manual QSOs); ADIF bulk import does NOT
+/// route through here, so re-importing a log never re-broadcasts. No-ops when
+/// disabled (the default) — new network egress is opt-in. Cross-platform: pure
+/// <see cref="UdpClient"/>, no native deps.
+/// </summary>
+public sealed class WsjtxUdpBroadcaster
+{
+    private readonly ILogger<WsjtxUdpBroadcaster> _log;
+    private readonly WsjtxManagementService _mgmt;
+    private readonly LogService _logService;
+
+    public WsjtxUdpBroadcaster(
+        ILogger<WsjtxUdpBroadcaster> log,
+        WsjtxManagementService mgmt,
+        LogService logService)
+    {
+        _log = log;
+        _mgmt = mgmt;
+        _logService = logService;
+    }
+
+    /// <summary>Broadcast one logged QSO. No-op when the broadcaster is disabled;
+    /// never throws (a send failure must not break the log POST).</summary>
+    public async Task BroadcastLoggedQsoAsync(LogEntry entry, CancellationToken ct = default)
+    {
+        var cfg = _mgmt.GetConfig();
+        if (!cfg.Enabled) return;
+
+        try
+        {
+            var adif = await _logService.ExportToAdifAsync(new[] { entry.Id }, ct);
+            var datagram = WsjtxMessage.EncodeLoggedAdif(cfg.InstanceId, adif);
+
+            using var udp = new UdpClient();
+            await udp.SendAsync(datagram, datagram.Length, cfg.Host, cfg.Port).ConfigureAwait(false);
+
+            _log.LogInformation(
+                "wsjtx.broadcast call={Call} -> {Host}:{Port} bytes={Bytes}",
+                entry.Callsign, cfg.Host, cfg.Port, datagram.Length);
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "wsjtx.broadcast failed call={Call}", entry.Callsign);
+        }
+    }
+}

--- a/Zeus.Server.Hosting/WsjtxConfigStore.cs
+++ b/Zeus.Server.Hosting/WsjtxConfigStore.cs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using LiteDB;
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+// Single-row collection for the WSJT-X logged-QSO broadcaster config. Mirrors
+// CatConfigStore — same Connection=shared pattern and Directory guard (no new
+// exposure to the Linux LiteDB shared-mode caveat, GH #682).
+public sealed class WsjtxConfigStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<WsjtxConfigEntry> _entries;
+    private readonly ILogger<WsjtxConfigStore> _log;
+    private readonly object _sync = new();
+
+    public WsjtxConfigStore(ILogger<WsjtxConfigStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _entries = _db.GetCollection<WsjtxConfigEntry>("wsjtx_config");
+
+        _log.LogInformation("WsjtxConfigStore initialized at {Path}", dbPath);
+    }
+
+    // null = nothing persisted yet — caller falls back to defaults.
+    public WsjtxRuntimeConfig? Get()
+    {
+        lock (_sync)
+        {
+            var e = _entries.FindAll().FirstOrDefault();
+            if (e is null) return null;
+            return new WsjtxRuntimeConfig(
+                Enabled: e.Enabled,
+                Host: e.Host,
+                Port: e.Port,
+                InstanceId: string.IsNullOrWhiteSpace(e.InstanceId) ? "WSJT-X" : e.InstanceId);
+        }
+    }
+
+    public void Set(WsjtxRuntimeConfig config)
+    {
+        lock (_sync)
+        {
+            var existing = _entries.FindAll().FirstOrDefault();
+            if (existing is null)
+            {
+                _entries.Insert(new WsjtxConfigEntry
+                {
+                    Enabled = config.Enabled,
+                    Host = config.Host,
+                    Port = config.Port,
+                    InstanceId = config.InstanceId,
+                    UpdatedUtc = DateTime.UtcNow,
+                });
+            }
+            else
+            {
+                existing.Enabled = config.Enabled;
+                existing.Host = config.Host;
+                existing.Port = config.Port;
+                existing.InstanceId = config.InstanceId;
+                existing.UpdatedUtc = DateTime.UtcNow;
+                _entries.Update(existing);
+            }
+        }
+    }
+
+    public void Dispose() => _db.Dispose();
+}
+
+public sealed class WsjtxConfigEntry
+{
+    public int Id { get; set; }
+    public bool Enabled { get; set; }
+    public string Host { get; set; } = "127.0.0.1";
+    public int Port { get; set; } = 2237;
+    public string InstanceId { get; set; } = "WSJT-X";
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/WsjtxManagementService.cs
+++ b/Zeus.Server.Hosting/WsjtxManagementService.cs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Owns the live config for the WSJT-X logged-QSO broadcaster. Unlike CAT/TCI
+/// (which hold a TcpListener and need a restart to rebind), the broadcaster only
+/// SENDS UDP, so config changes apply immediately — there is no current/pending
+/// split and no RequiresRestart. Persists through <see cref="WsjtxConfigStore"/>.
+/// </summary>
+public sealed class WsjtxManagementService
+{
+    private readonly ILogger<WsjtxManagementService> _log;
+    private readonly WsjtxConfigStore _store;
+    private readonly object _sync = new();
+    private WsjtxRuntimeConfig _config;
+
+    public WsjtxManagementService(ILogger<WsjtxManagementService> log, WsjtxConfigStore store)
+    {
+        _log = log;
+        _store = store;
+        // Default OFF / loopback when nothing is persisted — new network egress
+        // is opt-in only.
+        _config = _store.Get() ?? new WsjtxRuntimeConfig();
+    }
+
+    public WsjtxRuntimeConfig GetConfig()
+    {
+        lock (_sync) return _config;
+    }
+
+    public WsjtxStatus GetStatus()
+    {
+        var c = GetConfig();
+        return new WsjtxStatus(c.Enabled, c.Host, c.Port, c.InstanceId);
+    }
+
+    public WsjtxStatus SetConfig(WsjtxRuntimeConfig config)
+    {
+        var normalized = new WsjtxRuntimeConfig(
+            Enabled: config.Enabled,
+            Host: string.IsNullOrWhiteSpace(config.Host) ? "127.0.0.1" : config.Host.Trim(),
+            Port: config.Port is > 0 and < 65536 ? config.Port : 2237,
+            InstanceId: string.IsNullOrWhiteSpace(config.InstanceId) ? "WSJT-X" : config.InstanceId.Trim());
+
+        lock (_sync) _config = normalized;
+
+        try
+        {
+            _store.Set(normalized);
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "wsjtx.config.persist failed");
+        }
+
+        _log.LogInformation(
+            "wsjtx.config.updated enabled={Enabled} host={Host} port={Port}",
+            normalized.Enabled, normalized.Host, normalized.Port);
+
+        return GetStatus();
+    }
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -15,6 +15,7 @@ using Zeus.Protocol1.Discovery;
 using Zeus.Protocol2;
 using Zeus.Server.Diagnostics;
 using Zeus.Server.Tci;
+using Zeus.Server.Wsjtx;
 
 namespace Zeus.Server;
 
@@ -3234,11 +3235,19 @@ public static class ZeusEndpoints
             return Results.Ok(response);
         });
 
-        app.MapPost("/api/log/entry", async (CreateLogEntryRequest req, LogService logService, HttpContext ctx) =>
+        app.MapPost("/api/log/entry", async (CreateLogEntryRequest req, LogService logService, WsjtxUdpBroadcaster wsjtx, HttpContext ctx) =>
         {
             if (string.IsNullOrWhiteSpace(req.Callsign))
                 return Results.BadRequest(new { error = "callsign required" });
             var entry = await logService.CreateLogEntryAsync(req, ctx.RequestAborted);
+            // Push the just-logged QSO to a third-party logger if the operator has
+            // opted in (WSJT-X type-12 LoggedADIF). No-op when disabled; this is the
+            // only logging path that broadcasts (ADIF bulk import never does).
+            // Fire-and-forget so a slow/blocked send (e.g. a free-text Host whose
+            // DNS is dead) can never delay the operator's log confirmation. The
+            // broadcaster swallows all send failures internally; use a detached
+            // token so the post-response request abort doesn't cancel it.
+            _ = wsjtx.BroadcastLoggedQsoAsync(entry, CancellationToken.None);
             return Results.Ok(entry);
         });
 
@@ -3390,6 +3399,18 @@ public static class ZeusEndpoints
                 return Results.BadRequest(new { error = "bindAddress and port required" });
             var result = cat.TestPort(req.BindAddress.Trim(), req.Port);
             return Results.Ok(result);
+        });
+
+        // WSJT-X logged-QSO UDP broadcaster (outbound QSO-record push to
+        // JTAlert / Log4OM / GridTracker / N1MM). Default OFF / loopback; config
+        // applies live (no restart — there is no listener, only a UDP sender).
+        app.MapGet("/api/wsjtx/status", (WsjtxManagementService wsjtx) => wsjtx.GetStatus());
+
+        app.MapPost("/api/wsjtx/config", (WsjtxRuntimeConfig req, WsjtxManagementService wsjtx, HttpContext ctx) =>
+        {
+            log.LogInformation("api.wsjtx.config enabled={En} host={Host} port={Port}", req.Enabled, req.Host, req.Port);
+            var status = wsjtx.SetConfig(req);
+            return Results.Ok(status);
         });
 
         app.Map("/ws", async (HttpContext ctx, StreamingHub hub) =>

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -895,6 +895,15 @@ public static class ZeusHost
         builder.Services.AddHostedService(sp => sp.GetRequiredService<Cat.CatServer>());
         builder.Services.AddSingleton<CatManagementService>();
 
+        // WSJT-X logged-QSO UDP broadcaster — outbound QSO-record push to
+        // third-party loggers (JTAlert / Log4OM / GridTracker / N1MM). DISABLED
+        // by default; this is NEW network egress, opt-in via the Network settings
+        // tab. No listener / hosted service — it only sends a datagram from the
+        // /api/log/entry path, so config applies live (no restart).
+        builder.Services.AddSingleton<WsjtxConfigStore>();
+        builder.Services.AddSingleton<WsjtxManagementService>();
+        builder.Services.AddSingleton<Wsjtx.WsjtxUdpBroadcaster>();
+
         // ZeusChat — operator-to-operator chat over the Cloudflare relay.
         // Singleton (API surface) + hosted service (relay connection lifecycle),
         // same shape as SpotBroadcastService above. Opt-in persisted via

--- a/tests/Zeus.Server.Tests/AdifImportTests.cs
+++ b/tests/Zeus.Server.Tests/AdifImportTests.cs
@@ -71,6 +71,54 @@ public sealed class AdifImportTests
     }
 
     [Fact]
+    public void Export_Ft4_Emits_Mfsk_Mode_With_Ft4_Submode()
+    {
+        // FT4 is an MFSK SUBMODE in ADIF, not a MODE enum value. Strict parsers
+        // (LoTW / Club Log / QRZ) reject MODE=FT4, so a native FT4 QSO must export
+        // as MODE=MFSK + SUBMODE=FT4.
+        var doc = new LogEntryDocument
+        {
+            Id = Guid.NewGuid().ToString(),
+            QsoDateTimeUtc = new DateTime(2026, 6, 26, 12, 0, 0, DateTimeKind.Utc),
+            Callsign = "K1ABC",
+            Band = "20M",
+            Mode = "FT4",
+            RstSent = "-12",
+            RstRcvd = "-07",
+        };
+
+        var sb = new StringBuilder();
+        LogService.AppendAdifRecord(sb, doc);
+        var exported = sb.ToString();
+
+        Assert.Contains("<MODE:4>MFSK", exported);
+        Assert.Contains("<SUBMODE:3>FT4", exported);
+        Assert.DoesNotContain("<MODE:3>FT4", exported);
+    }
+
+    [Fact]
+    public void Export_Ft8_Keeps_Ft8_Mode_With_No_Submode()
+    {
+        var doc = new LogEntryDocument
+        {
+            Id = Guid.NewGuid().ToString(),
+            QsoDateTimeUtc = new DateTime(2026, 6, 26, 12, 0, 0, DateTimeKind.Utc),
+            Callsign = "K1ABC",
+            Band = "20M",
+            Mode = "FT8",
+            RstSent = "-12",
+            RstRcvd = "-07",
+        };
+
+        var sb = new StringBuilder();
+        LogService.AppendAdifRecord(sb, doc);
+        var exported = sb.ToString();
+
+        Assert.Contains("<MODE:3>FT8", exported);
+        Assert.DoesNotContain("<SUBMODE:", exported);
+    }
+
+    [Fact]
     public void Mapping_RejectsRecordsMissingMinimumQsoFields()
     {
         var record = new AdifRecord(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)

--- a/tests/Zeus.Server.Tests/Wsjtx/WsjtxManagementServiceTests.cs
+++ b/tests/Zeus.Server.Tests/Wsjtx/WsjtxManagementServiceTests.cs
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Pins the safety-critical invariants of the WSJT-X logged-QSO broadcaster
+// config: it is OFF by default (new network egress is opt-in), SetConfig
+// normalises hostile input, and the choice persists across store instances.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public sealed class WsjtxManagementServiceTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-wsjtx-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+    }
+
+    private WsjtxConfigStore NewStore() =>
+        new(NullLogger<WsjtxConfigStore>.Instance, _dbPath);
+
+    private static WsjtxManagementService NewService(WsjtxConfigStore store) =>
+        new(NullLogger<WsjtxManagementService>.Instance, store);
+
+    [Fact]
+    public void Defaults_To_Disabled_When_Nothing_Persisted()
+    {
+        using var store = NewStore();
+        var svc = NewService(store);
+
+        var cfg = svc.GetConfig();
+        Assert.False(cfg.Enabled); // the whole point: opt-in egress, off by default
+        Assert.Equal("127.0.0.1", cfg.Host);
+        Assert.Equal(2237, cfg.Port);
+        Assert.Equal("WSJT-X", cfg.InstanceId);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(65536)]
+    [InlineData(70000)]
+    public void SetConfig_Clamps_OutOfRange_Port_To_Default(int port)
+    {
+        using var store = NewStore();
+        var svc = NewService(store);
+
+        var status = svc.SetConfig(new WsjtxRuntimeConfig(Enabled: true, Port: port));
+        Assert.Equal(2237, status.Port);
+    }
+
+    [Fact]
+    public void SetConfig_Keeps_Valid_Port()
+    {
+        using var store = NewStore();
+        var svc = NewService(store);
+
+        var status = svc.SetConfig(new WsjtxRuntimeConfig(Enabled: true, Port: 2333));
+        Assert.Equal(2333, status.Port);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void SetConfig_Defaults_Blank_Host_To_Loopback(string? host)
+    {
+        using var store = NewStore();
+        var svc = NewService(store);
+
+        var status = svc.SetConfig(new WsjtxRuntimeConfig(Enabled: true, Host: host!));
+        Assert.Equal("127.0.0.1", status.Host);
+    }
+
+    [Fact]
+    public void SetConfig_Trims_Host_And_InstanceId_And_Defaults_Blank_Id()
+    {
+        using var store = NewStore();
+        var svc = NewService(store);
+
+        var trimmed = svc.SetConfig(new WsjtxRuntimeConfig(Enabled: true, Host: "  10.0.0.5  ", InstanceId: "  Shack  "));
+        Assert.Equal("10.0.0.5", trimmed.Host);
+        Assert.Equal("Shack", trimmed.InstanceId);
+
+        var blankId = svc.SetConfig(new WsjtxRuntimeConfig(Enabled: true, InstanceId: "   "));
+        Assert.Equal("WSJT-X", blankId.InstanceId);
+    }
+
+    [Fact]
+    public void SetConfig_Persists_Across_Store_Instances()
+    {
+        using (var store = NewStore())
+        {
+            var svc = NewService(store);
+            svc.SetConfig(new WsjtxRuntimeConfig(Enabled: true, Host: "192.168.1.50", Port: 2333, InstanceId: "Shack"));
+        }
+
+        // A fresh store + service over the same DB must re-read the saved config.
+        using var reopened = NewStore();
+        var reloaded = NewService(reopened).GetConfig();
+        Assert.True(reloaded.Enabled);
+        Assert.Equal("192.168.1.50", reloaded.Host);
+        Assert.Equal(2333, reloaded.Port);
+        Assert.Equal("Shack", reloaded.InstanceId);
+    }
+}

--- a/tests/Zeus.Server.Tests/Wsjtx/WsjtxMessageTests.cs
+++ b/tests/Zeus.Server.Tests/Wsjtx/WsjtxMessageTests.cs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+
+using System.Buffers.Binary;
+using System.Text;
+using Zeus.Server.Wsjtx;
+
+namespace Zeus.Server.Tests;
+
+public sealed class WsjtxMessageTests
+{
+    // Cursor over a WSJT-X NetworkMessage (Qt QDataStream: big-endian ints,
+    // length-prefixed utf8 strings).
+    private sealed class Reader(byte[] buf)
+    {
+        private int _pos;
+
+        public uint UInt32()
+        {
+            var v = BinaryPrimitives.ReadUInt32BigEndian(buf.AsSpan(_pos, 4));
+            _pos += 4;
+            return v;
+        }
+
+        public string? Utf8()
+        {
+            var len = UInt32();
+            if (len == 0xFFFFFFFF) return null;
+            var s = Encoding.UTF8.GetString(buf, _pos, (int)len);
+            _pos += (int)len;
+            return s;
+        }
+
+        public int Remaining => buf.Length - _pos;
+    }
+
+    [Fact]
+    public void EncodeLoggedAdif_WritesHeaderThenIdThenAdif()
+    {
+        var bytes = WsjtxMessage.EncodeLoggedAdif("WSJT-X", "<call:5>K1ABC<eor>");
+
+        var r = new Reader(bytes);
+        Assert.Equal(0xADBCCBDAu, r.UInt32());                 // magic
+        Assert.Equal(WsjtxMessage.DefaultSchema, r.UInt32());  // schema (2)
+        Assert.Equal(WsjtxMessage.LoggedAdifType, r.UInt32()); // type 12
+        Assert.Equal("WSJT-X", r.Utf8());                      // instance id
+        Assert.Equal("<call:5>K1ABC<eor>", r.Utf8());          // adif payload
+        Assert.Equal(0, r.Remaining);                          // nothing trailing
+    }
+
+    [Fact]
+    public void EncodeLoggedAdif_FirstFourBytesAreTheMagic()
+    {
+        var bytes = WsjtxMessage.EncodeLoggedAdif("WSJT-X", "x");
+        Assert.Equal(new byte[] { 0xAD, 0xBC, 0xCB, 0xDA }, bytes[..4]);
+    }
+
+    [Fact]
+    public void EncodeLoggedAdif_RoundTripsUtf8AndEmptyString()
+    {
+        // Non-ASCII instance id + empty ADIF exercises utf8 length + zero-length.
+        var bytes = WsjtxMessage.EncodeLoggedAdif("Zëus", string.Empty);
+
+        var r = new Reader(bytes);
+        r.UInt32();
+        r.UInt32();
+        r.UInt32();
+        Assert.Equal("Zëus", r.Utf8());
+        Assert.Equal(string.Empty, r.Utf8());
+    }
+
+    [Fact]
+    public void EncodeLoggedAdif_HonoursSchemaOverride()
+    {
+        var bytes = WsjtxMessage.EncodeLoggedAdif("WSJT-X", "x", schema: 3);
+        var r = new Reader(bytes);
+        r.UInt32();
+        Assert.Equal(3u, r.UInt32());
+    }
+}

--- a/tests/Zeus.Server.Tests/Wsjtx/WsjtxUdpBroadcasterTests.cs
+++ b/tests/Zeus.Server.Tests/Wsjtx/WsjtxUdpBroadcasterTests.cs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Pins the network-egress safety guarantees of the WSJT-X broadcaster:
+//   - DISABLED (the default) ⇒ no datagram leaves the box;
+//   - ENABLED ⇒ a well-formed type-12 LoggedADIF datagram is emitted;
+//   - a send to a dead endpoint never throws (a broken listener must not break
+//     the /api/log/entry POST).
+
+using System.Net;
+using System.Net.Sockets;
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server;
+using Zeus.Server.Wsjtx;
+
+namespace Zeus.Server.Tests;
+
+public sealed class WsjtxUdpBroadcasterTests : IDisposable
+{
+    private readonly string _prefsDbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-wsjtxbc-{Guid.NewGuid():N}.db");
+    private readonly string _logDbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-log-wsjtxbc-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_prefsDbPath)) File.Delete(_prefsDbPath); } catch { }
+        try { if (File.Exists(_logDbPath)) File.Delete(_logDbPath); } catch { }
+    }
+
+    private async Task<(WsjtxUdpBroadcaster bc, WsjtxManagementService mgmt, LogEntry entry, LogService log)>
+        BuildAsync(WsjtxConfigStore store)
+    {
+        var mgmt = new WsjtxManagementService(NullLogger<WsjtxManagementService>.Instance, store);
+        var log = new LogService(NullLogger<LogService>.Instance, _logDbPath);
+        var entry = await log.CreateLogEntryAsync(new CreateLogEntryRequest(
+            Callsign: "K1ABC",
+            Name: null,
+            FrequencyMhz: 14.074,
+            Band: "20M",
+            Mode: "FT8",
+            RstSent: "-12",
+            RstRcvd: "-07"));
+        var bc = new WsjtxUdpBroadcaster(NullLogger<WsjtxUdpBroadcaster>.Instance, mgmt, log);
+        return (bc, mgmt, entry, log);
+    }
+
+    [Fact]
+    public async Task Disabled_Broadcast_Sends_Nothing()
+    {
+        using var listener = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        var port = ((IPEndPoint)listener.Client.LocalEndPoint!).Port;
+
+        using var store = new WsjtxConfigStore(NullLogger<WsjtxConfigStore>.Instance, _prefsDbPath);
+        var (bc, mgmt, entry, _) = await BuildAsync(store);
+        mgmt.SetConfig(new WsjtxRuntimeConfig(Enabled: false, Host: "127.0.0.1", Port: port));
+
+        await bc.BroadcastLoggedQsoAsync(entry);
+
+        // Nothing should arrive on the listener when egress is disabled.
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(300));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            async () => await listener.ReceiveAsync(cts.Token));
+    }
+
+    [Fact]
+    public async Task Enabled_Broadcast_Emits_LoggedAdif_Datagram()
+    {
+        using var listener = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        var port = ((IPEndPoint)listener.Client.LocalEndPoint!).Port;
+
+        using var store = new WsjtxConfigStore(NullLogger<WsjtxConfigStore>.Instance, _prefsDbPath);
+        var (bc, mgmt, entry, _) = await BuildAsync(store);
+        mgmt.SetConfig(new WsjtxRuntimeConfig(Enabled: true, Host: "127.0.0.1", Port: port, InstanceId: "Zeus"));
+
+        await bc.BroadcastLoggedQsoAsync(entry);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var result = await listener.ReceiveAsync(cts.Token);
+
+        // Magic header + the call we logged in the ADIF payload.
+        Assert.Equal(new byte[] { 0xAD, 0xBC, 0xCB, 0xDA }, result.Buffer[..4]);
+        Assert.Contains("K1ABC", System.Text.Encoding.UTF8.GetString(result.Buffer));
+    }
+
+    [Fact]
+    public async Task Enabled_Send_To_Dead_Endpoint_Never_Throws()
+    {
+        // Reserve a loopback port, then close it so nothing is listening. A UDP
+        // send must not surface an exception into the log POST path.
+        int deadPort;
+        using (var probe = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0)))
+            deadPort = ((IPEndPoint)probe.Client.LocalEndPoint!).Port;
+
+        using var store = new WsjtxConfigStore(NullLogger<WsjtxConfigStore>.Instance, _prefsDbPath);
+        var (bc, mgmt, entry, _) = await BuildAsync(store);
+        mgmt.SetConfig(new WsjtxRuntimeConfig(Enabled: true, Host: "127.0.0.1", Port: deadPort));
+
+        // Must complete without throwing.
+        await bc.BroadcastLoggedQsoAsync(entry);
+    }
+}

--- a/zeus-web/src/api/wsjtx.ts
+++ b/zeus-web/src/api/wsjtx.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+// REST client for the WSJT-X logged-QSO UDP broadcaster (outbound QSO push to
+// JTAlert / Log4OM / GridTracker / N1MM). Mirrors api/cat.ts but has no port
+// test (UDP has no listener) and applies live (no restart). Mirrors api/cat.ts.
+
+import { ApiError } from './client';
+
+export type WsjtxStatus = {
+  enabled: boolean;
+  host: string;
+  port: number;
+  instanceId: string;
+};
+
+export type WsjtxConfig = {
+  enabled: boolean;
+  host: string;
+  port: number;
+};
+
+const DEFAULT_PORT = 2237;
+
+function normalizeStatus(raw: unknown): WsjtxStatus {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  return {
+    enabled: Boolean(r.enabled),
+    host: typeof r.host === 'string' ? r.host : '127.0.0.1',
+    port: typeof r.port === 'number' ? r.port : DEFAULT_PORT,
+    instanceId: typeof r.instanceId === 'string' ? r.instanceId : 'WSJT-X',
+  };
+}
+
+async function jsonFetch<T>(
+  input: RequestInfo,
+  init: RequestInit | undefined,
+  parse: (raw: unknown) => T,
+): Promise<T> {
+  const res = await fetch(input, init);
+  if (!res.ok) {
+    let message = `${res.status} ${res.statusText}`;
+    try {
+      const body = (await res.json()) as unknown;
+      if (body && typeof body === 'object' && 'error' in body && typeof (body as { error: unknown }).error === 'string') {
+        message = (body as { error: string }).error;
+      }
+    } catch {
+      /* non-JSON */
+    }
+    throw new ApiError(res.status, message);
+  }
+  return parse((await res.json()) as unknown);
+}
+
+export function getWsjtxStatus(signal?: AbortSignal): Promise<WsjtxStatus> {
+  return jsonFetch('/api/wsjtx/status', { signal }, normalizeStatus);
+}
+
+export function postWsjtxConfig(cfg: WsjtxConfig, signal?: AbortSignal): Promise<WsjtxStatus> {
+  return jsonFetch(
+    '/api/wsjtx/config',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(cfg),
+      signal,
+    },
+    normalizeStatus,
+  );
+}

--- a/zeus-web/src/components/NetworkSettingsPanel.tsx
+++ b/zeus-web/src/components/NetworkSettingsPanel.tsx
@@ -10,18 +10,21 @@
 
 import { CatSettingsPanel } from './CatSettingsPanel';
 import { TciSettingsPanel } from './TciSettingsPanel';
+import { WsjtxSettingsPanel } from './WsjtxSettingsPanel';
 
 // The Network tab hosts Zeus's external network-control servers. TCI (the
-// existing ExpertSDR3 WebSocket interface) and CAT (the Kenwood TS-2000 TCP
-// interface) are independent servers configured side by side. Each child panel
-// owns its own store, polling, and persistence — this container only stacks
-// them with a separating rule.
+// ExpertSDR3 WebSocket interface) and CAT (the Kenwood TS-2000 TCP interface)
+// are inbound rig-control servers; WSJT-X is the outbound logged-QSO push to a
+// third-party logger. Each child panel owns its own store and persistence —
+// this container only stacks them with separating rules.
 export function NetworkSettingsPanel() {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
       <TciSettingsPanel />
       <div style={{ borderTop: '1px solid var(--panel-border)' }} />
       <CatSettingsPanel />
+      <div style={{ borderTop: '1px solid var(--panel-border)' }} />
+      <WsjtxSettingsPanel />
     </div>
   );
 }

--- a/zeus-web/src/components/WsjtxSettingsPanel.tsx
+++ b/zeus-web/src/components/WsjtxSettingsPanel.tsx
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+import { useEffect, useState } from 'react';
+import { useWsjtxStore } from '../state/wsjtx-store';
+
+// Outbound QSO-record push: when Zeus's native FT8/FT4 completes a QSO it can
+// emit a WSJT-X type-12 LoggedADIF datagram to a logger (JTAlert / Log4OM /
+// GridTracker / N1MM). New network egress — DISABLED by default. (Rig control —
+// reading freq/mode, keying PTT — already works today via CAT or TCI; this is
+// the missing other direction.)
+export function WsjtxSettingsPanel() {
+  const config = useWsjtxStore((s) => s.config);
+  const status = useWsjtxStore((s) => s.status);
+  const saveConfig = useWsjtxStore((s) => s.saveConfig);
+
+  const [host, setHost] = useState(config.host);
+  const [port, setPort] = useState(String(config.port));
+  const [enabled, setEnabled] = useState(config.enabled);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setHost(config.host);
+    setPort(String(config.port));
+    setEnabled(config.enabled);
+  }, [config.host, config.port, config.enabled]);
+
+  async function onSave(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      const portNum = Number(port);
+      if (!Number.isFinite(portNum) || portNum <= 0 || portNum >= 65536) return;
+      await saveConfig({ enabled, host: host.trim() || '127.0.0.1', port: portNum });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const currentlyEnabled = status?.enabled ?? false;
+
+  return (
+    <div style={{ maxWidth: 700 }}>
+      <h3
+        style={{
+          margin: '0 0 14px',
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: '0.12em',
+          textTransform: 'uppercase',
+          color: 'var(--fg-2)',
+        }}
+      >
+        WSJT-X LOGGED-QSO BROADCAST
+      </h3>
+
+      <div
+        style={{
+          padding: 12,
+          marginBottom: 16,
+          fontSize: 11,
+          lineHeight: 1.5,
+          color: 'var(--fg-2)',
+          background: 'var(--bg-0)',
+          border: '1px solid var(--panel-border)',
+          borderRadius: 'var(--r-sm)',
+        }}
+      >
+        When enabled, each QSO logged in Zeus's native FT8/FT4 (auto-logged or via
+        LOG QSO) is sent as a WSJT-X "logged ADIF" UDP datagram so{' '}
+        <strong>JTAlert, Log4OM, GridTracker, and N1MM+</strong> pick it up. Point your
+        logger's WSJT-X / UDP input at the host:port below (the WSJT-X default is{' '}
+        <span style={{ fontFamily: 'monospace' }}>127.0.0.1:2237</span>). This sends QSO
+        records OUT only — it does not control the radio. Rig control (freq/mode/PTT) is
+        already available via CAT or TCI above. ADIF file imports are never broadcast.
+      </div>
+
+      <form onSubmit={onSave} style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+        <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+            style={{ accentColor: 'var(--accent)' }}
+          />
+          <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--fg-1)' }}>Enabled</span>
+        </label>
+
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--fg-2)' }}>Target Host</span>
+          <input
+            type="text"
+            value={host}
+            onChange={(e) => setHost(e.target.value)}
+            spellCheck={false}
+            placeholder="127.0.0.1"
+            style={{
+              padding: '6px 8px',
+              fontSize: 12,
+              fontFamily: 'monospace',
+              background: 'var(--bg-0)',
+              border: '1px solid var(--panel-border)',
+              borderRadius: 'var(--r-sm)',
+              color: 'var(--fg-0)',
+            }}
+          />
+          <span style={{ fontSize: 10, color: 'var(--fg-3)' }}>
+            127.0.0.1 sends to a logger on this machine; use the logger's LAN IP otherwise.
+            Datagrams are sent unauthenticated — keep this on a trusted network.
+          </span>
+        </label>
+
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--fg-2)' }}>Target Port</span>
+          <input
+            type="number"
+            value={port}
+            onChange={(e) => setPort(e.target.value)}
+            min={1}
+            max={65535}
+            style={{
+              padding: '6px 8px',
+              fontSize: 12,
+              fontFamily: 'monospace',
+              background: 'var(--bg-0)',
+              border: '1px solid var(--panel-border)',
+              borderRadius: 'var(--r-sm)',
+              color: 'var(--fg-0)',
+            }}
+          />
+          <span style={{ fontSize: 10, color: 'var(--fg-3)' }}>
+            Default: 2237 (the WSJT-X UDP port most loggers listen on). Applies immediately —
+            no restart required.
+          </span>
+        </label>
+
+        <div
+          style={{
+            padding: 10,
+            background: 'var(--bg-0)',
+            border: '1px solid var(--panel-border)',
+            borderRadius: 'var(--r-sm)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            fontSize: 12,
+            color: 'var(--fg-2)',
+          }}
+        >
+          <span
+            style={{
+              width: 8,
+              height: 8,
+              borderRadius: '50%',
+              background: currentlyEnabled ? 'var(--accent)' : 'var(--fg-3)',
+              flexShrink: 0,
+            }}
+          />
+          {currentlyEnabled
+            ? `Broadcasting logged QSOs to ${status?.host}:${status?.port}`
+            : 'WSJT-X broadcast is currently disabled'}
+        </div>
+
+        <div style={{ display: 'flex', gap: 6 }}>
+          <span style={{ flex: 1 }} />
+          <button type="submit" disabled={saving} className="btn sm active">
+            {saving ? 'SAVING…' : 'SAVE'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/zeus-web/src/components/design/geo.ts
+++ b/zeus-web/src/components/design/geo.ts
@@ -54,6 +54,23 @@ const toRad = (deg: number) => (deg * Math.PI) / 180;
 const toDeg = (rad: number) => (rad * 180) / Math.PI;
 
 /**
+ * Maidenhead grid locator → the lat/lon of the square's CENTRE. Accepts 4- or
+ * 6-character grids (extra characters past the 4-char field are ignored — the
+ * 4-char centre is plenty for an HF distance/bearing read). Returns null for
+ * anything that isn't a valid `AA00`-form locator.
+ */
+export function gridToLatLon(grid: string): { lat: number; lon: number } | null {
+  const g = grid.trim().toUpperCase();
+  if (!/^[A-R]{2}[0-9]{2}/.test(g)) return null;
+  const A = 'A'.charCodeAt(0);
+  const Z = '0'.charCodeAt(0);
+  // Field (20° lon × 10° lat) then square (2° lon × 1° lat), shifted to centre.
+  const lon = (g.charCodeAt(0) - A) * 20 - 180 + (g.charCodeAt(2) - Z) * 2 + 1;
+  const lat = (g.charCodeAt(1) - A) * 10 - 90 + (g.charCodeAt(3) - Z) * 1 + 0.5;
+  return { lat, lon };
+}
+
+/**
  * Solar elevation angle (degrees above the horizon) at a point and instant.
  * Standard NOAA approximation — accurate to a fraction of a degree, plenty for
  * a day/night/grayline read on the QRZ card. Negative = sun below horizon.

--- a/zeus-web/src/dsp/ft8-qso-log.test.ts
+++ b/zeus-web/src/dsp/ft8-qso-log.test.ts
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+import { describe, expect, it } from 'vitest';
+import { computeFt8Stats, qsoStateToLogEntry } from './ft8-qso-log';
+import { startCq, type QsoState } from './ft8-sequencer';
+import type { LogEntry } from '../api/log';
+
+function qso(overrides: Partial<QsoState> = {}): QsoState {
+  return {
+    ...startCq({ myCall: 'KB2UKA', myGrid4: 'FN42', mode: 'FT8' }),
+    dxCall: 'K1ABC',
+    dxGrid4: 'FN31',
+    sentReportToHim: -12,
+    rcvdReportFromHim: -7,
+    progress: 'done',
+    ...overrides,
+  };
+}
+
+const CTX = { band: '20m', freqMhz: 14.074, mode: 'FT8' as const };
+
+describe('qsoStateToLogEntry', () => {
+  it('maps a completed QSO into a create request', () => {
+    const now = new Date('2026-06-26T12:00:00.000Z');
+    const req = qsoStateToLogEntry(qso(), CTX, now);
+    expect(req).toEqual({
+      callsign: 'K1ABC',
+      frequencyMhz: 14.074,
+      band: '20M', // uppercased for ADIF/QRZ
+      mode: 'FT8',
+      rstSent: '-12',
+      rstRcvd: '-07',
+      grid: 'FN31',
+      qsoDateTimeUtc: '2026-06-26T12:00:00.000Z',
+    });
+  });
+
+  it('formats positive reports with a sign and 2 digits', () => {
+    const req = qsoStateToLogEntry(qso({ sentReportToHim: 3, rcvdReportFromHim: 0 }), CTX);
+    expect(req?.rstSent).toBe('+03');
+    expect(req?.rstRcvd).toBe('+00');
+  });
+
+  it('returns null when there is no DX call to log', () => {
+    expect(qsoStateToLogEntry(qso({ dxCall: null }), CTX)).toBeNull();
+  });
+
+  it('leaves RST blank when a report was never exchanged', () => {
+    const req = qsoStateToLogEntry(qso({ sentReportToHim: null, rcvdReportFromHim: null }), CTX);
+    expect(req?.rstSent).toBe('');
+    expect(req?.rstRcvd).toBe('');
+  });
+
+  it('carries FT4 mode through', () => {
+    const req = qsoStateToLogEntry(qso(), { ...CTX, mode: 'FT4' });
+    expect(req?.mode).toBe('FT4');
+  });
+});
+
+function entry(overrides: Partial<LogEntry> = {}): LogEntry {
+  return {
+    id: Math.random().toString(36),
+    qsoDateTimeUtc: '2026-06-26T12:00:00.000Z',
+    callsign: 'K1ABC',
+    name: null,
+    frequencyMhz: 14.074,
+    band: '20M',
+    mode: 'FT8',
+    rstSent: '-12',
+    rstRcvd: '-07',
+    grid: 'FN31',
+    country: null,
+    dxcc: null,
+    cqZone: null,
+    ituZone: null,
+    state: null,
+    comment: null,
+    createdUtc: '2026-06-26T12:00:00.000Z',
+    qrzLogId: null,
+    qrzUploadedUtc: null,
+    ...overrides,
+  };
+}
+
+describe('computeFt8Stats', () => {
+  const now = new Date('2026-06-26T18:00:00.000Z');
+
+  it('counts QSOs today by UTC day', () => {
+    const stats = computeFt8Stats(
+      [
+        entry({ qsoDateTimeUtc: '2026-06-26T01:00:00.000Z' }),
+        entry({ qsoDateTimeUtc: '2026-06-25T23:00:00.000Z' }),
+      ],
+      'FN42',
+      now,
+    );
+    expect(stats.qsosToday).toBe(1);
+    expect(stats.qsosTotal).toBe(2);
+  });
+
+  it('counts confirmed (QRZ-uploaded) and distinct grids/dxcc', () => {
+    const stats = computeFt8Stats(
+      [
+        entry({ grid: 'FN31', dxcc: 291, qrzUploadedUtc: '2026-06-26T13:00:00.000Z' }),
+        entry({ grid: 'FN31ab', dxcc: 291 }), // same 4-char grid + dxcc
+        entry({ grid: 'IO91', dxcc: 223 }),
+      ],
+      'FN42',
+      now,
+    );
+    expect(stats.confirmed).toBe(1);
+    expect(stats.distinctGrids).toBe(2);
+    expect(stats.distinctDxcc).toBe(2);
+  });
+
+  it('averages received SNR and finds best DX from the operator grid', () => {
+    const stats = computeFt8Stats(
+      [
+        entry({ callsign: 'K1ABC', grid: 'FN31', rstRcvd: '-10' }),
+        entry({ callsign: 'JA1XYZ', grid: 'PM95', rstRcvd: '-20' }),
+      ],
+      'FN42',
+      now,
+    );
+    expect(stats.avgSnrRx).toBe(-15);
+    expect(stats.bestDx?.callsign).toBe('JA1XYZ'); // Japan farther than FN31
+    expect(stats.bestDx!.km).toBeGreaterThan(5000);
+  });
+
+  it('excludes phone RST (e.g. 59) from the SNR average', () => {
+    const stats = computeFt8Stats(
+      [
+        entry({ mode: 'FT8', rstRcvd: '-10' }),
+        entry({ mode: 'SSB', rstRcvd: '59' }), // RST, not a dB SNR
+      ],
+      null,
+      now,
+    );
+    expect(stats.avgSnrRx).toBe(-10);
+  });
+
+  it('returns null best DX / avg SNR when data is missing', () => {
+    const stats = computeFt8Stats([entry({ grid: null, rstRcvd: '' })], null, now);
+    expect(stats.bestDx).toBeNull();
+    expect(stats.avgSnrRx).toBeNull();
+  });
+});

--- a/zeus-web/src/dsp/ft8-qso-log.ts
+++ b/zeus-web/src/dsp/ft8-qso-log.ts
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// ft8-qso-log — PURE glue between the FT8/FT4 QSO state machine and the native
+// logbook. `qsoStateToLogEntry` maps a completed QsoState (+ the dial context)
+// into the existing CreateLogEntryRequest used by LogService; `computeFt8Stats`
+// derives the workspace STATS panel numbers from the logbook entries. No I/O, no
+// React — same inputs, same output, so both are unit-testable directly.
+//
+// Reuses the existing logbook stack (LogService / useLoggerStore / /api/log) —
+// this module never opens a new store or DB.
+
+import { fmtSnr, type QsoState, type DigitalQsoMode } from './ft8-sequencer';
+import type { CreateLogEntryRequest, LogEntry } from '../api/log';
+import { distanceKm, gridToLatLon } from '../components/design/geo';
+
+/** Dial/mode context for a logged QSO — supplied by the workspace at log time. */
+export interface QsoLogContext {
+  /** Band label, e.g. "20m". */
+  band: string;
+  /** Dial frequency in MHz (the FT8/FT4 dial; audio offset is not added). */
+  freqMhz: number;
+  /** Logged mode — FT8 or FT4. */
+  mode: DigitalQsoMode;
+}
+
+/**
+ * Map a completed (or in-progress) QSO state into a logbook create request.
+ * Returns null when there is no DX callsign to log (nothing to record yet).
+ *
+ * FT8/FT4 report the SNR in dB, so RST SENT = the report we sent him
+ * (`sentReportToHim`) and RST RCVD = the report he sent us
+ * (`rcvdReportFromHim`), both formatted as signed 2-digit dB.
+ */
+export function qsoStateToLogEntry(
+  state: QsoState,
+  ctx: QsoLogContext,
+  now: Date = new Date(),
+): CreateLogEntryRequest | null {
+  const callsign = state.dxCall?.trim().toUpperCase();
+  if (!callsign) return null;
+
+  return {
+    callsign,
+    frequencyMhz: ctx.freqMhz,
+    // ADIF/QRZ expect the band as e.g. "20M"; the workspace label is "20m".
+    band: ctx.band.toUpperCase(),
+    mode: ctx.mode,
+    rstSent: state.sentReportToHim != null ? fmtSnr(state.sentReportToHim) : '',
+    rstRcvd: state.rcvdReportFromHim != null ? fmtSnr(state.rcvdReportFromHim) : '',
+    grid: state.dxGrid4 ?? null,
+    qsoDateTimeUtc: now.toISOString(),
+  };
+}
+
+/** Aggregate numbers for the FT8 STATS panel. */
+export interface Ft8Stats {
+  /** QSOs whose UTC date is today. */
+  qsosToday: number;
+  /** Total QSOs in the (loaded) logbook. */
+  qsosTotal: number;
+  /** QSOs marked confirmed (proxy: uploaded to QRZ). */
+  confirmed: number;
+  /** Distinct 4-char grids worked. */
+  distinctGrids: number;
+  /**
+   * Distinct DXCC entities. NOTE: only QSOs whose Country/Dxcc came from an
+   * ADIF import carry this — native FT8 QSOs have no country resolver yet
+   * (no cty.dat in-tree). Treat as a floor, not a true DXCC total.
+   */
+  distinctDxcc: number;
+  /** Average received SNR (dB) across digital QSOs, or null when none parse. */
+  avgSnrRx: number | null;
+  /** Farthest QSO from the operator grid, if both grids are known. */
+  bestDx: { callsign: string; grid: string; km: number } | null;
+}
+
+const isSameUtcDay = (a: Date, b: Date): boolean =>
+  a.getUTCFullYear() === b.getUTCFullYear() &&
+  a.getUTCMonth() === b.getUTCMonth() &&
+  a.getUTCDate() === b.getUTCDate();
+
+/** Parse a signed dB report ("-12", "+03", "R-09") to a number, or null. */
+function parseDbReport(rst: string | null | undefined): number | null {
+  if (!rst) return null;
+  const m = rst.trim().match(/^R?([+-]?\d{1,2})$/i);
+  if (!m) return null;
+  const n = Number(m[1]);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Derive the STATS-panel aggregates from the logbook entries. Pure over the
+ * entries + the operator grid (used only for the best-DX great-circle range).
+ */
+export function computeFt8Stats(
+  entries: readonly LogEntry[],
+  operatorGrid?: string | null,
+  now: Date = new Date(),
+): Ft8Stats {
+  const grids = new Set<string>();
+  const dxcc = new Set<number>();
+  const snrs: number[] = [];
+  let qsosToday = 0;
+  let confirmed = 0;
+
+  const opLatLon = operatorGrid ? gridToLatLon(operatorGrid) : null;
+  let bestDx: Ft8Stats['bestDx'] = null;
+
+  for (const e of entries) {
+    if (e.grid) grids.add(e.grid.slice(0, 4).toUpperCase());
+    if (e.dxcc != null) dxcc.add(e.dxcc);
+    if (e.qrzUploadedUtc) confirmed += 1;
+
+    const when = new Date(e.qsoDateTimeUtc);
+    if (!Number.isNaN(when.getTime()) && isSameUtcDay(when, now)) qsosToday += 1;
+
+    // Only FT8/FT4 reports are dB SNRs; a phone "59" is an RST, not an SNR, so
+    // restrict the average to the digital modes this workspace logs.
+    if (/^FT/i.test(e.mode)) {
+      const rx = parseDbReport(e.rstRcvd);
+      if (rx != null) snrs.push(rx);
+    }
+
+    if (opLatLon && e.grid) {
+      const there = gridToLatLon(e.grid);
+      if (there) {
+        const km = distanceKm(opLatLon.lat, opLatLon.lon, there.lat, there.lon);
+        if (!bestDx || km > bestDx.km) {
+          bestDx = { callsign: e.callsign, grid: e.grid.slice(0, 4).toUpperCase(), km };
+        }
+      }
+    }
+  }
+
+  return {
+    qsosToday,
+    qsosTotal: entries.length,
+    confirmed,
+    distinctGrids: grids.size,
+    distinctDxcc: dxcc.size,
+    avgSnrRx: snrs.length > 0 ? snrs.reduce((a, b) => a + b, 0) / snrs.length : null,
+    bestDx,
+  };
+}

--- a/zeus-web/src/dsp/ft8-tx-controller.test.ts
+++ b/zeus-web/src/dsp/ft8-tx-controller.test.ts
@@ -114,6 +114,32 @@ describe('Ft8TxController', () => {
     expect(ctrl.getState().dxCall).toBeNull();
   });
 
+  it('markLogged() latches so a manual log blocks the sequencer auto-log (exactly once)', () => {
+    const { fn } = makeFetch();
+    const logged: string[] = [];
+    const ctrl = new Ft8TxController({
+      myCall: 'KB2UKA',
+      myGrid4: 'FN12',
+      fetchFn: fn,
+      onLogQso: (s) => logged.push(s.dxCall ?? ''),
+    });
+
+    // CQ caller picks up an answerer, advances to the report stage.
+    ctrl.enableTx();
+    ctrl.onWindow(['KB2UKA K1ABC FN31']);
+    expect(ctrl.getState().dxCall).toBe('K1ABC');
+
+    // Operator hits LOG QSO mid-QSO — latch it as logged.
+    ctrl.markLogged();
+    expect(ctrl.getState().logged).toBe(true);
+
+    // The QSO then completes on the wire (R-report → 73). The auto-log guard is
+    // `!state.logged`, so onLogQso must NOT fire a second time.
+    ctrl.onWindow(['KB2UKA K1ABC R-12']);
+    ctrl.onWindow(['KB2UKA K1ABC 73']);
+    expect(logged).toEqual([]); // manual log already recorded it; no duplicate
+  });
+
   it('posts /halt on operator Halt', () => {
     const { fn, calls } = makeFetch();
     const ctrl = new Ft8TxController({ myCall: 'KB2UKA', fetchFn: fn });

--- a/zeus-web/src/dsp/ft8-tx-controller.ts
+++ b/zeus-web/src/dsp/ft8-tx-controller.ts
@@ -150,6 +150,13 @@ export class Ft8TxController {
     this.callFirst = on;
   }
 
+  /** Latch the live QSO as logged (the manual LOG QSO path). Once set, the
+   *  sequencer's auto-log guard (`!state.logged`) can never fire onLogQso for the
+   *  same QSO, so a manual log followed by sequence completion logs exactly once. */
+  markLogged(): void {
+    if (!this.state.logged) this.state = { ...this.state, logged: true };
+  }
+
   /** Operator disable (disable-after-73 also routes here). */
   disableTx(): void {
     this.state = { ...this.state, enableTx: false };

--- a/zeus-web/src/dsp/ft8-tx-runner.test.ts
+++ b/zeus-web/src/dsp/ft8-tx-runner.test.ts
@@ -3,22 +3,24 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   beaconDisarm,
   decodesForSlot,
+  measuredDxSnr,
+  rowsForSlot,
   slotIndexOf,
   slotMsFor,
   slotParity,
   startFt8SlotDriver,
 } from './ft8-tx-runner';
 import { Ft8TxController } from './ft8-tx-controller';
-import type { Slot } from './ft8-sequencer';
+import { startCq, type Slot } from './ft8-sequencer';
 import type { Ft8Row } from '../state/ft8-store';
 
-function row(slotStartUnixMs: number, text: string, i = 0): Ft8Row {
+function row(slotStartUnixMs: number, text: string, i = 0, snrDb = -10): Ft8Row {
   return {
     id: `0:${slotStartUnixMs}:${i}`,
     receiver: 0,
     protocol: 'FT8',
     slotStartUnixMs,
-    snrDb: -10,
+    snrDb,
     dtSec: 0.1,
     freqHz: 1000,
     score: 20,
@@ -56,6 +58,41 @@ describe('ft8-tx-runner slot helpers', () => {
     expect(decodesForSlot(rows, 1, slotMs)).toEqual(['CQ N0OLD AA00']);
     expect(decodesForSlot(rows, 0, slotMs)).toEqual([]);
   });
+
+  it('rowsForSlot returns the full rows (text + snr) for a slot', () => {
+    const slotMs = 15_000;
+    const rows = [
+      row(30_000, 'CQ K1ABC FN42', 0, -7),
+      row(15_000, 'CQ N0OLD AA00', 0, -3),
+    ];
+    const slot2 = rowsForSlot(rows, 2, slotMs);
+    expect(slot2).toHaveLength(1);
+    expect(slot2[0]?.snrDb).toBe(-7);
+  });
+});
+
+describe('measuredDxSnr', () => {
+  const base = startCq({ myCall: 'KB2UKA', myGrid4: 'FN12', mode: 'FT8' });
+
+  it('uses the SNR of the station calling us while still calling CQ', () => {
+    const rows = [
+      row(0, 'CQ DL9XX JO31', 0, -1), // not addressed to us
+      row(0, 'KB2UKA K1ABC FN31', 1, -7), // the answerer
+    ];
+    expect(measuredDxSnr(rows, { ...base, dxCall: null })).toBe(-7);
+  });
+
+  it('matches the latched DX station once a QSO is in progress', () => {
+    const rows = [
+      row(0, 'KB2UKA W9ZZZ -05', 0, -3), // someone else calling us
+      row(0, 'KB2UKA K1ABC R-12', 1, -9), // our DX
+    ];
+    expect(measuredDxSnr(rows, { ...base, dxCall: 'K1ABC' })).toBe(-9);
+  });
+
+  it('returns undefined when no matching row exists (sequencer keeps its fallback)', () => {
+    expect(measuredDxSnr([row(0, 'CQ DL9XX JO31')], { ...base, dxCall: 'K1ABC' })).toBeUndefined();
+  });
 });
 
 describe('startFt8SlotDriver (boundary → settle → decodes pipeline)', () => {
@@ -75,7 +112,7 @@ describe('startFt8SlotDriver (boundary → settle → decodes pipeline)', () => 
       slotMs,
       settleMs,
       getRows: () => rows,
-      onWindow: (texts, senderSlot) => windows.push({ texts, senderSlot }),
+      onWindow: (r, senderSlot) => windows.push({ texts: r.map((x) => x.text), senderSlot }),
     });
 
     // Cross into slot 1 (odd): a boundary tick fires and schedules the settle.
@@ -117,7 +154,7 @@ describe('startFt8SlotDriver (boundary → settle → decodes pipeline)', () => 
       slotMs,
       settleMs,
       getRows: () => rows,
-      onWindow: (texts, senderSlot) => ctrl.onWindow(texts, undefined, senderSlot),
+      onWindow: (r, senderSlot) => ctrl.onWindow(r.map((x) => x.text), undefined, senderSlot),
     });
 
     vi.advanceTimersByTime(slotMs + settleMs);
@@ -126,6 +163,35 @@ describe('startFt8SlotDriver (boundary → settle → decodes pipeline)', () => 
     expect(stage).toBeDefined();
     expect(stage?.body.slot).toBe('odd'); // reply goes in the slot opposite the CQ
     expect(String(stage?.body.message)).toContain('K1ABC');
+
+    stop();
+  });
+
+  it('threads the decoded DX SNR into the logged report (not a constant)', () => {
+    // A station answers our CQ with a grid (no report in the message) measured at
+    // -7 dB. The runner must report/log -7, not the sequencer's -10 fallback.
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const slotMs = 15_000;
+    const settleMs = 2_000;
+    const rows = [row(0, 'KB2UKA K1ABC FN31', 0, -7)];
+
+    const fetchFn = vi.fn(async () => ({}) as Response) as unknown as typeof fetch;
+    const ctrl = new Ft8TxController({ myCall: 'KB2UKA', myGrid4: 'FN12', fetchFn });
+    ctrl.enableTx(); // CQ caller, armed
+
+    const stop = startFt8SlotDriver({
+      slotMs,
+      settleMs,
+      getRows: () => rows,
+      onWindow: (r, senderSlot) =>
+        ctrl.onWindow(r.map((x) => x.text), measuredDxSnr(r, ctrl.getState()), senderSlot),
+    });
+
+    vi.advanceTimersByTime(slotMs + settleMs);
+
+    expect(ctrl.getState().dxCall).toBe('K1ABC');
+    expect(ctrl.getState().sentReportToHim).toBe(-7);
 
     stop();
   });

--- a/zeus-web/src/dsp/ft8-tx-runner.ts
+++ b/zeus-web/src/dsp/ft8-tx-runner.ts
@@ -23,6 +23,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useFt8Store, type Ft8Row } from '../state/ft8-store';
 import { Ft8TxController } from './ft8-tx-controller';
+import { parseFt8Message } from './ft8-message';
 import type { DigitalQsoMode, QsoState, Slot } from './ft8-sequencer';
 
 /** Slot length (ms) for a digital mode. FT8 = 15 s, FT4 = 7.5 s. */
@@ -59,7 +60,38 @@ export function slotParity(slotIndex: number): Slot {
  * membership is `floor(slotStartUnixMs / slotMs) === slotIndex`.
  */
 export function decodesForSlot(rows: readonly Ft8Row[], slotIndex: number, slotMs: number): string[] {
-  return rows.filter((r) => slotIndexOf(r.slotStartUnixMs, slotMs) === slotIndex).map((r) => r.text);
+  return rowsForSlot(rows, slotIndex, slotMs).map((r) => r.text);
+}
+
+/**
+ * The decode ROWS (text + snrDb + offset) that belong to a given UTC slot index.
+ * Sibling of {@link decodesForSlot}; the runner needs the full rows (not just the
+ * text) so it can read the measured SNR of the DX station for the outgoing
+ * report. Pure.
+ */
+export function rowsForSlot(rows: readonly Ft8Row[], slotIndex: number, slotMs: number): Ft8Row[] {
+  return rows.filter((r) => slotIndexOf(r.slotStartUnixMs, slotMs) === slotIndex);
+}
+
+/**
+ * The SNR (dB) we measured of the DX station in this window's decodes — the value
+ * to report to him (Tx2 / Tx3). When a QSO is already latched we match the
+ * station we're working (`state.dxCall`); while still calling CQ we use the SNR
+ * of the first station calling us (the prospective answerer the sequencer will
+ * pick). Returns undefined when no matching row exists, so the sequencer keeps
+ * its own fallback rather than logging a constant.
+ */
+export function measuredDxSnr(rows: readonly Ft8Row[], state: QsoState): number | undefined {
+  const dx = state.dxCall;
+  for (const r of rows) {
+    const m = parseFt8Message(r.text, state.myCall);
+    if (dx) {
+      if (m.deCall === dx) return r.snrDb;
+    } else if (m.isCallingMe && m.deCall) {
+      return r.snrDb;
+    }
+  }
+  return undefined;
 }
 
 export interface Ft8TxRunnerView {
@@ -84,6 +116,8 @@ export interface Ft8TxRunnerView {
   answerCq: (decodeText: string, senderSlot: Slot) => boolean;
   callStation: (decodeText: string, senderSlot: Slot) => boolean;
   stageMacro: (message: string) => void;
+  /** Latch the live QSO as logged (manual LOG QSO) so the auto-log can't double-fire. */
+  markLogged: () => void;
 }
 
 export interface UseFt8TxRunnerOpts {
@@ -109,7 +143,7 @@ export function startFt8SlotDriver(opts: {
   slotMs: number;
   settleMs: number;
   getRows: () => readonly Ft8Row[];
-  onWindow: (texts: string[], senderSlot: Slot) => void;
+  onWindow: (rows: Ft8Row[], senderSlot: Slot) => void;
 }): () => void {
   const { slotMs, settleMs, getRows, onWindow } = opts;
   let lastSlot = slotIndexOf(Date.now(), slotMs);
@@ -121,7 +155,7 @@ export function startFt8SlotDriver(opts: {
     const endedSlot = lastSlot; // the slot that just closed
     lastSlot = cur;
     const id = setTimeout(() => {
-      onWindow(decodesForSlot(getRows(), endedSlot, slotMs), slotParity(endedSlot));
+      onWindow(rowsForSlot(getRows(), endedSlot, slotMs), slotParity(endedSlot));
     }, settleMs);
     pending.push(id);
   };
@@ -178,8 +212,11 @@ export function useFt8TxRunner(opts: UseFt8TxRunnerOpts): Ft8TxRunnerView {
       slotMs: slotMsFor(mode),
       settleMs: settleMsFor(mode),
       getRows: () => useFt8Store.getState().rows,
-      onWindow: (texts, senderSlot) => {
-        ctrl.onWindow(texts, undefined, senderSlot);
+      onWindow: (rows, senderSlot) => {
+        // Thread the measured SNR of the DX station so the report we send (and
+        // log) is the real exchange, not a constant fallback.
+        const measured = measuredDxSnr(rows, ctrl.getState());
+        ctrl.onWindow(rows.map((r) => r.text), measured, senderSlot);
         sync();
       },
     });
@@ -258,6 +295,10 @@ export function useFt8TxRunner(opts: UseFt8TxRunnerOpts): Ft8TxRunnerView {
     },
     stageMacro: (message) => {
       ctrl.stageMacro(message);
+      sync();
+    },
+    markLogged: () => {
+      ctrl.markLogged();
       sync();
     },
   };

--- a/zeus-web/src/layout/ft8/Ft8ActivityLog.tsx
+++ b/zeus-web/src/layout/ft8/Ft8ActivityLog.tsx
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Ft8ActivityLog — the FT8/FT4 workspace ACTIVITY LOG (center column, fixed
+// slot, no close button). Pure presentation over the EXISTING logbook store
+// (useLoggerStore / /api/log / LogService) — it adds no store, API, or DB. QSOs
+// land here automatically when the sequencer completes one (auto-log) or when
+// the operator hits LOG QSO; EXPORT ADIF and VIEW LOG reuse the same backend.
+//
+// Columns follow docs/designs/ft8-ui.md: DATE/UTC/CALLSIGN/BAND/MODE/RST TX/RST
+// RX/COUNTRY/GRID/QSL. HUD tokens only (ft8-theme.css) — no raw hex.
+
+import { useLoggerStore } from '../../state/logger-store';
+import type { LogEntry } from '../../api/log';
+
+function fmtDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '—';
+  const p = (n: number) => n.toString().padStart(2, '0');
+  return `${d.getUTCFullYear()}-${p(d.getUTCMonth() + 1)}-${p(d.getUTCDate())}`;
+}
+
+function fmtTime(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '—';
+  const p = (n: number) => n.toString().padStart(2, '0');
+  return `${p(d.getUTCHours())}:${p(d.getUTCMinutes())}`;
+}
+
+export interface Ft8ActivityLogProps {
+  /** Manual LOG QSO — logs the in-progress QSO. Disabled when `canLog` is false. */
+  onLogQso?: () => void;
+  /** Whether there is a DX call staged to log right now. */
+  canLog?: boolean;
+}
+
+export function Ft8ActivityLog({ onLogQso, canLog = false }: Ft8ActivityLogProps) {
+  const entries = useLoggerStore((s) => s.entries);
+  const totalCount = useLoggerStore((s) => s.totalCount);
+  const exportAdif = useLoggerStore((s) => s.exportAdif);
+  const loadEntries = useLoggerStore((s) => s.loadEntries);
+
+  return (
+    <div className="ft8-log">
+      <div className="ft8-log__bar">
+        <span className="ft8-log__count">
+          {entries.length}
+          {totalCount > entries.length ? ` of ${totalCount}` : ''} QSOs
+        </span>
+        <span style={{ flex: 1 }} />
+        {onLogQso && (
+          <button
+            type="button"
+            className="ft8-log__btn"
+            onClick={onLogQso}
+            disabled={!canLog}
+            title="Log the in-progress QSO"
+          >
+            LOG QSO
+          </button>
+        )}
+        <button
+          type="button"
+          className="ft8-log__btn"
+          onClick={() => void loadEntries()}
+          title="Refresh the log from the server"
+        >
+          VIEW LOG
+        </button>
+        <button
+          type="button"
+          className="ft8-log__btn"
+          onClick={() => void exportAdif()}
+          disabled={entries.length === 0}
+          title="Download the logbook as an ADIF file"
+        >
+          EXPORT ADIF
+        </button>
+      </div>
+
+      {entries.length === 0 ? (
+        <div className="ft8-log__empty">No QSOs logged yet.</div>
+      ) : (
+        <div className="ft8-log__scroll">
+          <table className="ft8-log-table">
+            <thead>
+              <tr>
+                <th>Date</th>
+                <th>UTC</th>
+                <th>Callsign</th>
+                <th>Band</th>
+                <th>Mode</th>
+                <th>RST TX</th>
+                <th>RST RX</th>
+                <th>Country</th>
+                <th>Grid</th>
+                <th>QSL</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map((e: LogEntry) => (
+                <tr key={e.id}>
+                  <td>{fmtDate(e.qsoDateTimeUtc)}</td>
+                  <td className="num">{fmtTime(e.qsoDateTimeUtc)}</td>
+                  <td className="call">{e.callsign}</td>
+                  <td>{e.band}</td>
+                  <td>{e.mode}</td>
+                  <td className="num">{e.rstSent || '—'}</td>
+                  <td className="num">{e.rstRcvd || '—'}</td>
+                  <td>{e.country ?? '—'}</td>
+                  <td>{e.grid ?? '—'}</td>
+                  <td className="qsl">{e.qrzUploadedUtc ? '✓' : ''}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/zeus-web/src/layout/ft8/Ft8DecodeTable.test.ts
+++ b/zeus-web/src/layout/ft8/Ft8DecodeTable.test.ts
@@ -42,4 +42,27 @@ describe('classifyDecode', () => {
   it('defaults to normal', () => {
     expect(classifyDecode(row('GJ0KYZ RK9AX MO05'))).toBe('normal');
   });
+
+  it('lights a new (unworked) grid on a directed decode', () => {
+    const grids = new Set(['FN42']);
+    // MO05 not yet worked → new; FN42 already worked → normal.
+    expect(classifyDecode(row('GJ0KYZ RK9AX MO05'), undefined, undefined, grids)).toBe('new');
+    expect(classifyDecode(row('GJ0KYZ RK9AX FN42'), undefined, undefined, grids)).toBe('normal');
+  });
+
+  it('keeps CQ green even when its grid is new', () => {
+    const grids = new Set<string>();
+    expect(classifyDecode(row('CQ RK9AX MO05'), undefined, undefined, grids)).toBe('cq');
+  });
+
+  it('prefers worked-before over new-grid', () => {
+    const worked = new Set(['RK9AX']);
+    const grids = new Set<string>();
+    expect(classifyDecode(row('GJ0KYZ RK9AX MO05'), undefined, worked, grids)).toBe('worked');
+  });
+
+  it('returns normal for a directed decode with no grid', () => {
+    const grids = new Set<string>();
+    expect(classifyDecode(row('GJ0KYZ RK9AX -12'), undefined, undefined, grids)).toBe('normal');
+  });
 });

--- a/zeus-web/src/layout/ft8/Ft8DecodeTable.tsx
+++ b/zeus-web/src/layout/ft8/Ft8DecodeTable.tsx
@@ -6,17 +6,23 @@
 // move the audio cursor.
 
 import { useFt8Store, type Ft8Row } from '../../state/ft8-store';
+import { parseFt8Message } from '../../dsp/ft8-message';
 
 export type Ft8RowClass = 'cq' | 'me' | 'worked' | 'new' | 'normal';
 
 /**
  * Classify a decode for color-coding. `myCall` enables the directed-at-me
- * highlight; `workedCalls` (optional) dims stations already worked.
+ * highlight; `workedCalls` (optional) dims stations already worked; `workedGrids`
+ * (optional, 4-char upper-case) lights an otherwise-plain decode whose grid we
+ * have NOT worked yet ('new'). CQ keeps its own green class even when its grid is
+ * new — CQ is the louder signal in the table and the existing precedence is
+ * relied on elsewhere.
  */
 export function classifyDecode(
   row: Ft8Row,
   myCall?: string,
   workedCalls?: ReadonlySet<string>,
+  workedGrids?: ReadonlySet<string>,
 ): Ft8RowClass {
   const tokens = row.text.trim().split(/\s+/);
   const first = tokens[0]?.toUpperCase() ?? '';
@@ -27,6 +33,10 @@ export function classifyDecode(
   if (first === 'CQ') return 'cq';                  // a CQ row (even my own)
   if (me && first === me) return 'me';              // someone is calling ME
   if (workedCalls && second && workedCalls.has(second)) return 'worked';
+  if (workedGrids) {
+    const grid = parseFt8Message(row.text).grid;
+    if (grid && !workedGrids.has(grid.toUpperCase())) return 'new';
+  }
   return 'normal';
 }
 
@@ -47,10 +57,11 @@ const CLASS_CSS: Record<Ft8RowClass, string> = {
 export interface Ft8DecodeTableProps {
   myCall?: string;
   workedCalls?: ReadonlySet<string>;
+  workedGrids?: ReadonlySet<string>;
   onRowClick?: (row: Ft8Row) => void;
 }
 
-export function Ft8DecodeTable({ myCall, workedCalls, onRowClick }: Ft8DecodeTableProps) {
+export function Ft8DecodeTable({ myCall, workedCalls, workedGrids, onRowClick }: Ft8DecodeTableProps) {
   const rows = useFt8Store((s) => s.rows);
 
   if (rows.length === 0) {
@@ -70,7 +81,7 @@ export function Ft8DecodeTable({ myCall, workedCalls, onRowClick }: Ft8DecodeTab
       </thead>
       <tbody>
         {rows.map((r) => {
-          const cls = classifyDecode(r, myCall, workedCalls);
+          const cls = classifyDecode(r, myCall, workedCalls, workedGrids);
           return (
             <tr
               key={r.id}

--- a/zeus-web/src/layout/ft8/Ft8Stats.tsx
+++ b/zeus-web/src/layout/ft8/Ft8Stats.tsx
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Ft8Stats — the FT8/FT4 workspace STATS panel (right column, fixed slot). Pure
+// presentation over the EXISTING logbook store (useLoggerStore) via the pure
+// `computeFt8Stats` aggregator. HUD tokens only.
+//
+// DXCC caveat: there is no country/DXCC resolver in-tree (no cty.dat), so a
+// native FT8 QSO carries no DXCC entity. The DXCC tile therefore counts only
+// QSOs whose entity came from an ADIF import — it is a floor, not a true total,
+// and is labelled as such. Distinct GRIDS is the honest native worked-coverage
+// proxy. (#1015 follow-up: add a prefix→DXCC resolver.)
+
+import { useMemo } from 'react';
+import { useLoggerStore } from '../../state/logger-store';
+import { useOperatorStore } from '../../state/operator-store';
+import { computeFt8Stats } from '../../dsp/ft8-qso-log';
+
+function Stat({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div className="ft8-stat" title={hint}>
+      <div className="ft8-stat__value">{value}</div>
+      <div className="ft8-stat__label">{label}</div>
+    </div>
+  );
+}
+
+export function Ft8Stats() {
+  const entries = useLoggerStore((s) => s.entries);
+  const totalCount = useLoggerStore((s) => s.totalCount);
+  const myGrid = useOperatorStore((s) => s.grid);
+
+  const stats = useMemo(() => computeFt8Stats(entries, myGrid || null), [entries, myGrid]);
+
+  // The store only loads the most-recent 100 QSOs, so computeFt8Stats's window
+  // length undercounts the true total — use the server's totalCount for the
+  // headline tile so it matches the activity-log bar beside it. (Today/Grids/
+  // DXCC/Avg/BestDX still reflect the loaded window — see the note below.)
+  const total = Math.max(totalCount, stats.qsosTotal);
+
+  const avgSnr = (() => {
+    if (stats.avgSnrRx == null) return '—';
+    // Round first so e.g. -0.4 renders "0", never "-0".
+    const v = Math.round(stats.avgSnrRx);
+    return `${v > 0 ? '+' : ''}${v}`;
+  })();
+
+  const bestDx = stats.bestDx
+    ? `${Math.round(stats.bestDx.km).toLocaleString()} km`
+    : '—';
+
+  return (
+    <div className="ft8-stats">
+      <div className="ft8-stats__grid">
+        <Stat label="QSOs Today" value={String(stats.qsosToday)} />
+        <Stat label="Total QSOs" value={String(total)} />
+        <Stat
+          label="Confirmed"
+          value={String(stats.confirmed)}
+          hint="QSOs uploaded to QRZ"
+        />
+        <Stat label="Grids" value={String(stats.distinctGrids)} />
+        <Stat
+          label="DXCC*"
+          value={String(stats.distinctDxcc)}
+          hint="DXCC entities — ADIF-import QSOs only (no native resolver yet)"
+        />
+        <Stat label="Avg SNR RX" value={avgSnr} hint="Average received signal report (dB)" />
+      </div>
+      <div className="ft8-stats__bestdx">
+        <span className="ft8-stats__bestdx-label">Best DX</span>
+        <span className="ft8-stats__bestdx-value">
+          {stats.bestDx ? `${stats.bestDx.callsign} · ${bestDx}` : bestDx}
+        </span>
+      </div>
+      <div className="ft8-stats__note">
+        * DXCC counts ADIF-imported QSOs only — native FT8 QSOs have no country
+        resolver yet. Grids is the native coverage measure. Today / Grids / DXCC /
+        Avg SNR / Best DX reflect the most-recent 100 QSOs; Total QSOs is the full
+        logbook count.
+      </div>
+    </div>
+  );
+}

--- a/zeus-web/src/layout/ft8/Ft8Workspace.tsx
+++ b/zeus-web/src/layout/ft8/Ft8Workspace.tsx
@@ -17,9 +17,13 @@ import { useOperatorStore } from '../../state/operator-store';
 import { DIGITAL_BANDS } from '../../dsp/digital-segments';
 import { slotOf } from '../../dsp/ft8-sequencer';
 import { useFt8TxRunner } from '../../dsp/ft8-tx-runner';
+import { qsoStateToLogEntry } from '../../dsp/ft8-qso-log';
+import { useLoggerStore } from '../../state/logger-store';
 import { Ft8DecodeTable } from './Ft8DecodeTable';
 import { Ft8TxControl } from './Ft8TxControl';
 import { Ft8ReceivePanel } from './Ft8ReceivePanel';
+import { Ft8ActivityLog } from './Ft8ActivityLog';
+import { Ft8Stats } from './Ft8Stats';
 import '../../styles/ft8-theme.css';
 
 export interface Ft8WorkspaceProps {
@@ -61,14 +65,64 @@ export function Ft8Workspace({ onClose }: Ft8WorkspaceProps) {
   const setCall = useOperatorStore((s) => s.setCall);
   const setGrid = useOperatorStore((s) => s.setGrid);
 
+  const addLogEntry = useLoggerStore((s) => s.addLogEntry);
+  const entries = useLoggerStore((s) => s.entries);
+
+  // Worked-before / new-grid sets for decode-table highlighting, memoized from
+  // the logbook. NOTE: useLoggerStore.loadEntries caps at 100 entries, so these
+  // miss older QSOs — a bulk "worked callsigns/grids" endpoint (or a larger take
+  // for the workspace) is a follow-up (#1015).
+  const workedCalls = useMemo(
+    () => new Set(entries.map((e) => e.callsign.toUpperCase())),
+    [entries],
+  );
+  const workedGrids = useMemo(
+    () =>
+      new Set(
+        entries
+          .filter((e) => e.grid)
+          .map((e) => e.grid!.slice(0, 4).toUpperCase()),
+      ),
+    [entries],
+  );
+
   // Live TX runner: owns the QSO sequencer + backend keyer, driven once per slot.
+  // onLogQso fires exactly once per completed QSO (the sequencer's `logged`
+  // latch). It reads band/dial live from the stores so the captured closure can
+  // never log a stale band/frequency.
   const tx = useFt8TxRunner({
     myCall,
     myGrid: myGrid || null,
     mode: protocol,
     active: true,
     band,
+    onLogQso: (state) => {
+      const dialHz = useConnectionStore.getState().vfoHz ?? 0;
+      const req = qsoStateToLogEntry(state, {
+        band: useFt8Store.getState().band,
+        freqMhz: dialHz / 1e6,
+        mode: state.mode,
+      });
+      if (req) void useLoggerStore.getState().addLogEntry(req);
+    },
   });
+
+  // Manual LOG QSO — record the in-progress QSO on demand (same pure mapper).
+  // Latches the controller's `logged` flag so the auto-log path can't write a
+  // second identical row when the sequencer later completes the QSO. Bails if the
+  // QSO has already been logged (manual or auto).
+  const logCurrentQso = () => {
+    if (tx.qso.logged) return;
+    const req = qsoStateToLogEntry(tx.qso, {
+      band,
+      freqMhz: (vfoHz ?? 0) / 1e6,
+      mode: protocol,
+    });
+    if (req) {
+      void addLogEntry(req);
+      tx.markLogged();
+    }
+  };
 
   // Esc closes the workspace.
   useEffect(() => {
@@ -184,12 +238,22 @@ export function Ft8Workspace({ onClose }: Ft8WorkspaceProps) {
               )}
             </div>
             <div className="ft8-region__body">
-              <Ft8DecodeTable myCall={myCall || undefined} onRowClick={onRowClick} />
+              <Ft8DecodeTable
+                myCall={myCall || undefined}
+                workedCalls={workedCalls}
+                workedGrids={workedGrids}
+                onRowClick={onRowClick}
+              />
             </div>
           </section>
-          <section className="ft8-region">
+          <section className="ft8-region ft8-region--log">
             <div className="ft8-region__head">Activity log</div>
-            <div className="ft8-placeholder">QSO log — feeds existing LogService (ADIF, follow-up)</div>
+            <div className="ft8-region__body">
+              <Ft8ActivityLog
+                onLogQso={logCurrentQso}
+                canLog={!!tx.qso.dxCall && !tx.qso.logged}
+              />
+            </div>
           </section>
         </div>
 
@@ -202,8 +266,10 @@ export function Ft8Workspace({ onClose }: Ft8WorkspaceProps) {
             </div>
           </section>
           <section className="ft8-region">
-            <div className="ft8-region__head">Band map</div>
-            <div className="ft8-placeholder">great-circle map from decoded grids (follow-up)</div>
+            <div className="ft8-region__head">Stats</div>
+            <div className="ft8-region__body">
+              <Ft8Stats />
+            </div>
           </section>
         </div>
       </div>

--- a/zeus-web/src/state/wsjtx-store.test.ts
+++ b/zeus-web/src/state/wsjtx-store.test.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock the REST layer BEFORE the store imports it — the store fires a one-shot
+// status probe on module load.
+vi.mock('../api/wsjtx', () => ({
+  getWsjtxStatus: vi.fn(async () => ({
+    enabled: false,
+    host: '127.0.0.1',
+    port: 2237,
+    instanceId: 'WSJT-X',
+  })),
+  postWsjtxConfig: vi.fn(async (cfg: { enabled: boolean; host: string; port: number }) => ({
+    ...cfg,
+    instanceId: 'WSJT-X',
+  })),
+}));
+
+import { useWsjtxStore } from './wsjtx-store';
+import * as api from '../api/wsjtx';
+
+describe('wsjtx-store', () => {
+  it('defaults to disabled egress (opt-in)', () => {
+    expect(useWsjtxStore.getState().config.enabled).toBe(false);
+  });
+
+  it('never auto-POSTs config on load (no silent enable)', () => {
+    expect(api.postWsjtxConfig).not.toHaveBeenCalled();
+  });
+
+  it('saveConfig pushes the operator choice to the backend', async () => {
+    const cfg = { enabled: true, host: '127.0.0.1', port: 2237 };
+    const status = await useWsjtxStore.getState().saveConfig(cfg);
+    expect(api.postWsjtxConfig).toHaveBeenCalledWith(cfg);
+    expect(status.enabled).toBe(true);
+    expect(useWsjtxStore.getState().config.enabled).toBe(true);
+  });
+});

--- a/zeus-web/src/state/wsjtx-store.ts
+++ b/zeus-web/src/state/wsjtx-store.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+import { create } from 'zustand';
+import {
+  getWsjtxStatus,
+  postWsjtxConfig,
+  type WsjtxConfig,
+  type WsjtxStatus,
+} from '../api/wsjtx';
+
+// The backend (WsjtxConfigStore on disk) is the source of truth. The form
+// initialises from /api/wsjtx/status once it arrives. Do NOT seed from
+// localStorage and do NOT auto-POST on load (same lesson as TCI/CAT).
+const DEFAULT_CONFIG: WsjtxConfig = {
+  enabled: false,
+  host: '127.0.0.1',
+  port: 2237,
+};
+
+export type WsjtxStoreState = {
+  config: WsjtxConfig;
+  status: WsjtxStatus | null;
+
+  refreshStatus: () => Promise<void>;
+  saveConfig: (cfg: WsjtxConfig) => Promise<WsjtxStatus>;
+};
+
+export const useWsjtxStore = create<WsjtxStoreState>((set, get) => ({
+  config: DEFAULT_CONFIG,
+  status: null,
+
+  refreshStatus: async () => {
+    try {
+      const status = await getWsjtxStatus();
+      const current = get().config;
+      const synced =
+        current.enabled === status.enabled &&
+        current.host === status.host &&
+        current.port === status.port;
+      set({
+        status,
+        config: synced
+          ? current
+          : { enabled: status.enabled, host: status.host, port: status.port },
+      });
+    } catch {
+      /* transient — next refresh recovers */
+    }
+  },
+
+  saveConfig: async (cfg) => {
+    const status = await postWsjtxConfig(cfg);
+    set({ config: cfg, status });
+    return status;
+  },
+}));
+
+// Initial status probe (one-shot — config applies live so no polling needed).
+if (typeof window !== 'undefined') {
+  void useWsjtxStore.getState().refreshStatus();
+}

--- a/zeus-web/src/styles/ft8-theme.css
+++ b/zeus-web/src/styles/ft8-theme.css
@@ -423,3 +423,90 @@
    is the cluster's own .ft8-tx__tune button, so there is no .ft8-power__tune. */
 .ft8-power__row .knob-group { flex: 1; min-width: 0; }
 .ft8-tx__halt:hover { background: var(--tx); color: #1a0604; }
+
+/* ---- Activity log (center column) ---- */
+.ft8-region--log { flex: 0 0 auto; max-height: 42%; }
+.ft8-region--log .ft8-region__body { padding: 0; display: flex; flex-direction: column; min-height: 0; }
+.ft8-log { display: flex; flex-direction: column; min-height: 0; flex: 1; }
+.ft8-log__bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 8px;
+  border-bottom: 1px solid var(--hud-line);
+  background: var(--hud-panel-2);
+}
+.ft8-log__count { font-size: 10px; color: var(--hud-text-dim); font-variant-numeric: tabular-nums; }
+.ft8-log__btn {
+  background: var(--hud-panel);
+  border: 1px solid var(--hud-line);
+  color: var(--hud-text);
+  border-radius: 3px;
+  padding: 3px 9px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+}
+.ft8-log__btn:not(:disabled):hover { border-color: var(--hud-cyan-line); }
+.ft8-log__btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.ft8-log__empty { padding: 14px; text-align: center; color: var(--hud-text-dim); font-size: 11px; font-style: italic; }
+.ft8-log__scroll { overflow: auto; min-height: 0; flex: 1; }
+
+.ft8-log-table {
+  font-family: var(--font-mono, 'Archivo Narrow', monospace);
+  font-size: 11px;
+  width: 100%;
+  border-collapse: collapse;
+}
+.ft8-log-table th {
+  position: sticky;
+  top: 0;
+  text-align: left;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--hud-text-dim);
+  background: var(--hud-panel-2);
+  padding: 3px 8px;
+  border-bottom: 1px solid var(--hud-cyan-line);
+}
+.ft8-log-table td {
+  padding: 2px 8px;
+  border-bottom: 1px solid var(--hud-line);
+  white-space: nowrap;
+}
+.ft8-log-table td.num { text-align: right; font-variant-numeric: tabular-nums; }
+.ft8-log-table td.call { color: var(--hud-cyan); font-weight: 600; }
+.ft8-log-table td.qsl { color: var(--hud-cq); text-align: center; }
+
+/* ---- Stats (right column) ---- */
+.ft8-stats { display: flex; flex-direction: column; gap: 8px; }
+.ft8-stats__grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 6px; }
+.ft8-stat {
+  background: var(--hud-panel-2);
+  border: 1px solid var(--hud-line);
+  border-radius: 4px;
+  padding: 6px 8px;
+}
+.ft8-stat__value { font-size: 20px; font-variant-numeric: tabular-nums; color: var(--hud-cyan); line-height: 1.1; }
+.ft8-stat__label {
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--hud-text-dim);
+  margin-top: 2px;
+}
+.ft8-stats__bestdx {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 8px;
+  background: var(--hud-panel-2);
+  border: 1px solid var(--hud-line);
+  border-radius: 4px;
+}
+.ft8-stats__bestdx-label { font-size: 9px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--hud-text-dim); }
+.ft8-stats__bestdx-value { font-size: 13px; color: var(--hud-cyan); font-variant-numeric: tabular-nums; }
+.ft8-stats__note { font-size: 9px; line-height: 1.4; color: var(--hud-text-dim); font-style: italic; }


### PR DESCRIPTION
## ⛔ DO NOT MERGE — bench sign-off required

**Stack 3 of 4.** Base: `ft8/waterfall-power` (PR for #1016). Review the lower PRs first.

Adds the **native logbook** (primary/default) and an **opt-in third-party push**.

### What's in it
- Auto-log on QSO-complete (once-only latch; manual LOG QSO deduped against it). Real measured DX SNR logged as RST sent.
- Activity Log + Stats panels replace the placeholders (fixed slot). worked-B4 (callsign) + new-grid highlighting. ADIF export reused; FT4 → `MODE=MFSK`+`SUBMODE=FT4`. (DXCC-by-prefix deferred — needs cty.dat.)
- **Third-party investigation result:** CAT (TS-2000, PR #973) and TCI already give external loggers full rig control (freq/mode + PTT). The genuine gap was pushing the *completed* QSO outward, so this adds a minimal **opt-in WSJT-X UDP "logged ADIF" (type 12)** broadcast (default OFF, `127.0.0.1:2237`) — the format JTAlert/Log4OM/GridTracker/N1MM already ingest. Native log stays the default.

### Refs
#1015 (ADIF logging + highlighting).

### Safety / bench
- PureSignal untouched; no default changes; UDP push defaults OFF.
- **Bench:** confirm a third-party logger ingests the type-12 datagram live.
