### PR TITLE
fix(chat): groups visible to all, fix admin add-member, distinct group color

### DIFF
--- a/cloud/zeuschat-relay/src/chat-room.ts
+++ b/cloud/zeuschat-relay/src/chat-room.ts
@@ -412,9 +412,27 @@ export class ChatRoom extends DurableObject<Env> {
 
   private roomsFor(callsign: string): RoomInfo[] {
     const out: RoomInfo[] = [{ id: PUBLIC_ROOM, name: 'Public', kind: 'public', members: [] }];
+    // Groups are discoverable by EVERYONE — they always appear in the tab list,
+    // regardless of membership. Joining (reading history / posting) is still gated
+    // by canAccess(), so a non-member sees the group exists but cannot enter until
+    // an admin adds them. Each group carries its member list so the client can
+    // render a locked state and tell whether the viewer is a member.
+    const groups: RoomInfo[] = [];
+    for (const meta of this.rooms.values()) {
+      if (meta.kind !== 'group') continue;
+      groups.push({
+        id: meta.id,
+        name: meta.name,
+        kind: 'group',
+        members: [...(this.members.get(meta.id) ?? [])].sort(),
+      });
+    }
+    groups.sort((a, b) => a.name.localeCompare(b.name));
+    out.push(...groups);
+    // DMs stay private to their two parties — only the viewer's own DMs are sent.
     for (const roomId of this.userRooms.get(callsign) ?? []) {
       const meta = this.rooms.get(roomId);
-      if (!meta) continue;
+      if (!meta || meta.kind !== 'dm') continue;
       out.push({
         id: meta.id,
         name: meta.name,
@@ -430,6 +448,19 @@ export class ChatRoom extends DurableObject<Env> {
     for (const ws of this.ctx.getWebSockets()) {
       const att = ws.deserializeAttachment() as Attachment | null;
       if (att?.callsign === callsign) this.send(ws, { t: 'rooms', rooms });
+    }
+  }
+
+  /**
+   * Re-push the room list to every connected operator. Groups are global, so a
+   * create / delete / membership change must reach everyone — not just the
+   * affected member. (The old per-member pushRooms left the admin's own member
+   * roster stale after an add/remove, which made "add member" look like a no-op.)
+   */
+  private broadcastRooms(): void {
+    for (const ws of this.ctx.getWebSockets()) {
+      const att = ws.deserializeAttachment() as Attachment | null;
+      if (att?.callsign) this.send(ws, { t: 'rooms', rooms: this.roomsFor(att.callsign) });
     }
   }
 
@@ -469,7 +500,9 @@ export class ChatRoom extends DurableObject<Env> {
     addTo(this.userRooms, callsign, room);
     await this.ctx.storage.put(`rm:${room}:${callsign}`, Date.now());
     await this.ctx.storage.put(`um:${callsign}:${room}`, Date.now());
-    this.pushRooms(callsign);
+    // Everyone sees groups, so re-push to all: the new member unlocks the room
+    // and existing members + the admin see the updated roster immediately.
+    this.broadcastRooms();
   }
 
   private async removeMember(room: string, callsign: string): Promise<void> {
@@ -480,7 +513,9 @@ export class ChatRoom extends DurableObject<Env> {
     removeFrom(this.userRooms, callsign, room);
     await this.ctx.storage.delete(`rm:${room}:${callsign}`);
     await this.ctx.storage.delete(`um:${callsign}:${room}`);
-    this.pushRooms(callsign); // tab disappears for them
+    // Re-push to all: the removed member relocks the group, others see the
+    // roster shrink.
+    this.broadcastRooms();
   }
 
   private async deleteRoom(admin: string, room: string): Promise<void> {
@@ -497,7 +532,9 @@ export class ChatRoom extends DurableObject<Env> {
     await this.ctx.storage.delete(`room:${room}`);
     const msgKeys = [...(await this.ctx.storage.list({ prefix: `m:${room}:` })).keys()];
     if (msgKeys.length) await this.ctx.storage.delete(msgKeys);
-    for (const call of exMembers) this.pushRooms(call);
+    // Groups are visible to everyone, so the deleted tab must disappear for all,
+    // not just the ex-members.
+    this.broadcastRooms();
   }
 
   // --- admin: clear history / global announcement ----------------------------

--- a/zeus-web/src/layout/panels/ChatPanel.tsx
+++ b/zeus-web/src/layout/panels/ChatPanel.tsx
@@ -843,10 +843,46 @@ const GOLD_RING_HOVER =
 const GOLD_RING_ACTIVE =
   'inset 0 0 0 1px rgba(255,177,60,0.40), 0 0 14px rgba(255,177,60,0.20)';
 
+// Violet glow for group rooms — the same soft-ring treatment as the gold DM
+// glow, in the dedicated group hue (--chat-group, #b07cff) so a group tab reads
+// as visually distinct from a DM at a glance.
+const VIOLET_RING_IDLE =
+  'inset 0 0 0 1px rgba(176,124,255,0.22), 0 0 8px rgba(176,124,255,0.10)';
+const VIOLET_RING_HOVER =
+  'inset 0 0 0 1px rgba(176,124,255,0.35), 0 0 12px rgba(176,124,255,0.16)';
+const VIOLET_RING_ACTIVE =
+  'inset 0 0 0 1px rgba(176,124,255,0.40), 0 0 14px rgba(176,124,255,0.20)';
+
+/** Per-tab tone: which channel kind drives the accent color/glow. */
+type TabTone = 'public' | 'group' | 'dm';
+
+/**
+ * Whether `me` is a member of `room` (case-insensitive). Returns true when our
+ * callsign is unknown (pre-connect) so a group never shows as locked before we
+ * know who we are.
+ */
+function isRoomMember(room: { members: string[] }, me: string | null): boolean {
+  const meUp = (me ?? '').toUpperCase();
+  if (!meUp) return true;
+  return room.members.some((m) => m.toUpperCase() === meUp);
+}
+
+/** A small padlock, shown on a group tab the viewer isn't a member of. */
+function LockGlyph() {
+  return (
+    <svg width="9" height="9" viewBox="0 0 12 12" fill="none" aria-hidden="true" style={{ flexShrink: 0 }}>
+      <rect x="2.5" y="5.5" width="7" height="5" rx="1" stroke="currentColor" strokeWidth="1.1" />
+      <path d="M4 5.5V4a2 2 0 0 1 4 0v1.5" stroke="currentColor" strokeWidth="1.1" />
+    </svg>
+  );
+}
+
 interface TabItemProps {
   id: string;
   label: string;
-  isPrivate: boolean;
+  tone: TabTone;
+  /** Group the viewer isn't a member of: discoverable but locked until added. */
+  locked?: boolean;
   isActive: boolean;
   unread: number;
   closable?: boolean;
@@ -854,22 +890,23 @@ interface TabItemProps {
   onClose?: () => void;
 }
 
-function TabItem({ id: _id, label, isPrivate, isActive, unread, closable, onClick, onClose }: TabItemProps) {
+function TabItem({ id: _id, label, tone, locked, isActive, unread, closable, onClick, onClose }: TabItemProps) {
   const [hovered, setHovered] = useState(false);
 
-  const boxShadow = isPrivate
-    ? isActive
-      ? GOLD_RING_ACTIVE
-      : hovered
-      ? GOLD_RING_HOVER
-      : GOLD_RING_IDLE
-    : 'none';
+  const ring = (idle: string, hover: string, active: string) =>
+    isActive ? active : hovered ? hover : idle;
+  const boxShadow =
+    tone === 'dm'
+      ? ring(GOLD_RING_IDLE, GOLD_RING_HOVER, GOLD_RING_ACTIVE)
+      : tone === 'group'
+      ? ring(VIOLET_RING_IDLE, VIOLET_RING_HOVER, VIOLET_RING_ACTIVE)
+      : 'none';
 
-  const borderBottom = isActive
-    ? isPrivate
-      ? '2px solid var(--power)'
-      : '2px solid var(--accent-bright)'
-    : '2px solid transparent';
+  // Accent per channel kind: public=blue, group=violet, dm=gold.
+  const accent =
+    tone === 'dm' ? 'var(--power)' : tone === 'group' ? 'var(--chat-group)' : 'var(--accent-bright)';
+
+  const borderBottom = isActive ? `2px solid ${accent}` : '2px solid transparent';
 
   return (
     <div
@@ -894,16 +931,22 @@ function TabItem({ id: _id, label, isPrivate, isActive, unread, closable, onClic
         flexShrink: 0,
       }}
     >
+      {locked && (
+        <span style={{ color: accent, display: 'inline-flex', opacity: 0.85 }} title="Invite-only — an admin must add you">
+          <LockGlyph />
+        </span>
+      )}
       <span
         style={{
           fontSize: 11,
           fontWeight: isActive ? 700 : 500,
           letterSpacing: '0.04em',
           color: isActive
-            ? isPrivate
-              ? 'var(--power)'
-              : 'var(--fg-0)'
+            ? tone === 'public'
+              ? 'var(--fg-0)'
+              : accent
             : 'var(--fg-2)',
+          opacity: locked && !isActive ? 0.7 : 1,
           transition: `color var(--dur-fast) var(--ease-out)`,
           maxWidth: 88,
           overflow: 'hidden',
@@ -923,7 +966,8 @@ function TabItem({ id: _id, label, isPrivate, isActive, unread, closable, onClic
             height: 15,
             padding: '0 4px',
             borderRadius: 8,
-            background: isPrivate ? 'var(--power)' : 'var(--accent)',
+            background:
+              tone === 'dm' ? 'var(--power)' : tone === 'group' ? 'var(--chat-group)' : 'var(--accent)',
             color: '#fff',
             fontSize: 9,
             fontWeight: 700,
@@ -1788,12 +1832,20 @@ export function ChatPanel() {
     [rooms, activeRoom],
   );
 
-  const isPrivateRoom = activeRoomObj ? activeRoomObj.kind !== 'public' : false;
+  // Tone of the active room drives the thread/composer accent (group=violet, dm=gold).
+  const activeTone: TabTone =
+    activeRoomObj?.kind === 'group' ? 'group' : activeRoomObj?.kind === 'dm' ? 'dm' : 'public';
+  // The active room is a group the operator hasn't been added to: discoverable
+  // but invite-only — show a locked body and block the composer until an admin
+  // adds them. (Admins still get the management strip below to add members.)
+  const lockedActive =
+    !!activeRoomObj && activeRoomObj.kind === 'group' && !isRoomMember(activeRoomObj, ownCall);
 
   // Placeholder label for the composer
   const composerPlaceholder = (() => {
     if (!connected) return 'Not connected';
     if (!activeRoomObj) return 'Message… (Enter to send)';
+    if (lockedActive) return 'Invite-only group — an admin must add you to post';
     if (activeRoomObj.kind === 'dm') {
       const other = dmOther(activeRoomObj.id, ownCall);
       return `Message @${other ?? activeRoomObj.name} (Enter to send, Shift+Enter for newline)`;
@@ -1809,6 +1861,7 @@ export function ChatPanel() {
   const canSend =
     enabled &&
     connected &&
+    !lockedActive &&
     draft.length <= MAX_MESSAGE_CHARS &&
     (draft.trim().length > 0 || pendingAttachment !== null);
 
@@ -1863,10 +1916,20 @@ export function ChatPanel() {
   // Admin: create group room
   const handleCreateRoom = () => setCreatingRoom(true);
 
-  // Golden thread border for private rooms
-  const threadTopBorder = isPrivateRoom
-    ? '2px solid rgba(255,177,60,0.30)'
-    : '1px solid transparent';
+  // Accent thread/composer border for private rooms — violet for groups, gold
+  // for DMs, none for the public lobby.
+  const threadTopBorder =
+    activeTone === 'group'
+      ? '2px solid rgba(176,124,255,0.30)'
+      : activeTone === 'dm'
+      ? '2px solid rgba(255,177,60,0.30)'
+      : '1px solid transparent';
+  const composerBorder =
+    activeTone === 'group'
+      ? '1px solid rgba(176,124,255,0.28)'
+      : activeTone === 'dm'
+      ? '1px solid rgba(255,177,60,0.28)'
+      : '1px solid var(--line-strong)';
 
   return (
     <div
@@ -2238,7 +2301,11 @@ export function ChatPanel() {
             >
               {orderedRooms.map((room) => {
                 const isDm = room.kind === 'dm';
-                const isPrivate = room.kind !== 'public';
+                const tone: TabTone =
+                  room.kind === 'public' ? 'public' : room.kind === 'group' ? 'group' : 'dm';
+                // A group the viewer isn't a member of: visible but locked. Only
+                // flagged once we know our own callsign (avoids a false lock pre-connect).
+                const locked = room.kind === 'group' && !isRoomMember(room, ownCall);
                 const label = isDm
                   ? (dmOther(room.id, ownCall) ?? room.name)
                   : room.name;
@@ -2247,7 +2314,8 @@ export function ChatPanel() {
                     key={room.id}
                     id={room.id}
                     label={label}
-                    isPrivate={isPrivate}
+                    tone={tone}
+                    locked={locked}
                     isActive={activeRoom === room.id}
                     unread={unreadByRoom[room.id] ?? 0}
                     closable={isDm}
@@ -2314,7 +2382,32 @@ export function ChatPanel() {
               transition: `border-color var(--dur-fast) var(--ease-out)`,
             }}
           >
-            {activeMessages.length === 0 ? (
+            {lockedActive ? (
+              <div
+                style={{
+                  margin: 'auto',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  gap: 8,
+                  maxWidth: 260,
+                  textAlign: 'center',
+                  padding: 16,
+                  color: 'var(--fg-3)',
+                }}
+              >
+                <span style={{ color: 'var(--chat-group)', display: 'inline-flex' }}>
+                  <LockGlyph />
+                </span>
+                <div style={{ fontSize: 12.5, fontWeight: 700, color: 'var(--chat-group)' }}>
+                  {activeRoomObj?.name}
+                </div>
+                <div style={{ fontSize: 11.5, lineHeight: 1.5 }}>
+                  This is an invite-only group. An admin must add you before you can
+                  read or post here.
+                </div>
+              </div>
+            ) : activeMessages.length === 0 ? (
               <div
                 style={{
                   margin: 'auto',
@@ -2429,9 +2522,9 @@ export function ChatPanel() {
               <button
                 type="button"
                 className="btn sm"
-                disabled={!connected || attaching}
+                disabled={!connected || attaching || lockedActive}
                 onClick={() => fileInputRef.current?.click()}
-                title={connected ? 'Attach a photo' : 'Not connected'}
+                title={connected ? (lockedActive ? 'Not a member of this group' : 'Attach a photo') : 'Not connected'}
                 aria-label="Attach a photo"
                 style={{ flexShrink: 0, padding: '5px 8px' }}
               >
@@ -2459,7 +2552,7 @@ export function ChatPanel() {
                   }
                 }}
                 placeholder={composerPlaceholder}
-                disabled={!connected}
+                disabled={!connected || lockedActive}
                 rows={1}
                 maxLength={MAX_MESSAGE_CHARS + 64}
                 style={{
@@ -2471,9 +2564,7 @@ export function ChatPanel() {
                   padding: '5px 8px',
                   boxSizing: 'border-box',
                   borderRadius: 'var(--r-sm)',
-                  border: isPrivateRoom
-                    ? '1px solid rgba(255,177,60,0.28)'
-                    : '1px solid var(--line-strong)',
+                  border: composerBorder,
                   background: connected ? '#0c0c10' : 'var(--bg-1)',
                   color: '#d8d8dc',
                   fontSize: 12,

--- a/zeus-web/src/styles/tokens.css
+++ b/zeus-web/src/styles/tokens.css
@@ -50,6 +50,10 @@
   --tx-soft:       rgba(255,74,89,0.18);
   --power:         #ffb13c;
   --power-soft:    rgba(255,177,60,0.16);
+  /* Chat group rooms — a third channel hue, distinct from public (blue) and
+     DM (gold/amber). Used only by the Chat panel to color group tabs/threads. */
+  --chat-group:      #b07cff;
+  --chat-group-soft: rgba(176,124,255,0.16);
   --ok:            #2dd566;
   --ok-soft:       rgba(45,213,102,0.18);
   --green-soft:    #1aa84e;


### PR DESCRIPTION
## What & why

Reported issue: **can't add users to chat groups**. Two things were wrong, plus a requested behavior/visual change.

### The add-member bug
Group membership lives in the ZeusChat relay (`cloud/zeuschat-relay`, the Durable Object — the C# backend only mirrors its `rooms` frame). `addMember`/`removeMember`/`deleteRoom` only re-pushed the room list to the **affected** member, never to the admin. So after an admin added a callsign, the admin's own member roster never refreshed and the chip never appeared — it looked like a no-op. Fixed with a `broadcastRooms()` that re-pushes each connected operator's room list on any group mutation.

### Visibility model — "everyone can see them, only added users can join"
`roomsFor()` now returns **every group to everyone** (with its member list); DMs stay private to their two parties. `canAccess()` already gates reading/posting by membership, so a non-member sees the group exists but can't enter until an admin adds them.

### Distinct color + locked UI
- Group tabs/threads use a dedicated violet hue (`--chat-group` `#b07cff`), distinct from public (blue) and DM (gold). Previously groups and DMs shared the same gold styling.
- A group you're not a member of shows a padlock on the tab, an invite-only notice instead of the thread, and a disabled composer. Admins still get the management strip to add members.

## Files
- `cloud/zeuschat-relay/src/chat-room.ts` — `roomsFor()` returns all groups; `broadcastRooms()` on create/add/remove/delete
- `zeus-web/src/styles/tokens.css` — `--chat-group` / `--chat-group-soft`
- `zeus-web/src/layout/panels/ChatPanel.tsx` — 3-way tab tone (public/group/dm), lock state

No `Zeus.Contracts`/C# changes — `members` already flows end-to-end.

## Verification
- Relay `tsc --noEmit`: clean
- Web `tsc -b --noEmit`: clean
- ESLint (ChatPanel): clean

## Deploy note
The relay change (visibility + add-member fix) lives in the Cloudflare Worker and requires `wrangler deploy` from `cloud/zeuschat-relay` to take effect; the web changes ship on the next frontend build. Couldn't browser-verify the locked-group visuals locally (needs a live relay + a second operator + an admin add/remove).