### PR TITLE
fix(web,tx): TX waterfall slider sticks during MOX; VST OUT meter shows true overshoot

### DIFF
--- a/Zeus.Server.Hosting/AudioPluginBridge.cs
+++ b/Zeus.Server.Hosting/AudioPluginBridge.cs
@@ -546,11 +546,16 @@ public sealed class AudioPluginBridge : IHostedService, IAsyncDisposable
         bool processed;
         try { processed = vst.TryProcess(input, output, ctx); }
         finally { Volatile.Write(ref _engineGate, 0); }
-        DspPipelineService.SanitizeAudioBuffer(output[..sampleCount]);
         // Sample master IN/OUT peaks so the Audio Suite meters stay live in VST
-        // mode (the native chain's own metering path didn't run).
+        // mode (the native chain's own metering path didn't run). Tap the OUT
+        // peak from the RAW engine output BEFORE the ±1 safety clamp below, so
+        // the meter shows real overshoot (a hot plugin railing past full scale)
+        // instead of pinning at exactly 0 dBFS once the chain clips. This
+        // mirrors the native AudioChain, which also meters pre-clamp; BlockPeak
+        // skips non-finite samples, so reading un-sanitized output is safe.
         if (processed || recordPassthroughMeters)
             RecordEngineMeters(input, output[..sampleCount]);
+        DspPipelineService.SanitizeAudioBuffer(output[..sampleCount]);
         return true;
     }
 

--- a/zeus-web/src/state/display-settings-store.test.ts
+++ b/zeus-web/src/state/display-settings-store.test.ts
@@ -333,6 +333,18 @@ describe('TX auto-range', () => {
     expect(useDisplaySettingsStore.getState().txAutoRange).toBe(false);
   });
 
+  it('dragging the TX panadapter scale switches auto-range off so the drag sticks', () => {
+    useDisplaySettingsStore.setState({ txAutoRange: true });
+    useDisplaySettingsStore.getState().shiftTxDbRange(5);
+    expect(useDisplaySettingsStore.getState().txAutoRange).toBe(false);
+  });
+
+  it('dragging the TX waterfall scale switches auto-range off so the drag sticks', () => {
+    useDisplaySettingsStore.setState({ txAutoRange: true });
+    useDisplaySettingsStore.getState().shiftWfTxDbRange(5);
+    expect(useDisplaySettingsStore.getState().txAutoRange).toBe(false);
+  });
+
   describe('shouldTxAutoRange — engages only for voice MOX/PTT', () => {
     const tx = (over: Partial<{ moxOn: boolean; tunOn: boolean; twoToneOn: boolean }> = {}) => ({
       moxOn: false,

--- a/zeus-web/src/state/display-settings-store.ts
+++ b/zeus-web/src/state/display-settings-store.ts
@@ -825,7 +825,12 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
   shiftTxDbRange: (deltaDb) => {
     const { txDbMin, txDbMax } = get();
     const { min: nextMin, max: nextMax } = clampShift(txDbMin, txDbMax, deltaDb);
-    set({ txDbMin: nextMin, txDbMax: nextMax });
+    // Dragging the TX scale is a manual window edit — it must take over from
+    // auto-range, exactly like setTxDbRange. Without this the per-frame
+    // updateTxAutoRange EMA fights the drag and snaps it back every frame, so
+    // the scale appears frozen during voice MOX. (Thetis parity: TX uses a
+    // fixed manual threshold, not an auto fit.)
+    set({ txAutoRange: false, txDbMin: nextMin, txDbMax: nextMax });
     writeSavedTxRange(nextMin, nextMax);
     scheduleDbRangeSave();
   },
@@ -839,7 +844,13 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>((set, get) =
   shiftWfTxDbRange: (deltaDb) => {
     const { wfTxDbMin, wfTxDbMax } = get();
     const { min: nextMin, max: nextMax } = clampShift(wfTxDbMin, wfTxDbMax, deltaDb);
-    set({ wfTxDbMin: nextMin, wfTxDbMax: nextMax });
+    // Dragging the TX waterfall scale is a manual window edit — it must take
+    // over from auto-range, exactly like setWfTxDbRange. Without this the
+    // per-frame updateTxAutoRange EMA fights the drag and snaps it back every
+    // frame, so the waterfall slider appears to do nothing during voice MOX.
+    // (Thetis parity: the TX waterfall follows the operator's slider, not an
+    // auto fit.)
+    set({ txAutoRange: false, wfTxDbMin: nextMin, wfTxDbMax: nextMax });
     writeSavedWfTxRange(nextMin, nextMax);
     scheduleDbRangeSave();
   },


### PR DESCRIPTION
## Summary

Two TX-display fidelity fixes, both bringing Zeus in line with Thetis behavior. Reported from the bench: the Audio Suite **OUT** meter was pinned at full scale, and the **waterfall slider didn't adjust the TX waterfall** the way it does in Thetis.

### 1. TX waterfall slider now sticks during MOX (Thetis parity)
`txAutoRange` is on by default, and while keyed for voice MOX `updateTxAutoRange()` EMA-drives **both** TX windows every frame (`Panadapter.tsx`). Dragging the TX waterfall/panadapter scale called `shiftWfTxDbRange`/`shiftTxDbRange`, which — unlike the spin-box setters (`setWfTxDbRange`/`setTxDbRange`) and the RX `shiftDbRange` — did **not** clear `txAutoRange`. So the per-frame auto fit snapped the operator's drag back every frame and the slider appeared dead during TX.

Both shift setters now clear `txAutoRange` on drag (and persist), so a manual drag takes over from auto-range and stays put — mirroring Thetis's fixed manual `TXWFAmpMin`/`TXWFAmpMax` thresholds. Auto-range is still available via the Spectrum Scale settings checkbox.

### 2. VST chain OUT meter shows true overshoot ("OUT stuck at max")
In VST-engine mode the OUT chain meter was sampled in `AudioPluginBridge.TryProcessThroughEngine` **after** the ±1 `SanitizeAudioBuffer` clamp, so it pinned to exactly 0 dBFS and couldn't show how far a hot plugin railed past full scale. The native `AudioChain` already meters pre-clamp, so the two paths disagreed.

Moved the meter tap ahead of the clamp so it reads the raw engine output. **Audio-neutral** — the buffer sent to TX is still clamped; `BlockPeak` skips non-finite samples, so reading the un-sanitized output is safe. The advisor's "lower VST/plugin output trim" guidance still applies when a loaded plugin genuinely rails the output; the meter now shows *how much* to trim instead of just sitting at max.

## Tests
- `display-settings-store.test.ts`: added two regression tests asserting `shiftTxDbRange`/`shiftWfTxDbRange` disengage `txAutoRange`. Full store suite 28/28.
- Backend `AudioPluginBridge` tests 25/25.

## Notes
Not browser-verifiable in headless preview (WebGL waterfall + TX-keyed window; OUT meter needs a live radio + VST engine) — verified via unit tests and build. Worth a quick bench confirm while transmitting.