### PR TITLE
fix(agc): stop strong-signal loudness pumping in auto-AGC-T

### DIFF
--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -245,11 +245,6 @@ public sealed class RadioService : IDisposable
     // re-seeds to the new band's noise within ~1.5 s instead of averaging the
     // old band in (Thetis fast-attack on band/freq delta > 0.5 MHz).
     private const double AgcFastAttackVfoDeltaHz = 500_000.0;
-    private const double AgcMinEffectiveAgcT = 20.0;
-    private const double AgcMaxEffectiveAgcT = 100.0;
-    private const double AgcCutStressThresholdDb = -10.0;
-    private const double AgcCutTargetDb = -8.0;
-    private const double AgcAdcPressureThresholdDbfs = -6.0;
 
     // ── Auto-AGC-T threshold servo (Thetis parity) ──────────────────────────
     // Auto-AGC-T sets the AGC *threshold* (knee) to the noise floor, exactly as
@@ -2486,6 +2481,11 @@ public sealed class RadioService : IDisposable
     // which in this integration is the post-AGC audio-RMS fallback (it moves with
     // the signal, not the floor), is kept only as the degraded fallback for when
     // no fresh spectrum is available (stale analyzer frame / near-dead span).
+    //
+    // adcPkDbfs and agcGainDb are retained for call-site/back-compat and
+    // diagnostics only — they NO LONGER drive the loop. They previously fed a
+    // Zeus-only ADC-overload cut that pumped strong signals; Thetis's servo
+    // tracks the noise floor and nothing else (see the windowReady block below).
     internal void HandleRxMetersForAutoAgc(double signalDbm, double spectrumFloorDbm, double adcPkDbfs, double agcGainDb, long nowMs)
     {
         bool changedOffset = false;
@@ -2498,10 +2498,7 @@ public sealed class RadioService : IDisposable
             if (_mox) return;   // Pause during TX
             bool hasSpectrumFloor = double.IsFinite(spectrumFloorDbm) && spectrumFloorDbm > -250.0;
             bool hasSignalMeter = double.IsFinite(signalDbm) && signalDbm > -250.0;
-            bool hasAgcGain = double.IsFinite(agcGainDb) && agcGainDb > -199.5;
-            bool hasAdcPeak = double.IsFinite(adcPkDbfs) && adcPkDbfs > -199.5;
-            bool adcUnderPressure = hasAdcPeak && adcPkDbfs > AgcAdcPressureThresholdDbfs;
-            if (!hasSpectrumFloor && !hasSignalMeter && !hasAgcGain) return;
+            if (!hasSpectrumFloor && !hasSignalMeter) return;
 
             // If we paused for longer than the analysis window (TX,
             // just-toggled-on, RX dropout) the
@@ -2587,28 +2584,19 @@ public sealed class RadioService : IDisposable
                 double autoTop = AutoAgcTopFromNoiseFloor(noiseFloor);
                 desiredOffset = autoTop - _state.AgcTopDb;
             }
-            else if (_agcOffsetDb < 0.0 && (!hasAgcGain || agcGainDb >= AgcCutStressThresholdDb || !adcUnderPressure))
-            {
-                // Warm-up release: the window isn't ready yet (just re-seeded / too
-                // few samples) but a leftover negative offset from an earlier
-                // ADC-pressure cut is still applied. If the stress has cleared,
-                // release it to 0 until the noise-floor path can take over once the
-                // window fills. (With symmetric tracking, a steady-state negative
-                // offset is normal and is owned by the windowReady branch above —
-                // this branch only governs the not-ready transient.)
-                desiredOffset = 0.0;
-            }
-
-            if (hasAgcGain && agcGainDb < AgcCutStressThresholdDb && adcUnderPressure)
-            {
-                double effectiveNow = _state.AgcTopDb + _agcOffsetDb;
-                double adcUrgencyDb = Math.Min(6.0, adcPkDbfs + 6.0);
-                double targetEffective = Math.Clamp(
-                    effectiveNow + (agcGainDb - AgcCutTargetDb) - adcUrgencyDb,
-                    AgcMinEffectiveAgcT,
-                    AgcMaxEffectiveAgcT);
-                desiredOffset = Math.Min(desiredOffset, targetEffective - _state.AgcTopDb);
-            }
+            // Thetis's auto-AGC-T tick (console.cs tmrAutoAGC_Tick:46066) does ONE
+            // thing: seat the AGC threshold at the SETTLED noise floor. It never
+            // reacts to instantaneous signal level or ADC peak. An earlier Zeus-only
+            // "ADC overload protection" used to cut the effective AGC-T whenever WDSP
+            // was cutting hard AND the ADC ran hot — which, on a steady strong
+            // signal, pulled the gain down and then released it as the signal paused.
+            // That MANUFACTURED the loudness pumping operators reported ("a strong
+            // signal goes low then high"). Removed: the noise-floor servo alone is
+            // the Thetis-faithful, non-pumping behaviour. Recovering from a genuine
+            // ADC overload is the operator's RF-gain / attenuation call (auto-ATT
+            // owns that path) — it is not the audio AGC loop's job, and post-ADC AGC
+            // cannot un-clip an already-overdriven sample anyway. When the floor
+            // window isn't ready yet, desiredOffset simply holds the current offset.
 
             double delta = desiredOffset - _agcOffsetDb;
             // Deadband: ignore sub-0.5 dB wobble so a jumpy floor estimate can't

--- a/tests/Zeus.Server.Tests/RadioServiceAutoAgcTests.cs
+++ b/tests/Zeus.Server.Tests/RadioServiceAutoAgcTests.cs
@@ -199,29 +199,34 @@ public sealed class RadioServiceAutoAgcTests : IDisposable
     }
 
     [Fact]
-    public void AutoAgc_LowersEffectiveGainWhenWdspAgcIsCuttingAndAdcIsNearFullScale()
+    public void AutoAgc_IgnoresAdcPressureAndAgcCut_TracksNoiseFloorOnly()
     {
+        // Thetis parity (console.cs tmrAutoAGC_Tick): the auto-AGC-T servo seats the
+        // knee at the noise floor and does NOTHING else. A hot ADC (-5 dBfs) with
+        // WDSP cutting hard (-28 dB) must NOT pull the effective gain below the
+        // floor-path target. The old Zeus-only ADC-overload cut did exactly that and
+        // manufactured loudness pumping on strong signals ("low then high"); it has
+        // been removed. So the offset equals the pure noise-floor value regardless
+        // of ADC peak / WDSP AGC gain.
         using var radio = NewRadio();
         radio.SetAgcTop(60.0);
         radio.SetAutoAgc(true);
 
-        radio.HandleRxMetersForAutoAgc(signalDbm: -72.0, adcPkDbfs: -5.0, agcGainDb: -28.0, nowMs: 0);
+        for (int i = 0; i < 20; i++)
+            radio.HandleRxMetersForAutoAgc(signalDbm: -72.0, adcPkDbfs: -5.0, agcGainDb: -28.0, nowMs: i * 500);
 
-        // ADC overload protection now JUMPS the cut (fast protection) instead of
-        // crawling -0.5 dB/tick: effective target = clamp(60 + (-28-(-8)) - 1, 20,
-        // 100) = 39, so the offset snaps to 39-60 = -21 on the first event.
         var snap = radio.Snapshot();
         Assert.Equal(60.0, snap.AgcTopDb);
-        Assert.Equal(-21.0, snap.AgcOffsetDb);
+        Assert.Equal(radio.AutoAgcTopFromNoiseFloor(-72.0) - 60.0, snap.AgcOffsetDb);
     }
 
     [Fact]
     public void AutoAgc_DoesNotLowerEffectiveGainWhenWdspAgcCutsWithCleanAdcHeadroom()
     {
-        // The protective ADC cut must require ADC pressure: WDSP AGC cutting
-        // (agcGain -24.5) with clean ADC headroom (-60 dBfs) must NOT pull gain
-        // below what the noise-floor servo alone wants. So the offset equals the
-        // pure floor-path value (no extra protective cut applied).
+        // WDSP AGC cutting (agcGain -24.5) with clean ADC headroom (-60 dBfs) must
+        // track the pure noise-floor servo target — no extra cut. (With the ADC cut
+        // removed this is the same path as the hot-ADC case above; kept as a
+        // regression guard that AGC-gain alone never moves the offset.)
         using var radio = NewRadio();
         radio.SetAgcTop(52.0);
         radio.SetAutoAgc(true);
@@ -232,31 +237,6 @@ public sealed class RadioServiceAutoAgcTests : IDisposable
         var snap = radio.Snapshot();
         Assert.Equal(52.0, snap.AgcTopDb);
         Assert.Equal(radio.AutoAgcTopFromNoiseFloor(-92.0) - 52.0, snap.AgcOffsetDb);
-    }
-
-    [Fact]
-    public void AutoAgc_RecoversNegativeOffsetWhenAgcCutClears()
-    {
-        using var radio = NewRadio();
-        radio.SetAgcTop(60.0);
-        radio.SetAutoAgc(true);
-
-        // Floor-path target for a -70 dBm floor at baseline 60 (≈ -2 dB offset).
-        double floorOffset = radio.AutoAgcTopFromNoiseFloor(-70.0) - 60.0;
-
-        // Sustained overload (ADC near full scale, WDSP cutting hard) drives the
-        // protective cut BELOW the floor-path target (jumps fast).
-        for (int i = 0; i < 4; i++)
-            radio.HandleRxMetersForAutoAgc(signalDbm: -70.0, adcPkDbfs: -5.0, agcGainDb: -28.0, nowMs: i * 500);
-
-        Assert.True(radio.Snapshot().AgcOffsetDb < floorOffset,
-            "overload should cut the offset below the floor-path target");
-
-        // ADC pressure clears and WDSP is no longer cutting: the offset recovers
-        // (jumps) back to the pure noise-floor target.
-        radio.HandleRxMetersForAutoAgc(signalDbm: -70.0, adcPkDbfs: -18.0, agcGainDb: 0.0, nowMs: 2_000);
-
-        Assert.Equal(floorOffset, radio.Snapshot().AgcOffsetDb);
     }
 
     // ── issue #733: AGC-T slider must be authoritative ────────────────────────


### PR DESCRIPTION
## Problem

With **Auto-AGC-T enabled**, a steady strong signal swings **low then high** in loudness — pumping, not a static knee-placement issue. The flat-loudness goal (all signals same volume) was being undone dynamically.

## Root cause

Auto-AGC-T is supposed to seat the AGC knee at the noise floor and let slope-0 (flat) AGC hold everything above it at one loudness. But the servo carried a **Zeus-only "ADC overload protection"** (added in `672b9139d`, made jump-fast in `224f6d7cf`): whenever WDSP was cutting hard **and** the ADC peak ran hot (> −6 dBFS), it **jumped the effective AGC-T down** (its own test documented a −21 dB jump in one tick), then jumped it back as the signal paused. On a steady strong SSB signal that *manufactures* the pumping.

Thetis's reference servo (`console.cs` `tmrAutoAGC_Tick:46066`) does exactly **one** thing — `setAGCThresholdPoint(noiseFloor + offset)` — and never reacts to instantaneous signal or ADC level.

## Fix

Remove the ADC-pressure cut, its now-dead warm-up-release branch, and 5 orphaned constants. The auto-AGC-T servo now tracks the **settled noise floor only** — Thetis-faithful and non-pumping. `adcPkDbfs`/`agcGainDb` params are retained for call-site/back-compat + diagnostics but no longer drive the loop.

Genuine ADC-overload recovery remains the operator's RF-gain / attenuation call (auto-ATT owns that path); post-ADC AGC cannot un-clip an already-overdriven sample anyway.

## Behaviour after

- Steady strong signal holds steady loudness (no low-then-high swing).
- Weak and strong signals both flatten to the same level (slope 0 + knee at floor).
- **Side effect (intended):** on true ADC overload the audio is no longer auto-ducked — correct, since that's an antenna/attenuation problem, not an audio-AGC one.

## Tests

`RadioServiceAutoAgcTests` — replaced the two cut-behaviour tests with `AutoAgc_IgnoresAdcPressureAndAgcCut_TracksNoiseFloorOnly`, asserting the offset equals the pure noise-floor target regardless of ADC peak / WDSP AGC gain. **20/20 green** in the suite; build clean.

Diff is scoped to two files (`RadioService.cs`, `RadioServiceAutoAgcTests.cs`).