### PR TITLE
fix(web): contain Lightning Map control z-indexes to its panel

### DIFF
--- a/zeus-web/src/layout/panels/LightningMapPanel.css
+++ b/zeus-web/src/layout/panels/LightningMapPanel.css
@@ -14,6 +14,13 @@
   height: 100%;
   overflow: hidden;
   background: #04060c;
+  /* isolation: isolate contains every descendant z-index inside this panel's
+   * own stacking context — Leaflet's internal panes (200–700) and controls
+   * (800–1000) plus our HUD/recenter/alert buttons (450–600). Without it those
+   * high z-indexes escape the panel and paint over whatever sibling panel is
+   * layered on top (e.g. the VST editor overlay). Same fix as .rc-map in
+   * layout.css for the rotator compass. */
+  isolation: isolate;
 }
 
 .lightning-map .lm-host {


### PR DESCRIPTION
## Problem

The Lightning Map panel's controls (zoom +/−, RECENTER, ALERT, HUD) render **on top of** other panels layered in front of it — e.g. the VST editor overlay in the Audio Suite. The overlay correctly covers the map background, but the buttons poke through.

![symptom: lightning map buttons floating over the VST editor window]

## Root cause

`.lightning-map` never established its own **stacking context**, so three tiers of high-`z-index` descendants escaped the panel and competed globally with sibling panels:

- Leaflet's internal map panes — `z-index` 200–700
- Leaflet's zoom / attribution controls — `z-index` 800–1000
- The panel's own HUD / RECENTER / ALERT controls — `z-index` 450–600

## Fix

Add `isolation: isolate` to `.lightning-map`. That forces the panel to become a stacking context, so every descendant `z-index` is resolved *relative to the panel* and the whole panel stacks as a single unit by its normal paint order. Anything layered in front (the VST overlay) then cleanly covers it, buttons included.

This is the **identical remedy already proven** on the rotator-compass map (`.rc-map` in `layout.css:2624-2626`), which had the same Leaflet-pane-escape problem.

## Scope / risk

- One CSS property, one selector. No behaviour, palette, layout-default, UX, or contract change.
- Green-light: pure containment bug fix with a clear root cause.

## Verification note

Not browser-verifiable in the headless preview — the preview page can't render Leaflet/canvas map panels (off-screen, rAF never fires), and reproducing needs a loaded VST overlay composited with the map. Validated by the CSS stacking model and by parity with the existing `.rc-map` fix.