### PR TITLE
DO NOT MERGE: FT8 settings page + make TX testable end-to-end (#1012)

### DIFF
--- a/Zeus.Contracts/Ft8Settings.cs
+++ b/Zeus.Contracts/Ft8Settings.cs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+//
+// Ft8Settings — the operator's persisted FT8/FT4 workspace preferences (the
+// curated WSJT-X/JTDX KEEP set that is purely behaviour/UI, not radio control).
+// Persisted server-side (zeus-prefs.db) so they survive desktop restarts — the
+// frontend's old localStorage was port-scoped on the webview and lost on every
+// launch. Operator IDENTITY (callsign/grid) is NOT here: it lives in the shared
+// OperatorIdentity so spotting/FreeDV/TX all read one source.
+
+namespace Zeus.Contracts;
+
+/// <summary>
+/// Persisted FT8/FT4 behaviour preferences surfaced on the FT8 Settings page.
+/// Defaults are chosen so the first session behaves EXACTLY as it did before this
+/// page existed (auto-sequence on, RR73 ack, disable-after-73 on, 3 decode
+/// passes) — nothing an operator already feels changes until they touch a
+/// control. Most flags are wired to the auto-sequence controller / macros / log
+/// path; a couple (SkipGrid, ClearDxAfterLog) are persisted but not yet consumed
+/// and are surfaced disabled ("coming soon") on the page. TX still requires an
+/// explicit arm; none of these flags transmit on their own.
+/// </summary>
+public sealed record Ft8Settings(
+    // ── TX & auto-sequence ──────────────────────────────────────────────────
+    /// <summary>Master auto-sequence on/off. TX still requires ENABLE/arm.</summary>
+    bool AutoSequence = true,
+    bool CallFirst = false,
+    bool HoldTxFreq = false,
+    bool DisableTxAfter73 = true,
+    /// <summary>Default TX slot: 0 = 1st (even), 1 = 2nd (odd).</summary>
+    int DefaultTxSlot = 0,
+    /// <summary>Default TX audio offset (Hz). Bounded on write.</summary>
+    int DefaultTxOffsetHz = 1500,
+    // Advanced sequence flags. RR73 ack is ON by default to match the engine's
+    // pre-settings behaviour (the sequencer keys RR73) and modern WSJT-X FT8.
+    bool Rr73InsteadOfRrr = true,
+    bool SkipGrid = false,
+    /// <summary>Caller max retries before giving up (0 = unlimited).</summary>
+    int CallerMaxRetries = 0,
+    // ── Macros ──────────────────────────────────────────────────────────────
+    string CqMessage = "CQ",
+    string CqDxMessage = "CQ DX",
+    string FreeTextMacro = "",
+    // ── Decode ──────────────────────────────────────────────────────────────
+    /// <summary>
+    /// Decode depth as passes, matching the engine scale (1 = Normal/floor,
+    /// &gt;1 = Deep/multi). Default 3 mirrors Ft8Service.DecodePasses so the first
+    /// session decodes exactly as deep as before this page existed. 1..4.
+    /// </summary>
+    int DecodePasses = 3,
+    bool ShowOnlyCq = false,
+    bool HideWorkedBefore = false,
+    // ── Logging ─────────────────────────────────────────────────────────────
+    bool AutoLog = true,
+    bool PromptBeforeLog = false,
+    bool ClearDxAfterLog = true,
+    bool ReportToComment = false)
+{
+    public const int MinOffsetHz = 200;
+    public const int MaxTxOffsetHz = 4000;
+    public const int MaxMacroLength = 13;     // FT8 free-text is 13 chars
+    public const int MinPasses = 1;
+    public const int MaxPasses = 4;
+
+    /// <summary>
+    /// Clamp/trim so a hand-crafted POST or stale row can't push out-of-range
+    /// values: offset bounded, passes 1..4, slot 0/1, macros trimmed/capped,
+    /// retries non-negative.
+    /// </summary>
+    public Ft8Settings Normalized() => this with
+    {
+        DefaultTxSlot = DefaultTxSlot == 0 ? 0 : 1,
+        DefaultTxOffsetHz = Math.Clamp(DefaultTxOffsetHz, MinOffsetHz, MaxTxOffsetHz),
+        CallerMaxRetries = Math.Max(0, CallerMaxRetries),
+        DecodePasses = Math.Clamp(DecodePasses, MinPasses, MaxPasses),
+        CqMessage = Cap(CqMessage, 32),
+        CqDxMessage = Cap(CqDxMessage, 32),
+        FreeTextMacro = Cap(FreeTextMacro, MaxMacroLength),
+    };
+
+    private static string Cap(string? s, int max)
+    {
+        var t = (s ?? "").Trim();
+        return t.Length > max ? t[..max] : t;
+    }
+}

--- a/Zeus.Contracts/OperatorIdentity.cs
+++ b/Zeus.Contracts/OperatorIdentity.cs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+//
+// OperatorIdentity — the single shared station callsign + Maidenhead grid the
+// operator sets once and every reporting/TX surface reads. Before this, identity
+// was duplicated across SpottingSettingsStore and FreeDvReporterSettingsStore and
+// (on the frontend) lived only in port-scoped localStorage, so FT8 TX stayed
+// gated and the desktop lost the call on every restart. This is the server-
+// persisted override base; the QRZ home station remains the fallback when blank.
+
+namespace Zeus.Contracts;
+
+/// <summary>
+/// The operator's station identity (callsign + Maidenhead grid). This is the
+/// shared OVERRIDE consulted first by every operator resolver (FT8/FT4 TX,
+/// spotting uploaders, FreeDV Reporter); the QRZ home station is the fallback
+/// when a field is blank. Empty (the default) means "no override — use QRZ".
+/// </summary>
+public sealed record OperatorIdentity(
+    string Callsign = "",
+    string Grid = "")
+{
+    public const int MaxGridLength = 6;
+
+    /// <summary>
+    /// Trim/normalize so a hand-crafted POST or stale persisted row stays sane:
+    /// callsign upper-cased + trimmed, grid trimmed/capped to a Maidenhead-shaped
+    /// prefix. Anything that doesn't start letter-letter is dropped so a typo
+    /// can't be persisted as a bogus locator.
+    /// </summary>
+    public OperatorIdentity Normalized() => this with
+    {
+        Callsign = NormalizeCallsign(Callsign),
+        Grid = NormalizeGrid(Grid),
+    };
+
+    /// <summary>True when both a callsign and a grid are present.</summary>
+    public bool IsComplete =>
+        !string.IsNullOrWhiteSpace(Callsign) && !string.IsNullOrWhiteSpace(Grid);
+
+    public static string NormalizeCallsign(string? call) =>
+        string.IsNullOrWhiteSpace(call) ? "" : call.Trim().ToUpperInvariant();
+
+    public static string NormalizeGrid(string? grid)
+    {
+        var g = (grid ?? "").Trim();
+        if (g.Length == 0) return "";
+        if (g.Length > MaxGridLength) g = g[..MaxGridLength];
+        // A Maidenhead locator is field/square[/subsquare]: it must start with two
+        // letters. Drop anything that doesn't so a typo can't broadcast/persist a
+        // bogus location.
+        if (g.Length < 2 || !char.IsLetter(g[0]) || !char.IsLetter(g[1])) return "";
+        return g.ToUpperInvariant();
+    }
+}
+
+/// <summary>
+/// GET /api/operator response. Carries the operator's saved override AND the
+/// effective resolved identity (override first, QRZ home fallback) so the FT8
+/// Settings page can show the live values greyed when they come from QRZ.
+/// <paramref name="CallsignFromQrz"/> / <paramref name="GridFromQrz"/> are true
+/// when the resolved field fell back to the QRZ home station.
+/// </summary>
+public sealed record OperatorIdentityStatus(
+    string Callsign,            // saved override (empty if unset)
+    string Grid,                // saved override (empty if unset)
+    string ResolvedCallsign,    // effective: override else QRZ home
+    string ResolvedGrid,        // effective: override else QRZ home
+    bool CallsignFromQrz,
+    bool GridFromQrz)
+{
+    /// <summary>True when a callsign + grid are available from any source.</summary>
+    public bool IdentityResolved =>
+        !string.IsNullOrWhiteSpace(ResolvedCallsign) &&
+        !string.IsNullOrWhiteSpace(ResolvedGrid);
+}

--- a/Zeus.Server.Hosting/FreeDvReporterService.cs
+++ b/Zeus.Server.Hosting/FreeDvReporterService.cs
@@ -55,6 +55,7 @@ public sealed class FreeDvReporterService : BackgroundService
     private readonly RadioService _radio;
     private readonly QrzService _qrz;
     private readonly FreeDvReporterSettingsStore _settingsStore;
+    private readonly OperatorIdentityStore _identity;
     private readonly FreeDvService _freeDv;
 
     // Last values we actually emitted in report role, so a no-op change (e.g. a
@@ -72,12 +73,14 @@ public sealed class FreeDvReporterService : BackgroundService
         RadioService radio,
         QrzService qrz,
         FreeDvReporterSettingsStore settingsStore,
+        OperatorIdentityStore identity,
         FreeDvService freeDv)
     {
         _log = log;
         _radio = radio;
         _qrz = qrz;
         _settingsStore = settingsStore;
+        _identity = identity;
         _freeDv = freeDv;
         _client = new SocketIoReporterClient(HandleEvent, ResolveIdentity, log);
     }
@@ -192,28 +195,13 @@ public sealed class FreeDvReporterService : BackgroundService
             Os: OsLabel());
     }
 
-    // Operator callsign/grid: settings first, QRZ home station as a fallback for
-    // blank fields. Returns ("","") when neither source has them.
-    private (string Call, string Grid) ResolveOperator(FreeDvReporterSettings settings)
-    {
-        var call = settings.Callsign;
-        var grid = settings.GridSquare;
-        if (string.IsNullOrWhiteSpace(call) || string.IsNullOrWhiteSpace(grid))
-        {
-            var home = _qrz.GetStatus().Home;
-            if (home is not null)
-            {
-                if (string.IsNullOrWhiteSpace(call) && !string.IsNullOrWhiteSpace(home.Callsign))
-                    call = home.Callsign.Trim().ToUpperInvariant();
-                if (string.IsNullOrWhiteSpace(grid) && !string.IsNullOrWhiteSpace(home.Grid))
-                {
-                    var g = home.Grid!.Trim();
-                    grid = g.Length > 6 ? g[..6] : g;
-                }
-            }
-        }
-        return (call ?? "", grid ?? "");
-    }
+    // Operator callsign/grid. Precedence per field: the shared OperatorIdentity
+    // override first, then this reporter's own settings (legacy/secondary, kept
+    // additively), then the QRZ home station. Returns ("","") when no source has
+    // them. Shared with SpottingManagementService and /api/operator via
+    // OperatorIdentityResolver.
+    private (string Call, string Grid) ResolveOperator(FreeDvReporterSettings settings) =>
+        OperatorIdentityResolver.Resolve(_identity, _qrz, settings.Callsign, settings.GridSquare);
 
     private static string OsLabel()
     {

--- a/Zeus.Server.Hosting/Ft8SettingsStore.cs
+++ b/Zeus.Server.Hosting/Ft8SettingsStore.cs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Ft8SettingsStore — persists the FT8/FT4 workspace behaviour preferences
+// (Ft8Settings) in a single-row LiteDB collection sharing zeus-prefs.db,
+// mirroring SpottingSettingsStore. First run (no row) returns the Ft8Settings
+// defaults, which match the current pre-settings behaviour exactly. These are
+// behaviour/UI knobs only — none transmit; TX still requires an explicit arm.
+
+using LiteDB;
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Reads/writes the single <see cref="Ft8Settings"/> row. Thread-safe; values are
+/// normalized on write (offset/passes clamped, macros trimmed/capped).
+/// </summary>
+public sealed class Ft8SettingsStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<Ft8SettingsEntry> _entries;
+    private readonly ILogger<Ft8SettingsStore> _log;
+    private readonly object _sync = new();
+
+    public Ft8SettingsStore(ILogger<Ft8SettingsStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _entries = _db.GetCollection<Ft8SettingsEntry>("ft8_settings");
+
+        _log.LogInformation("Ft8SettingsStore initialized at {Path}", dbPath);
+    }
+
+    /// <summary>The saved settings (normalized), or the defaults if none.</summary>
+    public Ft8Settings Get()
+    {
+        lock (_sync)
+        {
+            var e = _entries.FindAll().FirstOrDefault();
+            if (e is null) return new Ft8Settings();
+            return new Ft8Settings(
+                AutoSequence: e.AutoSequence,
+                CallFirst: e.CallFirst,
+                HoldTxFreq: e.HoldTxFreq,
+                DisableTxAfter73: e.DisableTxAfter73,
+                DefaultTxSlot: e.DefaultTxSlot,
+                DefaultTxOffsetHz: e.DefaultTxOffsetHz,
+                Rr73InsteadOfRrr: e.Rr73InsteadOfRrr,
+                SkipGrid: e.SkipGrid,
+                CallerMaxRetries: e.CallerMaxRetries,
+                CqMessage: e.CqMessage ?? "CQ",
+                CqDxMessage: e.CqDxMessage ?? "CQ DX",
+                FreeTextMacro: e.FreeTextMacro ?? "",
+                DecodePasses: e.DecodePasses,
+                ShowOnlyCq: e.ShowOnlyCq,
+                HideWorkedBefore: e.HideWorkedBefore,
+                AutoLog: e.AutoLog,
+                PromptBeforeLog: e.PromptBeforeLog,
+                ClearDxAfterLog: e.ClearDxAfterLog,
+                ReportToComment: e.ReportToComment).Normalized();
+        }
+    }
+
+    /// <summary>Persist settings (normalized) and return what was stored.</summary>
+    public Ft8Settings Set(Ft8Settings settings)
+    {
+        var s = settings.Normalized();
+        lock (_sync)
+        {
+            var existing = _entries.FindAll().FirstOrDefault();
+            var nowUtc = DateTime.UtcNow;
+            if (existing is null)
+            {
+                _entries.Insert(FromSettings(new Ft8SettingsEntry(), s, nowUtc));
+            }
+            else
+            {
+                FromSettings(existing, s, nowUtc);
+                _entries.Update(existing);
+            }
+        }
+        return s;
+    }
+
+    private static Ft8SettingsEntry FromSettings(Ft8SettingsEntry e, Ft8Settings s, DateTime nowUtc)
+    {
+        e.AutoSequence = s.AutoSequence;
+        e.CallFirst = s.CallFirst;
+        e.HoldTxFreq = s.HoldTxFreq;
+        e.DisableTxAfter73 = s.DisableTxAfter73;
+        e.DefaultTxSlot = s.DefaultTxSlot;
+        e.DefaultTxOffsetHz = s.DefaultTxOffsetHz;
+        e.Rr73InsteadOfRrr = s.Rr73InsteadOfRrr;
+        e.SkipGrid = s.SkipGrid;
+        e.CallerMaxRetries = s.CallerMaxRetries;
+        e.CqMessage = s.CqMessage;
+        e.CqDxMessage = s.CqDxMessage;
+        e.FreeTextMacro = s.FreeTextMacro;
+        e.DecodePasses = s.DecodePasses;
+        e.ShowOnlyCq = s.ShowOnlyCq;
+        e.HideWorkedBefore = s.HideWorkedBefore;
+        e.AutoLog = s.AutoLog;
+        e.PromptBeforeLog = s.PromptBeforeLog;
+        e.ClearDxAfterLog = s.ClearDxAfterLog;
+        e.ReportToComment = s.ReportToComment;
+        e.UpdatedUtc = nowUtc;
+        return e;
+    }
+
+    public void Dispose() => _db.Dispose();
+}
+
+public sealed class Ft8SettingsEntry
+{
+    public int Id { get; set; }
+    public bool AutoSequence { get; set; } = true;
+    public bool CallFirst { get; set; }
+    public bool HoldTxFreq { get; set; }
+    public bool DisableTxAfter73 { get; set; } = true;
+    public int DefaultTxSlot { get; set; }
+    public int DefaultTxOffsetHz { get; set; } = 1500;
+    public bool Rr73InsteadOfRrr { get; set; }
+    public bool SkipGrid { get; set; }
+    public int CallerMaxRetries { get; set; }
+    public string? CqMessage { get; set; } = "CQ";
+    public string? CqDxMessage { get; set; } = "CQ DX";
+    public string? FreeTextMacro { get; set; } = "";
+    public int DecodePasses { get; set; } = 2;
+    public bool ShowOnlyCq { get; set; }
+    public bool HideWorkedBefore { get; set; }
+    public bool AutoLog { get; set; } = true;
+    public bool PromptBeforeLog { get; set; }
+    public bool ClearDxAfterLog { get; set; } = true;
+    public bool ReportToComment { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/OperatorIdentityResolver.cs
+++ b/Zeus.Server.Hosting/OperatorIdentityResolver.cs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// OperatorIdentityResolver — the single, shared operator-identity precedence
+// used by every resolver (FT8/FT4 TX, spotting uploaders, FreeDV Reporter, the
+// /api/operator endpoint). Order, per field: the shared OperatorIdentity
+// override first, then an optional service-local secondary (the legacy per-store
+// callsign/grid, kept additively), then the QRZ home station. This collapses the
+// three near-identical ResolveOperator copies that had drifted apart.
+
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+internal static class OperatorIdentityResolver
+{
+    /// <summary>
+    /// Resolve the effective operator callsign + grid. Precedence per field:
+    /// shared override → secondary (service-local) → QRZ home. Returns ("","")
+    /// when no source has a value. All outputs are normalized.
+    /// </summary>
+    public static (string Call, string Grid) Resolve(
+        OperatorIdentityStore shared,
+        QrzService qrz,
+        string? secondaryCall = null,
+        string? secondaryGrid = null)
+    {
+        var id = shared.Get(); // already normalized
+        var call = id.Callsign;
+        var grid = id.Grid;
+
+        if (string.IsNullOrWhiteSpace(call))
+            call = OperatorIdentity.NormalizeCallsign(secondaryCall);
+        if (string.IsNullOrWhiteSpace(grid))
+            grid = OperatorIdentity.NormalizeGrid(secondaryGrid);
+
+        if (string.IsNullOrWhiteSpace(call) || string.IsNullOrWhiteSpace(grid))
+        {
+            var home = qrz.GetStatus().Home;
+            if (home is not null)
+            {
+                if (string.IsNullOrWhiteSpace(call))
+                    call = OperatorIdentity.NormalizeCallsign(home.Callsign);
+                if (string.IsNullOrWhiteSpace(grid))
+                    grid = OperatorIdentity.NormalizeGrid(home.Grid);
+            }
+        }
+
+        return (call, grid);
+    }
+
+    /// <summary>
+    /// Build the /api/operator status: the saved override plus the effective
+    /// resolved identity (override → QRZ home), with per-field flags marking
+    /// which resolved values came from the QRZ fallback.
+    /// </summary>
+    public static OperatorIdentityStatus Status(OperatorIdentityStore shared, QrzService qrz)
+    {
+        var saved = shared.Get();
+        var resolvedCall = saved.Callsign;
+        var resolvedGrid = saved.Grid;
+        bool callFromQrz = false;
+        bool gridFromQrz = false;
+
+        if (string.IsNullOrWhiteSpace(resolvedCall) || string.IsNullOrWhiteSpace(resolvedGrid))
+        {
+            var home = qrz.GetStatus().Home;
+            if (home is not null)
+            {
+                if (string.IsNullOrWhiteSpace(resolvedCall))
+                {
+                    var c = OperatorIdentity.NormalizeCallsign(home.Callsign);
+                    if (!string.IsNullOrWhiteSpace(c)) { resolvedCall = c; callFromQrz = true; }
+                }
+                if (string.IsNullOrWhiteSpace(resolvedGrid))
+                {
+                    var g = OperatorIdentity.NormalizeGrid(home.Grid);
+                    if (!string.IsNullOrWhiteSpace(g)) { resolvedGrid = g; gridFromQrz = true; }
+                }
+            }
+        }
+
+        return new OperatorIdentityStatus(
+            Callsign: saved.Callsign,
+            Grid: saved.Grid,
+            ResolvedCallsign: resolvedCall,
+            ResolvedGrid: resolvedGrid,
+            CallsignFromQrz: callFromQrz,
+            GridFromQrz: gridFromQrz);
+    }
+}

--- a/Zeus.Server.Hosting/OperatorIdentityStore.cs
+++ b/Zeus.Server.Hosting/OperatorIdentityStore.cs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// OperatorIdentityStore — persists the single shared station callsign + grid
+// (OperatorIdentity) in a single-row LiteDB collection sharing zeus-prefs.db,
+// mirroring SpottingSettingsStore / FreeDvReporterSettingsStore. First run (no
+// row) returns the empty default, which means "no override — fall back to QRZ".
+// This is the one place operator identity is stored; the spotting / FreeDV /
+// FT8-TX resolvers all read it first (see OperatorIdentityResolver).
+
+using LiteDB;
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Reads/writes the shared <see cref="OperatorIdentity"/> override row. Thread-safe;
+/// values are normalized on write (callsign upper-cased, grid Maidenhead-shaped).
+/// </summary>
+public sealed class OperatorIdentityStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<OperatorIdentityEntry> _entries;
+    private readonly ILogger<OperatorIdentityStore> _log;
+    private readonly object _sync = new();
+
+    public OperatorIdentityStore(ILogger<OperatorIdentityStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _entries = _db.GetCollection<OperatorIdentityEntry>("operator_identity");
+
+        _log.LogInformation("OperatorIdentityStore initialized at {Path}", dbPath);
+    }
+
+    /// <summary>The saved override (normalized), or the empty default if none.</summary>
+    public OperatorIdentity Get()
+    {
+        lock (_sync)
+        {
+            var e = _entries.FindAll().FirstOrDefault();
+            if (e is null) return new OperatorIdentity();
+            return new OperatorIdentity(
+                Callsign: e.Callsign ?? "",
+                Grid: e.Grid ?? "").Normalized();
+        }
+    }
+
+    /// <summary>Persist the override (normalized) and return what was stored.</summary>
+    public OperatorIdentity Set(OperatorIdentity identity)
+    {
+        var id = identity.Normalized();
+        lock (_sync)
+        {
+            var existing = _entries.FindAll().FirstOrDefault();
+            var nowUtc = DateTime.UtcNow;
+            if (existing is null)
+            {
+                _entries.Insert(new OperatorIdentityEntry
+                {
+                    Callsign = id.Callsign,
+                    Grid = id.Grid,
+                    UpdatedUtc = nowUtc,
+                });
+            }
+            else
+            {
+                existing.Callsign = id.Callsign;
+                existing.Grid = id.Grid;
+                existing.UpdatedUtc = nowUtc;
+                _entries.Update(existing);
+            }
+        }
+        return id;
+    }
+
+    public void Dispose() => _db.Dispose();
+}
+
+public sealed class OperatorIdentityEntry
+{
+    public int Id { get; set; }
+    public string? Callsign { get; set; } = "";
+    public string? Grid { get; set; } = "";
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/SpottingManagementService.cs
+++ b/Zeus.Server.Hosting/SpottingManagementService.cs
@@ -27,6 +27,7 @@ public sealed class SpottingManagementService
 {
     private readonly ILogger<SpottingManagementService> _log;
     private readonly SpottingSettingsStore _store;
+    private readonly OperatorIdentityStore _identity;
     private readonly QrzService _qrz;
     private readonly object _sync = new();
     private SpottingRuntimeConfig _config;
@@ -34,10 +35,12 @@ public sealed class SpottingManagementService
     public SpottingManagementService(
         ILogger<SpottingManagementService> log,
         SpottingSettingsStore store,
+        OperatorIdentityStore identity,
         QrzService qrz)
     {
         _log = log;
         _store = store;
+        _identity = identity;
         _qrz = qrz;
         // Default OFF when nothing is persisted — new network egress is opt-in.
         _config = _store.Get() ?? new SpottingRuntimeConfig();
@@ -88,27 +91,16 @@ public sealed class SpottingManagementService
     }
 
     /// <summary>
-    /// Operator callsign/grid: the persisted override first, QRZ home station as a
-    /// fallback for blank fields. Returns ("","") when neither source has them.
-    /// Same precedence as FreeDvReporterService.ResolveOperator.
+    /// Operator callsign/grid. Precedence per field: the shared OperatorIdentity
+    /// override first, then this service's own persisted config (legacy/secondary,
+    /// kept additively), then the QRZ home station. Returns ("","") when no source
+    /// has them. Shared with FreeDvReporterService and /api/operator via
+    /// OperatorIdentityResolver.
     /// </summary>
     public (string Call, string Grid) ResolveOperator()
     {
         var c = GetConfig();
-        var call = c.Callsign;
-        var grid = c.Grid;
-        if (string.IsNullOrWhiteSpace(call) || string.IsNullOrWhiteSpace(grid))
-        {
-            var home = _qrz.GetStatus().Home;
-            if (home is not null)
-            {
-                if (string.IsNullOrWhiteSpace(call) && !string.IsNullOrWhiteSpace(home.Callsign))
-                    call = NormalizeCall(home.Callsign);
-                if (string.IsNullOrWhiteSpace(grid) && !string.IsNullOrWhiteSpace(home.Grid))
-                    grid = NormalizeGrid(home.Grid!);
-            }
-        }
-        return (call ?? "", grid ?? "");
+        return OperatorIdentityResolver.Resolve(_identity, _qrz, c.Callsign, c.Grid);
     }
 
     private static string NormalizeCall(string? call) =>

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -121,6 +121,41 @@ public static class ZeusEndpoints
             return Results.Ok(new { enabled = false });
         });
 
+        // Shared operator identity (callsign + Maidenhead grid). This is the SAME
+        // identity the spotting uploaders and FreeDV Reporter resolve from — set
+        // it once here and FT8/FT4 TX ungates everywhere. Server-persisted so the
+        // desktop webview no longer loses it on restart. GET returns both the saved
+        // override and the effective resolved value (override → QRZ home fallback),
+        // so the Settings page can grey QRZ-sourced values.
+        app.MapGet("/api/operator",
+            (OperatorIdentityStore store, QrzService qrz) =>
+                Results.Ok(OperatorIdentityResolver.Status(store, qrz)));
+
+        app.MapPost("/api/operator",
+            (Zeus.Contracts.OperatorIdentity body, OperatorIdentityStore store, QrzService qrz) =>
+            {
+                store.Set(body);
+                log.LogInformation("api.operator.set call={Call} grid={Grid}",
+                    body.Callsign, body.Grid);
+                return Results.Ok(OperatorIdentityResolver.Status(store, qrz));
+            });
+
+        // FT8/FT4 workspace behaviour preferences (auto-seq, decode depth, macros,
+        // logging). Persisted server-side so they survive desktop restarts. Pure
+        // behaviour/UI — none of these transmit; TX still requires an explicit arm.
+        app.MapGet("/api/ft8/settings",
+            (Ft8SettingsStore store) => Results.Ok(store.Get()));
+
+        app.MapPost("/api/ft8/settings",
+            (Zeus.Contracts.Ft8Settings body, Ft8SettingsStore store) =>
+            {
+                var saved = store.Set(body);
+                log.LogInformation(
+                    "api.ft8.settings autoseq={Auto} passes={Passes} autolog={Log}",
+                    saved.AutoSequence, saved.DecodePasses, saved.AutoLog);
+                return Results.Ok(saved);
+            });
+
         // WSPR native spotting control. nativeAvailable is false where the
         // zeus_wspr decoder isn't shipped (e.g. Windows encode-only build today).
         app.MapGet("/api/wspr",

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -844,6 +844,16 @@ public static class ZeusHost
         // Persists the operator's FreeDV Reporter "report mode" opt-in (default
         // OFF). Reporting only broadcasts the operator's callsign/grid/TX activity
         // to the public map after an explicit opt-in — see FreeDvReporterService.
+        // Shared operator identity (callsign + Maidenhead grid). One store, read
+        // first by every operator resolver (spotting / FreeDV Reporter / FT8-FT4
+        // TX) via OperatorIdentityResolver, with the QRZ home station as the
+        // fallback. Replaces the per-store identity duplication and the frontend's
+        // port-scoped localStorage that lost the call on every desktop restart.
+        builder.Services.AddSingleton<OperatorIdentityStore>();
+        // Persisted FT8/FT4 workspace behaviour preferences (auto-seq, decode
+        // depth, macros, logging). Behaviour/UI knobs only — none transmit.
+        builder.Services.AddSingleton<Ft8SettingsStore>();
+
         builder.Services.AddSingleton<FreeDvReporterSettingsStore>();
         builder.Services.AddSingleton<FreeDvReporterService>();
         builder.Services.AddHostedService(sp => sp.GetRequiredService<FreeDvReporterService>());

--- a/docs/designs/ft8-ui.md
+++ b/docs/designs/ft8-ui.md
@@ -192,3 +192,39 @@ UI is a later phase. Backend decode engine, `Zeus.Dsp.Ft8`, `Ft8Service`, and
 Contracts land first; the workspace is built once live decodes exist to render.
 Structure the React components theme-agnostic so the palette decision can be
 applied at the end without rework.
+
+## SETTINGS view — BUILT (TX-ready, DO-NOT-MERGE bench draft)
+
+The `DECODE | SETTINGS` view switch in the workspace header is now live
+(`Ft8SettingsView.tsx`), modelled on the curated WSJT-X + JTDX KEEP set with
+everything a native SDR already owns SCRAPPED (rig/CAT/PTT selection, sound-card
+in/out, split, the frequencies table, power/attenuator dials — Zeus owns all of
+those). Five sections: **Station/Operator · TX & Auto-sequence · Macros · Decode
+· Reporting & Logging**. Reporting (PSK Reporter / WSPRnet / WSJT-X UDP) is
+SURFACED as read-only status chips with a deep-link to the Network tab — not
+duplicated.
+
+### Identity-store decision (THE TX unblock)
+
+FT8 TX was gated on the operator callsign (`canCall`), and identity lived only in
+the desktop webview's localStorage — which is scoped to a loopback port the OS
+reassigns each launch, so the call was silently lost on every restart and TX
+never ungated.
+
+Fix: operator identity is now **server-authoritative and shared**. A single
+`OperatorIdentityStore` (LiteDB) backs `GET/POST /api/operator` and is the
+override base every resolver reads first (FT8/FT4 TX, PSK Reporter, WSPRnet,
+FreeDV Reporter), with the QRZ home station as the fallback. The frontend
+`operator-store.ts` is now backed by that endpoint (no localStorage
+system-of-record); the workspace TX/gating uses the **resolved** value (override
+else QRZ home) so a QRZ-home operator transmits without retyping. The Call/Grid
+edit fields moved OUT of the 44px clipping header into §Station; a compact
+read-only call chip remains in the header. An empty-call banner makes the TX gate
+reason visible (never a silent dead ENABLE button) and links to Settings.
+
+FT8/FT4 behaviour prefs (auto-seq, decode depth Fast/Normal/Deep → `/api/ft8`
+`passes`, editable macros, logging) persist via `Ft8SettingsStore` /
+`/api/ft8/settings`. Defaults mirror current behaviour exactly — nothing an
+operator feels changes until they touch a control, and TX still requires an
+explicit arm. **DO-NOT-MERGE until G2 bench confirms ungate → arm → auto-seq →
+log.**

--- a/tests/Zeus.Server.Tests/Ft8SettingsStoreTests.cs
+++ b/tests/Zeus.Server.Tests/Ft8SettingsStoreTests.cs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Pins the FT8/FT4 settings store: defaults match the pre-settings behaviour
+// (so surfacing them changes nothing an operator feels), out-of-range POSTs are
+// clamped on write, and the choice survives a store reopen (the desktop-restart
+// fix this whole feature exists for).
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public sealed class Ft8SettingsStoreTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-ft8-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+    }
+
+    private Ft8SettingsStore NewStore() =>
+        new(NullLogger<Ft8SettingsStore>.Instance, _dbPath);
+
+    [Fact]
+    public void Defaults_Match_Pre_Settings_Behaviour()
+    {
+        using var store = NewStore();
+        var s = store.Get();
+
+        Assert.True(s.AutoSequence);
+        Assert.True(s.DisableTxAfter73);
+        Assert.False(s.CallFirst);
+        Assert.False(s.HoldTxFreq);
+        Assert.Equal(0, s.DefaultTxSlot);
+        Assert.Equal(1500, s.DefaultTxOffsetHz);
+        Assert.Equal(3, s.DecodePasses); // matches Ft8Service.DecodePasses (Deep/multi)
+        Assert.True(s.Rr73InsteadOfRrr); // RR73 ack — the engine's pre-settings default
+        Assert.True(s.AutoLog);
+        Assert.False(s.PromptBeforeLog);
+        Assert.True(s.ClearDxAfterLog);
+        Assert.Equal("CQ", s.CqMessage);
+        Assert.Equal("CQ DX", s.CqDxMessage);
+    }
+
+    [Fact]
+    public void Set_Clamps_Offset_Passes_And_Slot()
+    {
+        using var store = NewStore();
+        var saved = store.Set(new Ft8Settings(
+            DefaultTxOffsetHz: 99999,
+            DecodePasses: 9,
+            DefaultTxSlot: 7,
+            CallerMaxRetries: -3));
+
+        Assert.Equal(Ft8Settings.MaxTxOffsetHz, saved.DefaultTxOffsetHz);
+        Assert.Equal(Ft8Settings.MaxPasses, saved.DecodePasses);
+        Assert.Equal(1, saved.DefaultTxSlot); // any non-zero collapses to 1 (odd)
+        Assert.Equal(0, saved.CallerMaxRetries);
+    }
+
+    [Fact]
+    public void Set_Clamps_Offset_Below_Minimum()
+    {
+        using var store = NewStore();
+        var saved = store.Set(new Ft8Settings(DefaultTxOffsetHz: 10));
+        Assert.Equal(Ft8Settings.MinOffsetHz, saved.DefaultTxOffsetHz);
+    }
+
+    [Fact]
+    public void Set_Caps_Free_Text_Macro_To_Thirteen()
+    {
+        using var store = NewStore();
+        var saved = store.Set(new Ft8Settings(FreeTextMacro: "THIS IS WAY TOO LONG FOR FT8"));
+        Assert.Equal(13, saved.FreeTextMacro.Length);
+    }
+
+    [Fact]
+    public void Set_Persists_Across_Store_Instances()
+    {
+        using (var store = NewStore())
+            store.Set(new Ft8Settings(
+                AutoSequence: false, CallFirst: true, DecodePasses: 4,
+                DefaultTxOffsetHz: 1200, AutoLog: false));
+
+        using var reopened = NewStore();
+        var s = reopened.Get();
+        Assert.False(s.AutoSequence);
+        Assert.True(s.CallFirst);
+        Assert.Equal(4, s.DecodePasses);
+        Assert.Equal(1200, s.DefaultTxOffsetHz);
+        Assert.False(s.AutoLog);
+    }
+}

--- a/tests/Zeus.Server.Tests/OperatorIdentityStoreTests.cs
+++ b/tests/Zeus.Server.Tests/OperatorIdentityStoreTests.cs
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Pins the shared operator-identity store + resolver: empty default (so the
+// QRZ home station fallback engages), normalization on write, persistence across
+// store instances (the desktop-restart bug), and the override → secondary → QRZ
+// precedence used by every operator resolver.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public sealed class OperatorIdentityStoreTests : IDisposable
+{
+    private readonly string _root =
+        Path.Combine(Path.GetTempPath(), $"zeus-operator-{Guid.NewGuid():N}");
+
+    public OperatorIdentityStoreTests() => Directory.CreateDirectory(_root);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private OperatorIdentityStore NewStore() =>
+        new(NullLogger<OperatorIdentityStore>.Instance, Path.Combine(_root, "operator.db"));
+
+    // Logged-out QRZ: GetStatus().Home is null, so the fallback path is exercised
+    // without touching the network.
+    private QrzService NewLoggedOutQrz() =>
+        new(new SingleClientFactory(), NullLogger<QrzService>.Instance,
+            new CredentialStore(NullLogger<CredentialStore>.Instance, Path.Combine(_root, "creds.db")));
+
+    [Fact]
+    public void Default_Is_Empty_Override()
+    {
+        using var store = NewStore();
+        var id = store.Get();
+        Assert.Equal("", id.Callsign);
+        Assert.Equal("", id.Grid);
+        Assert.False(id.IsComplete);
+    }
+
+    [Fact]
+    public void Set_Normalizes_Call_And_Grid()
+    {
+        using var store = NewStore();
+        var saved = store.Set(new OperatorIdentity("  w1aw  ", "  fn31pr  "));
+        Assert.Equal("W1AW", saved.Callsign);
+        Assert.Equal("FN31PR", saved.Grid); // upper-cased, capped at 6
+        Assert.True(saved.IsComplete);
+    }
+
+    [Fact]
+    public void Set_Drops_Non_Maidenhead_Grid()
+    {
+        using var store = NewStore();
+        var saved = store.Set(new OperatorIdentity("W1AW", "12FN")); // not letter-letter
+        Assert.Equal("", saved.Grid);
+    }
+
+    [Fact]
+    public void Set_Persists_Across_Store_Instances()
+    {
+        using (var store = NewStore())
+            store.Set(new OperatorIdentity("K1ABC", "FN42"));
+
+        using var reopened = NewStore();
+        var id = reopened.Get();
+        Assert.Equal("K1ABC", id.Callsign);
+        Assert.Equal("FN42", id.Grid);
+    }
+
+    [Fact]
+    public void Resolver_Override_Wins_Over_Secondary()
+    {
+        using var store = NewStore();
+        store.Set(new OperatorIdentity("W1AW", "FN31"));
+        var qrz = NewLoggedOutQrz();
+
+        var (call, grid) = OperatorIdentityResolver.Resolve(store, qrz, "K1ABC", "EM12");
+        Assert.Equal("W1AW", call);
+        Assert.Equal("FN31", grid);
+    }
+
+    [Fact]
+    public void Resolver_Falls_Back_To_Secondary_When_Override_Blank()
+    {
+        using var store = NewStore(); // empty override
+        var qrz = NewLoggedOutQrz();
+
+        var (call, grid) = OperatorIdentityResolver.Resolve(store, qrz, "k1abc", "fn42");
+        Assert.Equal("K1ABC", call); // secondary normalized
+        Assert.Equal("FN42", grid);
+    }
+
+    [Fact]
+    public void Resolver_Blank_When_No_Source()
+    {
+        using var store = NewStore();
+        var qrz = NewLoggedOutQrz();
+
+        var (call, grid) = OperatorIdentityResolver.Resolve(store, qrz);
+        Assert.Equal("", call);
+        Assert.Equal("", grid);
+    }
+
+    [Fact]
+    public void Status_Reports_Override_Without_Qrz_Flags()
+    {
+        using var store = NewStore();
+        store.Set(new OperatorIdentity("W1AW", "FN31"));
+        var qrz = NewLoggedOutQrz();
+
+        var status = OperatorIdentityResolver.Status(store, qrz);
+        Assert.Equal("W1AW", status.Callsign);
+        Assert.Equal("W1AW", status.ResolvedCallsign);
+        Assert.False(status.CallsignFromQrz);
+        Assert.False(status.GridFromQrz);
+        Assert.True(status.IdentityResolved);
+    }
+
+    [Fact]
+    public void Status_Unresolved_When_Empty_And_No_Qrz()
+    {
+        using var store = NewStore();
+        var qrz = NewLoggedOutQrz();
+
+        var status = OperatorIdentityResolver.Status(store, qrz);
+        Assert.Equal("", status.ResolvedCallsign);
+        Assert.False(status.IdentityResolved);
+    }
+
+    private sealed class SingleClientFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new();
+    }
+}

--- a/tests/Zeus.Server.Tests/Spotting/SpottingManagementServiceTests.cs
+++ b/tests/Zeus.Server.Tests/Spotting/SpottingManagementServiceTests.cs
@@ -37,8 +37,14 @@ public sealed class SpottingManagementServiceTests : IDisposable
         new(new SingleClientFactory(), NullLogger<QrzService>.Instance,
             new CredentialStore(NullLogger<CredentialStore>.Instance, Path.Combine(_root, "creds.db")));
 
+    private OperatorIdentityStore NewIdentityStore() =>
+        new(NullLogger<OperatorIdentityStore>.Instance, Path.Combine(_root, "operator.db"));
+
     private SpottingManagementService NewService(SpottingSettingsStore store) =>
-        new(NullLogger<SpottingManagementService>.Instance, store, NewLoggedOutQrz());
+        new(NullLogger<SpottingManagementService>.Instance, store, NewIdentityStore(), NewLoggedOutQrz());
+
+    private SpottingManagementService NewService(SpottingSettingsStore store, OperatorIdentityStore identity) =>
+        new(NullLogger<SpottingManagementService>.Instance, store, identity, NewLoggedOutQrz());
 
     [Fact]
     public void Defaults_Both_Uploaders_Disabled_When_Nothing_Persisted()
@@ -134,6 +140,36 @@ public sealed class SpottingManagementServiceTests : IDisposable
         var (call, grid) = svc.ResolveOperator();
         Assert.Equal("", call);
         Assert.Equal("", grid);
+    }
+
+    [Fact]
+    public void ResolveOperator_Shared_Identity_Wins_Over_Local_Config()
+    {
+        using var store = NewStore();
+        using var identity = NewIdentityStore();
+        identity.Set(new OperatorIdentity("W1AW", "FN31"));
+
+        var svc = NewService(store, identity);
+        // A different legacy/secondary call in the local spotting config must NOT
+        // override the shared identity.
+        svc.SetConfig(new SpottingRuntimeConfig(Callsign: "K1ABC", Grid: "EM12"));
+
+        var (call, grid) = svc.ResolveOperator();
+        Assert.Equal("W1AW", call);
+        Assert.Equal("FN31", grid);
+    }
+
+    [Fact]
+    public void ResolveOperator_Falls_Back_To_Local_Config_When_Shared_Blank()
+    {
+        using var store = NewStore();
+        using var identity = NewIdentityStore(); // empty shared override
+        var svc = NewService(store, identity);
+        svc.SetConfig(new SpottingRuntimeConfig(Callsign: "K1ABC", Grid: "FN42"));
+
+        var (call, grid) = svc.ResolveOperator();
+        Assert.Equal("K1ABC", call);
+        Assert.Equal("FN42", grid);
     }
 
     private sealed class SingleClientFactory : IHttpClientFactory

--- a/tests/Zeus.Server.Tests/Spotting/SpottingReporterGateTests.cs
+++ b/tests/Zeus.Server.Tests/Spotting/SpottingReporterGateTests.cs
@@ -45,7 +45,9 @@ public sealed class SpottingReporterGateTests : IDisposable
         var qrz = new QrzService(
             new SingleClientFactory(), NullLogger<QrzService>.Instance,
             new CredentialStore(NullLogger<CredentialStore>.Instance, Path.Combine(_root, $"creds-{Guid.NewGuid():N}.db")));
-        var svc = new SpottingManagementService(NullLogger<SpottingManagementService>.Instance, store, qrz);
+        var identity = new OperatorIdentityStore(
+            NullLogger<OperatorIdentityStore>.Instance, Path.Combine(_root, $"operator-{Guid.NewGuid():N}.db"));
+        var svc = new SpottingManagementService(NullLogger<SpottingManagementService>.Instance, store, identity, qrz);
         if (pskEnabled || wsprEnabled || call.Length > 0 || grid.Length > 0)
             svc.SetConfig(new SpottingRuntimeConfig(pskEnabled, wsprEnabled, call, grid));
         return svc;

--- a/zeus-web/src/api/ft8-settings.ts
+++ b/zeus-web/src/api/ft8-settings.ts
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+//
+// REST client for the persisted FT8/FT4 workspace preferences (the curated
+// WSJT-X/JTDX KEEP set that is pure behaviour/UI, not radio control). Backed by
+// the server (zeus-prefs.db) so the operator's choices survive desktop restarts.
+// Defaults mirror Zeus.Contracts.Ft8Settings exactly — surfacing existing engine
+// knobs, never changing a default an operator already feels. TX still requires an
+// explicit arm; none of these flags transmit on their own.
+
+import { ApiError } from './client';
+
+export type Ft8Settings = {
+  // TX & auto-sequence
+  autoSequence: boolean;
+  callFirst: boolean;
+  holdTxFreq: boolean;
+  disableTxAfter73: boolean;
+  /** 0 = 1st (even), 1 = 2nd (odd). */
+  defaultTxSlot: number;
+  defaultTxOffsetHz: number;
+  // Advanced sequence flags (default off to match WSJT-X)
+  rr73InsteadOfRrr: boolean;
+  skipGrid: boolean;
+  /** Caller max retries before giving up (0 = unlimited). */
+  callerMaxRetries: number;
+  // Macros
+  cqMessage: string;
+  cqDxMessage: string;
+  freeTextMacro: string;
+  // Decode
+  /** Decode depth as passes, matching the engine scale (1 = Normal/floor,
+   *  >1 = Deep/multi). Default 3 mirrors the engine. 1..4. */
+  decodePasses: number;
+  showOnlyCq: boolean;
+  hideWorkedBefore: boolean;
+  // Logging
+  autoLog: boolean;
+  promptBeforeLog: boolean;
+  clearDxAfterLog: boolean;
+  reportToComment: boolean;
+};
+
+/** Defaults must match Zeus.Contracts.Ft8Settings defaults exactly. */
+export const FT8_SETTINGS_DEFAULTS: Ft8Settings = {
+  autoSequence: true,
+  callFirst: false,
+  holdTxFreq: false,
+  disableTxAfter73: true,
+  defaultTxSlot: 0,
+  defaultTxOffsetHz: 1500,
+  rr73InsteadOfRrr: true,
+  skipGrid: false,
+  callerMaxRetries: 0,
+  cqMessage: 'CQ',
+  cqDxMessage: 'CQ DX',
+  freeTextMacro: '',
+  decodePasses: 3,
+  showOnlyCq: false,
+  hideWorkedBefore: false,
+  autoLog: true,
+  promptBeforeLog: false,
+  clearDxAfterLog: true,
+  reportToComment: false,
+};
+
+function normalize(raw: unknown): Ft8Settings {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  const d = FT8_SETTINGS_DEFAULTS;
+  const bool = (v: unknown, f: boolean) => (typeof v === 'boolean' ? v : f);
+  const num = (v: unknown, f: number) => (typeof v === 'number' && Number.isFinite(v) ? v : f);
+  const str = (v: unknown, f: string) => (typeof v === 'string' ? v : f);
+  return {
+    autoSequence: bool(r.autoSequence, d.autoSequence),
+    callFirst: bool(r.callFirst, d.callFirst),
+    holdTxFreq: bool(r.holdTxFreq, d.holdTxFreq),
+    disableTxAfter73: bool(r.disableTxAfter73, d.disableTxAfter73),
+    defaultTxSlot: num(r.defaultTxSlot, d.defaultTxSlot) === 0 ? 0 : 1,
+    defaultTxOffsetHz: num(r.defaultTxOffsetHz, d.defaultTxOffsetHz),
+    rr73InsteadOfRrr: bool(r.rr73InsteadOfRrr, d.rr73InsteadOfRrr),
+    skipGrid: bool(r.skipGrid, d.skipGrid),
+    callerMaxRetries: num(r.callerMaxRetries, d.callerMaxRetries),
+    cqMessage: str(r.cqMessage, d.cqMessage),
+    cqDxMessage: str(r.cqDxMessage, d.cqDxMessage),
+    freeTextMacro: str(r.freeTextMacro, d.freeTextMacro),
+    decodePasses: num(r.decodePasses, d.decodePasses),
+    showOnlyCq: bool(r.showOnlyCq, d.showOnlyCq),
+    hideWorkedBefore: bool(r.hideWorkedBefore, d.hideWorkedBefore),
+    autoLog: bool(r.autoLog, d.autoLog),
+    promptBeforeLog: bool(r.promptBeforeLog, d.promptBeforeLog),
+    clearDxAfterLog: bool(r.clearDxAfterLog, d.clearDxAfterLog),
+    reportToComment: bool(r.reportToComment, d.reportToComment),
+  };
+}
+
+async function jsonFetch(input: RequestInfo, init: RequestInit | undefined): Promise<Ft8Settings> {
+  const res = await fetch(input, init);
+  if (!res.ok) throw new ApiError(res.status, `${res.status} ${res.statusText}`);
+  return normalize((await res.json()) as unknown);
+}
+
+export function getFt8Settings(signal?: AbortSignal): Promise<Ft8Settings> {
+  return jsonFetch('/api/ft8/settings', { signal });
+}
+
+export function postFt8Settings(settings: Ft8Settings, signal?: AbortSignal): Promise<Ft8Settings> {
+  return jsonFetch('/api/ft8/settings', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(settings),
+    signal,
+  });
+}

--- a/zeus-web/src/api/operator.ts
+++ b/zeus-web/src/api/operator.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+//
+// REST client for the SHARED operator identity (callsign + Maidenhead grid).
+// This is the SAME identity the spotting uploaders and FreeDV Reporter resolve
+// from — set it once and FT8/FT4 TX ungates everywhere. Server-persisted
+// (zeus-prefs.db) so the desktop webview no longer loses it on every restart
+// (its old localStorage was scoped to a port the OS reassigns each launch).
+//
+// GET returns both the saved override AND the effective resolved identity
+// (override first, QRZ home fallback) so the FT8 Settings page can show the live
+// values greyed when they fall back to QRZ.
+
+import { ApiError } from './client';
+
+/** The operator's saved override (what they typed in Settings). */
+export type OperatorIdentity = {
+  callsign: string;
+  grid: string;
+};
+
+/** GET/POST /api/operator response — override + effective resolved identity. */
+export type OperatorIdentityStatus = {
+  /** Saved override (empty when unset). */
+  callsign: string;
+  grid: string;
+  /** Effective value: override else QRZ home. */
+  resolvedCallsign: string;
+  resolvedGrid: string;
+  /** True when the resolved field fell back to the QRZ home station. */
+  callsignFromQrz: boolean;
+  gridFromQrz: boolean;
+  /** True when a callsign + grid are available from any source. */
+  identityResolved: boolean;
+};
+
+function normalizeStatus(raw: unknown): OperatorIdentityStatus {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  const str = (v: unknown) => (typeof v === 'string' ? v : '');
+  return {
+    callsign: str(r.callsign),
+    grid: str(r.grid),
+    resolvedCallsign: str(r.resolvedCallsign),
+    resolvedGrid: str(r.resolvedGrid),
+    callsignFromQrz: Boolean(r.callsignFromQrz),
+    gridFromQrz: Boolean(r.gridFromQrz),
+    identityResolved: Boolean(r.identityResolved),
+  };
+}
+
+async function jsonFetch(
+  input: RequestInfo,
+  init: RequestInit | undefined,
+): Promise<OperatorIdentityStatus> {
+  const res = await fetch(input, init);
+  if (!res.ok) throw new ApiError(res.status, `${res.status} ${res.statusText}`);
+  return normalizeStatus((await res.json()) as unknown);
+}
+
+export function getOperator(signal?: AbortSignal): Promise<OperatorIdentityStatus> {
+  return jsonFetch('/api/operator', { signal });
+}
+
+export function postOperator(
+  identity: OperatorIdentity,
+  signal?: AbortSignal,
+): Promise<OperatorIdentityStatus> {
+  return jsonFetch('/api/operator', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(identity),
+    signal,
+  });
+}

--- a/zeus-web/src/dsp/ft8-sequencer.ts
+++ b/zeus-web/src/dsp/ft8-sequencer.ts
@@ -48,6 +48,9 @@ export interface QsoState {
   mode: DigitalQsoMode;
   myCall: string;
   myGrid4: string | null;
+  /** CQ directive for the calling state (e.g. "DX", "POTA"), or null for a plain
+   *  CQ. Set from the operator's CQ / CQ-DX macro text. */
+  cqDirective: string | null;
   dxCall: string | null;
   dxGrid4: string | null;
   /** Last numeric report HE sent us (logging only). */
@@ -121,6 +124,8 @@ export interface NewQsoOpts {
   holdTxFreq?: boolean;
   noReplyLimit?: number;
   singleShot?: boolean;
+  /** CQ directive (e.g. "DX") for the calling state; null/undefined = plain CQ. */
+  cqDirective?: string | null;
 }
 
 function baseState(opts: NewQsoOpts): QsoState {
@@ -130,6 +135,7 @@ function baseState(opts: NewQsoOpts): QsoState {
     mode: opts.mode ?? 'FT8',
     myCall: opts.myCall.toUpperCase(),
     myGrid4: opts.myGrid4 ?? null,
+    cqDirective: opts.cqDirective ?? null,
     dxCall: null,
     dxGrid4: null,
     rcvdReportFromHim: null,
@@ -176,7 +182,7 @@ export function currentOutgoing(s: QsoState): string | null {
   const his = s.dxCall ?? '';
   switch (s.progress) {
     case 'calling':
-      return genCq(s.myCall, s.myGrid4);
+      return genCq(s.myCall, s.myGrid4, s.cqDirective);
     case 'replying':
       return genTx1(his, s.myCall, s.myGrid4 ?? '');
     case 'report':

--- a/zeus-web/src/dsp/ft8-tx-controller.ts
+++ b/zeus-web/src/dsp/ft8-tx-controller.ts
@@ -26,13 +26,30 @@ import {
   startCq as seqStartCq,
   slotOf,
   step,
+  type AckToken,
   type DigitalQsoMode,
   type NewQsoOpts,
   type QsoState,
   type Slot,
 } from './ft8-sequencer';
 
-export interface Ft8TxControllerOpts {
+/** Behaviour preferences from the FT8 Settings page that change how the runner
+ *  drives the sequencer. All live-applicable (no controller rebuild needed). */
+export interface Ft8TxBehavior {
+  /** Master auto-sequence. When off, the runner keeps the operator's selected
+   *  message going while armed but never advances the QSO, auto-answers, logs,
+   *  or auto-disarms — the operator drives every step by hand. */
+  autoSequence?: boolean;
+  /** Auto-disarm once a QSO completes (73 sent). When off, the keyer stays armed
+   *  and idle after a completed QSO instead of disarming. */
+  disableTxAfter73?: boolean;
+  /** Caller no-reply give-up limit (0 = never). Maps to QsoState.noReplyLimit. */
+  noReplyLimit?: number;
+  /** Final ack token: RR73 (default) or RRR. */
+  txAck?: AckToken;
+}
+
+export interface Ft8TxControllerOpts extends Ft8TxBehavior {
   myCall: string;
   myGrid4?: string | null;
   mode?: DigitalQsoMode;
@@ -52,14 +69,29 @@ export class Ft8TxController {
   /** CALL 1ST: when armed and idle, auto-answer the first CQ heard. Off by
    *  default — auto-answer is an explicit operator opt-in. */
   private callFirst = false;
+  /** Master auto-sequence. When false the runner drives a manual keyer (no
+   *  state-machine progression, no auto-log, no auto-disarm). */
+  private autoSequence = true;
+  /** Auto-disarm after a completed QSO (73). When false the keyer stays armed. */
+  private disableTxAfter73 = true;
+  /** Caller no-reply give-up limit (0 = never). */
+  private noReplyLimit = 0;
+  /** Final ack token (RR73 / RRR). */
+  private txAck: AckToken = 'RR73';
   private readonly doFetch: typeof fetch;
   private readonly onLogQso?: (state: QsoState) => void;
 
   constructor(opts: Ft8TxControllerOpts) {
+    this.autoSequence = opts.autoSequence ?? true;
+    this.disableTxAfter73 = opts.disableTxAfter73 ?? true;
+    this.noReplyLimit = Math.max(0, opts.noReplyLimit ?? 0);
+    this.txAck = opts.txAck ?? 'RR73';
     this.state = seqStartCq({
       myCall: opts.myCall,
       myGrid4: opts.myGrid4 ?? null,
       mode: opts.mode ?? 'FT8',
+      txAck: this.txAck,
+      noReplyLimit: this.noReplyLimit,
     });
     this.audioHz = opts.audioHz ?? 1500;
     this.doFetch = opts.fetchFn ?? ((...a: Parameters<typeof fetch>) => fetch(...a));
@@ -94,6 +126,17 @@ export class Ft8TxController {
    * and disarms/halts as the machine dictates. Pure decision in, POSTs out.
    */
   onWindow(decoded: string[], measuredSnrOfDx?: number, senderSlot?: Slot): void {
+    // MANUAL MODE (auto-sequence off): keep the operator's currently-selected
+    // message going while armed, but never advance the QSO, auto-answer, log, or
+    // disarm on our own — every step is an explicit operator action.
+    if (!this.autoSequence) {
+      if (this.state.enableTx) {
+        const msg = currentOutgoing(this.state);
+        if (msg != null) void this.postStage(msg);
+      }
+      return;
+    }
+
     // CALL 1ST: while armed and idle (calling CQ, no DX latched yet), pounce on
     // the first decoded CQ. Requires the just-ended slot's parity so we answer
     // in the opposite slot. Explicit opt-in — never auto-engages.
@@ -128,9 +171,18 @@ export class Ft8TxController {
       this.onLogQso?.(this.state);
     }
     if (res.halt) {
+      // Halts (operator abort / no-reply limit) ALWAYS disarm, regardless of the
+      // disable-after-73 preference.
       void this.postHalt();
     } else if (res.disarmTx) {
-      void this.postArm(false);
+      // A completion disarm (no halt). Honour "Disable TX after 73": when the
+      // operator turned it off, keep the keyer armed and idle instead of
+      // dropping it, so they can immediately work the next station.
+      if (this.disableTxAfter73) {
+        void this.postArm(false);
+      } else {
+        this.state = { ...this.state, enableTx: true };
+      }
     }
   }
 
@@ -149,6 +201,40 @@ export class Ft8TxController {
   /** CALL 1ST toggle: auto-answer the first CQ while armed and idle. */
   setCallFirst(on: boolean): void {
     this.callFirst = on;
+  }
+
+  /** Apply the live FT8 Settings behaviour preferences. Safe to call any time —
+   *  noReplyLimit / txAck also update the in-flight QSO state so a mid-session
+   *  edit takes effect on the next decision, not only on the next new QSO. */
+  applyBehavior(b: Ft8TxBehavior): void {
+    if (b.autoSequence !== undefined) this.autoSequence = b.autoSequence;
+    if (b.disableTxAfter73 !== undefined) this.disableTxAfter73 = b.disableTxAfter73;
+    if (b.noReplyLimit !== undefined) {
+      this.noReplyLimit = Math.max(0, b.noReplyLimit);
+      this.state = { ...this.state, noReplyLimit: this.noReplyLimit };
+    }
+    if (b.txAck !== undefined) {
+      this.txAck = b.txAck;
+      this.state = { ...this.state, txAck: this.txAck };
+    }
+  }
+
+  /** Apply the persisted seed (slot / offset / hold / call-first) — used to
+   *  recover when the controller was constructed before the FT8 Settings store
+   *  finished hydrating. Only applied while idle (calling, no DX, disarmed) so it
+   *  can never disturb an in-flight QSO. */
+  applySeed(seed: { audioHz?: number; slot?: Slot; holdTxFreq?: boolean; callFirst?: boolean }): void {
+    const idle =
+      this.state.progress === 'calling' && !this.state.dxCall && !this.state.enableTx;
+    if (!idle) return;
+    // Offset BEFORE hold (setTxFreq is ignored while hold is engaged); set hold
+    // directly here since it isn't gated.
+    if (seed.audioHz !== undefined && Number.isFinite(seed.audioHz)) {
+      this.audioHz = Math.min(FT8_MAX_TX_OFFSET_HZ, Math.max(FT8_MIN_OFFSET_HZ, seed.audioHz));
+    }
+    if (seed.slot) this.state = { ...this.state, txSlot: seed.slot };
+    if (seed.holdTxFreq !== undefined) this.state = { ...this.state, holdTxFreq: seed.holdTxFreq };
+    if (seed.callFirst !== undefined) this.callFirst = seed.callFirst;
   }
 
   /** Latch the live QSO as logged (the manual LOG QSO path). Once set, the
@@ -223,12 +309,14 @@ export class Ft8TxController {
     if (msg != null) void this.postStage(msg);
   }
 
-  /** Start calling CQ (CALL 1ST). */
+  /** Start calling CQ. `opts.cqDirective` sets the CQ directive (CQ vs CQ DX). */
   startCq(opts?: Partial<NewQsoOpts>): void {
     this.state = seqStartCq({
       myCall: this.state.myCall,
       myGrid4: this.state.myGrid4,
       mode: this.state.mode,
+      txAck: this.txAck,
+      noReplyLimit: this.noReplyLimit,
       ...opts,
     });
   }
@@ -241,7 +329,13 @@ export class Ft8TxController {
     const parsed = parseFt8Message(decodeText, this.state.myCall);
     if (!parsed.deCall) return false;
     const next = seqAnswerCq(
-      { myCall: this.state.myCall, myGrid4: this.state.myGrid4, mode: this.state.mode },
+      {
+        myCall: this.state.myCall,
+        myGrid4: this.state.myGrid4,
+        mode: this.state.mode,
+        txAck: this.txAck,
+        noReplyLimit: this.noReplyLimit,
+      },
       { ...parsed, kind: 'cq' },
       senderSlot,
     );
@@ -258,6 +352,8 @@ export class Ft8TxController {
         myCall: this.state.myCall,
         myGrid4: this.state.myGrid4,
         mode: this.state.mode,
+        txAck: this.txAck,
+        noReplyLimit: this.noReplyLimit,
       },
       msg,
       cqSenderSlot,

--- a/zeus-web/src/dsp/ft8-tx-runner.ts
+++ b/zeus-web/src/dsp/ft8-tx-runner.ts
@@ -22,9 +22,9 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { useFt8Store, type Ft8Row } from '../state/ft8-store';
-import { Ft8TxController } from './ft8-tx-controller';
+import { Ft8TxController, type Ft8TxBehavior } from './ft8-tx-controller';
 import { parseFt8Message } from './ft8-message';
-import type { DigitalQsoMode, QsoState, Slot } from './ft8-sequencer';
+import type { DigitalQsoMode, NewQsoOpts, QsoState, Slot } from './ft8-sequencer';
 
 /** Slot length (ms) for a digital mode. FT8 = 15 s, FT4 = 7.5 s. */
 export function slotMsFor(mode: DigitalQsoMode): number {
@@ -112,7 +112,7 @@ export interface Ft8TxRunnerView {
   setHoldTxFreq: (hold: boolean) => void;
   setTxFreq: (hz: number) => void;
   setCallFirst: (on: boolean) => void;
-  startCq: () => void;
+  startCq: (opts?: Partial<NewQsoOpts>) => void;
   answerCq: (decodeText: string, senderSlot: Slot) => boolean;
   callStation: (decodeText: string, senderSlot: Slot) => boolean;
   stageMacro: (message: string) => void;
@@ -129,6 +129,24 @@ export interface UseFt8TxRunnerOpts {
   /** Current band — a change while armed force-disarms (never TX on a new band). */
   band?: string;
   onLogQso?: (state: QsoState) => void;
+  /** Persisted defaults seeded into the controller (FT8 Settings page →
+   *  Ft8Settings). These set the operator's starting slot / offset / hold /
+   *  call-first; they never arm and never override an in-flight QSO. Applied at
+   *  construction and re-applied once `seedReady` flips true while the controller
+   *  is still idle (covers the controller being built before the settings store
+   *  finished its async module-load hydrate). */
+  seed?: {
+    audioHz?: number;
+    slot?: Slot;
+    holdTxFreq?: boolean;
+    callFirst?: boolean;
+  };
+  /** True once the FT8 Settings store has hydrated from the server, so the seed
+   *  reflects the operator's saved defaults rather than the in-code fallbacks. */
+  seedReady?: boolean;
+  /** Live behaviour preferences (auto-sequence / disable-after-73 / no-reply
+   *  limit / ack token). Applied live whenever they change. */
+  behavior?: Ft8TxBehavior;
 }
 
 /**
@@ -183,18 +201,56 @@ export function beaconDisarm(): void {
  * per slot. Returns a reactive view + bound actions for the TX-control cluster.
  */
 export function useFt8TxRunner(opts: UseFt8TxRunnerOpts): Ft8TxRunnerView {
-  const { myCall, myGrid, mode, active, band, onLogQso } = opts;
+  const { myCall, myGrid, mode, active, band, onLogQso, seed, seedReady, behavior } = opts;
 
   // One controller for the lifetime of the workspace. Identity (call/grid) and
   // mode are pushed in via setters so an in-flight QSO survives a re-render.
   const ctrlRef = useRef<Ft8TxController | null>(null);
   if (ctrlRef.current === null) {
-    ctrlRef.current = new Ft8TxController({ myCall, myGrid4: myGrid, mode, onLogQso });
+    ctrlRef.current = new Ft8TxController({
+      myCall,
+      myGrid4: myGrid,
+      mode,
+      onLogQso,
+      audioHz: seed?.audioHz,
+      ...behavior,
+    });
+    // Seed persisted defaults exactly once. Order matters: set the offset (via
+    // the constructor above) BEFORE engaging HOLD, since setTxFreq is ignored
+    // while hold is on. None of these arm — arming is explicit only.
+    if (seed?.slot) ctrlRef.current.setTxSlot(seed.slot);
+    if (seed?.callFirst) ctrlRef.current.setCallFirst(true);
+    if (seed?.holdTxFreq) ctrlRef.current.setHoldTxFreq(true);
   }
   const ctrl = ctrlRef.current;
 
   const [view, setView] = useState(() => snapshot(ctrl));
   const sync = () => setView(snapshot(ctrl));
+
+  // Live behaviour prefs (auto-sequence / disable-after-73 / no-reply / ack):
+  // re-apply whenever any change, so a Settings edit takes effect mid-session.
+  useEffect(() => {
+    if (behavior) ctrl.applyBehavior(behavior);
+    sync();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    behavior?.autoSequence,
+    behavior?.disableTxAfter73,
+    behavior?.noReplyLimit,
+    behavior?.txAck,
+  ]);
+
+  // Seed-race recovery: if the controller was built before the settings store
+  // hydrated, re-apply the persisted seed once it's ready (no-op unless idle, so
+  // an in-flight QSO is never disturbed). Runs once per ready transition.
+  const seededRef = useRef(false);
+  useEffect(() => {
+    if (!seedReady || seededRef.current) return;
+    seededRef.current = true;
+    if (seed) ctrl.applySeed(seed);
+    sync();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [seedReady]);
 
   // Keep identity + mode current without resetting the live QSO.
   useEffect(() => {
@@ -279,8 +335,8 @@ export function useFt8TxRunner(opts: UseFt8TxRunnerOpts): Ft8TxRunnerView {
       ctrl.setCallFirst(on);
       sync();
     },
-    startCq: () => {
-      ctrl.startCq();
+    startCq: (opts) => {
+      ctrl.startCq(opts);
       sync();
     },
     answerCq: (text, senderSlot) => {

--- a/zeus-web/src/layout/ft8/Ft8DecodeTable.test.tsx
+++ b/zeus-web/src/layout/ft8/Ft8DecodeTable.test.tsx
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Decode-table client-side filter tests (FT8 Settings → Decode): Show-only-CQ
+// and Hide-worked-before. Import the harness first so its localStorage polyfill
+// and act-environment flag are installed before any store module loads.
+
+import { describe, expect, it, beforeEach } from 'vitest';
+import { createElement } from 'react';
+import { act, render } from '../../components/meters/__tests__/harness';
+import { Ft8DecodeTable } from './Ft8DecodeTable';
+import { useFt8Store, type Ft8Row } from '../../state/ft8-store';
+
+function row(text: string, i: number): Ft8Row {
+  return {
+    id: `r${i}`,
+    receiver: 0,
+    protocol: 'FT8',
+    slotStartUnixMs: 0,
+    snrDb: -10,
+    dtSec: 0.1,
+    freqHz: 1000 + i,
+    score: 0,
+    text,
+  };
+}
+
+const ROWS: Ft8Row[] = [
+  row('CQ K1ABC FN42', 0), // cq
+  row('K7XYZ K9QQQ FN31', 1), // normal (neither CQ, me, nor worked)
+  row('MYCALL K3ZZZ -05', 2), // me (directed at MYCALL)
+  row('K5AAA W1AW R-12', 3), // worked (sender W1AW is in the logbook)
+];
+
+function bodyRowCount(container: HTMLElement): number {
+  return container.querySelectorAll('tbody tr').length;
+}
+
+describe('Ft8DecodeTable filters', () => {
+  beforeEach(() => {
+    act(() => {
+      useFt8Store.setState({ rows: ROWS });
+    });
+  });
+
+  it('shows every row with no filter active', () => {
+    const { container, unmount } = render(
+      createElement(Ft8DecodeTable, { myCall: 'MYCALL' }),
+    );
+    expect(bodyRowCount(container)).toBe(4);
+    unmount();
+  });
+
+  it('Show-only-CQ keeps CQ rows and rows calling me', () => {
+    const { container, unmount } = render(
+      createElement(Ft8DecodeTable, { myCall: 'MYCALL', showOnlyCq: true }),
+    );
+    // The CQ row + the row directed at MYCALL survive; the other two drop.
+    expect(bodyRowCount(container)).toBe(2);
+    unmount();
+  });
+
+  it('Hide-worked-before drops rows whose sender is already logged', () => {
+    const { container, unmount } = render(
+      createElement(Ft8DecodeTable, {
+        myCall: 'MYCALL',
+        hideWorkedBefore: true,
+        workedCalls: new Set(['W1AW']),
+      }),
+    );
+    expect(bodyRowCount(container)).toBe(3); // the W1AW row is hidden
+    unmount();
+  });
+
+  it('shows a filter-specific empty message when nothing matches', () => {
+    act(() => {
+      useFt8Store.setState({ rows: [row('K7XYZ K9QQQ FN31', 9)] });
+    });
+    const { container, unmount } = render(
+      createElement(Ft8DecodeTable, { myCall: 'MYCALL', showOnlyCq: true }),
+    );
+    expect(bodyRowCount(container)).toBe(0);
+    expect(container.textContent).toContain('No decodes match');
+    unmount();
+  });
+});

--- a/zeus-web/src/layout/ft8/Ft8DecodeTable.tsx
+++ b/zeus-web/src/layout/ft8/Ft8DecodeTable.tsx
@@ -59,13 +59,40 @@ export interface Ft8DecodeTableProps {
   workedCalls?: ReadonlySet<string>;
   workedGrids?: ReadonlySet<string>;
   onRowClick?: (row: Ft8Row) => void;
+  /** FT8 Settings → Decode filters (client-side predicates over the live rows).
+   *  `showOnlyCq` keeps only CQ rows plus anything directed at my call (so the
+   *  operator never misses a station answering them); `hideWorkedBefore` drops
+   *  rows whose sender is already in the logbook. */
+  showOnlyCq?: boolean;
+  hideWorkedBefore?: boolean;
 }
 
-export function Ft8DecodeTable({ myCall, workedCalls, workedGrids, onRowClick }: Ft8DecodeTableProps) {
-  const rows = useFt8Store((s) => s.rows);
+export function Ft8DecodeTable({
+  myCall,
+  workedCalls,
+  workedGrids,
+  onRowClick,
+  showOnlyCq,
+  hideWorkedBefore,
+}: Ft8DecodeTableProps) {
+  const allRows = useFt8Store((s) => s.rows);
+
+  const rows =
+    showOnlyCq || hideWorkedBefore
+      ? allRows.filter((r) => {
+          const cls = classifyDecode(r, myCall, workedCalls, workedGrids);
+          if (showOnlyCq && cls !== 'cq' && cls !== 'me') return false;
+          if (hideWorkedBefore && cls === 'worked') return false;
+          return true;
+        })
+      : allRows;
 
   if (rows.length === 0) {
-    return <div className="ft8-decode-empty">Waiting for decodes…</div>;
+    return (
+      <div className="ft8-decode-empty">
+        {allRows.length === 0 ? 'Waiting for decodes…' : 'No decodes match the active filter'}
+      </div>
+    );
   }
 
   return (

--- a/zeus-web/src/layout/ft8/Ft8SettingsView.test.tsx
+++ b/zeus-web/src/layout/ft8/Ft8SettingsView.test.tsx
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Ft8SettingsView render tests — the SETTINGS page wires the server-backed
+// operator identity (the TX unblock) and the persisted FT8 prefs. Import the
+// harness first so its localStorage polyfill + act flag are installed before any
+// store module loads, and mock every REST layer the view's stores touch so no
+// real fetch fires.
+
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { createElement } from 'react';
+import { act, render } from '../../components/meters/__tests__/harness';
+
+vi.mock('../../api/operator', () => ({
+  getOperator: vi.fn(async () => ({
+    callsign: '',
+    grid: '',
+    resolvedCallsign: '',
+    resolvedGrid: '',
+    callsignFromQrz: false,
+    gridFromQrz: false,
+    identityResolved: false,
+  })),
+  postOperator: vi.fn(async (id: { callsign: string; grid: string }) => ({
+    callsign: id.callsign,
+    grid: id.grid,
+    resolvedCallsign: id.callsign,
+    resolvedGrid: id.grid,
+    callsignFromQrz: false,
+    gridFromQrz: false,
+    identityResolved: true,
+  })),
+}));
+
+const FT8_DEFAULTS = vi.hoisted(() => ({
+  autoSequence: true,
+  callFirst: false,
+  holdTxFreq: false,
+  disableTxAfter73: true,
+  defaultTxSlot: 0,
+  defaultTxOffsetHz: 1500,
+  rr73InsteadOfRrr: true,
+  skipGrid: false,
+  callerMaxRetries: 0,
+  cqMessage: 'CQ',
+  cqDxMessage: 'CQ DX',
+  freeTextMacro: '',
+  decodePasses: 3,
+  showOnlyCq: false,
+  hideWorkedBefore: false,
+  autoLog: true,
+  promptBeforeLog: false,
+  clearDxAfterLog: true,
+  reportToComment: false,
+}));
+
+vi.mock('../../api/ft8-settings', () => ({
+  FT8_SETTINGS_DEFAULTS: FT8_DEFAULTS,
+  getFt8Settings: vi.fn(async () => FT8_DEFAULTS),
+  postFt8Settings: vi.fn(async (s: unknown) => s),
+}));
+
+vi.mock('../../api/spotting', () => ({
+  getSpottingStatus: vi.fn(async () => ({
+    pskReporterEnabled: false,
+    wsprnetEnabled: false,
+    callsign: '',
+    grid: '',
+    identityResolved: false,
+  })),
+  postSpottingConfig: vi.fn(async (c: unknown) => c),
+}));
+
+vi.mock('../../api/wsjtx', () => ({
+  getWsjtxStatus: vi.fn(async () => ({ enabled: false, host: '127.0.0.1', port: 2237 })),
+  postWsjtxConfig: vi.fn(async (c: unknown) => c),
+}));
+
+import { Ft8SettingsView } from './Ft8SettingsView';
+import { useFt8Store } from '../../state/ft8-store';
+import { useFt8SettingsStore } from '../../state/ft8-settings-store';
+import * as operatorApi from '../../api/operator';
+import * as ft8SettingsApi from '../../api/ft8-settings';
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    'value',
+  )!.set!;
+  act(() => {
+    setter.call(input, value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+}
+
+describe('Ft8SettingsView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useFt8Store.setState({ enabled: false, passes: 3, receiver: -1, protocol: 'FT8' });
+    useFt8SettingsStore.setState({ settings: FT8_DEFAULTS, hydrated: true });
+  });
+
+  it('renders the Station / Operator identity fields (the unblock)', () => {
+    const { container, unmount } = render(createElement(Ft8SettingsView));
+    expect(container.textContent).toContain('My Call');
+    expect(container.textContent).toContain('My Grid');
+    expect(container.querySelectorAll('input.ft8-set-input').length).toBeGreaterThan(0);
+    unmount();
+  });
+
+  it('writing My Call persists the shared operator identity to the server', () => {
+    const { container, unmount } = render(createElement(Ft8SettingsView));
+    const callInput = container.querySelector('input.ft8-set-input') as HTMLInputElement;
+    setInputValue(callInput, 'k1abc');
+    expect(operatorApi.postOperator).toHaveBeenCalledWith({ callsign: 'K1ABC', grid: '' });
+    unmount();
+  });
+
+  it('decode-depth Deepest applies live (passes=4) and persists', () => {
+    const { container, unmount } = render(createElement(Ft8SettingsView));
+    // The depth scale maps to the engine: Normal=1, Deep=3, Deepest=4 (no bogus
+    // "Fast" — passes=1 is the engine floor).
+    const deepest = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Deepest',
+    ) as HTMLButtonElement;
+    act(() => deepest.click());
+    expect(useFt8Store.getState().passes).toBe(4);
+    expect(ft8SettingsApi.postFt8Settings).toHaveBeenCalledWith(
+      expect.objectContaining({ decodePasses: 4 }),
+    );
+    unmount();
+  });
+
+  it('surfaces the reporting status chips and a Network deep-link', () => {
+    const { container, unmount } = render(createElement(Ft8SettingsView));
+    expect(container.textContent).toContain('PSK Reporter');
+    expect(container.textContent).toContain('WSPRnet');
+    expect(container.textContent).toContain('WSJT-X UDP');
+    expect(container.textContent).toContain('Open Network settings');
+    unmount();
+  });
+});

--- a/zeus-web/src/layout/ft8/Ft8SettingsView.tsx
+++ b/zeus-web/src/layout/ft8/Ft8SettingsView.tsx
@@ -1,0 +1,445 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Ft8SettingsView — the FT8/FT4 workspace SETTINGS page (the curated WSJT-X +
+// JTDX KEEP set, with everything a native SDR already owns SCRAPPED: rig/CAT/PTT
+// selection, sound-card in/out, split, the frequencies table, power/attenuator
+// dials — Zeus owns all of those). Five grouped sections in one scrollable
+// column, fixed (non-closable) per the locked-workspace design.
+//
+// THE UNBLOCK lives in § Station / Operator: My Call + My Grid are persisted
+// SERVER-side (shared operator identity) so FT8 TX ungates and the desktop no
+// longer loses the call on restart. Reporting/logging that another subsystem
+// already owns (PSK Reporter / WSPRnet / WSJT-X UDP) is SURFACED and deep-linked,
+// never duplicated.
+//
+// Styling is HUD-token-only (ft8-theme.css --hud-*) — no raw hex.
+
+import { useEffect } from 'react';
+import { useOperatorStore } from '../../state/operator-store';
+import { useFt8SettingsStore } from '../../state/ft8-settings-store';
+import { useFt8Store } from '../../state/ft8-store';
+import { useSpottingStore } from '../../state/spotting-store';
+import { useWsjtxStore } from '../../state/wsjtx-store';
+import { useLayoutStore } from '../../state/layout-store';
+import { FT8_MAX_TX_OFFSET_HZ, FT8_MIN_OFFSET_HZ } from '../../dsp/ft8-passband';
+
+// ---- small token-styled controls ------------------------------------------
+
+function ToggleRow(props: {
+  label: string;
+  hint?: string;
+  checked: boolean;
+  /** Render disabled with a "coming soon" badge — persisted but not yet wired. */
+  comingSoon?: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <label className={`ft8-set-row ft8-set-row--toggle${props.comingSoon ? ' is-disabled' : ''}`}>
+      <span className="ft8-set-row__text">
+        <span className="ft8-set-row__label">
+          {props.label}
+          {props.comingSoon && <span className="ft8-set-soon">soon</span>}
+        </span>
+        {props.hint && <span className="ft8-set-row__hint">{props.hint}</span>}
+      </span>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={props.checked}
+        aria-label={props.label}
+        aria-disabled={props.comingSoon}
+        disabled={props.comingSoon}
+        className={`ft8-set-switch${props.checked ? ' is-on' : ''}`}
+        onClick={() => !props.comingSoon && props.onChange(!props.checked)}
+      >
+        {props.checked ? 'ON' : 'OFF'}
+      </button>
+    </label>
+  );
+}
+
+function SegRow<T extends string>(props: {
+  label: string;
+  hint?: string;
+  value: T;
+  options: ReadonlyArray<{ value: T; label: string }>;
+  onChange: (v: T) => void;
+}) {
+  return (
+    <div className="ft8-set-row">
+      <span className="ft8-set-row__text">
+        <span className="ft8-set-row__label">{props.label}</span>
+        {props.hint && <span className="ft8-set-row__hint">{props.hint}</span>}
+      </span>
+      <div className="ft8-set-seg" role="group" aria-label={props.label}>
+        {props.options.map((o) => (
+          <button
+            key={o.value}
+            type="button"
+            aria-pressed={props.value === o.value}
+            className={`ft8-set-seg__btn${props.value === o.value ? ' is-on' : ''}`}
+            onClick={() => props.onChange(o.value)}
+          >
+            {o.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TextRow(props: {
+  label: string;
+  hint?: string;
+  value: string;
+  placeholder?: string;
+  maxLength?: number;
+  upper?: boolean;
+  resolved?: { value: string; fromQrz: boolean };
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div className="ft8-set-row">
+      <span className="ft8-set-row__text">
+        <span className="ft8-set-row__label">{props.label}</span>
+        {props.hint && <span className="ft8-set-row__hint">{props.hint}</span>}
+        {props.resolved && props.resolved.fromQrz && props.resolved.value && (
+          <span className="ft8-set-row__resolved">
+            Using QRZ home: <strong>{props.resolved.value}</strong>
+          </span>
+        )}
+      </span>
+      <input
+        className="ft8-set-input"
+        value={props.value}
+        placeholder={props.placeholder}
+        maxLength={props.maxLength}
+        spellCheck={false}
+        style={props.upper ? { textTransform: 'uppercase' } : undefined}
+        onChange={(e) => props.onChange(e.target.value)}
+      />
+    </div>
+  );
+}
+
+function NumberRow(props: {
+  label: string;
+  hint?: string;
+  value: number;
+  min?: number;
+  max?: number;
+  step?: number;
+  suffix?: string;
+  disabled?: boolean;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div className="ft8-set-row">
+      <span className="ft8-set-row__text">
+        <span className="ft8-set-row__label">{props.label}</span>
+        {props.hint && <span className="ft8-set-row__hint">{props.hint}</span>}
+      </span>
+      <span className="ft8-set-num">
+        <input
+          type="number"
+          className="ft8-set-input ft8-set-input--num"
+          value={props.value}
+          min={props.min}
+          max={props.max}
+          step={props.step ?? 1}
+          disabled={props.disabled}
+          onChange={(e) => props.onChange(Number(e.target.value))}
+        />
+        {props.suffix && <span className="ft8-set-num__suffix">{props.suffix}</span>}
+      </span>
+    </div>
+  );
+}
+
+function Chip(props: { label: string; on: boolean }) {
+  return (
+    <span className={`ft8-set-chip${props.on ? ' is-on' : ''}`}>
+      <span className="ft8-set-chip__dot" />
+      {props.label} {props.on ? 'ON' : 'OFF'}
+    </span>
+  );
+}
+
+// ---- the view -------------------------------------------------------------
+
+export function Ft8SettingsView() {
+  // Operator identity (server-authoritative, shared with spotting/FreeDV/TX).
+  const opCall = useOperatorStore((s) => s.call);
+  const opGrid = useOperatorStore((s) => s.grid);
+  const resolvedCall = useOperatorStore((s) => s.resolvedCall);
+  const resolvedGrid = useOperatorStore((s) => s.resolvedGrid);
+  const callFromQrz = useOperatorStore((s) => s.callFromQrz);
+  const gridFromQrz = useOperatorStore((s) => s.gridFromQrz);
+  const setCall = useOperatorStore((s) => s.setCall);
+  const setGrid = useOperatorStore((s) => s.setGrid);
+
+  // Persisted FT8 behaviour preferences.
+  const settings = useFt8SettingsStore((s) => s.settings);
+  const update = useFt8SettingsStore((s) => s.update);
+
+  // Live decode depth (applies immediately + persists).
+  const setPasses = useFt8Store((s) => s.setPasses);
+  const setDecodeDepth = (passes: number) => {
+    setPasses(passes);
+    void update({ decodePasses: passes });
+  };
+
+  // Reporting status (read-only chips — owned by the Network tab, surfaced here).
+  const spotStatus = useSpottingStore((s) => s.status);
+  const refreshSpotting = useSpottingStore((s) => s.refreshStatus);
+  const wsjtxStatus = useWsjtxStore((s) => s.status);
+  const refreshWsjtx = useWsjtxStore((s) => s.refreshStatus);
+  useEffect(() => {
+    void refreshSpotting();
+    void refreshWsjtx();
+  }, [refreshSpotting, refreshWsjtx]);
+
+  // Deep-link to the Network settings tab. The FT8 workspace is a full-screen
+  // overlay, so to reveal the Network tab behind it we leave the workspace.
+  const setSettingsView = useLayoutStore((s) => s.setSettingsView);
+  const closeWorkspace = useFt8Store((s) => s.closeWorkspace);
+  const openNetworkSettings = () => {
+    closeWorkspace();
+    setSettingsView(true, 'network');
+  };
+
+  // Decode depth maps to the engine's pass scale: 1 = Normal (floor), >1 = Deep /
+  // multi-pass (there is no lighter-than-normal mode, so no bogus "Fast"). The
+  // default (3) lands on Deep, matching the pre-settings engine behaviour.
+  const depth =
+    settings.decodePasses >= 4 ? 'deepest' : settings.decodePasses <= 1 ? 'normal' : 'deep';
+  const depthToPasses = (v: 'normal' | 'deep' | 'deepest') =>
+    v === 'normal' ? 1 : v === 'deepest' ? 4 : 3;
+
+  return (
+    <div className="ft8-settings" aria-label="FT8 settings">
+      {/* § Station / Operator — THE unblock. */}
+      <section className="ft8-region ft8-set-section">
+        <div className="ft8-region__head">Station / Operator</div>
+        <div className="ft8-set-body">
+          <TextRow
+            label="My Call"
+            hint="Your station callsign — required to transmit. Shared with spotting & FreeDV."
+            value={opCall}
+            placeholder={resolvedCall && callFromQrz ? resolvedCall : 'MYCALL'}
+            upper
+            resolved={{ value: resolvedCall, fromQrz: callFromQrz }}
+            onChange={setCall}
+          />
+          <TextRow
+            label="My Grid"
+            hint="Maidenhead locator (4 or 6 chars). Falls back to your QRZ home grid."
+            value={opGrid}
+            placeholder={resolvedGrid && gridFromQrz ? resolvedGrid : 'FN42'}
+            maxLength={6}
+            upper
+            resolved={{ value: resolvedGrid, fromQrz: gridFromQrz }}
+            onChange={setGrid}
+          />
+          <p className="ft8-set-note">
+            Identity is stored on the server and survives restarts. Leave a field blank to use your
+            QRZ home station.
+          </p>
+        </div>
+      </section>
+
+      {/* § TX & Auto-sequence. */}
+      <section className="ft8-region ft8-set-section">
+        <div className="ft8-region__head">TX &amp; Auto-sequence</div>
+        <div className="ft8-set-body">
+          <ToggleRow
+            label="Auto-sequence"
+            hint="Run the QSO state machine. TX still requires ENABLE/arm — this never keys on its own."
+            checked={settings.autoSequence}
+            onChange={(v) => void update({ autoSequence: v })}
+          />
+          <ToggleRow
+            label="Call 1st"
+            hint="Auto-answer the first decoded CQ while armed."
+            checked={settings.callFirst}
+            onChange={(v) => void update({ callFirst: v })}
+          />
+          <ToggleRow
+            label="Hold TX freq"
+            hint="Lock the TX audio offset against waterfall clicks."
+            checked={settings.holdTxFreq}
+            onChange={(v) => void update({ holdTxFreq: v })}
+          />
+          <ToggleRow
+            label="Disable TX after 73"
+            hint="Auto-disarm once a QSO completes (73 sent)."
+            checked={settings.disableTxAfter73}
+            onChange={(v) => void update({ disableTxAfter73: v })}
+          />
+          <SegRow
+            label="Default TX slot"
+            hint="Which 15 s slot a fresh QSO transmits in."
+            value={settings.defaultTxSlot === 0 ? 'even' : 'odd'}
+            options={[
+              { value: 'even', label: '1ST (even)' },
+              { value: 'odd', label: '2ND (odd)' },
+            ]}
+            onChange={(v) => void update({ defaultTxSlot: v === 'even' ? 0 : 1 })}
+          />
+          <NumberRow
+            label="Default TX audio offset"
+            hint="Where a fresh TX tone defaults inside the SSB passband."
+            value={settings.defaultTxOffsetHz}
+            min={FT8_MIN_OFFSET_HZ}
+            max={FT8_MAX_TX_OFFSET_HZ}
+            suffix="Hz"
+            onChange={(v) => void update({ defaultTxOffsetHz: v })}
+          />
+          <div className="ft8-set-row ft8-set-row--readonly">
+            <span className="ft8-set-row__text">
+              <span className="ft8-set-row__label">TX watchdog</span>
+              <span className="ft8-set-row__hint">
+                Backend hard cap on unattended TX. Fixed for safety.
+              </span>
+            </span>
+            <span className="ft8-set-readonly-value">10 min</span>
+          </div>
+
+          <details className="ft8-set-advanced">
+            <summary>Advanced sequence (JTDX) — default off</summary>
+            <ToggleRow
+              label="Send RR73 instead of RRR"
+              checked={settings.rr73InsteadOfRrr}
+              onChange={(v) => void update({ rr73InsteadOfRrr: v })}
+            />
+            <ToggleRow
+              label="Skip grid (send report first)"
+              hint="JTDX-style opening with the report instead of the grid."
+              checked={settings.skipGrid}
+              comingSoon
+              onChange={(v) => void update({ skipGrid: v })}
+            />
+            <NumberRow
+              label="Caller max retries"
+              hint="0 = unlimited."
+              value={settings.callerMaxRetries}
+              min={0}
+              max={30}
+              onChange={(v) => void update({ callerMaxRetries: v })}
+            />
+          </details>
+        </div>
+      </section>
+
+      {/* § Macros. */}
+      <section className="ft8-region ft8-set-section">
+        <div className="ft8-region__head">Macros</div>
+        <div className="ft8-set-body">
+          <TextRow
+            label="CQ message"
+            hint="The CQ button text (e.g. CQ or CQ TEST)."
+            value={settings.cqMessage}
+            maxLength={32}
+            onChange={(v) => void update({ cqMessage: v })}
+          />
+          <TextRow
+            label="CQ DX message"
+            value={settings.cqDxMessage}
+            maxLength={32}
+            onChange={(v) => void update({ cqDxMessage: v })}
+          />
+          <TextRow
+            label="Free-text macro"
+            hint="A reusable 13-char free-text message."
+            value={settings.freeTextMacro}
+            maxLength={13}
+            upper
+            onChange={(v) => void update({ freeTextMacro: v })}
+          />
+        </div>
+      </section>
+
+      {/* § Decode. */}
+      <section className="ft8-region ft8-set-section">
+        <div className="ft8-region__head">Decode</div>
+        <div className="ft8-set-body">
+          <SegRow
+            label="Decode depth"
+            hint="Deeper digs out weaker signals at higher CPU cost."
+            value={depth}
+            options={[
+              { value: 'normal', label: 'Normal' },
+              { value: 'deep', label: 'Deep' },
+              { value: 'deepest', label: 'Deepest' },
+            ]}
+            onChange={(v) => setDecodeDepth(depthToPasses(v))}
+          />
+          <ToggleRow
+            label="Show only CQ"
+            hint="Hide non-CQ rows (still shows stations calling you)."
+            checked={settings.showOnlyCq}
+            onChange={(v) => void update({ showOnlyCq: v })}
+          />
+          <ToggleRow
+            label="Hide worked-before"
+            hint="Hide stations already in your logbook."
+            checked={settings.hideWorkedBefore}
+            onChange={(v) => void update({ hideWorkedBefore: v })}
+          />
+        </div>
+      </section>
+
+      {/* § Reporting & Logging — surface/deep-link, don't rebuild. */}
+      <section className="ft8-region ft8-set-section">
+        <div className="ft8-region__head">Reporting &amp; Logging</div>
+        <div className="ft8-set-body">
+          <div className="ft8-set-chips">
+            <Chip label="PSK Reporter" on={!!spotStatus?.pskReporterEnabled} />
+            <Chip label="WSPRnet" on={!!spotStatus?.wsprnetEnabled} />
+            <Chip label="WSJT-X UDP" on={!!wsjtxStatus?.enabled} />
+          </div>
+          <button type="button" className="ft8-set-link" onClick={openNetworkSettings}>
+            Open Network settings →
+          </button>
+          <p className="ft8-set-note">
+            PSK Reporter, WSPRnet and WSJT-X UDP push are configured on the Network tab. The link
+            leaves the FT8 workspace.
+          </p>
+
+          <div className="ft8-set-divider" />
+
+          <ToggleRow
+            label="Auto-log QSO"
+            hint="Write completed QSOs to the logbook automatically."
+            checked={settings.autoLog}
+            onChange={(v) => void update({ autoLog: v })}
+          />
+          <ToggleRow
+            label="Prompt before logging"
+            hint="Confirm each QSO before it is logged."
+            checked={settings.promptBeforeLog}
+            onChange={(v) => void update({ promptBeforeLog: v })}
+          />
+          <ToggleRow
+            label="Clear DX call/grid after log"
+            hint="Reset the QSO panel once a contact is logged."
+            checked={settings.clearDxAfterLog}
+            comingSoon
+            onChange={(v) => void update({ clearDxAfterLog: v })}
+          />
+          <ToggleRow
+            label="dB report → comment"
+            hint="Record the signal report in the QSO comment."
+            checked={settings.reportToComment}
+            onChange={(v) => void update({ reportToComment: v })}
+          />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/zeus-web/src/layout/ft8/Ft8Stats.tsx
+++ b/zeus-web/src/layout/ft8/Ft8Stats.tsx
@@ -27,7 +27,9 @@ function Stat({ label, value, hint }: { label: string; value: string; hint?: str
 export function Ft8Stats() {
   const entries = useLoggerStore((s) => s.entries);
   const totalCount = useLoggerStore((s) => s.totalCount);
-  const myGrid = useOperatorStore((s) => s.grid);
+  // Resolved grid (override else QRZ home) so best-DX distance still computes for
+  // a QRZ-home operator who never typed a grid override.
+  const myGrid = useOperatorStore((s) => s.resolvedGrid);
 
   const stats = useMemo(() => computeFt8Stats(entries, myGrid || null), [entries, myGrid]);
 

--- a/zeus-web/src/layout/ft8/Ft8TxControl.tsx
+++ b/zeus-web/src/layout/ft8/Ft8TxControl.tsx
@@ -28,9 +28,30 @@ export interface Ft8TxControlProps {
   runner: Ft8TxRunnerView;
   myCall: string;
   myGrid: string;
+  /** Operator's configured CQ macro text (e.g. "CQ" or "CQ POTA"). */
+  cqMessage?: string;
+  /** Operator's configured CQ-DX macro text (e.g. "CQ DX"). */
+  cqDxMessage?: string;
+  /** Operator's reusable 13-char free-text macro. */
+  freeTextMacro?: string;
 }
 
-export function Ft8TxControl({ runner, myCall, myGrid }: Ft8TxControlProps) {
+/** Extract the CQ directive from a configured CQ macro: "CQ" → null,
+ *  "CQ DX" → "DX", "CQ POTA" → "POTA". Drives both the staged message and the
+ *  sequencer's calling-state outgoing so the configured CQ survives a restage. */
+function cqDirectiveOf(msg: string | undefined): string | null {
+  const d = (msg ?? '').trim().replace(/^CQ\b\s*/i, '').trim();
+  return d.length > 0 ? d : null;
+}
+
+export function Ft8TxControl({
+  runner,
+  myCall,
+  myGrid,
+  cqMessage,
+  cqDxMessage,
+  freeTextMacro,
+}: Ft8TxControlProps) {
   const status = useFt8TxStore((s) => s.status);
   const [custom, setCustom] = useState('');
   // Server-authoritative TUN state + the action that keeps MOX/TUN mutually
@@ -139,9 +160,11 @@ export function Ft8TxControl({ runner, myCall, myGrid }: Ft8TxControlProps) {
           type="button"
           className="ft8-tx__macro"
           disabled={!canCall}
+          title={cqMessage && cqMessage.trim() !== 'CQ' ? `Call ${cqMessage}` : 'Call CQ'}
           onClick={() => {
-            runner.startCq();
-            runner.stageMacro(genCq(myCall, myGrid || null));
+            const dir = cqDirectiveOf(cqMessage);
+            runner.startCq({ cqDirective: dir });
+            runner.stageMacro(genCq(myCall, myGrid || null, dir));
           }}
         >
           CQ
@@ -150,9 +173,11 @@ export function Ft8TxControl({ runner, myCall, myGrid }: Ft8TxControlProps) {
           type="button"
           className="ft8-tx__macro"
           disabled={!canCall}
+          title={cqDxMessage ? `Call ${cqDxMessage}` : 'Call CQ DX'}
           onClick={() => {
-            runner.startCq();
-            runner.stageMacro(genCq(myCall, myGrid || null, 'DX'));
+            const dir = cqDirectiveOf(cqDxMessage ?? 'CQ DX');
+            runner.startCq({ cqDirective: dir });
+            runner.stageMacro(genCq(myCall, myGrid || null, dir));
           }}
         >
           CQ DX
@@ -190,6 +215,17 @@ export function Ft8TxControl({ runner, myCall, myGrid }: Ft8TxControlProps) {
         >
           CALL 1ST
         </button>
+        {freeTextMacro && freeTextMacro.trim() && (
+          <button
+            type="button"
+            className="ft8-tx__macro"
+            disabled={!canCall}
+            title={`Stage free-text macro: ${freeTextMacro.trim()}`}
+            onClick={() => runner.stageMacro(freeTextMacro.trim().toUpperCase())}
+          >
+            MSG
+          </button>
+        )}
       </div>
 
       {/* Free-form message stage. */}

--- a/zeus-web/src/layout/ft8/Ft8Workspace.tsx
+++ b/zeus-web/src/layout/ft8/Ft8Workspace.tsx
@@ -14,8 +14,9 @@ import { useEffect, useMemo, useState } from 'react';
 import { useFt8Store, type Ft8Row } from '../../state/ft8-store';
 import { useConnectionStore } from '../../state/connection-store';
 import { useOperatorStore } from '../../state/operator-store';
+import { useFt8SettingsStore } from '../../state/ft8-settings-store';
 import { DIGITAL_BANDS } from '../../dsp/digital-segments';
-import { slotOf } from '../../dsp/ft8-sequencer';
+import { slotOf, type Slot } from '../../dsp/ft8-sequencer';
 import { useFt8TxRunner } from '../../dsp/ft8-tx-runner';
 import { qsoStateToLogEntry } from '../../dsp/ft8-qso-log';
 import { useLoggerStore } from '../../state/logger-store';
@@ -24,6 +25,7 @@ import { Ft8TxControl } from './Ft8TxControl';
 import { Ft8ReceivePanel } from './Ft8ReceivePanel';
 import { Ft8ActivityLog } from './Ft8ActivityLog';
 import { Ft8Stats } from './Ft8Stats';
+import { Ft8SettingsView } from './Ft8SettingsView';
 import { SpottingIndicator } from './SpottingIndicator';
 import '../../styles/ft8-theme.css';
 
@@ -47,6 +49,22 @@ function fmtMHz(hz?: number): string {
   return (hz / 1e6).toFixed(6);
 }
 
+/** "Prompt before logging" gate. Returns true when logging should proceed.
+ *  window.confirm is unavailable in headless/test contexts — default to logging
+ *  there so the auto-log path never silently drops a QSO. */
+function confirmLog(dxCall: string | null): boolean {
+  if (typeof window === 'undefined' || typeof window.confirm !== 'function') return true;
+  return window.confirm(`Log QSO with ${dxCall ?? 'this station'}?`);
+}
+
+/** "dB report → comment": fold the exchanged reports into the QSO comment. */
+function reportComment(req: { rstSent: string; rstRcvd: string }): string {
+  const parts: string[] = [];
+  if (req.rstSent) parts.push(`Sent ${req.rstSent}`);
+  if (req.rstRcvd) parts.push(`Rcvd ${req.rstRcvd}`);
+  return parts.join(' ');
+}
+
 export function Ft8Workspace({ onClose }: Ft8WorkspaceProps) {
   const clock = useUtcClock();
   const protocol = useFt8Store((s) => s.protocol);
@@ -58,13 +76,24 @@ export function Ft8Workspace({ onClose }: Ft8WorkspaceProps) {
   const switchProtocol = useFt8Store((s) => s.switchProtocol);
   const qsyBand = useFt8Store((s) => s.qsyBand);
 
+  // DECODE (the live operating view) vs SETTINGS (the configuration page). The
+  // protocol tabs (FT8/FT4) stay a separate switch; this is the view switch.
+  const [view, setView] = useState<'decode' | 'settings'>('decode');
+
   const vfoHz = useConnectionStore((s) => s.vfoHz);
   const rxFocusHz = useFt8Store((s) => s.rxFocusHz);
   const setRxFocusHz = useFt8Store((s) => s.setRxFocusHz);
-  const myCall = useOperatorStore((s) => s.call);
-  const myGrid = useOperatorStore((s) => s.grid);
-  const setCall = useOperatorStore((s) => s.setCall);
-  const setGrid = useOperatorStore((s) => s.setGrid);
+  // Operator identity is server-authoritative. We TX/gate on the RESOLVED value
+  // (override else QRZ home) so a QRZ-home operator transmits without retyping;
+  // the editable override fields live on the Settings page, not the header.
+  const myCall = useOperatorStore((s) => s.resolvedCall);
+  const myGrid = useOperatorStore((s) => s.resolvedGrid);
+  const hydrateOperator = useOperatorStore((s) => s.hydrate);
+
+  // Persisted FT8 prefs — seed the TX controller defaults + drive the decode
+  // filters and the auto-log gate.
+  const settings = useFt8SettingsStore((s) => s.settings);
+  const settingsHydrated = useFt8SettingsStore((s) => s.hydrated);
 
   const addLogEntry = useLoggerStore((s) => s.addLogEntry);
   const entries = useLoggerStore((s) => s.entries);
@@ -97,14 +126,40 @@ export function Ft8Workspace({ onClose }: Ft8WorkspaceProps) {
     mode: protocol,
     active: true,
     band,
+    // Seed the controller's starting slot / offset / hold / call-first from the
+    // operator's persisted FT8 Settings (applied at construction, re-applied once
+    // the settings store reports hydrated to cover the construct-before-hydrate
+    // race).
+    seed: {
+      audioHz: settings.defaultTxOffsetHz,
+      slot: (settings.defaultTxSlot === 0 ? 'even' : 'odd') as Slot,
+      holdTxFreq: settings.holdTxFreq,
+      callFirst: settings.callFirst,
+    },
+    seedReady: settingsHydrated,
+    // Live behaviour prefs — auto-sequence, disable-after-73, no-reply limit and
+    // the RR73/RRR ack — applied live so a Settings edit takes effect mid-session.
+    behavior: {
+      autoSequence: settings.autoSequence,
+      disableTxAfter73: settings.disableTxAfter73,
+      noReplyLimit: settings.callerMaxRetries,
+      txAck: settings.rr73InsteadOfRrr ? 'RR73' : 'RRR',
+    },
     onLogQso: (state) => {
+      // Respect the operator's logging preferences (FT8 Settings → Logging).
+      const s = useFt8SettingsStore.getState().settings;
+      if (!s.autoLog) return;
+      if (s.promptBeforeLog && !confirmLog(state.dxCall)) return;
       const dialHz = useConnectionStore.getState().vfoHz ?? 0;
       const req = qsoStateToLogEntry(state, {
         band: useFt8Store.getState().band,
         freqMhz: dialHz / 1e6,
         mode: state.mode,
       });
-      if (req) void useLoggerStore.getState().addLogEntry(req);
+      if (req) {
+        if (s.reportToComment) req.comment = reportComment(req);
+        void useLoggerStore.getState().addLogEntry(req);
+      }
     },
   });
 
@@ -120,6 +175,9 @@ export function Ft8Workspace({ onClose }: Ft8WorkspaceProps) {
       mode: protocol,
     });
     if (req) {
+      // Manual log is an explicit action, so no prompt — but still honour the
+      // "dB report → comment" preference for parity with the auto-log path.
+      if (settings.reportToComment) req.comment = reportComment(req);
       void addLogEntry(req);
       tx.markLogged();
     }
@@ -132,7 +190,10 @@ export function Ft8Workspace({ onClose }: Ft8WorkspaceProps) {
   // covers the initial fetch.
   useEffect(() => {
     void useLoggerStore.getState().loadEntries();
-  }, []);
+    // Refresh the shared operator identity on open — QRZ home may resolve after
+    // the initial connect, and the override may have been edited elsewhere.
+    void hydrateOperator();
+  }, [hydrateOperator]);
 
   // Esc closes the workspace.
   useEffect(() => {
@@ -148,8 +209,13 @@ export function Ft8Workspace({ onClose }: Ft8WorkspaceProps) {
   }, [onClose]);
 
   // Click a decode → start calling that station (we reply in the opposite slot).
+  // With no operator call we can't generate Tx messages, so instead of silently
+  // doing nothing, send the operator to Settings to set their call.
   const onRowClick = (row: Ft8Row) => {
-    if (!myCall) return; // need an operator call to generate Tx messages
+    if (!myCall) {
+      setView('settings');
+      return;
+    }
     const secs = new Date(row.slotStartUnixMs).getUTCSeconds();
     const senderSlot = slotOf(secs, protocol);
     tx.callStation(row.text, senderSlot);
@@ -178,26 +244,30 @@ export function Ft8Workspace({ onClose }: Ft8WorkspaceProps) {
             </button>
           ))}
         </div>
-        <label className="ft8-ws-id">
-          <span>Call</span>
-          <input
-            value={myCall}
-            onChange={(e) => setCall(e.target.value)}
-            placeholder="MYCALL"
-            spellCheck={false}
-            size={8}
-          />
-        </label>
-        <label className="ft8-ws-id">
-          <span>Grid</span>
-          <input
-            value={myGrid}
-            onChange={(e) => setGrid(e.target.value)}
-            placeholder="FN42"
-            spellCheck={false}
-            size={6}
-          />
-        </label>
+        <div className="ft8-ws-tabs" role="tablist" aria-label="Workspace view">
+          {(['decode', 'settings'] as const).map((v) => (
+            <button
+              key={v}
+              type="button"
+              role="tab"
+              aria-selected={view === v}
+              className={`ft8-ws-tab${view === v ? ' is-active' : ''}`}
+              onClick={() => setView(v)}
+            >
+              {v === 'decode' ? 'DECODE' : 'SETTINGS'}
+            </button>
+          ))}
+        </div>
+        {/* Compact, read-only identity chip — editing lives on the Settings page
+            (out of this 44px clipping header). Click to jump to it. */}
+        <button
+          type="button"
+          className={`ft8-ws-call${myCall ? '' : ' is-empty'}`}
+          onClick={() => setView('settings')}
+          title="Edit your callsign / grid in Settings"
+        >
+          {myCall ? `${myCall}${myGrid ? ` · ${myGrid}` : ''}` : 'SET CALL'}
+        </button>
         <span className="ft8-ws-clock">{clock}</span>
         {onClose && (
           <button type="button" className="ft8-ws-close" onClick={onClose}>
@@ -206,7 +276,29 @@ export function Ft8Workspace({ onClose }: Ft8WorkspaceProps) {
         )}
       </header>
 
+      {view === 'settings' ? (
+        <div className="ft8-ws-body ft8-ws-body--settings">
+          <Ft8SettingsView />
+        </div>
+      ) : (
       <div className="ft8-ws-body">
+        {/* Empty-call prompt — TX is gated on an operator callsign, so make the
+            reason visible instead of leaving ENABLE a silent dead button. */}
+        {!myCall && (
+          <div className="ft8-ws-banner" role="alert">
+            <span className="ft8-ws-banner__text">
+              <strong>Set your callsign to transmit.</strong> TX, macros and click-to-call stay
+              disabled until your station call is set.
+            </span>
+            <button
+              type="button"
+              className="ft8-ws-banner__cta"
+              onClick={() => setView('settings')}
+            >
+              Open Settings →
+            </button>
+          </div>
+        )}
         {/* Left — radio / VFO / band */}
         <div className="ft8-ws-col">
           <section className="ft8-region">
@@ -253,6 +345,8 @@ export function Ft8Workspace({ onClose }: Ft8WorkspaceProps) {
                 workedCalls={workedCalls}
                 workedGrids={workedGrids}
                 onRowClick={onRowClick}
+                showOnlyCq={settings.showOnlyCq}
+                hideWorkedBefore={settings.hideWorkedBefore}
               />
             </div>
           </section>
@@ -272,7 +366,14 @@ export function Ft8Workspace({ onClose }: Ft8WorkspaceProps) {
           <section className="ft8-region ft8-region--grow">
             <div className="ft8-region__head">TX control · QSO</div>
             <div className="ft8-region__body">
-              <Ft8TxControl runner={tx} myCall={myCall} myGrid={myGrid} />
+              <Ft8TxControl
+                runner={tx}
+                myCall={myCall}
+                myGrid={myGrid}
+                cqMessage={settings.cqMessage}
+                cqDxMessage={settings.cqDxMessage}
+                freeTextMacro={settings.freeTextMacro}
+              />
             </div>
           </section>
           <section className="ft8-region">
@@ -283,6 +384,7 @@ export function Ft8Workspace({ onClose }: Ft8WorkspaceProps) {
           </section>
         </div>
       </div>
+      )}
 
       <footer className="ft8-ws-status">
         <span className={nativeAvailable ? 'ok' : 'warn'}>

--- a/zeus-web/src/state/ft8-settings-store.test.ts
+++ b/zeus-web/src/state/ft8-settings-store.test.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Ft8Settings } from '../api/ft8-settings';
+
+// vi.hoisted so the mock factory (also hoisted) can reference the defaults.
+const DEFAULTS = vi.hoisted<Ft8Settings>(() => ({
+  autoSequence: true,
+  callFirst: false,
+  holdTxFreq: false,
+  disableTxAfter73: true,
+  defaultTxSlot: 0,
+  defaultTxOffsetHz: 1500,
+  rr73InsteadOfRrr: true,
+  skipGrid: false,
+  callerMaxRetries: 0,
+  cqMessage: 'CQ',
+  cqDxMessage: 'CQ DX',
+  freeTextMacro: '',
+  decodePasses: 3,
+  showOnlyCq: false,
+  hideWorkedBefore: false,
+  autoLog: true,
+  promptBeforeLog: false,
+  clearDxAfterLog: true,
+  reportToComment: false,
+}));
+
+// Mock the REST layer BEFORE the store imports it (one-shot hydrate on load).
+vi.mock('../api/ft8-settings', () => ({
+  FT8_SETTINGS_DEFAULTS: DEFAULTS,
+  getFt8Settings: vi.fn(async () => DEFAULTS),
+  postFt8Settings: vi.fn(async (s: Ft8Settings) => s),
+}));
+
+import { useFt8SettingsStore } from './ft8-settings-store';
+import { useFt8Store } from './ft8-store';
+import * as api from '../api/ft8-settings';
+
+describe('ft8-settings-store (server-backed prefs)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useFt8SettingsStore.setState({ settings: DEFAULTS, hydrated: false });
+    useFt8Store.setState({ enabled: false, passes: 3, receiver: -1, protocol: 'FT8' });
+  });
+
+  it('defaults match the contract defaults (no felt change)', () => {
+    expect(useFt8SettingsStore.getState().settings).toEqual(DEFAULTS);
+  });
+
+  it('never auto-POSTs on load (opt-in writes only)', () => {
+    expect(api.postFt8Settings).not.toHaveBeenCalled();
+  });
+
+  it('update merges a partial and persists the whole record', async () => {
+    await useFt8SettingsStore.getState().update({ autoLog: false, showOnlyCq: true });
+    const s = useFt8SettingsStore.getState().settings;
+    expect(s.autoLog).toBe(false);
+    expect(s.showOnlyCq).toBe(true);
+    expect(s.autoSequence).toBe(true); // untouched
+    expect(api.postFt8Settings).toHaveBeenCalledWith(
+      expect.objectContaining({ autoLog: false, showOnlyCq: true }),
+    );
+  });
+
+  it('hydrate seeds the live decoder pass count from the persisted depth', async () => {
+    vi.mocked(api.getFt8Settings).mockResolvedValueOnce({ ...DEFAULTS, decodePasses: 4 });
+    await useFt8SettingsStore.getState().hydrate();
+    expect(useFt8SettingsStore.getState().settings.decodePasses).toBe(4);
+    expect(useFt8Store.getState().passes).toBe(4); // decode-depth wiring
+  });
+
+  it('optimistic update applies immediately even before the server responds', () => {
+    void useFt8SettingsStore.getState().update({ cqMessage: 'CQ TEST' });
+    expect(useFt8SettingsStore.getState().settings.cqMessage).toBe('CQ TEST');
+  });
+});

--- a/zeus-web/src/state/ft8-settings-store.ts
+++ b/zeus-web/src/state/ft8-settings-store.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Persisted FT8/FT4 workspace preferences (auto-seq behaviour, decode depth,
+// editable macros, logging prefs). Server-backed via /api/ft8/settings so the
+// operator's choices survive desktop restarts — the old client-only state was
+// lost with the webview's port-scoped storage.
+//
+// The backend (Ft8SettingsStore on disk) is the source of truth: the store
+// hydrates from GET on load and NEVER auto-POSTs (same lesson as TCI/WSJT-X/
+// spotting) — only an explicit operator edit writes. Defaults mirror
+// Zeus.Contracts.Ft8Settings exactly, so nothing an operator feels changes until
+// they touch a control.
+
+import { create } from 'zustand';
+import {
+  FT8_SETTINGS_DEFAULTS,
+  getFt8Settings,
+  postFt8Settings,
+  type Ft8Settings,
+} from '../api/ft8-settings';
+import { useFt8Store } from './ft8-store';
+
+interface Ft8SettingsState {
+  settings: Ft8Settings;
+  /** True once the first server hydrate has completed (success or failure). */
+  hydrated: boolean;
+
+  hydrate: (signal?: AbortSignal) => Promise<void>;
+  /** Merge a partial change into the current settings and persist to the server.
+   *  Optimistic: the local value updates immediately; the server response (the
+   *  normalized/clamped settings) reconciles. */
+  update: (patch: Partial<Ft8Settings>) => Promise<void>;
+}
+
+export const useFt8SettingsStore = create<Ft8SettingsState>((set, get) => ({
+  settings: FT8_SETTINGS_DEFAULTS,
+  hydrated: false,
+
+  hydrate: async (signal) => {
+    try {
+      const settings = await getFt8Settings(signal);
+      set({ settings, hydrated: true });
+      // Seed the live decoder pass count from the persisted depth so the
+      // operator's choice is in effect the moment they open the workspace. Only
+      // push when it actually differs from the engine's current value — the
+      // default (3) already matches Ft8Service.DecodePasses, so a fresh operator
+      // never has the decoder restarted at a shallower depth than before.
+      if (settings.decodePasses !== useFt8Store.getState().passes) {
+        useFt8Store.getState().setPasses(settings.decodePasses);
+      }
+    } catch {
+      set({ hydrated: true });
+    }
+  },
+
+  update: async (patch) => {
+    const next = { ...get().settings, ...patch };
+    set({ settings: next }); // optimistic
+    try {
+      const saved = await postFt8Settings(next);
+      set({ settings: saved });
+    } catch {
+      // Persist failed (offline) — optimistic value stands; a later hydrate
+      // reconciles. Never throw into the UI for a settings toggle.
+    }
+  },
+}));
+
+// One-shot hydrate on module load (mirrors wsjtx-store / spotting-store).
+if (typeof window !== 'undefined') {
+  void useFt8SettingsStore.getState().hydrate();
+}

--- a/zeus-web/src/state/ft8-store.ts
+++ b/zeus-web/src/state/ft8-store.ts
@@ -92,6 +92,11 @@ interface Ft8State {
   clear: () => void;
   /** Move the RX focus cursor to an audio offset (clamped to the passband). */
   setRxFocusHz: (hz: number) => void;
+  /** Set the decode depth (passes 1..4). Applies live: if the decoder is
+   *  currently enabled it re-enables on the same receiver/protocol to push the
+   *  new pass count to the backend; otherwise it just updates the value used by
+   *  the next enable. Persistence is the settings store's job, not this one. */
+  setPasses: (passes: number) => void;
 }
 
 export const useFt8Store = create<Ft8State>((set, get) => ({
@@ -217,4 +222,13 @@ export const useFt8Store = create<Ft8State>((set, get) => ({
 
   setRxFocusHz: (hz) =>
     set({ rxFocusHz: Math.min(FT8_MAX_OFFSET_HZ, Math.max(FT8_MIN_OFFSET_HZ, hz)) }),
+
+  setPasses: (passes) => {
+    const p = Math.min(4, Math.max(1, Math.round(passes)));
+    const { enabled, receiver, protocol } = get();
+    set({ passes: p });
+    if (enabled) {
+      void get().enable({ receiver: receiver >= 0 ? receiver : 0, protocol, passes: p });
+    }
+  },
 }));

--- a/zeus-web/src/state/operator-store.test.ts
+++ b/zeus-web/src/state/operator-store.test.ts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the REST layer BEFORE the store imports it — the store fires a one-shot
+// hydrate on module load. Default = unset identity (no override, no QRZ).
+vi.mock('../api/operator', () => ({
+  getOperator: vi.fn(async () => ({
+    callsign: '',
+    grid: '',
+    resolvedCallsign: '',
+    resolvedGrid: '',
+    callsignFromQrz: false,
+    gridFromQrz: false,
+    identityResolved: false,
+  })),
+  postOperator: vi.fn(async (id: { callsign: string; grid: string }) => ({
+    callsign: id.callsign,
+    grid: id.grid,
+    // Empty override falls back to a QRZ home value in this fake.
+    resolvedCallsign: id.callsign || 'W1QRZ',
+    resolvedGrid: id.grid || 'FN31',
+    callsignFromQrz: id.callsign === '',
+    gridFromQrz: id.grid === '',
+    identityResolved: true,
+  })),
+}));
+
+import { useOperatorStore } from './operator-store';
+import * as api from '../api/operator';
+
+describe('operator-store (server-authoritative)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useOperatorStore.setState({
+      call: '',
+      grid: '',
+      resolvedCall: '',
+      resolvedGrid: '',
+      callFromQrz: false,
+      gridFromQrz: false,
+      hydrated: false,
+    });
+  });
+
+  it('does not use localStorage as the system of record (server-backed)', () => {
+    // The old port-scoped localStorage path is gone — identity round-trips the
+    // server. Setting a call must POST, not write a localStorage key.
+    useOperatorStore.getState().setCall('k1abc');
+    expect(api.postOperator).toHaveBeenCalled();
+  });
+
+  it('hydrate maps the resolved identity + QRZ-fallback flags', async () => {
+    vi.mocked(api.getOperator).mockResolvedValueOnce({
+      callsign: '',
+      grid: '',
+      resolvedCallsign: 'W1QRZ',
+      resolvedGrid: 'FN31',
+      callsignFromQrz: true,
+      gridFromQrz: true,
+      identityResolved: true,
+    });
+    await useOperatorStore.getState().hydrate();
+    const s = useOperatorStore.getState();
+    expect(s.call).toBe(''); // no override
+    expect(s.resolvedCall).toBe('W1QRZ'); // from QRZ
+    expect(s.callFromQrz).toBe(true);
+    expect(s.gridFromQrz).toBe(true);
+    expect(s.hydrated).toBe(true);
+  });
+
+  it('ungates TX once a resolved call exists (the canCall condition)', async () => {
+    // canCall in the TX control is `resolvedCall.trim().length > 0`.
+    expect(useOperatorStore.getState().resolvedCall.trim().length > 0).toBe(false);
+    await useOperatorStore.getState().save({ call: 'K1ABC', grid: 'FN42' });
+    expect(useOperatorStore.getState().resolvedCall.trim().length > 0).toBe(true);
+  });
+
+  it('setCall is optimistic locally and persists upper-cased/trimmed to the server', async () => {
+    useOperatorStore.getState().setCall('  k1abc ');
+    expect(useOperatorStore.getState().call).toBe('K1ABC'); // optimistic, normalized
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(api.postOperator).toHaveBeenCalledWith({ callsign: 'K1ABC', grid: '' });
+  });
+
+  it('save round-trips the server response into resolved values', async () => {
+    await useOperatorStore.getState().save({ call: 'K1ABC', grid: 'FN42' });
+    const s = useOperatorStore.getState();
+    expect(s.call).toBe('K1ABC');
+    expect(s.resolvedCall).toBe('K1ABC');
+    expect(s.callFromQrz).toBe(false);
+  });
+
+  it('never throws when the server is unreachable (offline edit)', async () => {
+    vi.mocked(api.getOperator).mockRejectedValueOnce(new Error('offline'));
+    await expect(useOperatorStore.getState().hydrate()).resolves.toBeUndefined();
+    expect(useOperatorStore.getState().hydrated).toBe(true);
+  });
+});

--- a/zeus-web/src/state/operator-store.ts
+++ b/zeus-web/src/state/operator-store.ts
@@ -6,57 +6,143 @@
 //                         Christian Suarez (N9WAR), and contributors.
 //
 // Operator identity (own callsign + Maidenhead grid) for the digital modes.
-// Used by the FT8 workspace for the "calling me" decode highlight and
-// click-to-call message generation, and (later) by PSK Reporter / WSPRnet
-// spotting. Persisted to localStorage so it survives reloads — it is operator
-// preference, not radio state, so it lives client-side.
+// Used by the FT8/FT4/WSPR workspaces for the "calling me" decode highlight and
+// click-to-call message generation, and by the spotting uploaders / FreeDV
+// Reporter.
+//
+// SERVER-AUTHORITATIVE (PR: FT8 TX-ready). Identity is persisted in zeus-prefs.db
+// via /api/operator and is the SAME override every backend resolver reads first
+// (FT8/FT4 TX, PSK Reporter, WSPRnet, FreeDV Reporter), with the QRZ home station
+// as the fallback. The old localStorage system-of-record was scoped to the
+// desktop webview's loopback port, which the OS reassigns each launch, so the
+// operator's call was silently lost on every restart and FT8 TX stayed gated.
+//
+//  - `call` / `grid`       — the saved OVERRIDE (what the operator typed; bound
+//                            to the Settings inputs and the spotting prefill).
+//  - `resolvedCall` / `…`  — the EFFECTIVE identity (override else QRZ home) the
+//                            TX path and gating use, so a QRZ-home operator can
+//                            transmit without retyping.
 
 import { create } from 'zustand';
+import { getOperator, postOperator, type OperatorIdentityStatus } from '../api/operator';
 
-const LS_KEY = 'zeus.operator';
-
-interface Persisted {
+interface OperatorState {
+  /** Saved override callsign (empty when unset). */
   call: string;
+  /** Saved override grid (empty when unset). */
   grid: string;
-}
+  /** Effective callsign: override else QRZ home. */
+  resolvedCall: string;
+  /** Effective grid: override else QRZ home. */
+  resolvedGrid: string;
+  /** True when the resolved field fell back to the QRZ home station. */
+  callFromQrz: boolean;
+  gridFromQrz: boolean;
+  /** True once the first server hydrate has completed (success or failure). */
+  hydrated: boolean;
 
-function load(): Persisted {
-  try {
-    const raw = localStorage.getItem(LS_KEY);
-    if (!raw) return { call: '', grid: '' };
-    const j = JSON.parse(raw) as Record<string, unknown>;
-    return {
-      call: typeof j.call === 'string' ? j.call : '',
-      grid: typeof j.grid === 'string' ? j.grid : '',
-    };
-  } catch {
-    return { call: '', grid: '' };
-  }
-}
-
-function save(p: Persisted): void {
-  try {
-    localStorage.setItem(LS_KEY, JSON.stringify(p));
-  } catch {
-    /* private mode / no storage — non-fatal, identity is just not persisted */
-  }
-}
-
-interface OperatorState extends Persisted {
+  /** Load the saved + resolved identity from the server. Safe to call repeatedly
+   *  (e.g. on connect and on workspace open — QRZ home may resolve late). */
+  hydrate: (signal?: AbortSignal) => Promise<void>;
+  /** Set the override callsign and persist it to the server. */
   setCall: (call: string) => void;
+  /** Set the override grid and persist it to the server. */
   setGrid: (grid: string) => void;
+  /** Persist both override fields at once. */
+  save: (identity: { call: string; grid: string }) => Promise<void>;
 }
 
-export const useOperatorStore = create<OperatorState>((set, get) => ({
-  ...load(),
-  setCall: (call) => {
-    const c = call.toUpperCase().trim();
-    save({ call: c, grid: get().grid });
-    set({ call: c });
-  },
-  setGrid: (grid) => {
-    const g = grid.toUpperCase().trim();
-    save({ call: get().call, grid: g });
-    set({ grid: g });
-  },
-}));
+/** Full reconcile: server is the source of truth for BOTH the saved override and
+ *  the resolved identity. Used on hydrate and on an explicit save() commit. */
+function applyStatus(status: OperatorIdentityStatus): Partial<OperatorState> {
+  return {
+    call: status.callsign,
+    grid: status.grid,
+    ...applyResolved(status),
+  };
+}
+
+/** Resolved-only reconcile: apply the effective/QRZ fields WITHOUT touching the
+ *  override the operator is actively typing. This is the keystroke-edit path —
+ *  echoing the server-normalized override back into the bound input is what made
+ *  the Grid field unusable (the server returns "" for a partial Maidenhead
+ *  prefix, so every early character wiped itself before the next was typed). */
+function applyResolved(status: OperatorIdentityStatus): Partial<OperatorState> {
+  return {
+    resolvedCall: status.resolvedCallsign,
+    resolvedGrid: status.resolvedGrid,
+    callFromQrz: status.callsignFromQrz,
+    gridFromQrz: status.gridFromQrz,
+    hydrated: true,
+  };
+}
+
+export const useOperatorStore = create<OperatorState>((set, get) => {
+  // Monotonic id so an out-of-order POST response (multiple keystrokes in flight)
+  // can never clobber a newer one's reconcile.
+  let saveSeq = 0;
+
+  /** Persist the current override from a keystroke edit. Optimistic local value
+   *  is already set; only the resolved/QRZ fields are reconciled from the server
+   *  so the edit buffer the operator is typing is never overwritten mid-word. */
+  const persistOverride = async () => {
+    const seq = ++saveSeq;
+    try {
+      const status = await postOperator({ callsign: get().call, grid: get().grid });
+      if (seq !== saveSeq) return; // a newer keystroke superseded this write
+      set(applyResolved(status));
+    } catch {
+      // Offline — the optimistic local value stands; a later hydrate reconciles.
+    }
+  };
+
+  return {
+    call: '',
+    grid: '',
+    resolvedCall: '',
+    resolvedGrid: '',
+    callFromQrz: false,
+    gridFromQrz: false,
+    hydrated: false,
+
+    hydrate: async (signal) => {
+      try {
+        const status = await getOperator(signal);
+        set(applyStatus(status));
+      } catch {
+        // Transient (not connected yet / offline) — keep current values and let a
+        // later hydrate recover. Mark hydrated so the UI stops showing a spinner.
+        set({ hydrated: true });
+      }
+    },
+
+    setCall: (call) => {
+      set({ call: call.toUpperCase().trim() }); // optimistic so the input is responsive
+      void persistOverride();
+    },
+
+    setGrid: (grid) => {
+      set({ grid: grid.toUpperCase().trim() });
+      void persistOverride();
+    },
+
+    save: async ({ call, grid }) => {
+      const seq = ++saveSeq;
+      try {
+        const status = await postOperator({ callsign: call, grid });
+        if (seq !== saveSeq) return;
+        set(applyStatus(status));
+      } catch {
+        // Persist failed (offline) — the optimistic local value stands; a later
+        // hydrate/save reconciles. Never throw into the UI for an identity edit.
+      }
+    },
+  };
+});
+
+// One-shot hydrate on module load (mirrors wsjtx-store / spotting-store). Guarded
+// so test environments and pre-connect loads never throw — hydrate swallows its
+// own errors.
+if (typeof window !== 'undefined') {
+  void useOperatorStore.getState().hydrate();
+}

--- a/zeus-web/src/styles/ft8-theme.css
+++ b/zeus-web/src/styles/ft8-theme.css
@@ -27,6 +27,7 @@
   /* Text. */
   --hud-text:      #c8e4ef;
   --hud-text-dim:  #6f8a98;
+  --hud-ink:       #06121a;  /* dark foreground on filled cyan/amber chips */
 
   /* Decode-row classes (color-coded message table). */
   --hud-cq:        #45e08a;  /* CQ calls — green */
@@ -182,7 +183,7 @@
   font: inherit;
   letter-spacing: 0.06em;
 }
-.ft8-ws-tab.is-active { background: var(--hud-cyan); color: #06121a; font-weight: 700; }
+.ft8-ws-tab.is-active { background: var(--hud-cyan); color: var(--hud-ink); font-weight: 700; }
 .ft8-ws-id { display: flex; align-items: center; gap: 5px; font-size: 10px; color: var(--hud-text-dim); }
 .ft8-ws-id input {
   background: var(--hud-panel);
@@ -212,6 +213,191 @@
 }
 .ft8-ws-close:hover { filter: brightness(1.12); }
 
+/* Read-only identity chip in the header (editing lives on the Settings page). */
+.ft8-ws-call {
+  background: var(--hud-panel);
+  border: 1px solid var(--hud-cyan-line);
+  color: var(--hud-cyan);
+  border-radius: 3px;
+  padding: 2px 12px;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+}
+.ft8-ws-call:hover { background: var(--hud-cyan-soft); }
+.ft8-ws-call.is-empty {
+  color: var(--hud-me);
+  border-color: var(--hud-me);
+}
+
+/* Empty-call prompt banner — spans all body columns. */
+.ft8-ws-banner {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 8px 12px;
+  background: var(--hud-cyan-soft);
+  border: 1px solid var(--hud-me);
+  border-radius: 4px;
+  color: var(--hud-text);
+  font-size: 12px;
+}
+.ft8-ws-banner__text strong { color: var(--hud-me); }
+.ft8-ws-banner__cta {
+  margin-left: auto;
+  background: var(--hud-me);
+  border: 1px solid var(--hud-me);
+  color: var(--hud-ink);
+  border-radius: 3px;
+  padding: 4px 14px;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  white-space: nowrap;
+}
+.ft8-ws-banner__cta:hover { filter: brightness(1.1); }
+
+/* ---- Settings view ---- */
+.ft8-ws-body--settings { display: block; overflow: auto; padding: 8px; }
+.ft8-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 720px;
+  margin: 0 auto;
+}
+.ft8-set-section { flex: 0 0 auto; }
+.ft8-set-body { padding: 8px 12px 12px; display: flex; flex-direction: column; gap: 2px; }
+
+.ft8-set-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--hud-line);
+}
+.ft8-set-row:last-child { border-bottom: none; }
+.ft8-set-row__text { display: flex; flex-direction: column; gap: 2px; flex: 1; min-width: 0; }
+.ft8-set-row__label { font-size: 13px; color: var(--hud-text); }
+.ft8-set-row__hint { font-size: 10px; color: var(--hud-text-dim); line-height: 1.3; }
+.ft8-set-row__resolved { font-size: 10px; color: var(--hud-text-dim); }
+.ft8-set-row__resolved strong { color: var(--hud-cyan); }
+
+/* Toggle switch. */
+.ft8-set-switch {
+  flex: 0 0 auto;
+  min-width: 52px;
+  background: var(--hud-panel-2);
+  border: 1px solid var(--hud-line);
+  color: var(--hud-text-dim);
+  border-radius: 3px;
+  padding: 4px 12px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+.ft8-set-switch.is-on { background: var(--hud-cyan); color: var(--hud-ink); border-color: var(--hud-cyan); }
+.ft8-set-switch:disabled { cursor: default; opacity: 0.4; }
+
+/* "Coming soon" rows: persisted but not yet wired — dimmed, with a small badge. */
+.ft8-set-row.is-disabled { opacity: 0.55; }
+.ft8-set-soon {
+  margin-left: 6px;
+  padding: 0 5px;
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--hud-text-dim);
+  border: 1px solid var(--hud-line);
+  border-radius: 3px;
+  vertical-align: middle;
+}
+
+/* Segmented control. */
+.ft8-set-seg { display: flex; gap: 4px; flex: 0 0 auto; }
+.ft8-set-seg__btn {
+  background: var(--hud-panel-2);
+  border: 1px solid var(--hud-line);
+  color: var(--hud-text);
+  border-radius: 3px;
+  padding: 4px 12px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 11px;
+}
+.ft8-set-seg__btn:hover { border-color: var(--hud-cyan-line); }
+.ft8-set-seg__btn.is-on { background: var(--hud-cyan); color: var(--hud-ink); border-color: var(--hud-cyan); font-weight: 700; }
+
+/* Inputs. */
+.ft8-set-input {
+  background: var(--hud-panel);
+  border: 1px solid var(--hud-line);
+  color: var(--hud-cyan);
+  border-radius: 3px;
+  padding: 4px 8px;
+  font: inherit;
+  font-size: 13px;
+}
+.ft8-set-input:focus { outline: none; border-color: var(--hud-cyan-line); }
+.ft8-set-input--num { width: 6em; text-align: right; }
+.ft8-set-input:disabled { opacity: 0.5; }
+.ft8-set-num { display: inline-flex; align-items: center; gap: 5px; }
+.ft8-set-num__suffix { font-size: 10px; color: var(--hud-text-dim); }
+.ft8-set-readonly-value { font-size: 12px; color: var(--hud-text-dim); font-variant-numeric: tabular-nums; }
+
+.ft8-set-note { font-size: 10px; color: var(--hud-text-dim); line-height: 1.4; font-style: italic; margin: 6px 0 0; }
+.ft8-set-divider { height: 1px; background: var(--hud-cyan-line); margin: 8px 0; opacity: 0.5; }
+
+/* Advanced disclosure. */
+.ft8-set-advanced { margin-top: 6px; }
+.ft8-set-advanced > summary {
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--hud-text-dim);
+  cursor: pointer;
+  padding: 6px 0;
+}
+
+/* Reporting chips. */
+.ft8-set-chips { display: flex; flex-wrap: wrap; gap: 8px; padding: 4px 0 8px; }
+.ft8-set-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--hud-text-dim);
+  border: 1px solid var(--hud-line);
+  border-radius: 12px;
+  padding: 2px 10px;
+}
+.ft8-set-chip__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--hud-text-dim);
+}
+.ft8-set-chip.is-on { color: var(--hud-cq); border-color: var(--hud-cq); }
+.ft8-set-chip.is-on .ft8-set-chip__dot { background: var(--hud-cq); }
+
+.ft8-set-link {
+  align-self: flex-start;
+  background: var(--hud-panel-2);
+  border: 1px solid var(--hud-cyan-line);
+  color: var(--hud-cyan);
+  border-radius: 3px;
+  padding: 5px 14px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+}
+.ft8-set-link:hover { background: var(--hud-cyan-soft); }
+
 /* Band selector. */
 .ft8-band-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 4px; padding: 6px 8px 8px; }
 .ft8-band-btn {
@@ -225,7 +411,7 @@
   font-size: 11px;
 }
 .ft8-band-btn:hover { border-color: var(--hud-cyan-line); }
-.ft8-band-btn.is-active { background: var(--hud-cyan); color: #06121a; font-weight: 700; }
+.ft8-band-btn.is-active { background: var(--hud-cyan); color: var(--hud-ink); font-weight: 700; }
 
 /* ---- TX control cluster ---- */
 .ft8-tx { display: flex; flex-direction: column; gap: 8px; font-size: 12px; }
@@ -242,7 +428,7 @@
   color: var(--hud-text-dim);
   background: var(--hud-inset);
 }
-.ft8-tx__lamp.is-armed { color: #06121a; background: var(--hud-me); border-color: var(--hud-me); font-weight: 700; }
+.ft8-tx__lamp.is-armed { color: var(--hud-ink); background: var(--hud-me); border-color: var(--hud-me); font-weight: 700; }
 .ft8-tx__lamp.is-tx { color: #1a0604; background: var(--tx); border-color: var(--tx); font-weight: 700; }
 .ft8-tx__wdt { font-size: 10px; color: var(--hud-text-dim); font-variant-numeric: tabular-nums; }
 
@@ -259,7 +445,7 @@
   font-weight: 700;
   letter-spacing: 0.06em;
 }
-.ft8-tx__enable.is-on { background: var(--hud-me); color: #06121a; border-color: var(--hud-me); }
+.ft8-tx__enable.is-on { background: var(--hud-me); color: var(--hud-ink); border-color: var(--hud-me); }
 .ft8-tx__enable:disabled { opacity: 0.4; cursor: not-allowed; }
 
 /* Generic toggle / segmented / macro buttons. */
@@ -282,7 +468,7 @@
 .ft8-tx__tune:hover { border-color: var(--hud-cyan-line); }
 .ft8-tx__toggle.is-on,
 .ft8-tx__seg-btn.is-on,
-.ft8-tx__macro.is-on { background: var(--hud-cyan); color: #06121a; border-color: var(--hud-cyan); font-weight: 700; }
+.ft8-tx__macro.is-on { background: var(--hud-cyan); color: var(--hud-ink); border-color: var(--hud-cyan); font-weight: 700; }
 .ft8-tx__macro:disabled,
 .ft8-tx__toggle:disabled { opacity: 0.4; cursor: not-allowed; }
 
@@ -319,7 +505,7 @@
 .ft8-tx__custom input { flex: 1; width: auto; text-align: left; text-transform: uppercase; }
 
 .ft8-tx__tune { flex: 1; }
-.ft8-tx__tune.is-on { background: var(--power); color: #06121a; border-color: var(--power); font-weight: 700; }
+.ft8-tx__tune.is-on { background: var(--power); color: var(--hud-ink); border-color: var(--power); font-weight: 700; }
 .ft8-tx__halt {
   flex: 1;
   border-color: var(--tx);


### PR DESCRIPTION
## ⛔ DO NOT MERGE — bench sign-off required

**Stack 5 of 5.** Base: `ft8/spotting` (#1051). Top of the FT8 stack. Makes FT8/FT4 **TX testable end-to-end** and adds the **SETTINGS page** the mockup always called for.

### Why this exists (live bench finding)
On the G2 bench, TX ENABLE and click-a-station "did nothing." Root cause wasn't TX — the backend keyer is proven good (arming over `/api/ft8/tx/arm` works). It was: (1) the TX UI is gated on the operator callsign (`canCall`), (2) the Call/Grid inputs were **clipped** in the 44px `overflow:hidden` workspace header so the operator couldn't set them, and (3) operator identity lived only in **localStorage**, which is port-scoped on the desktop webview (OS reassigns the loopback port each launch) so it didn't survive restarts.

### What's in it
- **One server-persisted operator identity** (`OperatorIdentityStore`/`Resolver`, `/api/operator`) — shared with spotting / WSJT-X / FreeDV (no more parallel localStorage identity). Survives restarts.
- **`Ft8SettingsView`** — the mockup's SETTINGS tab, built: Call/Grid (moved out of the clipping header), decode depth (Normal=1 / Deep=3 / Deepest=4, matching the engine), auto-seq behavior (auto-sequence on/off, disable-Tx-after-73, Call-1st, no-reply limit, RR73/RRR ack), editable CQ + free-text macros, prompt-before-log, reporting toggles surfaced. Server-persisted (`Ft8SettingsStore`).
- **Empty-call prompt banner** so TX ENABLE is never a silent dead button.
- **Curated from WSJT-X + JTDX, scrapping what Zeus owns natively** — rig/CAT/PTT, soundcard in/out, split operation, frequencies table, power/attenuator. The keep/scrap rationale is in `docs/designs/ft8-ui.md`.

### Refs
#1012 (makes the TX work testable).

### Safety / scope
- Defaults preserved (decode depth stays **3**; RR73 ack default) — a regression to 2 was caught in review and reverted. PureSignal untouched; no power/drive default changes; TX still requires explicit arm.
- Genuinely complex items (skip-grid, clear-DX-after-log) ship **disabled with a "soon" badge** rather than faked active.
- **Bench:** set Call/Grid in Settings → TX ungates → click a station → ENABLE-TX → confirm on-air auto-sequence on the G2.
- **UI polish pass is deliberately deferred until you confirm TX works** (your call).

Build 0/0; 1910 server + 108 contracts + frontend suites green.
