### PR TITLE
DO NOT MERGE: FT8/WSPR spotting — PSK Reporter + WSPRnet + integration fixes (#1014)

### DIFF
--- a/Zeus.Contracts/SpottingDtos.cs
+++ b/Zeus.Contracts/SpottingDtos.cs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+namespace Zeus.Contracts;
+
+/// <summary>
+/// Persisted config for the digital-mode spotting uploaders. When enabled, FT8/
+/// FT4 decodes are uploaded to PSK Reporter (report.pskreporter.info) and/or WSPR
+/// spots to WSPRnet (wsprnet.org). Both are NEW network egress and DISABLED by
+/// default — they only run when the operator explicitly opts in AND a callsign +
+/// Maidenhead grid are available (from this override, or the QRZ home station).
+/// This is RX-spot push only; it never controls the radio or transmits.
+/// </summary>
+public sealed record SpottingRuntimeConfig(
+    bool PskReporterEnabled = false,
+    bool WsprnetEnabled = false,
+    string Callsign = "",
+    string Grid = "");
+
+/// <summary>
+/// Status/config view for the spotting uploaders. UDP/HTTP egress has no
+/// listener, so config applies live — there is no RequiresRestart.
+/// <paramref name="IdentityResolved"/> is true when a callsign + grid are
+/// available (override or QRZ home), so the panel can warn when they are missing.
+/// </summary>
+public sealed record SpottingStatus(
+    bool PskReporterEnabled,
+    bool WsprnetEnabled,
+    string Callsign,
+    string Grid,
+    bool IdentityResolved);

--- a/Zeus.Dsp.Ft8/Ft8MessageParse.cs
+++ b/Zeus.Dsp.Ft8/Ft8MessageParse.cs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using System.Text.RegularExpressions;
+
+namespace Zeus.Dsp.Ft8;
+
+/// <summary>
+/// Minimal backend port of the SENDER-extraction half of the frontend
+/// <c>ft8-message.ts</c> parser. Spotting (PSK Reporter) only needs to know
+/// "who transmitted this decode and, if present, their grid" — it does NOT need
+/// the full classification (report/RR73/73/calling-me) the UI uses. Kept here in
+/// <c>Zeus.Dsp.Ft8</c> (alongside the decoder) so it has no Server/web
+/// dependency; the frontend parser stays the source of truth for the UI.
+///
+/// Standard FT8/FT4 message grammar (all uppercase, space-separated):
+///   CQ [DIRECTIVE] CALL [GRID4]   — sender = CALL, grid if a 4-char Maidenhead
+///   TARGET DE PAYLOAD             — sender = DE (token 1); grid only when
+///                                   PAYLOAD is a plain 4-char locator
+/// Anything else (free text, no plausible callsign) yields false.
+/// </summary>
+public static class Ft8MessageParse
+{
+    // A 4-character Maidenhead locator: two A–R letters then two digits.
+    private static readonly Regex GridRe = new("^[A-R]{2}[0-9]{2}$", RegexOptions.Compiled);
+
+    // The "core" of a plausible amateur callsign: at least one letter AND one
+    // digit, composed only of letters/digits/slash (covers /P, /MM, prefixes).
+    private static readonly Regex CallCoreRe = new("^[A-Z0-9/]+$", RegexOptions.Compiled);
+
+    private static readonly char[] Whitespace = { ' ', '\t', '\r', '\n' };
+
+    /// <summary>
+    /// Extracts the sender (transmitting) callsign and, when present, the grid
+    /// from a decoded FT8/FT4 message line. Never throws. Returns false when no
+    /// plausible, reportable callsign can be identified (free text, or a
+    /// hashed/unresolvable <c>&lt;...&gt;</c> call we cannot report).
+    /// </summary>
+    public static bool TryParseSender(string? text, out string call, out string? grid)
+    {
+        call = "";
+        grid = null;
+        if (string.IsNullOrWhiteSpace(text)) return false;
+
+        var tokens = text.Trim().ToUpperInvariant().Split(Whitespace, StringSplitOptions.RemoveEmptyEntries);
+        if (tokens.Length == 0) return false;
+
+        // CQ family: "CQ [DIRECTIVE] CALL [GRID]".
+        if (tokens[0] == "CQ")
+        {
+            // A directive (DX / POTA / TEST / a zone number, etc.) sits between
+            // CQ and the callsign and is not itself a call.
+            int i = 1;
+            if (tokens.Length >= 3 && !LooksLikeCall(tokens[1]) && LooksLikeCall(tokens[2]))
+                i = 2;
+
+            if (i >= tokens.Length) return false;
+            if (!TryRealCall(tokens[i], out call)) return false;
+
+            if (i + 1 < tokens.Length && IsGrid(tokens[i + 1]))
+                grid = tokens[i + 1];
+            return true;
+        }
+
+        // Directed: "TARGET DE PAYLOAD" — sender is the DE call (token 1).
+        if (tokens.Length >= 2 && (LooksLikeCall(tokens[0]) || tokens[0].StartsWith('<')))
+        {
+            if (!TryRealCall(tokens[1], out call)) return false;
+
+            // The grid only appears as a plain Tx1 locator. RR73 also matches the
+            // grid regex (R,R,7,3) so it must be excluded explicitly; reports
+            // (+05 / R-12) and RRR/73 never match GridRe.
+            if (tokens.Length >= 3)
+            {
+                var payload = tokens[2];
+                if (payload != "RR73" && IsGrid(payload))
+                    grid = payload;
+            }
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsGrid(string token) => GridRe.IsMatch(token);
+
+    // Frontend parity: a hashed <...> token "looks like" a call for grammar
+    // disambiguation, as does any token with a letter+digit core.
+    private static bool LooksLikeCall(string token)
+    {
+        if (token.Length >= 2 && token[0] == '<' && token[^1] == '>') return true;
+        var core = StripHash(token);
+        return HasLetter(core) && HasDigit(core) && CallCoreRe.IsMatch(core);
+    }
+
+    // A reportable callsign: the hash markers are stripped and the remainder must
+    // be a real call (letter+digit, valid charset). A purely-hashed unknown call
+    // (e.g. "<...>") strips to junk and is rejected — we can't report it. A bare
+    // 4-char Maidenhead locator (e.g. "FN42") also satisfies the letter+digit core
+    // check but is NEVER a reportable callsign; rejecting it here stops free-text
+    // decodes such as "K1ABC FN42" or "G0XYZ FN42 73" from uploading a spot for a
+    // nonexistent station to a public network.
+    private static bool TryRealCall(string token, out string call)
+    {
+        var core = StripHash(token);
+        if (GridRe.IsMatch(core))
+        {
+            call = "";
+            return false;
+        }
+        if (HasLetter(core) && HasDigit(core) && CallCoreRe.IsMatch(core))
+        {
+            call = core;
+            return true;
+        }
+        call = "";
+        return false;
+    }
+
+    private static string StripHash(string token)
+    {
+        int start = 0, end = token.Length;
+        if (end > 0 && token[0] == '<') start = 1;
+        if (end > start && token[end - 1] == '>') end--;
+        return token.Substring(start, end - start);
+    }
+
+    private static bool HasLetter(string s)
+    {
+        foreach (var c in s) if (c is >= 'A' and <= 'Z') return true;
+        return false;
+    }
+
+    private static bool HasDigit(string s)
+    {
+        foreach (var c in s) if (c is >= '0' and <= '9') return true;
+        return false;
+    }
+}

--- a/Zeus.Server.Hosting/Spotting/PskReporterEncoder.cs
+++ b/Zeus.Server.Hosting/Spotting/PskReporterEncoder.cs
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using System.Text;
+
+namespace Zeus.Server.Spotting;
+
+/// <summary>
+/// Pure, allocation-bounded encoder for the PSK Reporter IPFIX (NetFlow v10)
+/// datagram. No I/O — it turns a receiver record + N sender records into the byte
+/// buffer that <see cref="PskReporterReporter"/> sends to
+/// report.pskreporter.info:4739. Kept separate and unit-tested because the
+/// byte layout is the load-bearing, error-prone part.
+///
+/// Wire format (big-endian throughout):
+///   16-byte message header
+///   rxInfo options-template descriptor (WSJT-X-compatible rxInfo block)
+///   txInfo template descriptor          (Zeus's own WSJT-X-compatible template)
+///   rxInfo data set   (one receiver record)
+///   txInfo data set   (N sender records packed back-to-back)
+///
+/// These are Zeus's own templates built from the enterprise-30351 element
+/// registry, not byte-for-byte copies of a WSJT-X capture: the rxInfo template is
+/// a 3-field subset (no antennaInformation 0x8009) and the txInfo template is a
+/// 6-field variant. IPFIX is template-driven, so any self-consistent template
+/// whose data records follow the declared field order is wire-valid; the exact
+/// element IDs are listed per field below so a reader can verify them against the
+/// registry without trusting this prose. Live PSK Reporter acceptance is a
+/// separate bench-validation step.
+///
+/// Including both descriptors in every datagram (rather than tracking template
+/// TTL) is simpler and immune to PSK Reporter's template-cache expiry; the cost
+/// is ~90 fixed bytes per datagram. Field IDs use enterprise number 30351
+/// (0x0000768F); the enterprise bit (0x8000) is set on those element IDs.
+/// flowStartSeconds is the IANA standard element 150 (0x0096), no enterprise.
+/// </summary>
+public static class PskReporterEncoder
+{
+    /// <summary>IPFIX version (NetFlow v10).</summary>
+    public const ushort Version = 0x000A;
+
+    /// <summary>PSK Reporter ingest host.</summary>
+    public const string Host = "report.pskreporter.info";
+
+    /// <summary>PSK Reporter ingest UDP port.</summary>
+    public const int Port = 4739;
+
+    // rxInfo options-template descriptor. Set ID 3, template ID 0x9992, three
+    // varlen fields: receiverCallsign (0x8002), receiverLocator (0x8004),
+    // decodingSoftware (0x8008), all enterprise 30351. Trailing 0x0000 pads the
+    // set to a 4-byte boundary. This is the WSJT-X-compatible rxInfo block (a
+    // 3-field subset — WSJT-X also carries antennaInformation 0x8009, which PSK
+    // Reporter treats as optional).
+    public static readonly byte[] RxDescriptor =
+    {
+        0x00, 0x03, 0x00, 0x24, 0x99, 0x92, 0x00, 0x03, 0x00, 0x00,
+        0x80, 0x02, 0xFF, 0xFF, 0x00, 0x00, 0x76, 0x8F,
+        0x80, 0x04, 0xFF, 0xFF, 0x00, 0x00, 0x76, 0x8F,
+        0x80, 0x08, 0xFF, 0xFF, 0x00, 0x00, 0x76, 0x8F,
+        0x00, 0x00,
+    };
+
+    // txInfo template descriptor. Set ID 2, template ID 0x9993, six fields in
+    // this exact order: senderCallsign (0x8001, varlen), senderLocator (0x8003,
+    // varlen), frequency (0x8005, 4 B), sNR (0x8006, 1 B), mode (0x800A, varlen)
+    // — all enterprise 30351 — then flowStartSeconds (0x0096, 4 B, IANA element
+    // 150, no enterprise number). The data records below MUST follow this order.
+    // Element IDs are the enterprise-30351 registry pairing where callsign IDs are
+    // sender/receiver (0x8001/0x8002) and locator IDs are sender/receiver
+    // (0x8003/0x8004) — so senderLocator is 0x8003 and frequency is 0x8005, the
+    // same layout WSJT-X uses.
+    public static readonly byte[] TxDescriptor =
+    {
+        0x00, 0x02, 0x00, 0x34, 0x99, 0x93, 0x00, 0x06,
+        0x80, 0x01, 0xFF, 0xFF, 0x00, 0x00, 0x76, 0x8F,
+        0x80, 0x03, 0xFF, 0xFF, 0x00, 0x00, 0x76, 0x8F,
+        0x80, 0x05, 0x00, 0x04, 0x00, 0x00, 0x76, 0x8F,
+        0x80, 0x06, 0x00, 0x01, 0x00, 0x00, 0x76, 0x8F,
+        0x80, 0x0A, 0xFF, 0xFF, 0x00, 0x00, 0x76, 0x8F,
+        0x00, 0x96, 0x00, 0x04,
+    };
+
+    private const ushort RxSetId = 0x9992;
+    private const ushort TxSetId = 0x9993;
+
+    /// <summary>One heard station to report.</summary>
+    public readonly record struct SenderRecord(
+        string Callsign,
+        string? Grid,
+        uint FrequencyHz,
+        sbyte SnrDb,
+        string Mode,
+        uint FlowStartSeconds);
+
+    /// <summary>Receiving station identity for the rxInfo record.</summary>
+    public readonly record struct ReceiverInfo(
+        string Callsign,
+        string Locator,
+        string DecodingSoftware);
+
+    /// <summary>
+    /// Encodes one IPFIX datagram. <paramref name="senders"/> must be non-empty.
+    /// </summary>
+    public static byte[] Encode(
+        ReceiverInfo rx,
+        IReadOnlyList<SenderRecord> senders,
+        uint exportTimeSeconds,
+        uint sequenceNumber,
+        uint observationDomainId)
+    {
+        var buf = new List<byte>(256);
+
+        // ---- 16-byte message header (length backpatched at the end) ----
+        WriteU16(buf, Version);
+        int lengthAt = buf.Count;
+        WriteU16(buf, 0); // total length placeholder
+        WriteU32(buf, exportTimeSeconds);
+        WriteU32(buf, sequenceNumber);
+        WriteU32(buf, observationDomainId);
+
+        // ---- template descriptors (both included in every datagram) ----
+        buf.AddRange(RxDescriptor);
+        buf.AddRange(TxDescriptor);
+
+        // ---- rxInfo data set ----
+        WriteSet(buf, RxSetId, body =>
+        {
+            WriteVarString(body, rx.Callsign);
+            WriteVarString(body, rx.Locator);
+            WriteVarString(body, rx.DecodingSoftware);
+        });
+
+        // ---- txInfo data set (all sender records, field order = template) ----
+        WriteSet(buf, TxSetId, body =>
+        {
+            foreach (var s in senders)
+            {
+                WriteVarString(body, s.Callsign);
+                WriteVarString(body, s.Grid ?? "");
+                WriteU32(body, s.FrequencyHz);
+                body.Add(unchecked((byte)s.SnrDb));
+                WriteVarString(body, s.Mode);
+                WriteU32(body, s.FlowStartSeconds);
+            }
+        });
+
+        // Backpatch total length.
+        Patch16(buf, lengthAt, (ushort)buf.Count);
+        return buf.ToArray();
+    }
+
+    // Writes a data set: set ID, length (backpatched), the body via <paramref
+    // name="writeBody"/>, then zero-padding to a 4-byte boundary (IPFIX requires
+    // every set length to be a multiple of 4). The pad is included in the length.
+    private static void WriteSet(List<byte> buf, ushort setId, Action<List<byte>> writeBody)
+    {
+        int setStart = buf.Count;
+        WriteU16(buf, setId);
+        int lenAt = buf.Count;
+        WriteU16(buf, 0); // set length placeholder
+        writeBody(buf);
+
+        int setLen = buf.Count - setStart;
+        int pad = (4 - (setLen % 4)) % 4;
+        for (int i = 0; i < pad; i++) buf.Add(0);
+
+        Patch16(buf, lenAt, (ushort)(buf.Count - setStart));
+    }
+
+    // IPFIX variable-length string: 1 length byte + UTF-8 bytes (the short form,
+    // valid for < 255 bytes — callsigns/grids/mode are always far shorter). An
+    // empty/absent value encodes as a single 0x00 length byte (e.g. no grid).
+    private static void WriteVarString(List<byte> buf, string value)
+    {
+        var bytes = string.IsNullOrEmpty(value) ? Array.Empty<byte>() : Encoding.UTF8.GetBytes(value);
+        if (bytes.Length > 254)
+            bytes = bytes[..254]; // defensive — never reached for legit fields
+        buf.Add((byte)bytes.Length);
+        buf.AddRange(bytes);
+    }
+
+    private static void WriteU16(List<byte> buf, ushort v)
+    {
+        buf.Add((byte)(v >> 8));
+        buf.Add((byte)(v & 0xFF));
+    }
+
+    private static void WriteU32(List<byte> buf, uint v)
+    {
+        buf.Add((byte)(v >> 24));
+        buf.Add((byte)(v >> 16));
+        buf.Add((byte)(v >> 8));
+        buf.Add((byte)(v & 0xFF));
+    }
+
+    private static void Patch16(List<byte> buf, int at, ushort v)
+    {
+        buf[at] = (byte)(v >> 8);
+        buf[at + 1] = (byte)(v & 0xFF);
+    }
+}

--- a/Zeus.Server.Hosting/Spotting/PskReporterReporter.cs
+++ b/Zeus.Server.Hosting/Spotting/PskReporterReporter.cs
@@ -127,6 +127,10 @@ public sealed class PskReporterReporter : BackgroundService
     {
         try
         {
+            // Gate on the enable flag BEFORE touching the radio so the
+            // disabled-default path never pays for a Snapshot() (StateDto alloc +
+            // _sync lock) on the decode thread. HandleDecodes re-checks the flag.
+            if (!_spotting.GetConfig().PskReporterEnabled) return;
             HandleDecodes(batch, _radio?.Snapshot().VfoHz ?? 0);
         }
         catch (Exception ex)

--- a/Zeus.Server.Hosting/Spotting/PskReporterReporter.cs
+++ b/Zeus.Server.Hosting/Spotting/PskReporterReporter.cs
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using System.Net.Sockets;
+using System.Reflection;
+using Microsoft.Extensions.Hosting;
+using Zeus.Dsp.Ft8;
+
+namespace Zeus.Server.Spotting;
+
+/// <summary>
+/// Subscribes to <see cref="Ft8Service.DecodesReady"/>, buffers reportable
+/// decodes, and periodically uploads them to PSK Reporter as one (or more) IPFIX
+/// datagrams. Same leaf-subscriber seam as Ft8BroadcastService / FreeDvReporter:
+/// the decode handler only ENQUEUES (never calls back into the radio/DSP/TX) and
+/// swallows its own errors, so a reporter fault can never disturb decode or TX.
+/// Flushing happens off the decode thread on a 5-minute timer (or sooner if the
+/// buffer fills). DISABLED by default and additionally no-ops when operator
+/// identity (callsign + grid) is unresolved.
+/// </summary>
+public sealed class PskReporterReporter : BackgroundService
+{
+    private static readonly TimeSpan FlushInterval = TimeSpan.FromMinutes(5);
+
+    // Bound memory: at most this many distinct callsigns buffered between flushes.
+    private const int MaxBufferedCalls = 512;
+
+    // Keep each datagram comfortably under a typical UDP MTU (~1500 B). Each
+    // sender record is ~30 B; 40 records + headers/descriptors stays < ~1.3 KB.
+    private const int MaxRecordsPerDatagram = 40;
+
+    private static readonly string DecodingSoftware = BuildSoftwareString();
+
+    private readonly ILogger<PskReporterReporter> _log;
+    private readonly Ft8Service? _ft8;
+    private readonly RadioService? _radio;
+    private readonly SpottingManagementService _spotting;
+
+    // Dedup buffer keyed by callsign — keeps the best-SNR sighting in the window
+    // (PSK Reporter only wants "heard X"). Guarded by _sync.
+    private readonly Dictionary<string, PskReporterEncoder.SenderRecord> _pending = new();
+    private readonly object _sync = new();
+
+    private readonly SemaphoreSlim _flushNow = new(0, 1);
+    private readonly uint _observationDomainId =
+        (uint)Random.Shared.Next(1, int.MaxValue);
+    private uint _sequenceNumber;
+
+    public PskReporterReporter(
+        ILogger<PskReporterReporter> log,
+        Ft8Service ft8,
+        RadioService radio,
+        SpottingManagementService spotting)
+    {
+        _log = log;
+        _ft8 = ft8;
+        _radio = radio;
+        _spotting = spotting;
+        _ft8.DecodesReady += OnDecodes;
+    }
+
+    // Test seam: no Ft8Service/RadioService wiring (so no DSP/radio graph needed).
+    // Exercise the gate via OnDecodes, the dedup/cap via EnqueueDecodes, and the
+    // flush gate via FlushAsync directly.
+    internal PskReporterReporter(
+        ILogger<PskReporterReporter> log,
+        SpottingManagementService spotting)
+    {
+        _log = log;
+        _ft8 = null;
+        _radio = null;
+        _spotting = spotting;
+    }
+
+    public override void Dispose()
+    {
+        if (_ft8 is not null) _ft8.DecodesReady -= OnDecodes;
+        _flushNow.Dispose();
+        base.Dispose();
+    }
+
+    // Test-only observability of the dedup buffer.
+    internal int PendingCount { get { lock (_sync) return _pending.Count; } }
+
+    internal bool TryGetPending(string call, out PskReporterEncoder.SenderRecord rec)
+    {
+        lock (_sync) return _pending.TryGetValue(call, out rec);
+    }
+
+    // Drive the flush gate directly (no timer) for tests.
+    internal Task FlushAsyncForTests() => FlushAsync(CancellationToken.None);
+
+    protected override async Task ExecuteAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                // Wake on the timer OR a fill-triggered signal, whichever first.
+                await _flushNow.WaitAsync(FlushInterval, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+
+            try
+            {
+                await FlushAsync(ct).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _log.LogDebug(ex, "psk-reporter flush failed");
+            }
+        }
+    }
+
+    // Decode-thread handler — gate then enqueue only, never throws.
+    private void OnDecodes(Ft8DecodeBatch batch)
+    {
+        try
+        {
+            HandleDecodes(batch, _radio?.Snapshot().VfoHz ?? 0);
+        }
+        catch (Exception ex)
+        {
+            _log.LogDebug(ex, "psk-reporter enqueue failed");
+        }
+    }
+
+    // Full decode-handler gate (enable + identity + RX0 + valid dial) then enqueue.
+    // Internal + dial-injected so the whole gate is unit-testable without a live
+    // radio: disabled => nothing buffered, no-identity => nothing buffered,
+    // non-RX0 => nothing buffered, enabled+identity => buffered.
+    internal void HandleDecodes(Ft8DecodeBatch batch, long dialHz)
+    {
+        if (!_spotting.GetConfig().PskReporterEnabled) return;
+
+        var (call, grid) = _spotting.ResolveOperator();
+        if (string.IsNullOrWhiteSpace(call) || string.IsNullOrWhiteSpace(grid))
+            return; // identity not set — nothing to report from
+
+        // FT8 native decodes on RX0 only today; the absolute RF frequency is
+        // RX0 dial + audio offset, so a batch from any other receiver would be
+        // reported on the wrong dial. Guard explicitly until multi-RX FT8 lands
+        // (then resolve the dial from batch.Receiver instead of the RX0 dial).
+        if (batch.Receiver != 0) return;
+
+        if (dialHz <= 0) return;
+
+        EnqueueDecodes(batch, dialHz);
+    }
+
+    // Dedup/cap a decoded batch into the pending buffer. Reached only after the
+    // gate in HandleDecodes. The dedup ("keep the strongest sighting") and the
+    // MaxBufferedCalls cap are exercised here. Signals an early flush on overflow.
+    private void EnqueueDecodes(Ft8DecodeBatch batch, long dialHz)
+    {
+        string mode = batch.Protocol == Ft8Protocol.Ft4 ? "FT4" : "FT8";
+        uint flowStart = ToFlowStartSeconds(batch.SlotStartUtc);
+
+        bool overflowed = false;
+        lock (_sync)
+        {
+            foreach (var d in batch.Decodes)
+            {
+                if (!Ft8MessageParse.TryParseSender(d.Text, out var senderCall, out var senderGrid))
+                    continue;
+
+                long absHz = dialHz + (long)Math.Round(d.FreqHz);
+                if (absHz <= 0 || absHz > uint.MaxValue) continue;
+
+                sbyte snr = (sbyte)Math.Clamp((int)Math.Round(d.SnrDb), -128, 127);
+
+                var rec = new PskReporterEncoder.SenderRecord(
+                    Callsign: senderCall,
+                    Grid: senderGrid,
+                    FrequencyHz: (uint)absHz,
+                    SnrDb: snr,
+                    Mode: mode,
+                    FlowStartSeconds: flowStart);
+
+                if (_pending.TryGetValue(senderCall, out var existing))
+                {
+                    // Keep the strongest sighting in the window.
+                    if (rec.SnrDb > existing.SnrDb)
+                        _pending[senderCall] = rec;
+                }
+                else
+                {
+                    if (_pending.Count >= MaxBufferedCalls)
+                    {
+                        overflowed = true;
+                        continue;
+                    }
+                    _pending[senderCall] = rec;
+                }
+            }
+
+            if (_pending.Count >= MaxBufferedCalls) overflowed = true;
+        }
+
+        if (overflowed && _flushNow.CurrentCount == 0)
+        {
+            try { _flushNow.Release(); } catch (SemaphoreFullException) { /* already signalled */ }
+        }
+    }
+
+    // PSK Reporter flowStartSeconds is a UNIX timestamp. SlotStartUtc is built in
+    // UTC today, but new DateTimeOffset(dt, TimeSpan.Zero) THROWS if Kind==Local,
+    // and that throw would be swallowed by OnDecodes' catch and silently kill ALL
+    // reporting. Normalize to UTC first so a future slot-time refactor can't.
+    private static uint ToFlowStartSeconds(DateTime slotStart)
+    {
+        var utc = slotStart.Kind switch
+        {
+            DateTimeKind.Utc => slotStart,
+            DateTimeKind.Local => slotStart.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(slotStart, DateTimeKind.Utc),
+        };
+        return (uint)new DateTimeOffset(utc, TimeSpan.Zero).ToUnixTimeSeconds();
+    }
+
+    // Split deduped records into datagram-sized chunks. Pure + internal so the
+    // off-by-one chunking can be unit-tested without sending UDP.
+    internal static List<List<PskReporterEncoder.SenderRecord>> Chunk(
+        IReadOnlyList<PskReporterEncoder.SenderRecord> records, int maxPerChunk)
+    {
+        var chunks = new List<List<PskReporterEncoder.SenderRecord>>();
+        for (int i = 0; i < records.Count; i += maxPerChunk)
+        {
+            int n = Math.Min(maxPerChunk, records.Count - i);
+            var chunk = new List<PskReporterEncoder.SenderRecord>(n);
+            for (int j = 0; j < n; j++) chunk.Add(records[i + j]);
+            chunks.Add(chunk);
+        }
+        return chunks;
+    }
+
+    private async Task FlushAsync(CancellationToken ct)
+    {
+        // Re-check the enable flag at flush time — the operator may have disabled
+        // it since the records were buffered.
+        if (!_spotting.GetConfig().PskReporterEnabled)
+        {
+            lock (_sync) _pending.Clear();
+            return;
+        }
+
+        var (call, grid) = _spotting.ResolveOperator();
+        if (string.IsNullOrWhiteSpace(call) || string.IsNullOrWhiteSpace(grid))
+        {
+            lock (_sync) _pending.Clear();
+            return;
+        }
+
+        List<PskReporterEncoder.SenderRecord> snapshot;
+        lock (_sync)
+        {
+            if (_pending.Count == 0) return;
+            snapshot = new List<PskReporterEncoder.SenderRecord>(_pending.Values);
+            _pending.Clear();
+        }
+
+        var rx = new PskReporterEncoder.ReceiverInfo(call, grid, DecodingSoftware);
+        uint exportTime = (uint)DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+        try
+        {
+            using var udp = new UdpClient();
+            foreach (var chunk in Chunk(snapshot, MaxRecordsPerDatagram))
+            {
+                var datagram = PskReporterEncoder.Encode(
+                    rx, chunk, exportTime, unchecked(_sequenceNumber++), _observationDomainId);
+                await udp.SendAsync(datagram, datagram.Length, PskReporterEncoder.Host, PskReporterEncoder.Port)
+                    .WaitAsync(TimeSpan.FromSeconds(10), ct).ConfigureAwait(false);
+            }
+            _log.LogInformation("psk-reporter uploaded {Count} spot(s)", snapshot.Count);
+        }
+        catch (Exception ex)
+        {
+            // Tolerate all network failure — never crash the decode path. The
+            // dropped batch is acceptable; the next window re-reports live stations.
+            _log.LogWarning(ex, "psk-reporter upload failed ({Count} spot(s) dropped)", snapshot.Count);
+        }
+    }
+
+    private static string BuildSoftwareString()
+    {
+        var v = Assembly.GetExecutingAssembly().GetName().Version;
+        var ver = v is null ? "" : $" {v.Major}.{v.Minor}.{v.Build}";
+        return $"Zeus{ver}";
+    }
+}

--- a/Zeus.Server.Hosting/Spotting/WsprnetReporter.cs
+++ b/Zeus.Server.Hosting/Spotting/WsprnetReporter.cs
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using System.Globalization;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Hosting;
+using Zeus.Dsp.Ft8;
+
+namespace Zeus.Server.Spotting;
+
+/// <summary>
+/// Subscribes to <see cref="WsprService.SpotsReady"/> and uploads each spot to
+/// WSPRnet (the wsprd-compatible <c>http://wsprnet.org/post</c> endpoint) as a
+/// fire-and-forget form POST. Same leaf-subscriber seam as the FT8 broadcasters:
+/// the handler never calls back into the radio/DSP/TX and swallows all errors, so
+/// a reporter or network fault can never disturb decode or TX. DISABLED by
+/// default and additionally no-ops when operator identity (callsign + grid) is
+/// unresolved.
+///
+/// WSPR decodes carry the heard station's call/grid/power inside the message
+/// text ("CALL GRID PWR"), not as separate fields, so <see cref="WsprnetMessage"/>
+/// splits it first. The receiver dial (rqrg) comes from the batch; the spot's
+/// absolute tx frequency (tqrg) from the spot.
+/// </summary>
+public sealed class WsprnetReporter : BackgroundService
+{
+    /// <summary>WSPRnet wsprd-compatible upload endpoint.</summary>
+    public const string PostUrl = "http://wsprnet.org/post";
+
+    private static readonly string Version = BuildSoftwareString();
+    private static readonly HttpClient SharedHttp = new() { Timeout = TimeSpan.FromSeconds(10) };
+
+    private readonly ILogger<WsprnetReporter> _log;
+    private readonly WsprService? _wspr;
+    private readonly SpottingManagementService _spotting;
+    private readonly HttpClient _http;
+
+    public WsprnetReporter(
+        ILogger<WsprnetReporter> log,
+        WsprService? wspr,
+        SpottingManagementService spotting,
+        HttpMessageHandler? handlerForTests = null)
+    {
+        _log = log;
+        _wspr = wspr;
+        _spotting = spotting;
+        _http = handlerForTests is null
+            ? SharedHttp
+            : new HttpClient(handlerForTests) { Timeout = TimeSpan.FromSeconds(10) };
+        if (_wspr is not null) _wspr.SpotsReady += OnSpots;
+    }
+
+    // Test seam: no WsprService subscription. Feed batches via HandleSpotsAsync and
+    // observe the supplied recording handler.
+    internal WsprnetReporter(
+        ILogger<WsprnetReporter> log,
+        SpottingManagementService spotting,
+        HttpMessageHandler handler)
+        : this(log, wspr: null, spotting, handler) { }
+
+    protected override Task ExecuteAsync(CancellationToken stoppingToken) => Task.CompletedTask;
+
+    public override void Dispose()
+    {
+        if (_wspr is not null) _wspr.SpotsReady -= OnSpots;
+        // Dispose only a per-instance (test) client; never the shared singleton.
+        if (!ReferenceEquals(_http, SharedHttp)) _http.Dispose();
+        base.Dispose();
+    }
+
+    // Worker-thread handler — fires the gated POSTs without blocking the decode
+    // path (fire-and-forget). Never throws into the decode path.
+    private void OnSpots(WsprSpotBatch batch)
+    {
+        try { _ = HandleSpotsAsync(batch); }
+        catch (Exception ex) { _log.LogDebug(ex, "wsprnet enqueue failed"); }
+    }
+
+    // Applies the enable + identity gate, splits/filters each spot, and POSTs the
+    // survivors. Returns the number of spots POSTed. Internal + awaitable so the
+    // gate (disabled => 0, no-identity => 0, enabled+identity => N) can be asserted
+    // against a recording handler. OnSpots calls this fire-and-forget, so the only
+    // synchronous work on the decode thread is the cheap gate + form building.
+    internal async Task<int> HandleSpotsAsync(WsprSpotBatch batch)
+    {
+        if (!_spotting.GetConfig().WsprnetEnabled) return 0;
+
+        var (rcall, rgrid) = _spotting.ResolveOperator();
+        if (string.IsNullOrWhiteSpace(rcall) || string.IsNullOrWhiteSpace(rgrid))
+            return 0;
+
+        var posts = new List<Task>();
+        foreach (var spot in batch.Spots)
+        {
+            if (!WsprnetMessage.TrySplit(spot.Message, out var tcall, out var tgrid, out var dbm))
+                continue;
+            // Hashed/partial calls can't be uploaded meaningfully.
+            if (tcall.Contains('<') || tcall.Contains('>')) continue;
+
+            var form = BuildSpotForm(
+                rcall, rgrid,
+                batch.DialFreqMhz, batch.SlotStartUtc,
+                spot.SnrDb, spot.DtSec, spot.DriftHz, spot.FreqMhz,
+                tcall, tgrid, dbm, Version);
+
+            posts.Add(PostSpotAsync(form));
+        }
+
+        if (posts.Count == 0) return 0;
+        await Task.WhenAll(posts).ConfigureAwait(false);
+        return posts.Count;
+    }
+
+    private async Task PostSpotAsync(IReadOnlyList<KeyValuePair<string, string>> form)
+    {
+        try
+        {
+            using var content = new FormUrlEncodedContent(form);
+            using var resp = await _http.PostAsync(PostUrl, content).ConfigureAwait(false);
+            if (!resp.IsSuccessStatusCode)
+                _log.LogDebug("wsprnet upload returned {Status}", (int)resp.StatusCode);
+        }
+        catch (Exception ex)
+        {
+            // Tolerate all network failure silently — never crash the decode path.
+            _log.LogWarning(ex, "wsprnet upload failed");
+        }
+    }
+
+    /// <summary>
+    /// Builds the wsprd-compatible WSPRnet POST form. Pure and deterministic
+    /// (date/time derived from <paramref name="slotStartUtc"/> in UTC, MHz at six
+    /// decimals, invariant culture) so the field set can be unit-tested directly.
+    /// </summary>
+    public static IReadOnlyList<KeyValuePair<string, string>> BuildSpotForm(
+        string rcall, string rgrid,
+        double dialFreqMhz, DateTime slotStartUtc,
+        float snrDb, float dtSec, int driftHz, double freqMhz,
+        string tcall, string? tgrid, int dbm, string version)
+    {
+        var utc = slotStartUtc.Kind == DateTimeKind.Utc
+            ? slotStartUtc
+            : slotStartUtc.ToUniversalTime();
+        var inv = CultureInfo.InvariantCulture;
+
+        return new List<KeyValuePair<string, string>>
+        {
+            new("function", "wspr"),
+            new("rcall", rcall),
+            new("rgrid", rgrid),
+            new("rqrg", dialFreqMhz.ToString("F6", inv)),
+            new("date", utc.ToString("yyMMdd", inv)),
+            new("time", utc.ToString("HHmm", inv)),
+            new("sig", ((int)Math.Round(snrDb)).ToString(inv)),
+            new("dt", dtSec.ToString("F1", inv)),
+            new("drift", driftHz.ToString(inv)),
+            new("tqrg", freqMhz.ToString("F6", inv)),
+            new("tcall", tcall),
+            new("tgrid", tgrid ?? ""),
+            new("dbm", dbm.ToString(inv)),
+            new("version", version),
+            // WSPR-2 — the only sub-mode the native WSPR path decodes today. Derive
+            // from the batch if WSPR-15 / FST4W are ever added.
+            new("mode", "2"),
+        };
+    }
+
+    private static string BuildSoftwareString()
+    {
+        var v = Assembly.GetExecutingAssembly().GetName().Version;
+        var ver = v is null ? "" : $" {v.Major}.{v.Minor}.{v.Build}";
+        return $"Zeus{ver}";
+    }
+}
+
+/// <summary>
+/// Splits a decoded WSPR message into the heard station's callsign, grid, and
+/// power (dBm). Three on-air message types:
+///   type 1: <c>CALL GRID4 DBM</c>           (e.g. "K1ABC FN42 37")
+///   type 2: <c>CALL DBM</c>                  (no grid; e.g. "K1ABC 37")
+///   type 3: <c>&lt;CALL&gt; GRID6 DBM</c>    (hashed call + 6-char grid)
+/// Anything else returns false. Pure and unit-tested.
+/// </summary>
+public static class WsprnetMessage
+{
+    private static readonly Regex Grid4Re = new("^[A-R]{2}[0-9]{2}$", RegexOptions.Compiled);
+    private static readonly Regex Grid6Re = new("^[A-R]{2}[0-9]{2}[A-X]{2}$", RegexOptions.Compiled);
+    private static readonly char[] Whitespace = { ' ', '\t', '\r', '\n' };
+
+    public static bool TrySplit(string? message, out string call, out string? grid, out int dbm)
+    {
+        call = "";
+        grid = null;
+        dbm = 0;
+        if (string.IsNullOrWhiteSpace(message)) return false;
+
+        var t = message.Trim().ToUpperInvariant().Split(Whitespace, StringSplitOptions.RemoveEmptyEntries);
+
+        if (t.Length == 3)
+        {
+            if (!int.TryParse(t[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out var p)) return false;
+            if (!Grid4Re.IsMatch(t[1]) && !Grid6Re.IsMatch(t[1])) return false;
+            call = t[0];
+            grid = t[1];
+            dbm = p;
+            return true;
+        }
+
+        if (t.Length == 2)
+        {
+            if (!int.TryParse(t[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var p)) return false;
+            call = t[0];
+            grid = null;
+            dbm = p;
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/Zeus.Server.Hosting/SpottingManagementService.cs
+++ b/Zeus.Server.Hosting/SpottingManagementService.cs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Owns the live config for the digital-mode spotting uploaders (PSK Reporter +
+/// WSPRnet). Like the WSJT-X broadcaster (and unlike CAT/TCI) these only SEND, so
+/// config changes apply immediately — there is no current/pending split and no
+/// RequiresRestart. Persists through <see cref="SpottingSettingsStore"/>.
+///
+/// Operator identity (callsign + grid) is required by both uploaders. It is
+/// resolved exactly like FreeDvReporterService: the persisted override first,
+/// then the QRZ home station as a fallback. The reporters additionally no-op when
+/// identity is unresolved, on top of the per-uploader enable flag.
+/// </summary>
+public sealed class SpottingManagementService
+{
+    private readonly ILogger<SpottingManagementService> _log;
+    private readonly SpottingSettingsStore _store;
+    private readonly QrzService _qrz;
+    private readonly object _sync = new();
+    private SpottingRuntimeConfig _config;
+
+    public SpottingManagementService(
+        ILogger<SpottingManagementService> log,
+        SpottingSettingsStore store,
+        QrzService qrz)
+    {
+        _log = log;
+        _store = store;
+        _qrz = qrz;
+        // Default OFF when nothing is persisted — new network egress is opt-in.
+        _config = _store.Get() ?? new SpottingRuntimeConfig();
+    }
+
+    public SpottingRuntimeConfig GetConfig()
+    {
+        lock (_sync) return _config;
+    }
+
+    public SpottingStatus GetStatus()
+    {
+        var c = GetConfig();
+        var (call, grid) = ResolveOperator();
+        return new SpottingStatus(
+            PskReporterEnabled: c.PskReporterEnabled,
+            WsprnetEnabled: c.WsprnetEnabled,
+            Callsign: call,
+            Grid: grid,
+            IdentityResolved: !string.IsNullOrWhiteSpace(call) && !string.IsNullOrWhiteSpace(grid));
+    }
+
+    public SpottingStatus SetConfig(SpottingRuntimeConfig config)
+    {
+        var normalized = new SpottingRuntimeConfig(
+            PskReporterEnabled: config.PskReporterEnabled,
+            WsprnetEnabled: config.WsprnetEnabled,
+            Callsign: NormalizeCall(config.Callsign),
+            Grid: NormalizeGrid(config.Grid));
+
+        lock (_sync) _config = normalized;
+
+        try
+        {
+            _store.Set(normalized);
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "spotting.config.persist failed");
+        }
+
+        _log.LogInformation(
+            "spotting.config.updated psk={Psk} wsprnet={Wspr} call={Call} grid={Grid}",
+            normalized.PskReporterEnabled, normalized.WsprnetEnabled,
+            normalized.Callsign, normalized.Grid);
+
+        return GetStatus();
+    }
+
+    /// <summary>
+    /// Operator callsign/grid: the persisted override first, QRZ home station as a
+    /// fallback for blank fields. Returns ("","") when neither source has them.
+    /// Same precedence as FreeDvReporterService.ResolveOperator.
+    /// </summary>
+    public (string Call, string Grid) ResolveOperator()
+    {
+        var c = GetConfig();
+        var call = c.Callsign;
+        var grid = c.Grid;
+        if (string.IsNullOrWhiteSpace(call) || string.IsNullOrWhiteSpace(grid))
+        {
+            var home = _qrz.GetStatus().Home;
+            if (home is not null)
+            {
+                if (string.IsNullOrWhiteSpace(call) && !string.IsNullOrWhiteSpace(home.Callsign))
+                    call = NormalizeCall(home.Callsign);
+                if (string.IsNullOrWhiteSpace(grid) && !string.IsNullOrWhiteSpace(home.Grid))
+                    grid = NormalizeGrid(home.Grid!);
+            }
+        }
+        return (call ?? "", grid ?? "");
+    }
+
+    private static string NormalizeCall(string? call) =>
+        string.IsNullOrWhiteSpace(call) ? "" : call.Trim().ToUpperInvariant();
+
+    private static string NormalizeGrid(string? grid)
+    {
+        if (string.IsNullOrWhiteSpace(grid)) return "";
+        var g = grid.Trim().ToUpperInvariant();
+        return g.Length > 6 ? g[..6] : g;
+    }
+}

--- a/Zeus.Server.Hosting/SpottingSettingsStore.cs
+++ b/Zeus.Server.Hosting/SpottingSettingsStore.cs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using LiteDB;
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+// Single-row collection for the digital-mode spotting uploaders' config. Mirrors
+// WsjtxConfigStore — same Connection=shared pattern and Directory guard (no new
+// exposure to the Linux LiteDB shared-mode caveat, GH #682). Both enables persist
+// false-on-fresh — egress is opt-in only.
+public sealed class SpottingSettingsStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<SpottingConfigEntry> _entries;
+    private readonly ILogger<SpottingSettingsStore> _log;
+    private readonly object _sync = new();
+
+    public SpottingSettingsStore(ILogger<SpottingSettingsStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _entries = _db.GetCollection<SpottingConfigEntry>("spotting_config");
+
+        _log.LogInformation("SpottingSettingsStore initialized at {Path}", dbPath);
+    }
+
+    // null = nothing persisted yet — caller falls back to defaults (both OFF).
+    public SpottingRuntimeConfig? Get()
+    {
+        lock (_sync)
+        {
+            var e = _entries.FindAll().FirstOrDefault();
+            if (e is null) return null;
+            return new SpottingRuntimeConfig(
+                PskReporterEnabled: e.PskReporterEnabled,
+                WsprnetEnabled: e.WsprnetEnabled,
+                Callsign: e.Callsign ?? "",
+                Grid: e.Grid ?? "");
+        }
+    }
+
+    public void Set(SpottingRuntimeConfig config)
+    {
+        lock (_sync)
+        {
+            var existing = _entries.FindAll().FirstOrDefault();
+            if (existing is null)
+            {
+                _entries.Insert(new SpottingConfigEntry
+                {
+                    PskReporterEnabled = config.PskReporterEnabled,
+                    WsprnetEnabled = config.WsprnetEnabled,
+                    Callsign = config.Callsign,
+                    Grid = config.Grid,
+                    UpdatedUtc = DateTime.UtcNow,
+                });
+            }
+            else
+            {
+                existing.PskReporterEnabled = config.PskReporterEnabled;
+                existing.WsprnetEnabled = config.WsprnetEnabled;
+                existing.Callsign = config.Callsign;
+                existing.Grid = config.Grid;
+                existing.UpdatedUtc = DateTime.UtcNow;
+                _entries.Update(existing);
+            }
+        }
+    }
+
+    public void Dispose() => _db.Dispose();
+}
+
+public sealed class SpottingConfigEntry
+{
+    public int Id { get; set; }
+    public bool PskReporterEnabled { get; set; }
+    public bool WsprnetEnabled { get; set; }
+    public string? Callsign { get; set; } = "";
+    public string? Grid { get; set; } = "";
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -3413,6 +3413,20 @@ public static class ZeusEndpoints
             return Results.Ok(status);
         });
 
+        // Digital-mode spotting uploaders (FT8/FT4 -> PSK Reporter, WSPR ->
+        // WSPRnet). NEW network egress, both DISABLED by default; config applies
+        // live (the uploaders only send UDP/HTTP — there is no listener).
+        app.MapGet("/api/spotting/status", (SpottingManagementService spotting) => spotting.GetStatus());
+
+        app.MapPost("/api/spotting/config", (SpottingRuntimeConfig req, SpottingManagementService spotting) =>
+        {
+            log.LogInformation(
+                "api.spotting.config psk={Psk} wsprnet={Wspr}",
+                req.PskReporterEnabled, req.WsprnetEnabled);
+            var status = spotting.SetConfig(req);
+            return Results.Ok(status);
+        });
+
         app.Map("/ws", async (HttpContext ctx, StreamingHub hub) =>
         {
             if (!ctx.WebSockets.IsWebSocketRequest)

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -904,6 +904,18 @@ public static class ZeusHost
         builder.Services.AddSingleton<WsjtxManagementService>();
         builder.Services.AddSingleton<Wsjtx.WsjtxUdpBroadcaster>();
 
+        // Digital-mode spotting uploaders — FT8/FT4 decodes to PSK Reporter and
+        // WSPR spots to WSPRnet. NEW network egress; both DISABLED by default and
+        // additionally no-op until operator callsign + grid are resolved. The two
+        // reporters are leaf subscribers to Ft8Service/WsprService — they enqueue/
+        // POST only and never touch the radio/DSP/TX path.
+        builder.Services.AddSingleton<SpottingSettingsStore>();
+        builder.Services.AddSingleton<SpottingManagementService>();
+        builder.Services.AddSingleton<Spotting.PskReporterReporter>();
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<Spotting.PskReporterReporter>());
+        builder.Services.AddSingleton<Spotting.WsprnetReporter>();
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<Spotting.WsprnetReporter>());
+
         // ZeusChat — operator-to-operator chat over the Cloudflare relay.
         // Singleton (API surface) + hosted service (relay connection lifecycle),
         // same shape as SpotBroadcastService above. Opt-in persisted via

--- a/tests/Zeus.Dsp.Ft8.Tests/Ft8MessageParseTests.cs
+++ b/tests/Zeus.Dsp.Ft8.Tests/Ft8MessageParseTests.cs
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Pins the backend FT8/FT4 sender-extraction parser used by PSK Reporter
+// spotting. Cross-checked against the frontend ft8-message.ts behaviour so the
+// two stay in lockstep.
+
+using Zeus.Dsp.Ft8;
+
+namespace Zeus.Dsp.Ft8.Tests;
+
+public sealed class Ft8MessageParseTests
+{
+    [Fact]
+    public void Cq_With_Grid()
+    {
+        Assert.True(Ft8MessageParse.TryParseSender("CQ K1ABC FN42", out var call, out var grid));
+        Assert.Equal("K1ABC", call);
+        Assert.Equal("FN42", grid);
+    }
+
+    [Fact]
+    public void Cq_Dx_Directive()
+    {
+        Assert.True(Ft8MessageParse.TryParseSender("CQ DX G0XYZ IO91", out var call, out var grid));
+        Assert.Equal("G0XYZ", call);
+        Assert.Equal("IO91", grid);
+    }
+
+    [Fact]
+    public void Cq_Pota_Directive()
+    {
+        Assert.True(Ft8MessageParse.TryParseSender("CQ POTA W9XYZ EN52", out var call, out var grid));
+        Assert.Equal("W9XYZ", call);
+        Assert.Equal("EN52", grid);
+    }
+
+    [Fact]
+    public void Cq_Without_Grid()
+    {
+        Assert.True(Ft8MessageParse.TryParseSender("CQ W9XYZ", out var call, out var grid));
+        Assert.Equal("W9XYZ", call);
+        Assert.Null(grid);
+    }
+
+    [Fact]
+    public void Directed_Tx1_Grid_Reply_Sender_Is_De()
+    {
+        // "TARGET DE GRID" — sender is the DE call (token 1), not the target.
+        Assert.True(Ft8MessageParse.TryParseSender("K1ABC G0XYZ IO91", out var call, out var grid));
+        Assert.Equal("G0XYZ", call);
+        Assert.Equal("IO91", grid);
+    }
+
+    [Fact]
+    public void Directed_Report_No_Grid()
+    {
+        Assert.True(Ft8MessageParse.TryParseSender("K1ABC G0XYZ -12", out var call, out var grid));
+        Assert.Equal("G0XYZ", call);
+        Assert.Null(grid);
+    }
+
+    [Fact]
+    public void Directed_RReport_No_Grid()
+    {
+        Assert.True(Ft8MessageParse.TryParseSender("K1ABC G0XYZ R+05", out var call, out var grid));
+        Assert.Equal("G0XYZ", call);
+        Assert.Null(grid);
+    }
+
+    [Fact]
+    public void Rr73_Is_Not_A_Grid()
+    {
+        // "RR73" matches the 4-char grid regex (R,R,7,3) but must NOT be reported
+        // as a locator. Sender is still extracted.
+        Assert.True(Ft8MessageParse.TryParseSender("K1ABC G0XYZ RR73", out var call, out var grid));
+        Assert.Equal("G0XYZ", call);
+        Assert.Null(grid);
+    }
+
+    [Fact]
+    public void Rrr_And_73_Sender_Extracted_No_Grid()
+    {
+        Assert.True(Ft8MessageParse.TryParseSender("K1ABC G0XYZ 73", out var call, out _));
+        Assert.Equal("G0XYZ", call);
+        Assert.True(Ft8MessageParse.TryParseSender("K1ABC G0XYZ RRR", out var call2, out _));
+        Assert.Equal("G0XYZ", call2);
+    }
+
+    [Fact]
+    public void Hashed_Sender_Is_Rejected()
+    {
+        // A purely-hashed DE call cannot be reported.
+        Assert.False(Ft8MessageParse.TryParseSender("K1ABC <...> RR73", out _, out _));
+    }
+
+    [Fact]
+    public void Hashed_Target_With_Real_Sender_Is_Accepted()
+    {
+        Assert.True(Ft8MessageParse.TryParseSender("<...> G0XYZ IO91", out var call, out var grid));
+        Assert.Equal("G0XYZ", call);
+        Assert.Equal("IO91", grid);
+    }
+
+    [Fact]
+    public void Hashed_Sender_With_Real_Call_Inside_Is_Accepted()
+    {
+        Assert.True(Ft8MessageParse.TryParseSender("K1ABC <PJ4/K1ABC> +03", out var call, out _));
+        Assert.Equal("PJ4/K1ABC", call);
+    }
+
+    [Fact]
+    public void Lowercase_Is_Normalized()
+    {
+        Assert.True(Ft8MessageParse.TryParseSender("cq k1abc fn42", out var call, out var grid));
+        Assert.Equal("K1ABC", call);
+        Assert.Equal("FN42", grid);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("HELLO WORLD")]
+    [InlineData("TNX FER QSO")]
+    public void Free_Text_Returns_False(string text)
+    {
+        Assert.False(Ft8MessageParse.TryParseSender(text, out var call, out var grid));
+        Assert.Equal("", call);
+        Assert.Null(grid);
+    }
+
+    [Fact]
+    public void Null_Returns_False()
+    {
+        Assert.False(Ft8MessageParse.TryParseSender(null, out _, out _));
+    }
+
+    [Theory]
+    [InlineData("K1ABC FN42")]      // 2-token free text: token[1] is a grid, not a call
+    [InlineData("G0XYZ FN42 73")]   // 3-token free text: token[1] is a grid, not a call
+    [InlineData("CQ FN42")]         // CQ followed by a grid where the call should be
+    public void Grid_Like_Sender_Token_Is_Rejected(string text)
+    {
+        // A bare 4-char Maidenhead locator satisfies the loose letter+digit core
+        // check but must never be reported as a transmitting callsign (it would
+        // upload a spot for a nonexistent station to PSK Reporter).
+        Assert.False(Ft8MessageParse.TryParseSender(text, out var call, out var grid));
+        Assert.Equal("", call);
+        Assert.Null(grid);
+    }
+
+    [Fact]
+    public void Portable_Call_With_Slash_Is_Accepted()
+    {
+        Assert.True(Ft8MessageParse.TryParseSender("CQ K1ABC/P FN42", out var call, out var grid));
+        Assert.Equal("K1ABC/P", call);
+        Assert.Equal("FN42", grid);
+    }
+}

--- a/tests/Zeus.Server.Tests/Spotting/PskReporterEncoderTests.cs
+++ b/tests/Zeus.Server.Tests/Spotting/PskReporterEncoderTests.cs
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Byte-layout pins for the PSK Reporter IPFIX encoder — the load-bearing,
+// error-prone part of spotting. These prove OUR intended bytes (the WSJT-X-
+// compatible field IDs, varlen lengths, IANA-vs-enterprise distinction, 4-byte
+// set padding, and the backpatched total length); live PSK Reporter acceptance
+// is a separate wire-validation step (bench-gated).
+
+using Zeus.Server.Spotting;
+
+namespace Zeus.Server.Tests.Spotting;
+
+public sealed class PskReporterEncoderTests
+{
+    private static ushort ReadU16(byte[] b, int at) => (ushort)((b[at] << 8) | b[at + 1]);
+    private static uint ReadU32(byte[] b, int at) =>
+        (uint)((b[at] << 24) | (b[at + 1] << 16) | (b[at + 2] << 8) | b[at + 3]);
+
+    [Fact]
+    public void Descriptors_Have_Expected_Field_Layout()
+    {
+        // rxInfo options template: set ID 3, template 0x9992, length 36.
+        Assert.Equal(0x0003, ReadU16(PskReporterEncoder.RxDescriptor, 0));
+        Assert.Equal(36, ReadU16(PskReporterEncoder.RxDescriptor, 2));
+        Assert.Equal(36, PskReporterEncoder.RxDescriptor.Length);
+        Assert.Equal(0x9992, ReadU16(PskReporterEncoder.RxDescriptor, 4));
+
+        // txInfo template: set ID 2, template 0x9993, length 52, 6 fields.
+        Assert.Equal(0x0002, ReadU16(PskReporterEncoder.TxDescriptor, 0));
+        Assert.Equal(52, ReadU16(PskReporterEncoder.TxDescriptor, 2));
+        Assert.Equal(52, PskReporterEncoder.TxDescriptor.Length);
+        Assert.Equal(0x9993, ReadU16(PskReporterEncoder.TxDescriptor, 4));
+        Assert.Equal(6, ReadU16(PskReporterEncoder.TxDescriptor, 6));
+
+        // Field 2 (offset 8 + 8 = 16) is senderLocator: element 0x8003, varlen.
+        // Field 3 (offset 8 + 2*8 = 24) is frequency: element 0x8005, fixed 4-byte,
+        // enterprise 30351. The sender/receiver pairing (callsign 0x8001/0x8002,
+        // locator 0x8003/0x8004) forces this ordering — the data write order in
+        // Encode() (Callsign, Grid, FrequencyHz, ...) MUST match it. Swapping these
+        // two IDs ships every spot's grid into the frequency element and vice
+        // versa, so these assertions lock the IDs in place.
+        Assert.Equal(0x8003, ReadU16(PskReporterEncoder.TxDescriptor, 16)); // senderLocator
+        Assert.Equal(0xFFFF, ReadU16(PskReporterEncoder.TxDescriptor, 18)); // varlen
+        Assert.Equal(0x8005, ReadU16(PskReporterEncoder.TxDescriptor, 24)); // frequency (enterprise bit set)
+        Assert.Equal(0x0004, ReadU16(PskReporterEncoder.TxDescriptor, 26)); // 4-byte length
+        Assert.Equal(30351u, ReadU32(PskReporterEncoder.TxDescriptor, 28)); // enterprise number
+        // flowStartSeconds is the last field: element 0x0096 (150), length 4, no
+        // enterprise number follows.
+        Assert.Equal(0x0096, ReadU16(PskReporterEncoder.TxDescriptor, 48));
+        Assert.Equal(0x0004, ReadU16(PskReporterEncoder.TxDescriptor, 50));
+    }
+
+    [Fact]
+    public void Single_Decode_Encodes_Expected_Layout()
+    {
+        var rx = new PskReporterEncoder.ReceiverInfo("K1ABC", "FN42", "Zeus");
+        var sender = new PskReporterEncoder.SenderRecord(
+            Callsign: "W1AW",
+            Grid: "FN31",
+            FrequencyHz: 14074500,
+            SnrDb: -10,
+            Mode: "FT8",
+            FlowStartSeconds: 1700000000);
+
+        var dg = PskReporterEncoder.Encode(
+            rx, new[] { sender },
+            exportTimeSeconds: 1700000123,
+            sequenceNumber: 7,
+            observationDomainId: 0x12345678);
+
+        // ---- header ----
+        Assert.Equal(0x000A, ReadU16(dg, 0));            // version
+        Assert.Equal(dg.Length, ReadU16(dg, 2));         // backpatched total length
+        Assert.Equal(1700000123u, ReadU32(dg, 4));       // exportTime
+        Assert.Equal(7u, ReadU32(dg, 8));                // sequence number
+        Assert.Equal(0x12345678u, ReadU32(dg, 12));      // observation domain id
+
+        // ---- descriptors follow verbatim ----
+        int pos = 16;
+        Assert.Equal(PskReporterEncoder.RxDescriptor,
+            dg[pos..(pos + PskReporterEncoder.RxDescriptor.Length)]);
+        pos += PskReporterEncoder.RxDescriptor.Length;
+        Assert.Equal(PskReporterEncoder.TxDescriptor,
+            dg[pos..(pos + PskReporterEncoder.TxDescriptor.Length)]);
+        pos += PskReporterEncoder.TxDescriptor.Length;
+
+        // ---- rxInfo data set ----
+        Assert.Equal(0x9992, ReadU16(dg, pos));          // rx set ID
+        // body: "K1ABC"(1+5) + "FN42"(1+4) + "Zeus"(1+4) = 16; set = 4 + 16 = 20,
+        // already a multiple of 4 (no padding).
+        Assert.Equal(20, ReadU16(dg, pos + 2));
+        int rb = pos + 4;
+        Assert.Equal(5, dg[rb]);                         // varlen length byte
+        Assert.Equal("K1ABC", System.Text.Encoding.UTF8.GetString(dg, rb + 1, 5));
+        rb += 6;
+        Assert.Equal(4, dg[rb]);
+        Assert.Equal("FN42", System.Text.Encoding.UTF8.GetString(dg, rb + 1, 4));
+        rb += 5;
+        Assert.Equal(4, dg[rb]);
+        Assert.Equal("Zeus", System.Text.Encoding.UTF8.GetString(dg, rb + 1, 4));
+        pos += 20;
+
+        // ---- txInfo data set ----
+        Assert.Equal(0x9993, ReadU16(dg, pos));          // tx set ID
+        // record: "W1AW"(1+4) + "FN31"(1+4) + freq(4) + snr(1) + "FT8"(1+3) +
+        // flow(4) = 23; set = 4 + 23 = 27, padded to 28 (one 0x00 byte).
+        Assert.Equal(28, ReadU16(dg, pos + 2));
+        int tb = pos + 4;
+        Assert.Equal(4, dg[tb]);
+        Assert.Equal("W1AW", System.Text.Encoding.UTF8.GetString(dg, tb + 1, 4));
+        tb += 5;
+        Assert.Equal(4, dg[tb]);
+        Assert.Equal("FN31", System.Text.Encoding.UTF8.GetString(dg, tb + 1, 4));
+        tb += 5;
+        Assert.Equal(14074500u, ReadU32(dg, tb));        // frequency
+        tb += 4;
+        Assert.Equal(0xF6, dg[tb]);                      // sNR -10 as int8
+        tb += 1;
+        Assert.Equal(3, dg[tb]);
+        Assert.Equal("FT8", System.Text.Encoding.UTF8.GetString(dg, tb + 1, 3));
+        tb += 4;
+        Assert.Equal(1700000000u, ReadU32(dg, tb));      // flowStartSeconds
+        tb += 4;
+        Assert.Equal(0, dg[tb]);                         // 4-byte pad
+
+        // Total length is internally consistent.
+        Assert.Equal(pos + 28, dg.Length);
+    }
+
+    [Fact]
+    public void Empty_Grid_Encodes_As_Zero_Length_Varstring()
+    {
+        var rx = new PskReporterEncoder.ReceiverInfo("K1ABC", "FN42", "Zeus");
+        var sender = new PskReporterEncoder.SenderRecord(
+            "W1AW", null, 14074500, 0, "FT4", 1700000000);
+
+        var dg = PskReporterEncoder.Encode(rx, new[] { sender }, 1, 1, 1);
+
+        int pos = 16 + PskReporterEncoder.RxDescriptor.Length + PskReporterEncoder.TxDescriptor.Length;
+        pos += 20; // rxInfo set (same fixed size as above)
+        int tb = pos + 4;
+        Assert.Equal(4, dg[tb]);                 // "W1AW"
+        tb += 5;
+        Assert.Equal(0, dg[tb]);                 // empty grid -> single 0x00 length byte
+    }
+
+    [Fact]
+    public void Snr_Boundaries_Encode_As_Signed_Bytes()
+    {
+        var rx = new PskReporterEncoder.ReceiverInfo("K1ABC", "FN42", "Zeus");
+        var lo = PskReporterEncoder.Encode(rx,
+            new[] { new PskReporterEncoder.SenderRecord("W1AW", "FN31", 14074000, sbyte.MinValue, "FT8", 1) }, 1, 1, 1);
+        var hi = PskReporterEncoder.Encode(rx,
+            new[] { new PskReporterEncoder.SenderRecord("W1AW", "FN31", 14074000, sbyte.MaxValue, "FT8", 1) }, 1, 1, 1);
+
+        // sNR offset within the tx record: setStart + 4 (set header) + "W1AW"(1+4)
+        // + "FN31"(1+4) + freq(4).
+        int snrAt = 16 + PskReporterEncoder.RxDescriptor.Length + PskReporterEncoder.TxDescriptor.Length
+                    + 20 /* rx set */ + 4 + 5 + 5 + 4;
+        Assert.Equal(0x80, lo[snrAt]); // -128
+        Assert.Equal(0x7F, hi[snrAt]); // +127
+    }
+
+    [Fact]
+    public void Multiple_Senders_Pack_Into_One_Tx_Set()
+    {
+        var rx = new PskReporterEncoder.ReceiverInfo("K1ABC", "FN42", "Zeus");
+        var senders = new[]
+        {
+            new PskReporterEncoder.SenderRecord("W1AW", "FN31", 14074000, -1, "FT8", 1700000000),
+            new PskReporterEncoder.SenderRecord("G0XYZ", "IO91", 14074200, -5, "FT8", 1700000000),
+        };
+        var dg = PskReporterEncoder.Encode(rx, senders, 1, 1, 1);
+
+        int pos = 16 + PskReporterEncoder.RxDescriptor.Length + PskReporterEncoder.TxDescriptor.Length + 20;
+        Assert.Equal(0x9993, ReadU16(dg, pos)); // one tx set holds both records
+        ushort setLen = ReadU16(dg, pos + 2);
+        Assert.Equal(dg.Length, pos + setLen);  // tx set runs to end of datagram
+    }
+}

--- a/tests/Zeus.Server.Tests/Spotting/SpottingManagementServiceTests.cs
+++ b/tests/Zeus.Server.Tests/Spotting/SpottingManagementServiceTests.cs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Pins the safety-critical invariants of the spotting config: BOTH uploaders are
+// OFF by default (new network egress is opt-in), SetConfig normalises operator
+// identity, the choice persists across store instances, and IdentityResolved is
+// false until a callsign + grid exist.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests.Spotting;
+
+public sealed class SpottingManagementServiceTests : IDisposable
+{
+    private readonly string _root =
+        Path.Combine(Path.GetTempPath(), $"zeus-spotting-{Guid.NewGuid():N}");
+
+    public SpottingManagementServiceTests() => Directory.CreateDirectory(_root);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private SpottingSettingsStore NewStore() =>
+        new(NullLogger<SpottingSettingsStore>.Instance, Path.Combine(_root, "spotting.db"));
+
+    // A fresh, logged-out QRZ service: GetStatus().Home is null, so ResolveOperator
+    // falls through to the override only (no network ever touched).
+    private QrzService NewLoggedOutQrz() =>
+        new(new SingleClientFactory(), NullLogger<QrzService>.Instance,
+            new CredentialStore(NullLogger<CredentialStore>.Instance, Path.Combine(_root, "creds.db")));
+
+    private SpottingManagementService NewService(SpottingSettingsStore store) =>
+        new(NullLogger<SpottingManagementService>.Instance, store, NewLoggedOutQrz());
+
+    [Fact]
+    public void Defaults_Both_Uploaders_Disabled_When_Nothing_Persisted()
+    {
+        using var store = NewStore();
+        var svc = NewService(store);
+
+        var cfg = svc.GetConfig();
+        Assert.False(cfg.PskReporterEnabled); // opt-in egress, off by default
+        Assert.False(cfg.WsprnetEnabled);
+        Assert.Equal("", cfg.Callsign);
+        Assert.Equal("", cfg.Grid);
+
+        var status = svc.GetStatus();
+        Assert.False(status.PskReporterEnabled);
+        Assert.False(status.WsprnetEnabled);
+        Assert.False(status.IdentityResolved); // no call/grid yet
+    }
+
+    [Fact]
+    public void SetConfig_Normalizes_Call_And_Grid()
+    {
+        using var store = NewStore();
+        var svc = NewService(store);
+
+        var status = svc.SetConfig(new SpottingRuntimeConfig(
+            PskReporterEnabled: true, WsprnetEnabled: false,
+            Callsign: "  k1abc  ", Grid: "  fn42aa  "));
+
+        Assert.Equal("K1ABC", status.Callsign);   // upper-cased + trimmed
+        Assert.Equal("FN42AA", status.Grid);      // upper-cased + trimmed (<=6)
+        Assert.True(status.PskReporterEnabled);
+        Assert.True(status.IdentityResolved);
+    }
+
+    [Fact]
+    public void SetConfig_Truncates_Grid_To_Six_Chars()
+    {
+        using var store = NewStore();
+        var svc = NewService(store);
+
+        var status = svc.SetConfig(new SpottingRuntimeConfig(Grid: "FN42AA99"));
+        Assert.Equal("FN42AA", status.Grid);
+    }
+
+    [Fact]
+    public void IdentityResolved_False_When_Only_Call_Set()
+    {
+        using var store = NewStore();
+        var svc = NewService(store);
+
+        var status = svc.SetConfig(new SpottingRuntimeConfig(Callsign: "K1ABC", Grid: ""));
+        Assert.False(status.IdentityResolved);
+    }
+
+    [Fact]
+    public void SetConfig_Persists_Across_Store_Instances()
+    {
+        using (var store = NewStore())
+        {
+            var svc = NewService(store);
+            svc.SetConfig(new SpottingRuntimeConfig(
+                PskReporterEnabled: true, WsprnetEnabled: true,
+                Callsign: "K1ABC", Grid: "FN42"));
+        }
+
+        using var reopened = NewStore();
+        var reloaded = NewService(reopened).GetConfig();
+        Assert.True(reloaded.PskReporterEnabled);
+        Assert.True(reloaded.WsprnetEnabled);
+        Assert.Equal("K1ABC", reloaded.Callsign);
+        Assert.Equal("FN42", reloaded.Grid);
+    }
+
+    [Fact]
+    public void ResolveOperator_Returns_Override_When_Set()
+    {
+        using var store = NewStore();
+        var svc = NewService(store);
+        svc.SetConfig(new SpottingRuntimeConfig(Callsign: "K1ABC", Grid: "FN42"));
+
+        var (call, grid) = svc.ResolveOperator();
+        Assert.Equal("K1ABC", call);
+        Assert.Equal("FN42", grid);
+    }
+
+    [Fact]
+    public void ResolveOperator_Blank_When_No_Override_And_No_Qrz_Home()
+    {
+        using var store = NewStore();
+        var svc = NewService(store);
+
+        var (call, grid) = svc.ResolveOperator();
+        Assert.Equal("", call);
+        Assert.Equal("", grid);
+    }
+
+    private sealed class SingleClientFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new();
+    }
+}

--- a/tests/Zeus.Server.Tests/Spotting/SpottingReporterGateTests.cs
+++ b/tests/Zeus.Server.Tests/Spotting/SpottingReporterGateTests.cs
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Pins the egress-safety gate of the two spotting reporters: no upload unless the
+// uploader is ENABLED *and* operator identity (callsign + grid) is resolved. This
+// is the load-bearing safety promise for a network-egress feature, so it gets
+// direct coverage here (disabled => zero, enabled-but-no-identity => zero,
+// enabled+identity => exactly the expected uploads), plus the PSK Reporter dedup,
+// cap, and datagram-chunk decisions.
+
+using System.Net;
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Dsp.Ft8;
+using Zeus.Server;
+using Zeus.Server.Spotting;
+
+namespace Zeus.Server.Tests.Spotting;
+
+public sealed class SpottingReporterGateTests : IDisposable
+{
+    private readonly string _root =
+        Path.Combine(Path.GetTempPath(), $"zeus-spotgate-{Guid.NewGuid():N}");
+
+    public SpottingReporterGateTests() => Directory.CreateDirectory(_root);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    // A spotting service backed by a temp store and a logged-out QRZ (Home == null,
+    // so ResolveOperator never touches the network and falls through to the
+    // override only). Optionally pre-configured enabled with an explicit identity.
+    private SpottingManagementService NewSpotting(
+        bool pskEnabled = false, bool wsprEnabled = false,
+        string call = "", string grid = "")
+    {
+        var store = new SpottingSettingsStore(
+            NullLogger<SpottingSettingsStore>.Instance, Path.Combine(_root, $"spot-{Guid.NewGuid():N}.db"));
+        var qrz = new QrzService(
+            new SingleClientFactory(), NullLogger<QrzService>.Instance,
+            new CredentialStore(NullLogger<CredentialStore>.Instance, Path.Combine(_root, $"creds-{Guid.NewGuid():N}.db")));
+        var svc = new SpottingManagementService(NullLogger<SpottingManagementService>.Instance, store, qrz);
+        if (pskEnabled || wsprEnabled || call.Length > 0 || grid.Length > 0)
+            svc.SetConfig(new SpottingRuntimeConfig(pskEnabled, wsprEnabled, call, grid));
+        return svc;
+    }
+
+    // ---- PSK Reporter (FT8/FT4) -------------------------------------------------
+
+    private static Ft8DecodeBatch Ft8Batch(int receiver, params string[] messages)
+    {
+        var decodes = new List<Ft8DecodeResult>();
+        foreach (var m in messages)
+            decodes.Add(new Ft8DecodeResult(SnrDb: -10, DtSec: 0.1f, FreqHz: 1500, Score: 1, LdpcErrors: 0, Text: m));
+        return new Ft8DecodeBatch(receiver, new DateTime(2026, 6, 26, 14, 0, 0, DateTimeKind.Utc), Ft8Protocol.Ft8, decodes);
+    }
+
+    [Fact]
+    public void Psk_Disabled_Buffers_Nothing()
+    {
+        var spotting = NewSpotting(pskEnabled: false, call: "K1ABC", grid: "FN42");
+        using var r = new PskReporterReporter(NullLogger<PskReporterReporter>.Instance, spotting);
+
+        r.HandleDecodes(Ft8Batch(0, "CQ W1AW FN31"), dialHz: 14_074_000);
+
+        Assert.Equal(0, r.PendingCount);
+    }
+
+    [Fact]
+    public void Psk_Enabled_Without_Identity_Buffers_Nothing()
+    {
+        var spotting = NewSpotting(pskEnabled: true); // no call/grid, logged-out QRZ
+        using var r = new PskReporterReporter(NullLogger<PskReporterReporter>.Instance, spotting);
+
+        r.HandleDecodes(Ft8Batch(0, "CQ W1AW FN31"), dialHz: 14_074_000);
+
+        Assert.Equal(0, r.PendingCount);
+    }
+
+    [Fact]
+    public void Psk_NonRx0_Batch_Buffers_Nothing()
+    {
+        var spotting = NewSpotting(pskEnabled: true, call: "K1ABC", grid: "FN42");
+        using var r = new PskReporterReporter(NullLogger<PskReporterReporter>.Instance, spotting);
+
+        r.HandleDecodes(Ft8Batch(receiver: 1, "CQ W1AW FN31"), dialHz: 14_074_000);
+
+        Assert.Equal(0, r.PendingCount);
+    }
+
+    [Fact]
+    public void Psk_Enabled_With_Identity_Buffers_Parsed_Senders()
+    {
+        var spotting = NewSpotting(pskEnabled: true, call: "K1ABC", grid: "FN42");
+        using var r = new PskReporterReporter(NullLogger<PskReporterReporter>.Instance, spotting);
+
+        // Two real senders + one free-text line that must be rejected by the parser.
+        r.HandleDecodes(Ft8Batch(0, "CQ W1AW FN31", "K1ABC G0XYZ IO91", "TNX FER QSO"), dialHz: 14_074_000);
+
+        Assert.Equal(2, r.PendingCount);
+        Assert.True(r.TryGetPending("W1AW", out var w1aw));
+        Assert.Equal(14_074_000u + 1500u, w1aw.FrequencyHz);
+        Assert.True(r.TryGetPending("G0XYZ", out _));
+    }
+
+    [Fact]
+    public void Psk_Dedup_Keeps_Strongest_Sighting()
+    {
+        var spotting = NewSpotting(pskEnabled: true, call: "K1ABC", grid: "FN42");
+        using var r = new PskReporterReporter(NullLogger<PskReporterReporter>.Instance, spotting);
+
+        var batch = new Ft8DecodeBatch(0, new DateTime(2026, 6, 26, 14, 0, 0, DateTimeKind.Utc), Ft8Protocol.Ft8,
+            new List<Ft8DecodeResult>
+            {
+                new(SnrDb: -18, DtSec: 0.1f, FreqHz: 1500, Score: 1, LdpcErrors: 0, Text: "CQ W1AW FN31"),
+                new(SnrDb: -5,  DtSec: 0.1f, FreqHz: 1500, Score: 1, LdpcErrors: 0, Text: "CQ W1AW FN31"),
+            });
+
+        r.HandleDecodes(batch, dialHz: 14_074_000);
+
+        Assert.Equal(1, r.PendingCount);
+        Assert.True(r.TryGetPending("W1AW", out var rec));
+        Assert.Equal((sbyte)-5, rec.SnrDb); // strongest kept
+    }
+
+    [Fact]
+    public void Psk_Caps_Buffer_At_MaxBufferedCalls()
+    {
+        var spotting = NewSpotting(pskEnabled: true, call: "K1ABC", grid: "FN42");
+        using var r = new PskReporterReporter(NullLogger<PskReporterReporter>.Instance, spotting);
+
+        // 600 distinct senders; the dedup buffer must cap at 512.
+        var decodes = new List<Ft8DecodeResult>();
+        for (int i = 0; i < 600; i++)
+            decodes.Add(new Ft8DecodeResult(-10, 0.1f, 1500, 1, 0, $"CQ W{i}ABC FN31"));
+        var batch = new Ft8DecodeBatch(0, new DateTime(2026, 6, 26, 14, 0, 0, DateTimeKind.Utc), Ft8Protocol.Ft8, decodes);
+
+        r.HandleDecodes(batch, dialHz: 14_074_000);
+
+        Assert.Equal(512, r.PendingCount);
+    }
+
+    [Fact]
+    public async Task Psk_Flush_Clears_Buffer_When_Disabled_Without_Sending()
+    {
+        // Buffer while enabled, then disable: FlushAsync must drop the buffer and
+        // never touch the network. (We assert the buffer was cleared; a UDP send
+        // would require an enabled+identity flush, which is bench-validated.)
+        var spotting = NewSpotting(pskEnabled: true, call: "K1ABC", grid: "FN42");
+        using var r = new PskReporterReporter(NullLogger<PskReporterReporter>.Instance, spotting);
+        r.HandleDecodes(Ft8Batch(0, "CQ W1AW FN31"), dialHz: 14_074_000);
+        Assert.Equal(1, r.PendingCount);
+
+        spotting.SetConfig(new SpottingRuntimeConfig(PskReporterEnabled: false, Callsign: "K1ABC", Grid: "FN42"));
+        await r.FlushAsyncForTests();
+
+        Assert.Equal(0, r.PendingCount);
+    }
+
+    // ---- PSK Reporter datagram chunking ----------------------------------------
+
+    private static PskReporterEncoder.SenderRecord Rec(string call) =>
+        new(call, "FN31", 14_074_000, -10, "FT8", 1700000000);
+
+    [Fact]
+    public void Chunk_Splits_On_Datagram_Boundary()
+    {
+        var recs = new List<PskReporterEncoder.SenderRecord>();
+        for (int i = 0; i < 41; i++) recs.Add(Rec($"W{i}ABC"));
+
+        var chunks = PskReporterReporter.Chunk(recs, 40);
+
+        Assert.Equal(2, chunks.Count);
+        Assert.Equal(40, chunks[0].Count);
+        Assert.Single(chunks[1]);
+    }
+
+    [Fact]
+    public void Chunk_Single_Datagram_When_Under_Limit()
+    {
+        var recs = new List<PskReporterEncoder.SenderRecord> { Rec("W1AW"), Rec("G0XYZ") };
+        var chunks = PskReporterReporter.Chunk(recs, 40);
+        Assert.Single(chunks);
+        Assert.Equal(2, chunks[0].Count);
+    }
+
+    [Fact]
+    public void Chunk_Empty_Yields_No_Datagrams()
+    {
+        Assert.Empty(PskReporterReporter.Chunk(Array.Empty<PskReporterEncoder.SenderRecord>(), 40));
+    }
+
+    // ---- WSPRnet ----------------------------------------------------------------
+
+    private static WsprSpotBatch WsprBatch(params string[] messages)
+    {
+        var spots = new List<WsprSpot>();
+        foreach (var m in messages)
+            spots.Add(new WsprSpot(SnrDb: -20, DtSec: 0.0f, FreqMhz: 14.097061f, DriftHz: 0, Message: m));
+        return new WsprSpotBatch(0, new DateTime(2026, 6, 26, 14, 0, 0, DateTimeKind.Utc), 14.0956, spots);
+    }
+
+    [Fact]
+    public async Task Wsprnet_Disabled_Sends_Nothing()
+    {
+        var handler = new RecordingHandler();
+        var spotting = NewSpotting(wsprEnabled: false, call: "K1ABC", grid: "FN42");
+        using var r = new WsprnetReporter(NullLogger<WsprnetReporter>.Instance, spotting, handler);
+
+        Assert.Equal(0, await r.HandleSpotsAsync(WsprBatch("W1AW FN31 37")));
+        Assert.Equal(0, handler.Count);
+    }
+
+    [Fact]
+    public async Task Wsprnet_Enabled_Without_Identity_Sends_Nothing()
+    {
+        var handler = new RecordingHandler();
+        var spotting = NewSpotting(wsprEnabled: true); // no call/grid
+        using var r = new WsprnetReporter(NullLogger<WsprnetReporter>.Instance, spotting, handler);
+
+        Assert.Equal(0, await r.HandleSpotsAsync(WsprBatch("W1AW FN31 37")));
+        Assert.Equal(0, handler.Count);
+    }
+
+    [Fact]
+    public async Task Wsprnet_Enabled_With_Identity_Sends_One_Per_Spot()
+    {
+        var handler = new RecordingHandler();
+        var spotting = NewSpotting(wsprEnabled: true, call: "K1ABC", grid: "FN42");
+        using var r = new WsprnetReporter(NullLogger<WsprnetReporter>.Instance, spotting, handler);
+
+        // Two valid spots + one hashed call (dropped) + one junk line (dropped).
+        int sent = await r.HandleSpotsAsync(
+            WsprBatch("W1AW FN31 37", "G0XYZ IO91 30", "<PJ4/K1ABC> FK52UD 33", "NOT A SPOT"));
+
+        Assert.Equal(2, sent);
+        Assert.Equal(2, handler.Count);
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private int _count;
+        public int Count => Volatile.Read(ref _count);
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _count);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
+    }
+
+    private sealed class SingleClientFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new();
+    }
+}

--- a/tests/Zeus.Server.Tests/Spotting/WsprnetReporterTests.cs
+++ b/tests/Zeus.Server.Tests/Spotting/WsprnetReporterTests.cs
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Pins the two pure pieces of WSPRnet upload: the WSPR message splitter and the
+// wsprd-compatible form builder (deterministic date/time/MHz formatting). The
+// HTTP plumbing itself is BCL (FormUrlEncodedContent + HttpClient) and is
+// wire-validated on the bench.
+
+using Zeus.Server.Spotting;
+
+namespace Zeus.Server.Tests.Spotting;
+
+public sealed class WsprnetMessageTests
+{
+    [Fact]
+    public void Type1_Call_Grid4_Power()
+    {
+        Assert.True(WsprnetMessage.TrySplit("K1ABC FN42 37", out var call, out var grid, out var dbm));
+        Assert.Equal("K1ABC", call);
+        Assert.Equal("FN42", grid);
+        Assert.Equal(37, dbm);
+    }
+
+    [Fact]
+    public void Type2_Call_Power_No_Grid()
+    {
+        Assert.True(WsprnetMessage.TrySplit("K1ABC 30", out var call, out var grid, out var dbm));
+        Assert.Equal("K1ABC", call);
+        Assert.Null(grid);
+        Assert.Equal(30, dbm);
+    }
+
+    [Fact]
+    public void Type3_Hashed_Call_Grid6_Power()
+    {
+        Assert.True(WsprnetMessage.TrySplit("<PJ4/K1ABC> FK52UD 33", out var call, out var grid, out var dbm));
+        Assert.Equal("<PJ4/K1ABC>", call);
+        Assert.Equal("FK52UD", grid);
+        Assert.Equal(33, dbm);
+    }
+
+    [Fact]
+    public void Lowercase_Is_Normalized()
+    {
+        Assert.True(WsprnetMessage.TrySplit("k1abc fn42 37", out var call, out var grid, out _));
+        Assert.Equal("K1ABC", call);
+        Assert.Equal("FN42", grid);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("K1ABC FN42 NOTANUMBER")]   // power not numeric
+    [InlineData("K1ABC NOTAGRID 37")]       // middle token not a grid
+    [InlineData("ONLYONE")]
+    [InlineData("A B C D")]                  // four tokens
+    public void Junk_Returns_False(string msg)
+    {
+        Assert.False(WsprnetMessage.TrySplit(msg, out var call, out var grid, out var dbm));
+        Assert.Equal("", call);
+        Assert.Null(grid);
+        Assert.Equal(0, dbm);
+    }
+
+    [Fact]
+    public void Null_Returns_False()
+    {
+        Assert.False(WsprnetMessage.TrySplit(null, out _, out _, out _));
+    }
+}
+
+public sealed class WsprnetFormBuilderTests
+{
+    private static string Get(IReadOnlyList<KeyValuePair<string, string>> form, string key)
+    {
+        foreach (var kv in form)
+            if (kv.Key == key) return kv.Value;
+        throw new KeyNotFoundException(key);
+    }
+
+    [Fact]
+    public void Builds_Wsprd_Compatible_Field_Set_From_Fixed_Utc()
+    {
+        // 2026-06-26 14:08:00 UTC -> date 260626, time 1408.
+        var slot = new DateTime(2026, 6, 26, 14, 8, 0, DateTimeKind.Utc);
+
+        var form = WsprnetReporter.BuildSpotForm(
+            rcall: "K1ABC", rgrid: "FN42",
+            dialFreqMhz: 14.095600, slotStartUtc: slot,
+            snrDb: -21.4f, dtSec: 0.3f, driftHz: -1, freqMhz: 14.097061,
+            tcall: "W1AW", tgrid: "FN31", dbm: 37, version: "Zeus 0.10.0");
+
+        Assert.Equal("wspr", Get(form, "function"));
+        Assert.Equal("K1ABC", Get(form, "rcall"));
+        Assert.Equal("FN42", Get(form, "rgrid"));
+        Assert.Equal("14.095600", Get(form, "rqrg"));
+        Assert.Equal("260626", Get(form, "date"));
+        Assert.Equal("1408", Get(form, "time"));
+        Assert.Equal("-21", Get(form, "sig"));        // rounded to int dB
+        Assert.Equal("0.3", Get(form, "dt"));
+        Assert.Equal("-1", Get(form, "drift"));
+        Assert.Equal("14.097061", Get(form, "tqrg"));
+        Assert.Equal("W1AW", Get(form, "tcall"));
+        Assert.Equal("FN31", Get(form, "tgrid"));
+        Assert.Equal("37", Get(form, "dbm"));
+        Assert.Equal("Zeus 0.10.0", Get(form, "version"));
+        Assert.Equal("2", Get(form, "mode"));
+    }
+
+    [Fact]
+    public void Local_Kind_Time_Is_Converted_To_Utc()
+    {
+        // A non-UTC slot time must be normalised to UTC before formatting.
+        var local = new DateTime(2026, 6, 26, 14, 8, 0, DateTimeKind.Local);
+        var expected = local.ToUniversalTime();
+
+        var form = WsprnetReporter.BuildSpotForm(
+            "K1ABC", "FN42", 14.0956, local,
+            -20f, 0f, 0, 14.097, "W1AW", "FN31", 30, "Zeus");
+
+        Assert.Equal(expected.ToString("yyMMdd"), Get(form, "date"));
+        Assert.Equal(expected.ToString("HHmm"), Get(form, "time"));
+    }
+
+    [Fact]
+    public void Missing_Tgrid_Is_Empty_String()
+    {
+        var slot = new DateTime(2026, 6, 26, 14, 8, 0, DateTimeKind.Utc);
+        var form = WsprnetReporter.BuildSpotForm(
+            "K1ABC", "FN42", 14.0956, slot, -20f, 0f, 0, 14.097, "W1AW", null, 30, "Zeus");
+        Assert.Equal("", Get(form, "tgrid"));
+    }
+}

--- a/zeus-web/src/api/spotting.ts
+++ b/zeus-web/src/api/spotting.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+//
+// REST client for the digital-mode spotting uploaders (FT8/FT4 -> PSK Reporter,
+// WSPR -> WSPRnet). Mirrors api/wsjtx.ts: no port test (UDP/HTTP has no
+// listener) and applies live (no restart). Both uploaders default OFF.
+
+import { ApiError } from './client';
+
+export type SpottingStatus = {
+  pskReporterEnabled: boolean;
+  wsprnetEnabled: boolean;
+  callsign: string;
+  grid: string;
+  identityResolved: boolean;
+};
+
+export type SpottingConfig = {
+  pskReporterEnabled: boolean;
+  wsprnetEnabled: boolean;
+  callsign: string;
+  grid: string;
+};
+
+function normalizeStatus(raw: unknown): SpottingStatus {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  return {
+    pskReporterEnabled: Boolean(r.pskReporterEnabled),
+    wsprnetEnabled: Boolean(r.wsprnetEnabled),
+    callsign: typeof r.callsign === 'string' ? r.callsign : '',
+    grid: typeof r.grid === 'string' ? r.grid : '',
+    identityResolved: Boolean(r.identityResolved),
+  };
+}
+
+async function jsonFetch<T>(
+  input: RequestInfo,
+  init: RequestInit | undefined,
+  parse: (raw: unknown) => T,
+): Promise<T> {
+  const res = await fetch(input, init);
+  if (!res.ok) {
+    let message = `${res.status} ${res.statusText}`;
+    try {
+      const body = (await res.json()) as unknown;
+      if (
+        body &&
+        typeof body === 'object' &&
+        'error' in body &&
+        typeof (body as { error: unknown }).error === 'string'
+      ) {
+        message = (body as { error: string }).error;
+      }
+    } catch {
+      /* non-JSON */
+    }
+    throw new ApiError(res.status, message);
+  }
+  return parse((await res.json()) as unknown);
+}
+
+export function getSpottingStatus(signal?: AbortSignal): Promise<SpottingStatus> {
+  return jsonFetch('/api/spotting/status', { signal }, normalizeStatus);
+}
+
+export function postSpottingConfig(cfg: SpottingConfig, signal?: AbortSignal): Promise<SpottingStatus> {
+  return jsonFetch(
+    '/api/spotting/config',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(cfg),
+      signal,
+    },
+    normalizeStatus,
+  );
+}

--- a/zeus-web/src/components/NetworkSettingsPanel.tsx
+++ b/zeus-web/src/components/NetworkSettingsPanel.tsx
@@ -11,12 +11,14 @@
 import { CatSettingsPanel } from './CatSettingsPanel';
 import { TciSettingsPanel } from './TciSettingsPanel';
 import { WsjtxSettingsPanel } from './WsjtxSettingsPanel';
+import { SpottingSettingsPanel } from './SpottingSettingsPanel';
 
 // The Network tab hosts Zeus's external network-control servers. TCI (the
 // ExpertSDR3 WebSocket interface) and CAT (the Kenwood TS-2000 TCP interface)
 // are inbound rig-control servers; WSJT-X is the outbound logged-QSO push to a
-// third-party logger. Each child panel owns its own store and persistence —
-// this container only stacks them with separating rules.
+// third-party logger; Spotting uploads RX decodes to PSK Reporter / WSPRnet.
+// Each child panel owns its own store and persistence — this container only
+// stacks them with separating rules.
 export function NetworkSettingsPanel() {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
@@ -25,6 +27,8 @@ export function NetworkSettingsPanel() {
       <CatSettingsPanel />
       <div style={{ borderTop: '1px solid var(--panel-border)' }} />
       <WsjtxSettingsPanel />
+      <div style={{ borderTop: '1px solid var(--panel-border)' }} />
+      <SpottingSettingsPanel />
     </div>
   );
 }

--- a/zeus-web/src/components/SpottingSettingsPanel.tsx
+++ b/zeus-web/src/components/SpottingSettingsPanel.tsx
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+import { useEffect, useState } from 'react';
+import { useSpottingStore } from '../state/spotting-store';
+import { useOperatorStore } from '../state/operator-store';
+
+// Digital-mode spotting: upload RX decodes to the community spotting networks —
+// FT8/FT4 to PSK Reporter and WSPR to WSPRnet. New network egress — both
+// DISABLED by default. Uploads are spot reports OUT only; nothing controls the
+// radio or transmits. A callsign + Maidenhead grid are required (PSK Reporter /
+// WSPRnet attribute every spot to your station).
+export function SpottingSettingsPanel() {
+  const config = useSpottingStore((s) => s.config);
+  const status = useSpottingStore((s) => s.status);
+  const saveConfig = useSpottingStore((s) => s.saveConfig);
+
+  // Seed call/grid from the client operator identity so the operator usually
+  // doesn't retype — but the authoritative value is what's persisted server-side.
+  const opCall = useOperatorStore((s) => s.call);
+  const opGrid = useOperatorStore((s) => s.grid);
+
+  const [psk, setPsk] = useState(config.pskReporterEnabled);
+  const [wsprnet, setWsprnet] = useState(config.wsprnetEnabled);
+  const [call, setCall] = useState(config.callsign || opCall);
+  const [grid, setGrid] = useState(config.grid || opGrid);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setPsk(config.pskReporterEnabled);
+    setWsprnet(config.wsprnetEnabled);
+    setCall(config.callsign || opCall);
+    setGrid(config.grid || opGrid);
+  }, [config.pskReporterEnabled, config.wsprnetEnabled, config.callsign, config.grid, opCall, opGrid]);
+
+  async function onSave(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      await saveConfig({
+        pskReporterEnabled: psk,
+        wsprnetEnabled: wsprnet,
+        callsign: call.trim().toUpperCase(),
+        grid: grid.trim().toUpperCase(),
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const anyEnabled = status ? status.pskReporterEnabled || status.wsprnetEnabled : false;
+  const identityResolved = status?.identityResolved ?? false;
+  const identityMissing = anyEnabled && !identityResolved;
+
+  const inputStyle: React.CSSProperties = {
+    padding: '6px 8px',
+    fontSize: 12,
+    fontFamily: 'monospace',
+    background: 'var(--bg-0)',
+    border: '1px solid var(--panel-border)',
+    borderRadius: 'var(--r-sm)',
+    color: 'var(--fg-0)',
+  };
+
+  return (
+    <div style={{ maxWidth: 700 }}>
+      <h3
+        style={{
+          margin: '0 0 14px',
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: '0.12em',
+          textTransform: 'uppercase',
+          color: 'var(--fg-2)',
+        }}
+      >
+        DIGITAL-MODE SPOTTING
+      </h3>
+
+      <div
+        style={{
+          padding: 12,
+          marginBottom: 16,
+          fontSize: 11,
+          lineHeight: 1.5,
+          color: 'var(--fg-2)',
+          background: 'var(--bg-0)',
+          border: '1px solid var(--panel-border)',
+          borderRadius: 'var(--r-sm)',
+        }}
+      >
+        When enabled, Zeus uploads what it RECEIVES to the community spotting
+        networks: FT8/FT4 decodes go to{' '}
+        <strong>PSK Reporter</strong> (report.pskreporter.info) and WSPR spots to{' '}
+        <strong>WSPRnet</strong> (wsprnet.org). This is spot-report egress OUT only — it
+        never controls the radio or transmits. Your <strong>callsign and grid</strong> are
+        required (every spot is attributed to your station). Both networks are public.
+      </div>
+
+      <form onSubmit={onSave} style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+        <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <input
+            type="checkbox"
+            checked={psk}
+            onChange={(e) => setPsk(e.target.checked)}
+            style={{ accentColor: 'var(--accent)' }}
+          />
+          <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--fg-1)' }}>
+            Upload FT8/FT4 decodes to PSK Reporter
+          </span>
+        </label>
+
+        <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <input
+            type="checkbox"
+            checked={wsprnet}
+            onChange={(e) => setWsprnet(e.target.checked)}
+            style={{ accentColor: 'var(--accent)' }}
+          />
+          <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--fg-1)' }}>
+            Upload WSPR spots to WSPRnet
+          </span>
+        </label>
+
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--fg-2)' }}>Callsign</span>
+          <input
+            type="text"
+            value={call}
+            onChange={(e) => setCall(e.target.value)}
+            spellCheck={false}
+            placeholder="K1ABC"
+            style={inputStyle}
+          />
+        </label>
+
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--fg-2)' }}>
+            Maidenhead Grid
+          </span>
+          <input
+            type="text"
+            value={grid}
+            onChange={(e) => setGrid(e.target.value)}
+            spellCheck={false}
+            placeholder="FN42"
+            maxLength={6}
+            style={inputStyle}
+          />
+          <span style={{ fontSize: 10, color: 'var(--fg-3)' }}>
+            4 or 6 characters. Leave callsign/grid blank to fall back to your QRZ home
+            station. Applies immediately — no restart required.
+          </span>
+        </label>
+
+        {identityMissing && (
+          <div
+            style={{
+              padding: 10,
+              fontSize: 11,
+              color: 'var(--tx)',
+              background: 'var(--bg-0)',
+              border: '1px solid var(--tx)',
+              borderRadius: 'var(--r-sm)',
+            }}
+          >
+            Spotting is enabled but no callsign/grid is available — uploads are paused
+            until you set them (here or via QRZ login).
+          </div>
+        )}
+
+        <div
+          style={{
+            padding: 10,
+            background: 'var(--bg-0)',
+            border: '1px solid var(--panel-border)',
+            borderRadius: 'var(--r-sm)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            fontSize: 12,
+            color: 'var(--fg-2)',
+          }}
+        >
+          <span
+            style={{
+              width: 8,
+              height: 8,
+              borderRadius: '50%',
+              background: anyEnabled && identityResolved ? 'var(--accent)' : 'var(--fg-3)',
+              flexShrink: 0,
+            }}
+          />
+          {!anyEnabled
+            ? 'Spotting is currently disabled'
+            : status?.pskReporterEnabled && status?.wsprnetEnabled
+              ? 'Uploading to PSK Reporter + WSPRnet'
+              : status?.pskReporterEnabled
+                ? 'Uploading FT8/FT4 to PSK Reporter'
+                : 'Uploading WSPR to WSPRnet'}
+        </div>
+
+        <div style={{ display: 'flex', gap: 6 }}>
+          <span style={{ flex: 1 }} />
+          <button type="submit" disabled={saving} className="btn sm active">
+            {saving ? 'SAVING…' : 'SAVE'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/zeus-web/src/dsp/ft8-passband.ts
+++ b/zeus-web/src/dsp/ft8-passband.ts
@@ -22,6 +22,13 @@
 export const FT8_MIN_OFFSET_HZ = 0;
 export const FT8_MAX_OFFSET_HZ = 3000;
 
+/** The TX audio-offset range — narrower than the RX search span so a transmitted
+ *  tone stays comfortably inside the SSB passband. This is the SINGLE source of
+ *  truth for TX-offset clamping: the waterfall click, the OFFSET input, and the
+ *  controller (`setTxFreq`) all clamp to it so click, type, and the value POSTed
+ *  to the keyer always agree. Distinct from the wider RX `FT8_MAX_OFFSET_HZ`. */
+export const FT8_MAX_TX_OFFSET_HZ = 2500;
+
 /** Snap a waterfall click to a nearby decode when the cursor lands within this
  *  many screen pixels of a decoded signal's audio offset. Light, ham-friendly. */
 export const DECODE_SNAP_RADIUS_PX = 30;
@@ -146,5 +153,12 @@ export function resolveWaterfallClick(
   offsetHz: number,
   holdTxFreq: boolean,
 ): WaterfallClickResult {
-  return { rxFocusHz: offsetHz, txOffsetHz: holdTxFreq ? null : offsetHz };
+  // RX focus follows the full search span; the TX offset is clamped to the
+  // narrower TX range so a click past it can't stage an out-of-band tone.
+  return {
+    rxFocusHz: offsetHz,
+    txOffsetHz: holdTxFreq
+      ? null
+      : clampOffsetHz(offsetHz, FT8_MIN_OFFSET_HZ, FT8_MAX_TX_OFFSET_HZ),
+  };
 }

--- a/zeus-web/src/dsp/ft8-tx-controller.ts
+++ b/zeus-web/src/dsp/ft8-tx-controller.ts
@@ -18,6 +18,7 @@
 // true, so a disarmed controller never POSTs /tx.
 
 import { parseFt8Message } from './ft8-message';
+import { FT8_MAX_TX_OFFSET_HZ, FT8_MIN_OFFSET_HZ } from './ft8-passband';
 import {
   answerCq as seqAnswerCq,
   currentOutgoing,
@@ -170,9 +171,12 @@ export class Ft8TxController {
     void this.postHalt();
   }
 
-  /** TX EVEN / ODD. */
+  /** TX EVEN / ODD. While armed, re-stage the current message immediately so the
+   *  slot flip reaches the keyer this slot instead of waiting for the next
+   *  per-window restage. */
   setTxSlot(slot: Slot): void {
     this.state = { ...this.state, txSlot: slot };
+    this.restageIfArmed();
   }
 
   /** FT8 ↔ FT4 (slot timing differs; sequencer text is identical). */
@@ -195,10 +199,28 @@ export class Ft8TxController {
     this.state = { ...this.state, holdTxFreq: hold };
   }
 
-  /** Waterfall click → TX offset. Ignored while HOLD TX FREQ is engaged. */
+  /** Waterfall click / OFFSET input → TX offset. Ignored while HOLD TX FREQ is
+   *  engaged. Clamped to the TX-offset range (the single source of truth shared
+   *  with the waterfall click and the OFFSET input) so click, type, and the
+   *  value POSTed to the keyer always agree. While armed, re-stage immediately so
+   *  the new offset reaches the keyer this slot. */
   setTxFreq(hz: number): void {
     if (this.state.holdTxFreq) return;
-    this.audioHz = hz;
+    const clamped = Number.isFinite(hz)
+      ? Math.min(FT8_MAX_TX_OFFSET_HZ, Math.max(FT8_MIN_OFFSET_HZ, hz))
+      : FT8_MIN_OFFSET_HZ;
+    this.audioHz = clamped;
+    this.restageIfArmed();
+  }
+
+  /** Re-POST the currently-staged message when armed, so an operator adjustment
+   *  (offset / slot) propagates within the same slot instead of waiting for the
+   *  next per-window restage. No-op when disarmed (a disarmed controller never
+   *  POSTs /tx). */
+  private restageIfArmed(): void {
+    if (!this.state.enableTx) return;
+    const msg = currentOutgoing(this.state);
+    if (msg != null) void this.postStage(msg);
   }
 
   /** Start calling CQ (CALL 1ST). */

--- a/zeus-web/src/layout/ft8/Ft8TxControl.tsx
+++ b/zeus-web/src/layout/ft8/Ft8TxControl.tsx
@@ -18,6 +18,7 @@ import { useState } from 'react';
 import { setTun } from '../../api/client';
 import { DriveSlider } from '../../components/DriveSlider';
 import { TunePowerSlider } from '../../components/TunePowerSlider';
+import { FT8_MAX_TX_OFFSET_HZ, FT8_MIN_OFFSET_HZ } from '../../dsp/ft8-passband';
 import { genCq, genTx4, genTx5 } from '../../dsp/ft8-sequencer';
 import type { Ft8TxRunnerView } from '../../dsp/ft8-tx-runner';
 import { useFt8TxStore } from '../../state/ft8-tx-store';
@@ -109,8 +110,8 @@ export function Ft8TxControl({ runner, myCall, myGrid }: Ft8TxControlProps) {
           <span>OFFSET</span>
           <input
             type="number"
-            min={0}
-            max={2500}
+            min={FT8_MIN_OFFSET_HZ}
+            max={FT8_MAX_TX_OFFSET_HZ}
             step={1}
             value={Math.round(runner.audioHz)}
             disabled={qso.holdTxFreq}

--- a/zeus-web/src/layout/ft8/Ft8Workspace.tsx
+++ b/zeus-web/src/layout/ft8/Ft8Workspace.tsx
@@ -24,6 +24,7 @@ import { Ft8TxControl } from './Ft8TxControl';
 import { Ft8ReceivePanel } from './Ft8ReceivePanel';
 import { Ft8ActivityLog } from './Ft8ActivityLog';
 import { Ft8Stats } from './Ft8Stats';
+import { SpottingIndicator } from './SpottingIndicator';
 import '../../styles/ft8-theme.css';
 
 export interface Ft8WorkspaceProps {
@@ -281,6 +282,9 @@ export function Ft8Workspace({ onClose }: Ft8WorkspaceProps) {
         <span>{decodeCount} decodes</span>
         {error && <span className="warn">{error}</span>}
         <span style={{ marginLeft: 'auto' }}>
+          <SpottingIndicator kind="psk" />
+        </span>
+        <span>
           {protocol} native · {band}
         </span>
       </footer>

--- a/zeus-web/src/layout/ft8/Ft8Workspace.tsx
+++ b/zeus-web/src/layout/ft8/Ft8Workspace.tsx
@@ -125,6 +125,15 @@ export function Ft8Workspace({ onClose }: Ft8WorkspaceProps) {
     }
   };
 
+  // Hydrate the logbook once when the workspace opens. The mode-picker opens
+  // this overlay directly, so without this the Activity Log and the
+  // worked-before / new-grid highlighting stay empty until SpotsPanel mounts or
+  // the first QSO is logged. addLogEntry re-loads after each write, so this only
+  // covers the initial fetch.
+  useEffect(() => {
+    void useLoggerStore.getState().loadEntries();
+  }, []);
+
   // Esc closes the workspace.
   useEffect(() => {
     if (!onClose) return;

--- a/zeus-web/src/layout/ft8/SpottingIndicator.tsx
+++ b/zeus-web/src/layout/ft8/SpottingIndicator.tsx
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Small status-bar indicator for the digital-mode spotting uploaders. Accent
+// (blue) when the relevant uploader is enabled AND operator identity is resolved;
+// --tx (red) when enabled but missing callsign/grid; dim when off. Read-only — it
+// reflects the /api/spotting state that the Network settings tab owns.
+
+import { useEffect } from 'react';
+import { useSpottingStore } from '../../state/spotting-store';
+
+export function SpottingIndicator({ kind }: { kind: 'psk' | 'wsprnet' }) {
+  const status = useSpottingStore((s) => s.status);
+  const refreshStatus = useSpottingStore((s) => s.refreshStatus);
+
+  // Pick up any toggle made on the settings tab while a workspace is open.
+  useEffect(() => {
+    void refreshStatus();
+  }, [refreshStatus]);
+
+  const enabled =
+    kind === 'psk' ? (status?.pskReporterEnabled ?? false) : (status?.wsprnetEnabled ?? false);
+  const identityResolved = status?.identityResolved ?? false;
+  const label = kind === 'psk' ? 'PSK REPORTER' : 'WSPRNET';
+
+  const color = !enabled
+    ? 'var(--fg-3)'
+    : identityResolved
+      ? 'var(--accent)'
+      : 'var(--tx)';
+
+  const text = !enabled
+    ? `${label} off`
+    : identityResolved
+      ? `${label} on`
+      : `${label} — set call/grid`;
+
+  return (
+    <span
+      title="Digital-mode spotting (Settings → Network)"
+      style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}
+    >
+      <span
+        style={{
+          width: 8,
+          height: 8,
+          borderRadius: '50%',
+          background: color,
+          flexShrink: 0,
+        }}
+      />
+      {text}
+    </span>
+  );
+}

--- a/zeus-web/src/layout/ft8/WsprWorkspace.tsx
+++ b/zeus-web/src/layout/ft8/WsprWorkspace.tsx
@@ -11,6 +11,7 @@ import { useConnectionStore } from '../../state/connection-store';
 import { useOperatorStore } from '../../state/operator-store';
 import { DIGITAL_BANDS } from '../../dsp/digital-segments';
 import { WsprTxControl } from './WsprTxControl';
+import { SpottingIndicator } from './SpottingIndicator';
 import '../../styles/ft8-theme.css';
 
 function useUtcClock(): string {
@@ -140,7 +141,10 @@ export function WsprWorkspace({ onClose }: { onClose?: () => void }) {
         </span>
         <span>{rows.length} spots</span>
         {error && <span className="warn">{error}</span>}
-        <span style={{ marginLeft: 'auto' }}>WSPR native · {band}</span>
+        <span style={{ marginLeft: 'auto' }}>
+          <SpottingIndicator kind="wsprnet" />
+        </span>
+        <span>WSPR native · {band}</span>
       </footer>
     </div>
   );

--- a/zeus-web/src/state/spotting-store.test.ts
+++ b/zeus-web/src/state/spotting-store.test.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock the REST layer BEFORE the store imports it — the store fires a one-shot
+// status probe on module load. Both uploaders default OFF.
+vi.mock('../api/spotting', () => ({
+  getSpottingStatus: vi.fn(async () => ({
+    pskReporterEnabled: false,
+    wsprnetEnabled: false,
+    callsign: '',
+    grid: '',
+    identityResolved: false,
+  })),
+  postSpottingConfig: vi.fn(
+    async (cfg: {
+      pskReporterEnabled: boolean;
+      wsprnetEnabled: boolean;
+      callsign: string;
+      grid: string;
+    }) => ({
+      ...cfg,
+      identityResolved: cfg.callsign !== '' && cfg.grid !== '',
+    }),
+  ),
+}));
+
+import { useSpottingStore } from './spotting-store';
+import * as api from '../api/spotting';
+
+describe('spotting-store', () => {
+  it('defaults both uploaders to disabled egress (opt-in)', () => {
+    const { config } = useSpottingStore.getState();
+    expect(config.pskReporterEnabled).toBe(false);
+    expect(config.wsprnetEnabled).toBe(false);
+  });
+
+  it('never auto-POSTs config on load (no silent enable)', () => {
+    expect(api.postSpottingConfig).not.toHaveBeenCalled();
+  });
+
+  it('saveConfig pushes the operator choice to the backend', async () => {
+    const cfg = {
+      pskReporterEnabled: true,
+      wsprnetEnabled: false,
+      callsign: 'K1ABC',
+      grid: 'FN42',
+    };
+    const status = await useSpottingStore.getState().saveConfig(cfg);
+    expect(api.postSpottingConfig).toHaveBeenCalledWith(cfg);
+    expect(status.pskReporterEnabled).toBe(true);
+    expect(status.identityResolved).toBe(true);
+    expect(useSpottingStore.getState().config.pskReporterEnabled).toBe(true);
+    expect(useSpottingStore.getState().config.callsign).toBe('K1ABC');
+  });
+});

--- a/zeus-web/src/state/spotting-store.ts
+++ b/zeus-web/src/state/spotting-store.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+import { create } from 'zustand';
+import {
+  getSpottingStatus,
+  postSpottingConfig,
+  type SpottingConfig,
+  type SpottingStatus,
+} from '../api/spotting';
+
+// The backend (SpottingSettingsStore on disk) is the source of truth. The form
+// initialises from /api/spotting/status once it arrives. Do NOT seed from
+// localStorage and do NOT auto-POST on load (same lesson as TCI/CAT/WSJT-X).
+// Both uploaders default OFF — new network egress is opt-in only.
+const DEFAULT_CONFIG: SpottingConfig = {
+  pskReporterEnabled: false,
+  wsprnetEnabled: false,
+  callsign: '',
+  grid: '',
+};
+
+export type SpottingStoreState = {
+  config: SpottingConfig;
+  status: SpottingStatus | null;
+
+  refreshStatus: () => Promise<void>;
+  saveConfig: (cfg: SpottingConfig) => Promise<SpottingStatus>;
+};
+
+export const useSpottingStore = create<SpottingStoreState>((set, get) => ({
+  config: DEFAULT_CONFIG,
+  status: null,
+
+  refreshStatus: async () => {
+    try {
+      const status = await getSpottingStatus();
+      const current = get().config;
+      const synced =
+        current.pskReporterEnabled === status.pskReporterEnabled &&
+        current.wsprnetEnabled === status.wsprnetEnabled &&
+        current.callsign === status.callsign &&
+        current.grid === status.grid;
+      set({
+        status,
+        config: synced
+          ? current
+          : {
+              pskReporterEnabled: status.pskReporterEnabled,
+              wsprnetEnabled: status.wsprnetEnabled,
+              callsign: status.callsign,
+              grid: status.grid,
+            },
+      });
+    } catch {
+      /* transient — next refresh recovers */
+    }
+  },
+
+  saveConfig: async (cfg) => {
+    const status = await postSpottingConfig(cfg);
+    set({
+      status,
+      config: {
+        pskReporterEnabled: status.pskReporterEnabled,
+        wsprnetEnabled: status.wsprnetEnabled,
+        callsign: status.callsign,
+        grid: status.grid,
+      },
+    });
+    return status;
+  },
+}));
+
+// Initial status probe (one-shot — config applies live so no polling needed).
+if (typeof window !== 'undefined') {
+  void useSpottingStore.getState().refreshStatus();
+}


### PR DESCRIPTION
## ⛔ DO NOT MERGE — bench sign-off required (network egress)

**Stack 4 of 4.** Base: `ft8/adif-log` (PR for #1015). Top of the stack — also carries the final cross-cutting integration fixes for all four features.

Adds **opt-in spotting** and the integration fixes from the final full-stack audit.

### What's in it
- **PSK Reporter** (FT8/FT4) — IPFIX datagram, batched/deduped, flush every 5 min to `report.pskreporter.info:4739`. **WSPRnet** (WSPR) — form POST per spot.
- Pure-C# sender call/grid extractor (rejects bare grids so free text never spots a nonexistent station). Network-tab settings panel + enable indicator, mirroring the CAT/WSJT-X idiom.
- **Final integration fixes** (cross-team seams no per-feature review could catch): hydrate the logbook on workspace open; single source of truth for the TX audio-offset clamp (waterfall/input/controller now agree, nothing out-of-range reaches the keyer); re-stage on offset/slot change while armed; gate PSK Reporter before the radio snapshot on the decode thread.

### Refs
#1014 (spotting).

### Safety / bench
- **Default OFF, never auto-enables**; nothing uploads until the operator enables a network AND callsign/grid resolve. Failures swallowed off the RX thread.
- PureSignal untouched; no default changes.
- **Bench:** confirm PSK Reporter / WSPRnet accept our uploads (callsign appears on the maps).
