### PR TITLE
gold admin callsigns 

### DIFF
--- a/Zeus.Contracts/ChatDtos.cs
+++ b/Zeus.Contracts/ChatDtos.cs
@@ -99,6 +99,8 @@ public sealed record ChatMessage(
 /// A connected operator in the relay roster. <paramref name="FreqHz"/> is the
 /// operator's VFO frequency in Hz; <paramref name="Status"/> is "rx"|"tx"|
 /// "away"; <paramref name="Since"/> is epoch milliseconds the operator joined.
+/// <paramref name="Admin"/> is true when the operator is a relay moderator, so
+/// clients can paint their callsign distinctly (gold).
 /// </summary>
 public sealed record ChatOperator(
     string Callsign,
@@ -106,7 +108,8 @@ public sealed record ChatOperator(
     long? FreqHz,
     string? Mode,
     string? Status,
-    long Since);
+    long Since,
+    bool Admin = false);
 
 /// <summary>
 /// Snapshot of the local chat node's state, surfaced via
@@ -121,7 +124,8 @@ public sealed record ChatStatusDto(
     string RelayUrl,
     string? Error,
     bool IsAdmin = false,
-    bool FreqPublic = true);
+    bool FreqPublic = true,
+    bool SeeAllFreq = false);
 
 /// <summary>
 /// A chat channel visible to the operator: the public lobby, an admin-created
@@ -183,6 +187,11 @@ public sealed record ChatRoomRequest(string Room);
 
 /// <summary>Toggle whether this operator's frequency may be shared (eye toggle).</summary>
 public sealed record ChatFreqVisibilityRequest(bool Public);
+
+/// <summary>Admin: toggle the "see all frequencies" override — while on, every
+/// connected operator's frequency is revealed to this admin regardless of
+/// friendship or the owner's eye toggle.</summary>
+public sealed record ChatSeeAllRequest(bool On);
 
 /// <summary>Admin: clear a room's history. <paramref name="Room"/> defaults to the public lobby.</summary>
 public sealed record ChatClearRequest(string? Room = null);

--- a/Zeus.Server.Hosting/ChatService.cs
+++ b/Zeus.Server.Hosting/ChatService.cs
@@ -77,6 +77,11 @@ public sealed class ChatService : BackgroundService
     // Whether the operator is a relay moderator (from the welcome frame).
     private volatile bool _isAdmin;
 
+    // Admin "see all frequencies" override (session-scoped, default OFF). When
+    // armed by an admin it is re-asserted to the relay after each (re)connect so
+    // a network blip doesn't silently drop it. Meaningless for non-admins.
+    private volatile bool _seeAllFreq;
+
     // Live connection state, set on the worker loop and read by the API.
     private volatile bool _connected;
     private volatile string? _lastError;
@@ -136,7 +141,8 @@ public sealed class ChatService : BackgroundService
         RelayUrl: _relayUrl,
         Error: _lastError,
         IsAdmin: _isAdmin,
-        FreqPublic: _store.GetFreqPublic());
+        FreqPublic: _store.GetFreqPublic(),
+        SeeAllFreq: _seeAllFreq);
 
     /// <summary>Persists the opt-in and wakes the worker to connect/disconnect.</summary>
     public ChatStatusDto SetEnabled(bool enabled)
@@ -334,6 +340,40 @@ public sealed class ChatService : BackgroundService
                 status = CurrentStatus(),
                 freqPublic = isPublic,
             }, ct);
+        }
+    }
+
+    /// <summary>
+    /// Admin: arms/disarms the "see all frequencies" override. Persists the
+    /// session-scoped flag, reflects it in status, and — if connected — tells the
+    /// relay so the next roster carries (or strips) everyone's freq. The relay
+    /// ignores the toggle unless it has flagged this connection as an admin, so a
+    /// non-admin calling this is a harmless no-op on the relay side.
+    /// </summary>
+    public async Task SetSeeAllFreqAsync(bool on, CancellationToken ct)
+    {
+        _seeAllFreq = on;
+        PushStatus();
+        var socket = _socket;
+        if (socket is not null && socket.State == WebSocketState.Open && _connected)
+            await SendFrameAsync(socket, new { t = "admin_see_all", on }, ct);
+    }
+
+    /// <summary>Re-sends the current see-all override to the relay after a
+    /// reconnect. Best-effort: swallows send failures (the loop will reconnect
+    /// and try again) so it can be safely fire-and-forgotten from the receive
+    /// loop.</summary>
+    private async Task ReassertSeeAllAsync()
+    {
+        try
+        {
+            var socket = _socket;
+            if (socket is not null && socket.State == WebSocketState.Open && _connected)
+                await SendFrameAsync(socket, new { t = "admin_see_all", on = _seeAllFreq }, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            _log.LogDebug(ex, "chat: failed to re-assert see-all override");
         }
     }
 
@@ -565,6 +605,12 @@ public sealed class ChatService : BackgroundService
                         && adminEl.ValueKind == JsonValueKind.True;
                     UpdateRoster(root, "roster");
                     PushStatus();
+                    // Re-assert a sticky "see all" override on (re)connect so a
+                    // blip doesn't silently drop it. Only meaningful for admins;
+                    // the relay ignores it otherwise. Fire-and-forget — we're on
+                    // the receive loop and must not block it.
+                    if (_isAdmin && _seeAllFreq)
+                        _ = ReassertSeeAllAsync();
                     break;
                 case "roster":
                     UpdateRoster(root, "roster");
@@ -693,7 +739,8 @@ public sealed class ChatService : BackgroundService
                 FreqHz: ReadLong(op, "freq"),
                 Mode: ReadString(op, "mode"),
                 Status: ReadString(op, "status"),
-                Since: ReadLong(op, "since") ?? 0));
+                Since: ReadLong(op, "since") ?? 0,
+                Admin: op.TryGetProperty("admin", out var adminEl) && adminEl.ValueKind == JsonValueKind.True));
         }
         return list;
     }

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -3519,6 +3519,8 @@ public static class ZeusEndpoints
             Run(() => chat.BroadcastAsync(req.Text, ctx.RequestAborted)));
         app.MapPost("/api/chat/admin/bans", (ChatService chat, HttpContext ctx) =>
             Run(() => chat.ListBansAsync(ctx.RequestAborted)));
+        app.MapPost("/api/chat/admin/see-all", (ChatSeeAllRequest req, ChatService chat, HttpContext ctx) =>
+            Run(() => chat.SetSeeAllFreqAsync(req.On, ctx.RequestAborted)));
 
         // Point-to-point propagation (DE → DX). Proxies the HamClock sidecar's
         // ITU-R P.533-14 engine; always returns 200 with an {available:false}

--- a/cloud/zeuschat-relay/src/chat-room.ts
+++ b/cloud/zeuschat-relay/src/chat-room.ts
@@ -36,6 +36,10 @@ interface Attachment {
   status?: PresenceStatus;
   /** Whether this operator's freq may ever be shared (eye toggle). Default true. */
   freqPublic?: boolean;
+  /** Admin-only "see all frequencies" override: while true, this connection's
+   *  roster carries everyone's freq regardless of friendship / eye toggle.
+   *  Ignored for non-admins. Default false. */
+  seeAllFreq?: boolean;
   since: number;
   // Per-connection message rate-limit window (fixed window).
   rlWindowStart?: number;
@@ -81,7 +85,9 @@ function norm(callsign: string): string {
  *
  * Frequency is private: an operator's freq is only included in another
  * operator's roster when (a) they are mutual friends AND (b) the owner has not
- * hidden their frequency via the eye toggle (freqPublic=false).
+ * hidden their frequency via the eye toggle (freqPublic=false). The one
+ * exception is an admin who has armed the per-connection "see all" override
+ * (admin_see_all), which reveals every operator's freq to that admin alone.
  */
 export class ChatRoom extends DurableObject<Env> {
   // Friend graph (callsign -> related callsigns).
@@ -170,7 +176,7 @@ export class ChatRoom extends DurableObject<Env> {
         ws.serializeAttachment(next);
         this.send(ws, {
           t: 'welcome',
-          self: toOperator(next),
+          self: toOperator(next, true, this.admins.has(callsign)),
           roster: this.rosterFor(callsign),
           isAdmin: this.admins.has(callsign),
         });
@@ -272,6 +278,14 @@ export class ChatRoom extends DurableObject<Env> {
         return;
       case 'admin_list_bans':
         if (this.isAdmin(me)) this.sendBans(ws);
+        return;
+      case 'admin_see_all':
+        if (this.isAdmin(me)) {
+          ws.serializeAttachment({ ...att, seeAllFreq: !!msg.on });
+          // Only the toggling admin's own view changes — re-push their roster
+          // with freqs now un/revealed; everyone else's roster is untouched.
+          this.send(ws, { t: 'roster', roster: this.rosterFor(me) });
+        }
         return;
 
       case 'ping':
@@ -745,12 +759,18 @@ export class ChatRoom extends DurableObject<Env> {
       const cur = best.get(att.callsign);
       if (!cur || attRank(att) > attRank(cur)) best.set(att.callsign, att);
     }
+    // Admin "see all" override: an admin viewer who has armed it sees every
+    // operator's frequency, regardless of friendship or the owner's eye toggle.
+    // Gated on the viewer actually being an admin so a stale/forged attachment
+    // flag can never widen a non-admin's view.
+    const seeAll = this.admins.has(viewer) && best.get(viewer)?.seeAllFreq === true;
     const out: Operator[] = [];
     for (const att of best.values()) {
       const canSeeFreq =
         att.callsign === viewer ||
+        seeAll ||
         (att.freqPublic !== false && (fset?.has(att.callsign) ?? false));
-      out.push(toOperator(att, canSeeFreq));
+      out.push(toOperator(att, canSeeFreq, this.admins.has(att.callsign)));
     }
     out.sort((a, b) => a.callsign.localeCompare(b.callsign));
     return out;
@@ -815,7 +835,7 @@ function attRank(a: Attachment): number {
   return helloed * 1e15 + (a.since ?? 0);
 }
 
-function toOperator(a: Attachment, includeFreq = true): Operator {
+function toOperator(a: Attachment, includeFreq = true, isAdmin = false): Operator {
   return {
     callsign: a.callsign,
     grid: a.grid,
@@ -823,5 +843,6 @@ function toOperator(a: Attachment, includeFreq = true): Operator {
     mode: a.mode,
     status: a.status,
     since: a.since,
+    admin: isAdmin || undefined,
   };
 }

--- a/cloud/zeuschat-relay/src/protocol.ts
+++ b/cloud/zeuschat-relay/src/protocol.ts
@@ -38,6 +38,9 @@ export interface Operator {
   status?: PresenceStatus;
   /** Epoch ms the operator connected. */
   since: number;
+  /** True when this operator is a relay moderator. Lets clients paint admin
+   *  callsigns distinctly (gold). Omitted (falsy) for ordinary operators. */
+  admin?: boolean;
 }
 
 /** A chat channel the operator can see: the public lobby, a group, or a DM. */
@@ -130,6 +133,10 @@ export type ClientToRelay =
   | { t: 'admin_broadcast'; text: string }
   // Ask the relay for the current ban list (relay replies with a `bans` frame).
   | { t: 'admin_list_bans' }
+  // Toggle the admin "see all frequencies" override for THIS connection: while
+  // on, the operator's roster carries every connected operator's frequency,
+  // regardless of friendship or the owner's eye toggle. Ignored unless admin.
+  | { t: 'admin_see_all'; on: boolean }
   // Keepalive. The relay auto-responds with {t:"pong"} without waking (see
   // setWebSocketAutoResponse in chat-room.ts) — send this EXACT string:
   // '{"t":"ping"}'.

--- a/tests/Zeus.Server.Tests/ChatServiceTests.cs
+++ b/tests/Zeus.Server.Tests/ChatServiceTests.cs
@@ -189,6 +189,18 @@ public class ChatServiceTests : IDisposable
     }
 
     [Fact]
+    public void ParseRoster_ReadsAdminFlag_DefaultingFalse()
+    {
+        using var doc = JsonDocument.Parse(
+            """{"t":"roster","roster":[{"callsign":"N9WAR","admin":true,"since":1},{"callsign":"EI6LF","since":2}]}""");
+
+        var roster = ChatService.ParseRoster(doc.RootElement, "roster");
+        Assert.NotNull(roster);
+        Assert.True(roster![0].Admin);  // explicit admin:true
+        Assert.False(roster[1].Admin);  // absent → default false
+    }
+
+    [Fact]
     public void ParseRoster_ReturnsNull_WhenPropertyMissingOrNotArray()
     {
         using var doc = JsonDocument.Parse("""{"t":"welcome"}""");
@@ -304,11 +316,27 @@ public class ChatServiceTests : IDisposable
         var status = chat.GetStatus();
         Assert.False(status.Enabled);   // opt-in default OFF
         Assert.False(status.Connected); // worker never ran a connection
+        Assert.False(status.SeeAllFreq); // admin see-all override default OFF
         Assert.Equal(ChatService.DefaultRelayUrl, status.RelayUrl);
 
         // Send must fail with 409-mapped exception when not connected.
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => chat.SendMessageAsync("hello", null, null, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task SetSeeAllFreq_ReflectsInStatus_WhenDisconnected()
+    {
+        using var chat = BuildChat();
+
+        // Toggling the override while offline persists the session flag and shows
+        // in status (no relay frame is sent — there's no socket), so the admin
+        // console reflects their choice immediately.
+        await chat.SetSeeAllFreqAsync(true, CancellationToken.None);
+        Assert.True(chat.GetStatus().SeeAllFreq);
+
+        await chat.SetSeeAllFreqAsync(false, CancellationToken.None);
+        Assert.False(chat.GetStatus().SeeAllFreq);
     }
 
     [Fact]

--- a/zeus-web/src/api/chat.ts
+++ b/zeus-web/src/api/chat.ts
@@ -27,6 +27,8 @@ export type ChatOperator = {
   status: ChatOperatorStatus | null;
   /** Epoch ms — when this operator joined / was last seen. */
   since: number;
+  /** True when this operator is a relay moderator (callsign painted gold). */
+  admin: boolean;
 };
 
 /**
@@ -74,6 +76,8 @@ export type ChatStatus = {
   isAdmin: boolean;
   /** Whether this operator's frequency is shared at all (eye toggle). */
   freqPublic: boolean;
+  /** Admin only: whether the "see all frequencies" override is armed. */
+  seeAllFreq: boolean;
 };
 
 export type ChatRoomKind = 'public' | 'group' | 'dm';
@@ -116,6 +120,7 @@ export function normalizeStatus(raw: unknown): ChatStatus {
     error: toStr(r.error),
     isAdmin: Boolean(r.isAdmin),
     freqPublic: r.freqPublic !== false, // default visible
+    seeAllFreq: Boolean(r.seeAllFreq),
   };
 }
 
@@ -139,6 +144,7 @@ export function normalizeOperator(raw: unknown): ChatOperator {
     mode: toStr(r.mode),
     status: toStatus(r.status),
     since: toNum(r.since) ?? 0,
+    admin: Boolean(r.admin),
   };
 }
 
@@ -375,3 +381,7 @@ export const chatBroadcast = (text: string, signal?: AbortSignal) =>
 /** Admin: request the current ban list (relay replies with a `bans` push frame). */
 export const chatListBans = (signal?: AbortSignal) =>
   postOk('/api/chat/admin/bans', {}, signal);
+/** Admin: arm/disarm the "see all frequencies" override (reveals every
+ *  operator's freq to this admin regardless of friendship / eye toggle). */
+export const chatSetSeeAll = (on: boolean, signal?: AbortSignal) =>
+  postOk('/api/chat/admin/see-all', { on }, signal);

--- a/zeus-web/src/layout/panels/ChatPanel.tsx
+++ b/zeus-web/src/layout/panels/ChatPanel.tsx
@@ -210,18 +210,24 @@ function CallsignButton({
   onOpen,
   prominent,
   own,
+  admin,
 }: {
   callsign: string;
   onOpen: (callsign: string) => void;
   prominent?: boolean;
   own?: boolean;
+  /** Relay moderator — callsign is painted gold (takes priority over `own`). */
+  admin?: boolean;
 }) {
+  // Admins are gold network-wide; otherwise your own callsign reads in the
+  // accent blue, and everyone else in the default foreground.
+  const color = admin ? 'var(--power)' : own ? 'var(--accent-bright)' : 'var(--fg-0)';
   return (
     <button
       type="button"
       className="mono"
       onClick={() => onOpen(callsign)}
-      title={`Open ${callsign} on QRZ`}
+      title={admin ? `Open ${callsign} on QRZ · ZeusChat moderator` : `Open ${callsign} on QRZ`}
       style={{
         background: 'none',
         border: 'none',
@@ -231,7 +237,7 @@ function CallsignButton({
         fontWeight: prominent ? 700 : 600,
         fontSize: prominent ? 12.5 : 12,
         letterSpacing: '0.04em',
-        color: own ? 'var(--accent-bright)' : 'var(--fg-0)',
+        color,
         textAlign: 'left',
       }}
       onMouseEnter={(e) => (e.currentTarget.style.textDecoration = 'underline')}
@@ -318,7 +324,7 @@ function RosterRow({
     >
       <StatusDot status={op.status} />
       <div style={{ minWidth: 0, flex: 1 }}>
-        <CallsignButton callsign={op.callsign} onOpen={onOpen} prominent />
+        <CallsignButton callsign={op.callsign} onOpen={onOpen} prominent admin={op.admin} />
         {/* Frequency / mode — only present for friends sharing their freq
             (the relay strips freqHz for everyone else). */}
         {freq !== '—' && (
@@ -530,11 +536,14 @@ function PaperclipIcon() {
 function MessageRow({
   msg,
   own,
+  fromAdmin,
   onOpen,
   onExpandImage,
 }: {
   msg: ChatMessage;
   own: boolean;
+  /** Sender is a relay moderator — paint their callsign gold. */
+  fromAdmin: boolean;
   onOpen: (callsign: string) => void;
   onExpandImage: (att: ChatAttachment) => void;
 }) {
@@ -554,7 +563,7 @@ function MessageRow({
       }}
     >
       <div style={{ display: 'flex', gap: 6, alignItems: 'baseline' }}>
-        <CallsignButton callsign={msg.from} onOpen={onOpen} own={own} />
+        <CallsignButton callsign={msg.from} onOpen={onOpen} own={own} admin={fromAdmin} />
         <span
           className="mono"
           title={fmtClock(msg.ts)}
@@ -1301,6 +1310,103 @@ function AdminAction({
 }
 
 /**
+ * A toggle row in the admin console: icon + title + one-line description and a
+ * pill switch on the right. Mirrors AdminAction's layout but drives an on/off
+ * state rather than a one-shot action.
+ */
+function AdminToggle({
+  icon,
+  title,
+  description,
+  on,
+  onToggle,
+}: {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  on: boolean;
+  onToggle: (next: boolean) => void;
+}) {
+  const [hovered, setHovered] = useState(false);
+  const accent = 'var(--power)';
+  return (
+    <div
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        padding: '7px 9px',
+        borderRadius: 'var(--r-sm)',
+        background: 'var(--bg-2)',
+        border: '1px solid var(--line)',
+        boxShadow: on || hovered ? ADMIN_GOLD_RING : 'none',
+        transition: 'box-shadow var(--dur-fast) var(--ease-out)',
+      }}
+    >
+      <span
+        aria-hidden
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 26,
+          height: 26,
+          flexShrink: 0,
+          borderRadius: 'var(--r-sm)',
+          background: 'var(--power-soft)',
+          color: accent,
+        }}
+      >
+        {icon}
+      </span>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 11.5, fontWeight: 700, color: 'var(--fg-0)', letterSpacing: '0.02em' }}>
+          {title}
+        </div>
+        <div style={{ fontSize: 10, color: 'var(--fg-3)', lineHeight: 1.35, marginTop: 1 }}>
+          {description}
+        </div>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={on}
+        aria-label={title}
+        onClick={() => onToggle(!on)}
+        style={{
+          flexShrink: 0,
+          position: 'relative',
+          width: 34,
+          height: 18,
+          borderRadius: 9,
+          border: '1px solid var(--line-strong)',
+          background: on ? 'var(--power)' : 'var(--bg-3)',
+          cursor: 'pointer',
+          padding: 0,
+          transition: 'background var(--dur-fast) var(--ease-out)',
+        }}
+      >
+        <span
+          aria-hidden
+          style={{
+            position: 'absolute',
+            top: 1,
+            left: on ? 17 : 1,
+            width: 14,
+            height: 14,
+            borderRadius: '50%',
+            background: on ? '#1a1205' : 'var(--fg-2)',
+            transition: 'left var(--dur-fast) var(--ease-out)',
+          }}
+        />
+      </button>
+    </div>
+  );
+}
+
+/**
  * The unban surface: a live list of every currently-banned callsign (relay-
  * authoritative, persisted across relay restarts). Each row lifts that ban; the
  * relay echoes the updated list back so the dialog updates in place and stays
@@ -1404,6 +1510,8 @@ function AdminConsole() {
   const listBans = useChatStore((s) => s.listBans);
   const bannedUsers = useChatStore((s) => s.bannedUsers);
   const ownCall = useChatStore((s) => s.callsign);
+  const seeAllFreq = useChatStore((s) => s.seeAllFreq);
+  const setSeeAll = useChatStore((s) => s.setSeeAll);
 
   // Refresh the ban list whenever the console is opened, so the count + list are
   // current without waiting for the next ban/unban push.
@@ -1479,6 +1587,13 @@ function AdminConsole() {
             . These actions affect <strong style={{ color: 'var(--fg-1)' }}>every connected operator</strong>.
           </div>
 
+          <AdminToggle
+            icon={<EyeIcon open />}
+            title="See all frequencies"
+            description="Reveal every operator's frequency on your roster and panadapter — regardless of friendship or their eye toggle. Visible to you only."
+            on={seeAllFreq}
+            onToggle={(next) => void setSeeAll(next)}
+          />
           <AdminAction
             icon={<MegaphoneIcon />}
             title="Global message"
@@ -1706,6 +1821,12 @@ export function ChatPanel() {
   const friendSet = useMemo(() => new Set(acceptedFriends.map((c) => c.toUpperCase())), [acceptedFriends]);
   const outgoingSet = useMemo(() => new Set(outgoingRequests.map((c) => c.toUpperCase())), [outgoingRequests]);
   const incomingSet = useMemo(() => new Set(incomingRequests.map((c) => c.toUpperCase())), [incomingRequests]);
+  // Callsigns the relay flagged as moderators — drives the gold callsign paint
+  // for message authors (roster rows read op.admin directly).
+  const adminCalls = useMemo(
+    () => new Set(roster.filter((op) => op.admin).map((op) => op.callsign.toUpperCase())),
+    [roster],
+  );
 
   const friendsOnline = useMemo(
     () => sortedRoster.filter((op) => friendSet.has(op.callsign.toUpperCase())),
@@ -2398,6 +2519,7 @@ export function ChatPanel() {
                     key={m.id || `${m.from}-${m.ts}`}
                     msg={m}
                     own={own}
+                    fromAdmin={adminCalls.has(m.from.toUpperCase())}
                     onOpen={openProfile}
                     onExpandImage={setLightbox}
                   />

--- a/zeus-web/src/state/chat-store.ts
+++ b/zeus-web/src/state/chat-store.ts
@@ -48,6 +48,7 @@ import {
   chatClearRoom,
   chatBroadcast,
   chatListBans,
+  chatSetSeeAll,
   normalizeStatus,
   normalizeOperator,
   normalizeMessage,
@@ -109,6 +110,8 @@ export type ChatStoreState = {
   relayError: string | null;
   isAdmin: boolean;
   freqPublic: boolean;
+  /** Admin only: whether the "see all frequencies" override is armed. */
+  seeAllFreq: boolean;
   roster: ChatOperator[];
 
   // Channels + per-room message threads + which tab is active.
@@ -148,6 +151,8 @@ export type ChatStoreState = {
   closeDm: (room: string) => void;
   requestRoomHistory: (room: string) => Promise<void>;
   setFreqVisibility: (isPublic: boolean) => Promise<void>;
+  /** Admin: arm/disarm the "see all frequencies" override. */
+  setSeeAll: (on: boolean) => Promise<void>;
   requestFriend: (callsign: string) => Promise<void>;
   acceptFriend: (callsign: string) => Promise<void>;
   denyFriend: (callsign: string) => Promise<void>;
@@ -176,6 +181,7 @@ function applyStatus(s: ChatStatus): Partial<ChatStoreState> {
     relayError: s.error,
     isAdmin: s.isAdmin,
     freqPublic: s.freqPublic,
+    seeAllFreq: s.seeAllFreq,
   };
 }
 
@@ -216,6 +222,7 @@ export const useChatStore = create<ChatStoreState>((set, get) => ({
   relayError: null,
   isAdmin: false,
   freqPublic: true,
+  seeAllFreq: false,
   roster: [],
   rooms: [{ id: PUBLIC_ROOM, name: 'Public', kind: 'public', members: [] }],
   activeRoom: PUBLIC_ROOM,
@@ -355,6 +362,16 @@ export const useChatStore = create<ChatStoreState>((set, get) => ({
     set({ freqPublic: isPublic }); // optimistic; status frame confirms
     try {
       await chatSetFreqVisibility(isPublic);
+    } catch (err) {
+      set({ relayError: errMsg(err) });
+      void get().refreshStatus();
+    }
+  },
+
+  setSeeAll: async (on) => {
+    set({ seeAllFreq: on }); // optimistic; status frame confirms
+    try {
+      await chatSetSeeAll(on);
     } catch (err) {
       set({ relayError: errMsg(err) });
       void get().refreshStatus();


### PR DESCRIPTION
## What

Two moderator-facing ZeusChat features, end-to-end across the relay, C# backend, and web frontend.

### 1. Admin callsigns render gold
The relay roster `Operator` now carries an `admin` flag (set from the DO's admin set in `toOperator`), mirrored as `ChatOperator.Admin` (C#) and `ChatOperator.admin` (web). `CallsignButton` paints admins in `--power` gold — priority over the blue *own* colour — for both roster rows (`op.admin`) and message authors (via an `adminCalls` set built from the roster).

### 2. Admin "see all frequencies" override
A per-connection toggle in the **Admin Console** reveals **every** operator's frequency to that admin alone.

- Wire path: web `setSeeAll` → `POST /api/chat/admin/see-all` → `ChatService.SetSeeAllFreqAsync` → relay `{t:'admin_see_all',on}`, stored on the DO connection attachment (`seeAllFreq`) and applied in `rosterFor`.
- **Bypasses both the friendship gate and the owner's eye toggle** (`freqPublic=false`) — full oversight, matching "see all".
- Gated on `this.admins.has(viewer)` so a forged/stale attachment flag can never widen a non-admin's view.
- Session-scoped (default **OFF**); re-asserted to the relay after each reconnect so a network blip doesn't silently drop it.

## Design note
The "see all" override is intentionally a *full* override (friendship **and** eye toggle). If maintainers would rather it respect an operator who explicitly hid their freq, that's a one-line change in `rosterFor`.

## Testing
- ✅ .NET build + **24 chat tests** pass (adds `ParseRoster_ReadsAdminFlag_DefaultingFalse` + `SetSeeAllFreq_ReflectsInStatus_WhenDisconnected`)
- ✅ Relay `tsc --noEmit` clean
- ✅ Web `tsc -b --noEmit` clean + **10 chat-store tests** pass

## Notes
- Wire-format change (`Zeus.Contracts` `ChatOperator.Admin`, `ChatStatusDto.SeeAllFreq`) — additive, backward-compatible (new fields default false). Flagging per the contracts red-light rule.
- The gold callsign colour reuses the existing `--power` token; no new palette.