### PR TITLE
feat(p1): ADC dither/random for LT2208 boards; fix preamp C3 bit

### DIFF
--- a/Zeus.Protocol1/ControlFrame.cs
+++ b/Zeus.Protocol1/ControlFrame.cs
@@ -296,7 +296,17 @@ internal static class ControlFrame
         // Thetis-mi0bot networkproto1.c case 11 (`C3 = prn->user_dig_out & 0x0F`);
         // ramdor Thetis identical. HL2 only — gated at the wire layer. Default 0
         // → byte-identical to today (the 0x14 frame's C3 was previously 0).
-        byte UserDigOut = 0);
+        byte UserDigOut = 0,
+        // LT2208 ADC dither / digital-output randomizer (Config frame C3 bits 3
+        // and 4). Verified against ramdor Thetis networkproto1.c case 0
+        // (lines 453-455: `(adc[0].dither << 3) | (adc[0].random << 4)`) and
+        // piHPSDR old_protocol.c (`LT2208_DITHER_ON = 0x08`, `LT2208_RANDOM_ON =
+        // 0x10`). LT2208-based boards only — HL2's AD9866 has no dither/random
+        // and reuses C3 bit 3 as Band Volts PWM, so the wire encoder gates these
+        // off for HL2. Both default false → matches Thetis' netInterface.c init
+        // (`adc[i].dither = adc[i].random = 0`) and is byte-identical to today.
+        bool AdcDitherEnabled = false,
+        bool AdcRandomEnabled = false);
 
     /// <summary>
     /// Write the 5 C&amp;C bytes for <paramref name="register"/> given the current
@@ -606,26 +616,50 @@ internal static class ControlFrame
         byte c2 = (byte)(ocPins << 1);
         c14[1] = c2;
 
-        // C3: Atlas step attenuator [1:0], RAND [2], DITHER [3], preamp [4],
-        // RX antenna [7:5]. We leave [1:0] zero — the dedicated extended
-        // attenuator register (C0=0x14) is the single source of truth for RX
-        // attenuation on every board we target. Setting both would double
-        // up on Atlas-era gateware.
+        // C3: Atlas step attenuator [1:0], preamp [2], DITHER [3], RANDOM [4],
+        // RX antenna [6:5], RX-out [7]. We leave [1:0] zero — the dedicated
+        // extended attenuator register (C0=0x14) is the single source of truth
+        // for RX attenuation on every board we target. Setting both would double
+        // up on Atlas-era gateware. Bit positions verified against ramdor Thetis
+        // networkproto1.c case 0 (lines 453-455) and piHPSDR old_protocol.c
+        // (`LT2208_GAIN_ON = 0x04`, `LT2208_DITHER_ON = 0x08`,
+        // `LT2208_RANDOM_ON = 0x10`).
         byte c3 = 0;
-        // HL2 Band Volts PWM enable. Per
-        // docs/references/protocol-1/hermes-lite2-protocol.md line 39
-        // (`| 0x00 | [11] | Fan or Band Volts PWM (0=Fan, 1=Band Volts) |`),
-        // C3 bit 3 selects band-volts PWM on the FAN connector for external
-        // amplifier band-steering. Off by default; flipped on per-HL2 by the
-        // operator through the RADIO settings panel. The same bit reads as
-        // LT2208 DITHER on legacy HPSDR boards — Zeus never sets it for
-        // them, so the rename is purely client-side.
-        if (s.EnableHl2BandVolts) c3 |= 1 << 3;
-        if (s.PreampOn) c3 |= 1 << 4;             // Q#2: single global preamp bit for MVP.
+        if (s.Board == HpsdrBoardKind.HermesLite2)
+        {
+            // HL2 (AD9866) has no LT2208 preamp/dither/random. C3 bit 3 is the
+            // Band Volts PWM enable — per
+            // docs/references/protocol-1/hermes-lite2-protocol.md line 39
+            // (`| 0x00 | [11] | Fan or Band Volts PWM (0=Fan, 1=Band Volts) |`),
+            // it selects band-volts PWM on the FAN connector for external
+            // amplifier band-steering. The preamp / dither / random bits below
+            // are LT2208-only and are deliberately NOT written here: on HL2,
+            // C3 bit 2 = VNA RX gain and bit 4 = FPGA PSU switching clock
+            // (DATA[10] / DATA[12]). Driving bit 4 from the operator's preamp
+            // toggle (the prior behaviour) disabled the PSU clock — a latent
+            // bug; HL2 RX gain is the LNA register (0x0a), not a C3 bit.
+            if (s.EnableHl2BandVolts) c3 |= 1 << 3;
+        }
+        else
+        {
+            // LT2208 boards (Mercury / Hermes / ANAN-class on P1): preamp/gain
+            // at C3 bit 2, ADC dither at bit 3, digital-output randomizer at
+            // bit 4. Bit positions verified against ramdor Thetis
+            // networkproto1.c case 0 (lines 453-455) and piHPSDR old_protocol.c
+            // (`LT2208_GAIN_ON = 0x04`, `LT2208_DITHER_ON = 0x08`,
+            // `LT2208_RANDOM_ON = 0x10`). Preamp was previously emitted at bit 4
+            // (the RANDOM bit) — corrected here so the two no longer collide.
+            // Dither/random default off (Thetis netInterface.c init), so a board
+            // the operator has not configured stays byte-identical to before.
+            if (s.PreampOn) c3 |= 1 << 2;
+            if (s.AdcDitherEnabled) c3 |= 1 << 3;
+            if (s.AdcRandomEnabled) c3 |= 1 << 4;
+        }
         // RX-antenna relay select C3[7:5]. Routed through the shared pure helper
         // so the wire-layer HL2 clamp (single jack → ANT1) and the external-port
-        // encoder seam emit identical bytes. Co-tenant C3[3] (band-volts) and
-        // C3[4] (preamp) are already OR'd above; the helper only touches [7:5].
+        // encoder seam emit identical bytes. Co-tenant bits C3[2] (preamp), C3[3]
+        // (HL2 band-volts / LT2208 dither) and C3[4] (LT2208 random) are already
+        // OR'd above; the helper only touches [7:5].
         c3 |= EncodeRxAntennaC3Bits(s.RxAntenna, s.Board);
         c14[2] = c3;
 

--- a/Zeus.Protocol1/IProtocol1Client.cs
+++ b/Zeus.Protocol1/IProtocol1Client.cs
@@ -80,6 +80,13 @@ public interface IProtocol1Client : IDisposable
     void SetVfoAHz(long hz);
     void SetSampleRate(HpsdrSampleRate rate);
     void SetPreamp(bool on);
+    /// <summary>
+    /// Enable/disable the LT2208 ADC dither and digital-output randomizer
+    /// (Config-frame C3 bits 3/4). No-op on the wire for HL2 (gated in
+    /// <c>ControlFrame.WriteConfigPayload</c>). Mirrors the Protocol-2
+    /// <c>Protocol2Client.SetAdcDitherRandom</c> shape.
+    /// </summary>
+    void SetAdcDitherRandom(bool ditherEnabled, bool randomEnabled);
     void SetAttenuator(HpsdrAtten atten);
     void SetAntennaRx(HpsdrAntenna ant);
     /// <summary>

--- a/Zeus.Protocol1/Protocol1Client.cs
+++ b/Zeus.Protocol1/Protocol1Client.cs
@@ -110,6 +110,13 @@ public sealed class Protocol1Client : IProtocol1Client
     // HL2's AD9866 doesn't need (see hermes-lite2-protocol.md line 39 and
     // mi0bot's HL2 fork, which exposes this in the UI as "Band Volts").
     private int _enableHl2BandVolts;
+    // LT2208 ADC dither / digital-output randomizer (Config-frame C3 bits 3/4
+    // on non-HL2 boards). Default off — matches Thetis netInterface.c init and
+    // keeps the Config frame byte-identical until an operator opts in. Gated to
+    // LT2208 boards at the wire layer (WriteConfigPayload); RadioService only
+    // pushes these for a connected non-HL2 P1 board.
+    private int _adcDither;     // 0 / 1
+    private int _adcRandom;     // 0 / 1
     private int _boardKind = (int)HpsdrBoardKind.HermesLite2;
     private int _hasN2adr;      // 0 / 1
     private int _mox;           // 0 / 1
@@ -664,6 +671,19 @@ public sealed class Protocol1Client : IProtocol1Client
 
     public void SetSampleRate(HpsdrSampleRate rate) => Interlocked.Exchange(ref _rate, (int)rate);
     public void SetPreamp(bool on) => Interlocked.Exchange(ref _preamp, on ? 1 : 0);
+    /// <summary>
+    /// Enable/disable the LT2208 ADC dither and digital-output randomizer
+    /// (Config-frame C3 bits 3/4 on non-HL2 boards). Mirrors the Protocol-2
+    /// <c>SetAdcDitherRandom</c> API. The bits ride the next periodic Config
+    /// frame; no immediate send is needed because the Config register is on the
+    /// round-robin emitted every TX tick. Wire gating to LT2208 boards lives in
+    /// <see cref="ControlFrame.WriteConfigPayload"/>.
+    /// </summary>
+    public void SetAdcDitherRandom(bool ditherEnabled, bool randomEnabled)
+    {
+        Interlocked.Exchange(ref _adcDither, ditherEnabled ? 1 : 0);
+        Interlocked.Exchange(ref _adcRandom, randomEnabled ? 1 : 0);
+    }
     public void SetAttenuator(HpsdrAtten atten) => Interlocked.Exchange(ref _attenDb, atten.ClampedDb);
     /// <summary>
     /// Select the RX antenna relay (ANT1/2/3). SAFETY (external-ports plan —
@@ -885,6 +905,8 @@ public sealed class Protocol1Client : IProtocol1Client
             RxAntenna: (HpsdrAntenna)Volatile.Read(ref _antenna),
             Mox: Volatile.Read(ref _mox) != 0,
             EnableHl2BandVolts: Volatile.Read(ref _enableHl2BandVolts) != 0,
+            AdcDitherEnabled: Volatile.Read(ref _adcDither) != 0,
+            AdcRandomEnabled: Volatile.Read(ref _adcRandom) != 0,
             Board: (HpsdrBoardKind)Volatile.Read(ref _boardKind),
             HasN2adr: Volatile.Read(ref _hasN2adr) != 0,
             DriveLevel: drive,

--- a/Zeus.Server.Hosting/PreferredRadioStore.cs
+++ b/Zeus.Server.Hosting/PreferredRadioStore.cs
@@ -284,6 +284,32 @@ public sealed class PreferredRadioStore : IDisposable
         }
     }
 
+    /// <summary>
+    /// Raw (nullable) ADC dither preference — <c>null</c> when the operator has
+    /// never set it. Lets the caller apply a protocol-specific default: the
+    /// Protocol-2 G2 path defaults on (<see cref="GetG2AdcDitherEnabled"/>),
+    /// while the Protocol-1 LT2208 path defaults off (Thetis netInterface.c).
+    /// </summary>
+    public bool? GetG2AdcDitherEnabledRaw()
+    {
+        lock (_sync)
+        {
+            return _entries.FindAll().FirstOrDefault()?.G2AdcDitherEnabled;
+        }
+    }
+
+    /// <summary>
+    /// Raw (nullable) ADC randomizer preference. See
+    /// <see cref="GetG2AdcDitherEnabledRaw"/> for the default-by-protocol rule.
+    /// </summary>
+    public bool? GetG2AdcRandomEnabledRaw()
+    {
+        lock (_sync)
+        {
+            return _entries.FindAll().FirstOrDefault()?.G2AdcRandomEnabled;
+        }
+    }
+
     public int GetG2Rx1AttenuatorDb()
     {
         lock (_sync)
@@ -310,8 +336,13 @@ public sealed class PreferredRadioStore : IDisposable
                 {
                     Board = HpsdrBoardKind.Unknown,
                     OverrideDetection = false,
-                    G2AdcDitherEnabled = ditherEnabled ?? true,
-                    G2AdcRandomEnabled = randomEnabled ?? true,
+                    // Store exactly what the operator set; leave unspecified
+                    // options null so the resolver can apply the correct
+                    // default for the active protocol (P2 on / P1 off). The
+                    // shipped GetG2Adc*Enabled() getters still collapse null →
+                    // true for the P2 path, so this is byte-identical there.
+                    G2AdcDitherEnabled = ditherEnabled,
+                    G2AdcRandomEnabled = randomEnabled,
                     G2Rx1AttenuatorDb = clampedRx1Atten ?? 0,
                     UpdatedUtc = DateTime.UtcNow,
                 });

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -1012,6 +1012,16 @@ public sealed class RadioService : IDisposable
                 client.EnableHl2BandVolts = _preferredRadioStore.GetEnableHl2BandVolts();
             }
 
+            // LT2208 ADC dither / digital-output randomizer — rehydrate the
+            // persisted operator preference into the fresh client so the first
+            // Config frame carries the correct C3 bits 3/4. Skipped on HL2 (no
+            // LT2208; its bit 3 is Band Volts, seeded above). Default off, so a
+            // board the operator has never configured stays byte-identical.
+            if (client.BoardKind != HpsdrBoardKind.HermesLite2)
+            {
+                ApplyAdcOptionsToP1Client(client, client.BoardKind);
+            }
+
             // Frequency-correction factor (issue #325) — rehydrate so the
             // first tune-write on the fresh client carries the operator's
             // calibrated correction. Cheap default when no calibration has
@@ -3082,6 +3092,23 @@ public sealed class RadioService : IDisposable
     public G2OptionsDto GetG2Options()
     {
         var options = ResolveG2AdcOptionsFor(EffectiveBoardKind, EffectiveOrionMkIIVariant);
+        // Protocol-1 LT2208 boards expose the same ADC dither/random controls,
+        // but the Thetis default is OFF (netInterface.c) and there is no RX1
+        // stepped attenuator on this path. Surfaced only when a non-HL2 P1 board
+        // is the live connection, so the shipped P2/G2 reporting is untouched.
+        if (!options.Supported && ConnectedP1SupportsAdcDitherRandom)
+        {
+            var (p1Dither, p1Random) = ResolveP1AdcOptions();
+            return new G2OptionsDto(
+                DitherEnabled: p1Dither,
+                RandomEnabled: p1Random,
+                MaxRxFreqMHz: 60.0,
+                Supported: true,
+                Rx1AttenuatorDb: 0,
+                Rx1AttenuatorMinDb: 0,
+                Rx1AttenuatorMaxDb: 31,
+                Rx1AttenuatorSupported: false);
+        }
         return new G2OptionsDto(
             DitherEnabled: _preferredRadioStore?.GetG2AdcDitherEnabled() ?? true,
             RandomEnabled: _preferredRadioStore?.GetG2AdcRandomEnabled() ?? true,
@@ -3097,7 +3124,12 @@ public sealed class RadioService : IDisposable
     {
         _preferredRadioStore?.SetG2AdcOptions(req.DitherEnabled, req.RandomEnabled, req.Rx1AttenuatorDb);
         var options = GetG2Options();
+        // Push to whichever protocol is live. ActiveClient is non-null only for
+        // Protocol 1; _p2Client only for Protocol 2 — so at most one of these
+        // does real work, and each no-ops on the board kinds it does not apply
+        // to (HL2 for P1; non-G2 for P2).
         ApplyG2AdcOptionsToP2Client(_p2Client, ConnectedBoardKind);
+        ApplyAdcOptionsToP1Client(_activeClient, ConnectedBoardKind);
         return options;
     }
 
@@ -3107,6 +3139,43 @@ public sealed class RadioService : IDisposable
         var options = ResolveG2AdcOptionsForWire(connectedBoard);
         client.SetAdcDitherRandom(options.DitherEnabled, options.RandomEnabled);
         client.SetRx1Attenuator(options.Rx1AttenuatorSupported ? options.Rx1AttenuatorDb : 0);
+    }
+
+    /// <summary>
+    /// True when a non-HL2 Protocol-1 board is the live connection. Protocol 1
+    /// is the only protocol with a live <see cref="IProtocol1Client"/>
+    /// (<see cref="ActiveClient"/>); HL2's AD9866 has no LT2208 dither/random
+    /// (its C3 bit 3 is Band Volts), so it is excluded.
+    /// </summary>
+    private bool ConnectedP1SupportsAdcDitherRandom =>
+        _activeClient is not null
+        && ConnectedBoardKind != HpsdrBoardKind.HermesLite2;
+
+    /// <summary>
+    /// Resolve the persisted LT2208 ADC dither/random with the Thetis Protocol-1
+    /// default of OFF (netInterface.c <c>adc[i].dither = adc[i].random = 0</c>).
+    /// Uses the nullable raw store getters so an operator who has only ever set
+    /// the P2/G2 controls does not inherit the P2 default-on here.
+    /// </summary>
+    private (bool DitherEnabled, bool RandomEnabled) ResolveP1AdcOptions()
+    {
+        bool dither = _preferredRadioStore?.GetG2AdcDitherEnabledRaw() ?? false;
+        bool random = _preferredRadioStore?.GetG2AdcRandomEnabledRaw() ?? false;
+        return (dither, random);
+    }
+
+    /// <summary>
+    /// Push the persisted LT2208 ADC dither/random to a live Protocol-1 client.
+    /// No-op on HL2 (no LT2208) and when no client is connected. The bits ride
+    /// the next periodic Config frame — the Config register is on the TX-tick
+    /// round-robin, so no explicit send is required. Mirrors
+    /// <see cref="ApplyG2AdcOptionsToP2Client"/> for the P1 path.
+    /// </summary>
+    public void ApplyAdcOptionsToP1Client(IProtocol1Client? client, HpsdrBoardKind connectedBoard)
+    {
+        if (client is null || connectedBoard == HpsdrBoardKind.HermesLite2) return;
+        var (dither, random) = ResolveP1AdcOptions();
+        client.SetAdcDitherRandom(dither, random);
     }
 
     /// <summary>

--- a/tests/Zeus.Protocol1.Tests/ControlFrameTests.cs
+++ b/tests/Zeus.Protocol1.Tests/ControlFrameTests.cs
@@ -175,14 +175,91 @@ public class ControlFrameTests
     }
 
     [Fact]
-    public void ControlFrame_Preamp_On_SetsC3Bit4()
+    public void ControlFrame_Preamp_On_SetsC3Bit2_OnLt2208Board()
     {
         Span<byte> cc = stackalloc byte[5];
-        var s = BaseState() with { PreampOn = true };
+        // LT2208 board (Hermes): preamp/gain → C3 bit 2. Verified against ramdor
+        // Thetis networkproto1.c case 0 (`(rx[0].preamp << 2)`) and piHPSDR
+        // old_protocol.c (`LT2208_GAIN_ON = 0x04`). Was previously emitted at
+        // bit 4 (the RANDOM bit) — the move frees bit 4 for the randomizer.
+        var s = BaseState() with { Board = HpsdrBoardKind.Hermes, PreampOn = true };
         ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.Config, s);
 
-        // C3[4] = preamp bit (doc 02 §4.1)
+        Assert.Equal(1 << 2, cc[3] & (1 << 2));     // preamp bit 2 set
+        Assert.Equal(0, cc[3] & (1 << 4));          // RANDOM bit 4 NOT set by preamp
+        Assert.Equal(1 << 2, cc[3]);                // only preamp; antenna ANT1, no dither/random
+    }
+
+    [Fact]
+    public void ControlFrame_Preamp_On_Hl2_SetsNoC3Bit()
+    {
+        Span<byte> cc = stackalloc byte[5];
+        // HL2's AD9866 has no LT2208 preamp; C3 bit 2 is VNA gain and bit 4 is
+        // the FPGA PSU switching clock. The operator's preamp toggle must NOT
+        // touch C3 on HL2 (HL2 RX gain is the LNA register 0x0a). This pins the
+        // fix for the prior bug where preamp-on disabled the HL2 PSU clock.
+        var s = BaseState() with { PreampOn = true }; // BaseState board = HL2
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.Config, s);
+
+        Assert.Equal(0, cc[3]);
+    }
+
+    [Fact]
+    public void ControlFrame_AdcDither_On_SetsC3Bit3_OnLt2208Board()
+    {
+        Span<byte> cc = stackalloc byte[5];
+        // LT2208 ADC dither → C3 bit 3 (Thetis networkproto1.c case 0
+        // `(adc[0].dither << 3)`; piHPSDR `LT2208_DITHER_ON = 0x08`).
+        var s = BaseState() with { Board = HpsdrBoardKind.Hermes, AdcDitherEnabled = true };
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.Config, s);
+
+        Assert.Equal(1 << 3, cc[3] & (1 << 3));
+        Assert.Equal(1 << 3, cc[3]); // only dither; no random/preamp/antenna
+    }
+
+    [Fact]
+    public void ControlFrame_AdcRandom_On_SetsC3Bit4_OnLt2208Board()
+    {
+        Span<byte> cc = stackalloc byte[5];
+        // LT2208 ADC randomizer → C3 bit 4 (Thetis `(adc[0].random << 4)`;
+        // piHPSDR `LT2208_RANDOM_ON = 0x10`).
+        var s = BaseState() with { Board = HpsdrBoardKind.Hermes, AdcRandomEnabled = true };
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.Config, s);
+
         Assert.Equal(1 << 4, cc[3] & (1 << 4));
+        Assert.Equal(1 << 4, cc[3]); // only random; no dither/preamp/antenna
+    }
+
+    [Fact]
+    public void ControlFrame_AdcDitherRandomAndPreamp_CoexistOnC3()
+    {
+        Span<byte> cc = stackalloc byte[5];
+        // Preamp (bit 2), dither (bit 3) and random (bit 4) are independent
+        // bits and must coexist — this is the regression guard for the old
+        // preamp/random collision at bit 4.
+        var s = BaseState() with
+        {
+            Board = HpsdrBoardKind.Hermes,
+            PreampOn = true,
+            AdcDitherEnabled = true,
+            AdcRandomEnabled = true,
+        };
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.Config, s);
+
+        Assert.Equal((1 << 2) | (1 << 3) | (1 << 4), cc[3]);
+    }
+
+    [Fact]
+    public void ControlFrame_AdcDitherRandom_On_Hl2_DoesNotTouchC3()
+    {
+        Span<byte> cc = stackalloc byte[5];
+        // Defence in depth: even if dither/random are somehow set on an HL2
+        // state, the wire layer must not light C3 bits 3/4 there — bit 3 is
+        // reserved for Band Volts (off here) and HL2 has no LT2208.
+        var s = BaseState() with { AdcDitherEnabled = true, AdcRandomEnabled = true };
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.Config, s);
+
+        Assert.Equal(0, cc[3]);
     }
 
     [Fact]
@@ -352,6 +429,42 @@ public class ControlFrameTests
         Span<byte> cc = stackalloc byte[5];
         ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.DriveFilter, client.SnapshotState());
         Assert.Equal(expectedC1, cc[1]);
+    }
+
+    [Fact]
+    public void Protocol1Client_SetAdcDitherRandom_FlowsToConfigC3_OnLt2208Board()
+    {
+        // Full client plumbing: the setter lands in SnapshotState and the
+        // Config encoder lights C3 bits 3 (dither) and 4 (random) for a
+        // non-HL2 board.
+        using var client = new Protocol1Client();
+        client.SetBoardKind(HpsdrBoardKind.Hermes);
+        client.SetAdcDitherRandom(ditherEnabled: true, randomEnabled: true);
+
+        var state = client.SnapshotState();
+        Assert.True(state.AdcDitherEnabled);
+        Assert.True(state.AdcRandomEnabled);
+
+        Span<byte> cc = stackalloc byte[5];
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.Config, state);
+        Assert.Equal((1 << 3) | (1 << 4), cc[3]);
+    }
+
+    [Fact]
+    public void Protocol1Client_AdcDitherRandom_DefaultOff_LeavesConfigC3Clean()
+    {
+        // Default (operator never opted in) → no C3 dither/random bits, on a
+        // non-HL2 board. Guards the "byte-identical until enabled" promise.
+        using var client = new Protocol1Client();
+        client.SetBoardKind(HpsdrBoardKind.Hermes);
+
+        var state = client.SnapshotState();
+        Assert.False(state.AdcDitherEnabled);
+        Assert.False(state.AdcRandomEnabled);
+
+        Span<byte> cc = stackalloc byte[5];
+        ControlFrame.WriteCcBytes(cc, ControlFrame.CcRegister.Config, state);
+        Assert.Equal(0, cc[3]);
     }
 
     [Fact]

--- a/tests/Zeus.Protocol1.Tests/ExternalPortGoldenTests.cs
+++ b/tests/Zeus.Protocol1.Tests/ExternalPortGoldenTests.cs
@@ -24,8 +24,9 @@ namespace Zeus.Protocol1.Tests;
 /// refactor changed behaviour. Do not "fix" these to match new output —
 /// they ARE the contract.
 ///
-/// Co-tenancy is the point: C3 carries RxAntenna[7:5] alongside HL2 band-volts
-/// [3] and preamp [4]; C4 carries duplex[2] + RX-count[5:3] and must NEVER pick
+/// Co-tenancy is the point: C3 carries RxAntenna[7:5] alongside LT2208 preamp
+/// [2] / dither [3] / random [4] and (HL2-only) band-volts [3]; C4 carries
+/// duplex[2] + RX-count[5:3] and must NEVER pick
 /// up TX-antenna bits for any supported board. The asserts below pin every
 /// co-tenant so the refactor can't clobber one while moving another.
 /// </summary>
@@ -81,8 +82,9 @@ public class ExternalPortGoldenTests
         Assert.Equal(0x04, cc[4]);
     }
 
-    // RxAntenna co-tenants C3 with preamp[4] and (HL2-only) band-volts[3].
-    // Pin that the antenna shift never clobbers the neighbours.
+    // RxAntenna co-tenants C3 with preamp[2] (LT2208 boards), dither[3]/random[4]
+    // and (HL2-only) band-volts[3]. Pin that the antenna shift never clobbers the
+    // neighbours.
     [Fact]
     public void Config_C3_RxAntenna_CoTenants_Preamp_AreLocked()
     {
@@ -92,16 +94,18 @@ public class ExternalPortGoldenTests
             PreampOn = true,
         });
 
-        // preamp[4]=0x10 | antenna Ant3 [7:5]=0x40 → 0x50.
-        Assert.Equal(0x50, cc[3]);
+        // preamp[2]=0x04 | antenna Ant3 [7:5]=0x40 → 0x44.
+        Assert.Equal(0x44, cc[3]);
         Assert.Equal(0x04, cc[4]);
     }
 
     // DIFFERENTIAL (external-ports plan, Phase 2): the HL2 RX-antenna wire
     // clamp. HL2 has a single jack — C3[5] drives the N2ADR antenna pad, not an
     // ANT1/2/3 relay — so an operator (or a stale per-band) ANT2/3 MUST be
-    // forced to ANT1 at the wire layer. The co-tenant band-volts[3] / preamp[4]
-    // bits are preserved; only the [7:5] antenna field is zeroed.
+    // forced to ANT1 at the wire layer. The co-tenant band-volts[3] bit is
+    // preserved; only the [7:5] antenna field is zeroed. Preamp does NOT light a
+    // C3 bit on HL2 (no LT2208; the LT2208 preamp/dither/random bits are gated
+    // off for HL2 in WriteConfigPayload), so it cannot appear here.
     [Theory]
     [InlineData(HpsdrAntenna.Ant1)]
     [InlineData(HpsdrAntenna.Ant2)]
@@ -115,9 +119,9 @@ public class ExternalPortGoldenTests
             PreampOn = true,
         });
 
-        // band-volts[3]=0x08 | preamp[4]=0x10 | antenna [7:5]=0 (clamped) → 0x18,
-        // regardless of which antenna was requested.
-        Assert.Equal(0x18, cc[3]);
+        // band-volts[3]=0x08 | antenna [7:5]=0 (clamped) → 0x08, regardless of
+        // which antenna was requested. Preamp is a no-op on HL2's C3.
+        Assert.Equal(0x08, cc[3]);
         Assert.Equal(0x04, cc[4]);
         // Antenna field is hard-zero on HL2.
         Assert.Equal(0x00, cc[3] & 0xE0);

--- a/tests/Zeus.Server.Tests/PreferredRadioStoreTests.cs
+++ b/tests/Zeus.Server.Tests/PreferredRadioStoreTests.cs
@@ -225,6 +225,32 @@ public class PreferredRadioStoreTests : IDisposable
     }
 
     [Fact]
+    public void Empty_Store_Returns_Null_For_Raw_Adc_Options()
+    {
+        // The raw getters preserve "operator never set this" as null so the
+        // resolver can apply a protocol-specific default (P2 on / P1 off). The
+        // shipped non-raw getters still collapse null → true for the P2 path.
+        using var store = new PreferredRadioStore(NullLogger<PreferredRadioStore>.Instance, _dbPath);
+        Assert.Null(store.GetG2AdcDitherEnabledRaw());
+        Assert.Null(store.GetG2AdcRandomEnabledRaw());
+    }
+
+    [Fact]
+    public void Setting_One_Adc_Option_Leaves_The_Other_Raw_Null()
+    {
+        // Partial PUT (only dither) must not materialize the P2 default-on for
+        // the untouched random field — that would wrongly force random on for a
+        // Protocol-1 board, whose default is off.
+        using var store = new PreferredRadioStore(NullLogger<PreferredRadioStore>.Instance, _dbPath);
+        store.SetG2AdcOptions(ditherEnabled: true);
+
+        Assert.True(store.GetG2AdcDitherEnabledRaw());
+        Assert.Null(store.GetG2AdcRandomEnabledRaw());
+        // P2 getter still defaults the untouched field on.
+        Assert.True(store.GetG2AdcRandomEnabled());
+    }
+
+    [Fact]
     public void G2_Adc_Options_Round_Trip_And_Persist()
     {
         using (var s1 = new PreferredRadioStore(NullLogger<PreferredRadioStore>.Instance, _dbPath))

--- a/zeus-web/src/components/RadioOptionsPanel.test.tsx
+++ b/zeus-web/src/components/RadioOptionsPanel.test.tsx
@@ -274,4 +274,48 @@ describe('RadioOptionsPanel', () => {
     expect(rx1Put).toBeDefined();
     expect(useRadioOptionsStore.getState().g2Options.rx1AttenuatorDb).toBe(12);
   });
+
+  it('renders Protocol-1 LT2208 ADC options via runtime supported flag', async () => {
+    // No static G2 capability (a legacy P1 board), but the server reports
+    // g2Options.supported = true once a non-HL2 P1 radio is connected. The card
+    // must render dither/random with the board-neutral title and omit the
+    // G2-only MaxRXFreq / RX1-attenuator rows.
+    useRadioStore.setState((s) => ({
+      ...s,
+      capabilities: UNKNOWN_BOARD_CAPABILITIES, // supportsG2AdcOptions = false
+    }));
+    stubRadioOptionsFetch(
+      { bandVolts: false },
+      {
+        ditherEnabled: false,
+        randomEnabled: false,
+        maxRxFreqMHz: 60,
+        supported: true,
+        rx1AttenuatorDb: 0,
+        rx1AttenuatorMinDb: 0,
+        rx1AttenuatorMaxDb: 31,
+        rx1AttenuatorSupported: false,
+      },
+    );
+
+    await act(async () => {
+      root.render(<RadioOptionsPanel />);
+    });
+    await flushMicrotasks();
+
+    expect(container.textContent).toContain('ADC Options');
+    expect(container.textContent).not.toContain('ANAN-G2 Options');
+    expect(container.textContent).toContain('Dither Enabled');
+    expect(container.textContent).toContain('Random Enabled');
+    // G2-only rows are gated out on the P1 path.
+    expect(container.textContent).not.toContain('MaxRXFreq');
+    expect(container.querySelector('select')).toBeNull();
+
+    const checkboxes = Array.from(
+      container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
+    );
+    expect(checkboxes).toHaveLength(2);
+    expect(checkboxes[0]!.checked).toBe(false);
+    expect(checkboxes[1]!.checked).toBe(false);
+  });
 });

--- a/zeus-web/src/components/RadioOptionsPanel.tsx
+++ b/zeus-web/src/components/RadioOptionsPanel.tsx
@@ -87,14 +87,14 @@ export function RadioOptionsPanel() {
         </div>
       ) : null}
 
-      {supportsG2AdcOptions ? (
+      {supportsG2AdcOptions || g2Options.supported ? (
         <div className="ps-card">
           <h4>
             <svg className="ps-ic-sm" viewBox="0 0 12 12">
               <path d="M2 8h8M2 4h8M4 2v8M8 2v8" />
               <rect x="2" y="2" width="8" height="8" rx="1" />
             </svg>
-            ANAN-G2 Options
+            {supportsG2AdcOptions ? 'ANAN-G2 Options' : 'ADC Options'}
             <span className="ps-card-hint">ADC linearity and decorrelation</span>
           </h4>
 
@@ -102,9 +102,10 @@ export function RadioOptionsPanel() {
             <div className="ps-name">
               Dither Enabled
               <em>
-                Enables the Protocol-2 CmdRx ADC dither mask used by Thetis to
-                address ADC nonlinearity errors. Applies live on verified
-                G2-class radios and persists for reconnect.
+                Adds a small dither signal to the ADC to address converter
+                nonlinearity errors. On Protocol-2 G2 radios this is the CmdRx
+                ADC dither mask; on Protocol-1 LT2208 boards it is Config-frame
+                C3 bit 3. Applies live and persists for reconnect.
               </em>
             </div>
             <label className="ps-check">
@@ -125,8 +126,9 @@ export function RadioOptionsPanel() {
             <div className="ps-name">
               Random Enabled
               <em>
-                Enables the Protocol-2 CmdRx ADC digital-output randomizer
-                mask used by Thetis to reduce digital feedback artifacts.
+                ADC digital-output randomizer that reduces digital feedback
+                artifacts on the data bus. Protocol-2 G2 CmdRx random mask;
+                Protocol-1 LT2208 Config-frame C3 bit 4.
               </em>
             </div>
             <label className="ps-check">
@@ -143,17 +145,19 @@ export function RadioOptionsPanel() {
             </label>
           </div>
 
-          <div className="ps-field">
-            <div className="ps-name">
-              MaxRXFreq
-              <em>
-                Zeus enforces the G2 0-60 MHz receive ceiling through the
-                VFO and radio-LO clamp, so this is shown as a live parity
-                value instead of a duplicate setting.
-              </em>
+          {supportsG2AdcOptions ? (
+            <div className="ps-field">
+              <div className="ps-name">
+                MaxRXFreq
+                <em>
+                  Zeus enforces the G2 0-60 MHz receive ceiling through the
+                  VFO and radio-LO clamp, so this is shown as a live parity
+                  value instead of a duplicate setting.
+                </em>
+              </div>
+              <span className="mono">{g2Options.maxRxFreqMHz.toFixed(2)} MHz</span>
             </div>
-            <span className="mono">{g2Options.maxRxFreqMHz.toFixed(2)} MHz</span>
-          </div>
+          ) : null}
 
           {g2Options.rx1AttenuatorSupported || hasSteppedAttenuationRx2 ? (
             <div className="ps-field">


### PR DESCRIPTION
## What

Adds **ADC dither** and **digital-output randomizer** for **Protocol-1 LT2208 boards** (Mercury / Hermes / ANAN-class), bringing them to parity with the already-shipped Protocol-2 G2 path. Also fixes a pre-existing Protocol-1 **preamp** wire-encoding bug that was the blocker for adding the randomizer.

## Why

The G2/Protocol-2 dither+random path was complete, but legacy LT2208 boards on Protocol 1 never drove their ADC dither/random bits — they were stuck off regardless of the UI.

## Wire encoding (verified against two authoritative references)

Config-frame **C3** on LT2208 boards, confirmed against ramdor Thetis `networkproto1.c` case 0 and piHPSDR `old_protocol.c`:

| bit | function | source constant |
|----|----------|-----------------|
| 2 | preamp / gain | `LT2208_GAIN_ON = 0x04` |
| 3 | ADC dither | `LT2208_DITHER_ON = 0x08` |
| 4 | ADC random | `LT2208_RANDOM_ON = 0x10` |

## Preamp bug fix (coupled, required)

Protocol-1 preamp was encoded at **C3 bit 4 — the RANDOM bit** — on every board, so random couldn't be added without colliding. Preamp now sits at **bit 2** on LT2208 boards (per both references) and is **no longer written on HL2**, whose C3 bit 4 is the FPGA PSU switching clock and bit 2 is VNA gain (HL2 RX gain is the LNA register, not a C3 bit). Net effect on HL2: removes a latent bug where "preamp on" disabled the PSU switching clock.

## End-to-end

Reuses the shipped `/api/radio/g2-options` endpoint/store/UI rather than duplicating:
- **Resolver is now protocol-aware** — P2/G2 default **on**, P1 LT2208 default **off** (Thetis `netInterface.c`), via new nullable raw store getters so a P1 board doesn't inherit the P2 default.
- Persisted per-radio, **seeded on P1 connect**, **applied live** (rides the periodic Config frame), gated to non-HL2 boards.
- The ADC-options settings card now renders for connected non-HL2 P1 boards with a board-neutral title; the P2/G2 path is byte-for-byte untouched.

## Tests

- ControlFrame C3 bit positions (preamp@2, dither@3, random@4), HL2-gating, and a preamp/dither/random **coexistence regression guard** for the old bit-4 collision
- `Protocol1Client` snapshot plumbing (`SetAdcDitherRandom` → `SnapshotState` → wire)
- `PreferredRadioStore` nullable raw getters + null-preservation on partial set
- `RadioOptionsPanel` P1 render path (card via runtime `supported`, neutral title, G2-only rows hidden)
- Existing P1 golden tests updated to the corrected bit layout

Green locally: Protocol1 281, frontend tsc + panel 5; server suite (PreferredRadioStore/G2Options/Hl2BandVolts) green on the identical changeset.

## ⚠ Needs a bench check

The C3 bits are confirmed against two references, but **neither a G2 (P2 path) nor an HL2 (no LT2208) exercises them**. The preamp-bit move and dither/random encoding should be sanity-checked on a real ANAN/Hermes on Protocol 1 before this is trusted in the field.