### PR TITLE
fix(desktop): dispose the host on window close (no more crash dialog on exit)

### DIFF
--- a/OpenhpsdrZeus/Program.cs
+++ b/OpenhpsdrZeus/Program.cs
@@ -660,8 +660,26 @@ public partial class Program
         // native window was still alive. We deliberately do NOT save here — the
         // window is torn down and its size getters are unsafe to read.
         Console.WriteLine("Window closed; stopping backend.");
-        app.StopAsync().GetAwaiter().GetResult();
+        StopAndDisposeHost(app);
         return 0;
+    }
+
+    // Desktop/status-window paths drive the host lifecycle by hand (Photino owns
+    // the main thread, so we can't use app.Run()). They historically called only
+    // StopAsync and returned — which stops hosted services but never disposes the
+    // DI container, so no IAsyncDisposable singleton's DisposeAsync ran. That left
+    // in-process macOS Audio Units in the active TX/RX chain undisposed: the
+    // plugin's JUCE Timer thread survived into CLR teardown and faulted with a
+    // SIGSEGV in juce::MessageQueue::post on the freed MessageManager mutex — the
+    // "crash dialog on window close" symptom. Disposing the host runs
+    // AudioPluginBridge.DisposeAsync (AudioChain teardown → AudioComponentInstanceDispose)
+    // and RxVstEngineService.DisposeAsync (out-of-process VST engine kill, which
+    // also stops it orphaning the engine process). The web/service path doesn't
+    // need this because app.RunAsync() disposes the host in its finally block.
+    private static void StopAndDisposeHost(WebApplication app)
+    {
+        app.StopAsync().GetAwaiter().GetResult();
+        ((IAsyncDisposable)app).DisposeAsync().AsTask().GetAwaiter().GetResult();
     }
 
     // Photino occasionally opens the frame off the visible desktop on
@@ -1194,7 +1212,7 @@ public partial class Program
         window.WaitForClose();
 
         Console.WriteLine("Status window closed; stopping backend.");
-        app.StopAsync().GetAwaiter().GetResult();
+        StopAndDisposeHost(app);
         return 0;
     }
 }


### PR DESCRIPTION
Fixes #1065.

## Problem
Closing the macOS **desktop** window sometimes pops a system crash dialog. The radio session is fine — it only happens during teardown — but the dialog is alarming. It's intermittent: it appears after you've used the app with audio-chain plugins (Audio Units) loaded; a fresh launch closed immediately exits clean.

## Root cause
The desktop and status-window paths (`RunDesktop`, `RunServerWithStatus`) call `app.StopAsync()` and `return` — they **never dispose the WebApplication host**. So no `IAsyncDisposable` singleton's `DisposeAsync` runs. In-process macOS Audio Units in the active chain are left undisposed; the plugin's JUCE `Timer` thread survives into CLR teardown and faults:

```
pthread_mutex_lock
juce::MessageQueue::post(...)        ← plugin image "Clear"
juce::Timer::TimerThread::run()      ← plugin image "Clear"
```

The web/service path doesn't hit this because `app.RunAsync()` disposes the host in its `finally`.

## Fix
After `StopAsync()`, dispose the host (shared `StopAndDisposeHost` helper used by both desktop exit sites). Disposal runs the disposal chain that was being skipped:

`host.DisposeAsync` → `AudioPluginBridge.DisposeAsync` → `AudioChain.DisposeAsync` → `VstHostAudioPlugin.DisposeAsync` → `_bridge.Unload(handle)` (native AU instance freed → JUCE thread stopped). Also runs `RxVstEngineService.DisposeAsync`, which kills the out-of-process RX VST engine instead of orphaning it.

## Scope / safety
- Two-line lifecycle correction; no new threads, deps, or signal-routing changes. Cross-platform (the disposal path is identical on all platforms; the AU case is macOS-only but the fix is platform-agnostic).
- Green-light bug fix with a clear root cause.

## Verification
- `dotnet build Zeus.slnx` clean (0 warnings, 0 errors).
- Full test suite green: **3000+ tests, 0 failures** (Server 2121, Protocol1/2, Dsp, Plugins.Host, Contracts).
- `npm --prefix zeus-web run build` clean.
- Disposal chain confirmed end-to-end in source.
- **Not** reproduced via an automated window-close: Photino owns the close on the main thread and the crash needs AU plugins natively loaded through the UI, so the final "no dialog on close" confirmation is on the operator with their plugin chain. The proven lifecycle defect is fixed regardless.