### PR TITLE
feat(web,chat): voice message recording (60s) in chat

### DIFF
--- a/Zeus.Contracts/ChatDtos.cs
+++ b/Zeus.Contracts/ChatDtos.cs
@@ -53,15 +53,16 @@ namespace Zeus.Contracts;
 // names serialise camelCase on the wire (JsonSerializerDefaults.Web).
 
 /// <summary>
-/// An inline media attachment carried alongside a chat message. Photos are sent
-/// "like a text message": the bytes ride inside the message as a base64 data URL
-/// (<paramref name="DataUrl"/>, e.g. <c>data:image/jpeg;base64,…</c>) rather than
-/// via out-of-band blob storage. The web client downscales/compresses before
-/// sending so the encoded size stays within <see cref="MaxDataUrlLength"/> — the
-/// relay persists the whole message in a single Durable-Object value (128 KiB
-/// cap), so the attachment must comfortably fit under that with room to spare.
-/// <paramref name="Kind"/> is "image" for now (the only supported kind);
-/// unknown kinds are ignored by clients so future kinds stay compatible.
+/// An inline media attachment carried alongside a chat message. Photos and voice
+/// snippets are sent "like a text message": the bytes ride inside the message as
+/// a base64 data URL (<paramref name="DataUrl"/>, e.g. <c>data:image/jpeg;base64,…</c>
+/// or <c>data:audio/webm;base64,…</c>) rather than via out-of-band blob storage.
+/// The web client downscales/compresses photos and records voice at a low Opus
+/// bitrate before sending so the encoded size stays within
+/// <see cref="MaxDataUrlLength"/> — the relay persists the whole message in a
+/// single Durable-Object value (128 KiB cap), so the attachment must comfortably
+/// fit under that with room to spare. <paramref name="Kind"/> is "image" or
+/// "audio"; unknown kinds are ignored by clients so future kinds stay compatible.
 /// </summary>
 public sealed record ChatAttachment(
     string Kind,

--- a/Zeus.Server.Hosting/ChatService.cs
+++ b/Zeus.Server.Hosting/ChatService.cs
@@ -221,24 +221,30 @@ public sealed class ChatService : BackgroundService
     }
 
     /// <summary>
-    /// Validates an outgoing attachment: image kind, image/* MIME, non-empty
-    /// data URL within <see cref="ChatAttachment.MaxDataUrlLength"/>. Returns the
-    /// attachment unchanged (passthrough) or null when none was supplied. Throws
+    /// Validates an outgoing attachment: image or audio kind with a matching
+    /// MIME family + data-URL scheme, non-empty data URL within
+    /// <see cref="ChatAttachment.MaxDataUrlLength"/>. Returns the attachment
+    /// unchanged (passthrough) or null when none was supplied. Throws
     /// <see cref="ArgumentException"/> (mapped to 400 by the endpoint) on a bad
     /// or oversized attachment so a buggy/hostile client can't push payloads the
-    /// relay would store. The web client downscales to fit before sending; this
-    /// is the backend guardrail, not the primary size control.
+    /// relay would store. The web client downscales photos / records voice at a
+    /// low bitrate to fit before sending; this is the backend guardrail, not the
+    /// primary size control.
     /// </summary>
     private static ChatAttachment? ValidateAttachment(ChatAttachment? attachment)
     {
         if (attachment is null) return null;
-        if (!string.Equals(attachment.Kind, "image", StringComparison.Ordinal))
+        var isImage = string.Equals(attachment.Kind, "image", StringComparison.Ordinal);
+        var isAudio = string.Equals(attachment.Kind, "audio", StringComparison.Ordinal);
+        if (!isImage && !isAudio)
             throw new ArgumentException("unsupported attachment kind", nameof(attachment));
+        var mimePrefix = isAudio ? "audio/" : "image/";
+        var dataPrefix = isAudio ? "data:audio/" : "data:image/";
         if (string.IsNullOrEmpty(attachment.Mime) ||
-            !attachment.Mime.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
-            throw new ArgumentException("attachment must be an image", nameof(attachment));
+            !attachment.Mime.StartsWith(mimePrefix, StringComparison.OrdinalIgnoreCase))
+            throw new ArgumentException($"attachment must be {(isAudio ? "audio" : "an image")}", nameof(attachment));
         if (string.IsNullOrEmpty(attachment.DataUrl) ||
-            !attachment.DataUrl.StartsWith("data:image/", StringComparison.OrdinalIgnoreCase))
+            !attachment.DataUrl.StartsWith(dataPrefix, StringComparison.OrdinalIgnoreCase))
             throw new ArgumentException("attachment data is empty or malformed", nameof(attachment));
         if (attachment.DataUrl.Length > ChatAttachment.MaxDataUrlLength)
             throw new ArgumentException("attachment is too large", nameof(attachment));
@@ -651,9 +657,11 @@ public sealed class ChatService : BackgroundService
 
     /// <summary>
     /// Parses an optional <c>attachment</c> object out of a relay message frame.
-    /// Returns null when absent, malformed, not an image, or oversized — a bad
-    /// attachment degrades to a plain message rather than dropping it. Internal
-    /// for unit tests.
+    /// Returns null when absent, malformed, an unsupported media type, or
+    /// oversized — a bad attachment degrades to a plain message rather than
+    /// dropping it. Accepts image and audio (voice snippet) kinds, deriving the
+    /// <c>kind</c> from the MIME/scheme family so a mislabelled payload can't slip
+    /// through. Internal for unit tests.
     /// </summary>
     internal static ChatAttachment? ParseAttachment(JsonElement root)
     {
@@ -662,10 +670,14 @@ public sealed class ChatService : BackgroundService
         var dataUrl = ReadString(a, "dataUrl");
         var mime = ReadString(a, "mime");
         if (string.IsNullOrEmpty(dataUrl) || string.IsNullOrEmpty(mime)) return null;
-        if (!dataUrl.StartsWith("data:image/", StringComparison.OrdinalIgnoreCase)) return null;
+        var isImage = mime.StartsWith("image/", StringComparison.OrdinalIgnoreCase) &&
+            dataUrl.StartsWith("data:image/", StringComparison.OrdinalIgnoreCase);
+        var isAudio = mime.StartsWith("audio/", StringComparison.OrdinalIgnoreCase) &&
+            dataUrl.StartsWith("data:audio/", StringComparison.OrdinalIgnoreCase);
+        if (!isImage && !isAudio) return null;
         if (dataUrl.Length > ChatAttachment.MaxDataUrlLength) return null;
         return new ChatAttachment(
-            Kind: ReadString(a, "kind") ?? "image",
+            Kind: isAudio ? "audio" : "image",
             Mime: mime,
             DataUrl: dataUrl,
             Name: ReadString(a, "name"),

--- a/cloud/zeuschat-relay/src/chat-room.ts
+++ b/cloud/zeuschat-relay/src/chat-room.ts
@@ -770,16 +770,19 @@ export class ChatRoom extends DurableObject<Env> {
  * undefined when absent/malformed/oversized/not-an-image — in which case the
  * message still delivers as text. Defensive: a backend or hostile client could
  * send anything, and the result is persisted + broadcast to the whole room, so
- * enforce the image-only + size invariants here regardless of the C# guard.
+ * enforce the image|audio + size invariants here regardless of the C# guard. The
+ * `kind` is derived from the MIME/scheme family so a mislabelled payload can't
+ * slip through.
  */
 function sanitizeAttachment(a: MsgAttachment | undefined): MsgAttachment | undefined {
   if (!a || typeof a !== 'object') return undefined;
   const mime = typeof a.mime === 'string' ? a.mime : '';
   const dataUrl = typeof a.dataUrl === 'string' ? a.dataUrl : '';
-  if (!mime.startsWith('image/')) return undefined;
-  if (!dataUrl.startsWith('data:image/')) return undefined;
+  const isImage = mime.startsWith('image/') && dataUrl.startsWith('data:image/');
+  const isAudio = mime.startsWith('audio/') && dataUrl.startsWith('data:audio/');
+  if (!isImage && !isAudio) return undefined;
   if (dataUrl.length > MAX_ATTACHMENT_DATAURL_LEN) return undefined;
-  const clean: MsgAttachment = { kind: 'image', mime, dataUrl };
+  const clean: MsgAttachment = { kind: isAudio ? 'audio' : 'image', mime, dataUrl };
   if (typeof a.name === 'string' && a.name) clean.name = a.name.slice(0, 200);
   if (typeof a.width === 'number' && Number.isFinite(a.width)) clean.width = a.width;
   if (typeof a.height === 'number' && Number.isFinite(a.height)) clean.height = a.height;

--- a/cloud/zeuschat-relay/src/protocol.ts
+++ b/cloud/zeuschat-relay/src/protocol.ts
@@ -55,15 +55,16 @@ export interface RoomInfo {
  * An inline media attachment carried with a message. Photos are sent "like a
  * text message": the bytes ride inside the message as a base64 data URL rather
  * than via out-of-band blob storage. The Zeus web client downscales/compresses
- * so `dataUrl` stays under MAX_ATTACHMENT_DATAURL_LEN — the whole message is
- * stored in a single Durable-Object value (128 KiB cap), so it must fit with
- * headroom. `kind` is "image" for now; unknown kinds are ignored by clients.
+ * photos and records voice at a low Opus bitrate so `dataUrl` stays under
+ * MAX_ATTACHMENT_DATAURL_LEN — the whole message is stored in a single
+ * Durable-Object value (128 KiB cap), so it must fit with headroom. `kind` is
+ * "image" or "audio"; unknown kinds are ignored by clients.
  */
 export interface Attachment {
   kind: string;
-  /** MIME type, e.g. "image/jpeg". Must start with "image/". */
+  /** MIME type, e.g. "image/jpeg" or "audio/webm". Must match the kind family. */
   mime: string;
-  /** Base64 data URL, e.g. "data:image/jpeg;base64,…". */
+  /** Base64 data URL, e.g. "data:image/jpeg;base64,…" or "data:audio/webm;base64,…". */
   dataUrl: string;
   /** Original filename, if known. */
   name?: string;

--- a/tests/Zeus.Server.Tests/ChatServiceTests.cs
+++ b/tests/Zeus.Server.Tests/ChatServiceTests.cs
@@ -149,12 +149,31 @@ public class ChatServiceTests : IDisposable
     }
 
     [Fact]
+    public void ParseMessage_ReadsAudioAttachment()
+    {
+        using var doc = JsonDocument.Parse(
+            """{"t":"msg","from":"N9WAR","text":"","room":"lobby","attachment":{"kind":"audio","mime":"audio/webm","dataUrl":"data:audio/webm;base64,GkXfAA==","name":"voice-message.webm","size":2048}}""");
+        var msg = ChatService.ParseMessage(doc.RootElement);
+
+        Assert.NotNull(msg.Attachment);
+        Assert.Equal("audio", msg.Attachment!.Kind);
+        Assert.Equal("audio/webm", msg.Attachment.Mime);
+        Assert.StartsWith("data:audio/webm;base64,", msg.Attachment.DataUrl);
+        Assert.Equal("voice-message.webm", msg.Attachment.Name);
+    }
+
+    [Fact]
     public void ParseAttachment_DropsNonImageOrOversize()
     {
-        // Non-image data URL → dropped (message degrades to text-only).
+        // Non-image / non-audio data URL → dropped (message degrades to text-only).
         using var bad = JsonDocument.Parse(
             """{"t":"msg","from":"N9WAR","text":"x","attachment":{"kind":"image","mime":"application/pdf","dataUrl":"data:application/pdf;base64,AAAA"}}""");
         Assert.Null(ChatService.ParseMessage(bad.RootElement).Attachment);
+
+        // Mismatched family (audio MIME but image data scheme) → dropped.
+        using var mismatch = JsonDocument.Parse(
+            """{"t":"msg","from":"N9WAR","text":"x","attachment":{"kind":"audio","mime":"audio/webm","dataUrl":"data:image/png;base64,AAAA"}}""");
+        Assert.Null(ChatService.ParseMessage(mismatch.RootElement).Attachment);
 
         // Oversized data URL → dropped.
         var huge = new string('A', ChatAttachment.MaxDataUrlLength + 1);

--- a/zeus-web/src/api/chat.ts
+++ b/zeus-web/src/api/chat.ts
@@ -30,15 +30,16 @@ export type ChatOperator = {
 };
 
 /**
- * An inline media attachment carried with a message. Photos are sent "like a
- * text message": the bytes ride inside the message as a base64 data URL. The
- * client downscales/compresses before sending (see util/chat-image.ts) so the
- * encoded size stays within the relay's per-message storage cap.
+ * An inline media attachment carried with a message. Photos and voice snippets
+ * are sent "like a text message": the bytes ride inside the message as a base64
+ * data URL. The client downscales/compresses photos (see util/chat-image.ts) and
+ * records voice at a low Opus bitrate (see util/chat-audio.ts) so the encoded
+ * size stays within the relay's per-message storage cap.
  */
 export type ChatAttachment = {
-  /** Only "image" today; unknown kinds are ignored when rendering. */
+  /** "image" or "audio"; unknown kinds are ignored when rendering. */
   kind: string;
-  /** MIME type, e.g. "image/jpeg". */
+  /** MIME type, e.g. "image/jpeg" or "audio/webm". */
   mime: string;
   /** Base64 data URL — usable directly as an <img> src. */
   dataUrl: string;
@@ -158,20 +159,23 @@ export function normalizeFriends(raw: unknown): ChatFriends {
 }
 
 /**
- * Parse an optional attachment. Returns null unless it is a well-formed image
- * data URL within the size cap — a malformed/oversized attachment degrades the
- * message to text-only rather than rendering a broken image.
+ * Parse an optional attachment. Returns null unless it is a well-formed image or
+ * audio data URL within the size cap — a malformed/oversized/unsupported
+ * attachment degrades the message to text-only rather than rendering a broken
+ * one. The `kind` is derived from the MIME family so a hostile/buggy sender
+ * can't mislabel an image as audio (or vice-versa).
  */
 export function normalizeAttachment(raw: unknown): ChatAttachment | null {
   if (!raw || typeof raw !== 'object') return null;
   const r = raw as Record<string, unknown>;
   const mime = typeof r.mime === 'string' ? r.mime : '';
   const dataUrl = typeof r.dataUrl === 'string' ? r.dataUrl : '';
-  if (!mime.startsWith('image/')) return null;
-  if (!dataUrl.startsWith('data:image/')) return null;
+  const isImage = mime.startsWith('image/') && dataUrl.startsWith('data:image/');
+  const isAudio = mime.startsWith('audio/') && dataUrl.startsWith('data:audio/');
+  if (!isImage && !isAudio) return null;
   if (dataUrl.length > MAX_ATTACHMENT_DATAURL_LEN) return null;
   return {
-    kind: 'image',
+    kind: isAudio ? 'audio' : 'image',
     mime,
     dataUrl,
     name: toStr(r.name),
@@ -179,6 +183,11 @@ export function normalizeAttachment(raw: unknown): ChatAttachment | null {
     height: toNum(r.height),
     size: toNum(r.size),
   };
+}
+
+/** Whether an attachment is a voice/audio clip (vs. an inline photo). */
+export function isAudioAttachment(att: ChatAttachment | null | undefined): boolean {
+  return !!att && (att.kind === 'audio' || att.mime.startsWith('audio/'));
 }
 
 export function normalizeMessage(raw: unknown): ChatMessage {

--- a/zeus-web/src/layout/panels/ChatPanel.tsx
+++ b/zeus-web/src/layout/panels/ChatPanel.tsx
@@ -32,6 +32,8 @@ import {
   ChatImageError,
   CHAT_IMAGE_ACCEPT,
 } from '../../util/chat-image';
+import { useVoiceRecorder, fmtDuration, MAX_VOICE_MS } from '../../util/chat-audio';
+import { isAudioAttachment } from '../../api/chat';
 import { useQrzStore } from '../../state/qrz-store';
 import { useProfileOverlayStore } from '../../state/profile-overlay-store';
 import { useDisplaySettingsStore } from '../../state/display-settings-store';
@@ -507,6 +509,28 @@ function RequestRow({
   );
 }
 
+/** Small microphone glyph for the voice-record button (inherits text color). */
+function MicIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      style={{ display: 'block' }}
+    >
+      <rect x="9" y="2" width="6" height="11" rx="3" />
+      <path d="M5 10v1a7 7 0 0 0 14 0v-1" />
+      <line x1="12" y1="18" x2="12" y2="22" />
+    </svg>
+  );
+}
+
 /** Small paperclip glyph for the attach button (inherits text color). */
 function PaperclipIcon() {
   return (
@@ -540,6 +564,7 @@ function MessageRow({
 }) {
   const att = msg.attachment;
   const hasText = msg.text.trim().length > 0;
+  const audio = isAudioAttachment(att);
   // Constrain the thumbnail to the message's native aspect when known so the
   // bubble doesn't jump as the image decodes.
   const ratio = att && att.width && att.height ? att.width / att.height : undefined;
@@ -572,7 +597,33 @@ function MessageRow({
           maxWidth: '85%',
         }}
       >
-        {att ? (
+        {att && audio ? (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              padding: '6px 10px',
+              borderRadius: 'var(--r-lg)',
+              border: own ? '1px solid var(--accent-line)' : '1px solid var(--line)',
+              background: own ? 'var(--accent-soft)' : 'var(--bg-2)',
+              maxWidth: '100%',
+            }}
+          >
+            <span
+              aria-hidden
+              style={{ display: 'flex', alignItems: 'center', color: own ? 'var(--accent-bright)' : 'var(--fg-2)', flexShrink: 0 }}
+            >
+              <MicIcon />
+            </span>
+            <audio
+              src={att.dataUrl}
+              controls
+              preload="metadata"
+              style={{ height: 32, maxWidth: 220 }}
+            />
+          </div>
+        ) : att ? (
           <button
             type="button"
             onClick={() => onExpandImage(att)}
@@ -1830,6 +1881,17 @@ export function ChatPanel() {
     }
   }, []);
 
+  // Voice snippet capture — a finished recording stages exactly like a photo
+  // (pendingAttachment), so the operator can add a caption then Send.
+  const onVoiceComplete = useCallback((att: ChatAttachment) => {
+    setAttachError(null);
+    setPendingAttachment(att);
+    inputRef.current?.focus();
+  }, []);
+  const voice = useVoiceRecorder(onVoiceComplete);
+  // Surface either the photo-attach error or the recorder error in one slot.
+  const composerError = attachError ?? voice.error;
+
   // Status pill
   const statusPill = (() => {
     if (!enabled) return { color: 'var(--fg-3)', bg: 'var(--bg-2)', label: 'Disabled' };
@@ -2429,7 +2491,7 @@ export function ChatPanel() {
               }}
             />
 
-            {/* Pending photo preview + attach error. */}
+            {/* Pending attachment preview (photo or voice snippet) + error. */}
             {pendingAttachment ? (
               <div
                 style={{
@@ -2442,116 +2504,219 @@ export function ChatPanel() {
                   border: '1px solid var(--line)',
                 }}
               >
-                <img
-                  src={pendingAttachment.dataUrl}
-                  alt={pendingAttachment.name ?? 'Attached photo'}
-                  style={{
-                    width: 40,
-                    height: 40,
-                    objectFit: 'cover',
-                    borderRadius: 'var(--r-sm)',
-                    flexShrink: 0,
-                  }}
-                />
-                <span
-                  className="mono"
-                  style={{
-                    flex: 1,
-                    minWidth: 0,
-                    fontSize: 10.5,
-                    color: 'var(--fg-2)',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                  }}
-                >
-                  {pendingAttachment.name ?? 'photo.jpg'}
-                  {pendingAttachment.size
-                    ? ` · ${Math.max(1, Math.round(pendingAttachment.size / 1024))} KB`
-                    : ''}
-                </span>
+                {isAudioAttachment(pendingAttachment) ? (
+                  <>
+                    <span
+                      aria-hidden
+                      style={{ display: 'flex', alignItems: 'center', color: 'var(--accent-bright)', flexShrink: 0, paddingLeft: 2 }}
+                    >
+                      <MicIcon />
+                    </span>
+                    <audio
+                      src={pendingAttachment.dataUrl}
+                      controls
+                      preload="metadata"
+                      style={{ flex: 1, minWidth: 0, height: 32 }}
+                    />
+                  </>
+                ) : (
+                  <>
+                    <img
+                      src={pendingAttachment.dataUrl}
+                      alt={pendingAttachment.name ?? 'Attached photo'}
+                      style={{
+                        width: 40,
+                        height: 40,
+                        objectFit: 'cover',
+                        borderRadius: 'var(--r-sm)',
+                        flexShrink: 0,
+                      }}
+                    />
+                    <span
+                      className="mono"
+                      style={{
+                        flex: 1,
+                        minWidth: 0,
+                        fontSize: 10.5,
+                        color: 'var(--fg-2)',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {pendingAttachment.name ?? 'photo.jpg'}
+                      {pendingAttachment.size
+                        ? ` · ${Math.max(1, Math.round(pendingAttachment.size / 1024))} KB`
+                        : ''}
+                    </span>
+                  </>
+                )}
                 <button
                   type="button"
                   className="btn sm"
                   onClick={() => setPendingAttachment(null)}
-                  title="Remove photo"
+                  title={isAudioAttachment(pendingAttachment) ? 'Remove voice message' : 'Remove photo'}
+                  style={{ flexShrink: 0 }}
                 >
                   ✕
                 </button>
               </div>
             ) : null}
-            {attachError ? (
+            {composerError ? (
               <div className="mono" style={{ fontSize: 10, color: 'var(--tx)', paddingLeft: 2 }}>
-                {attachError}
+                {composerError}
               </div>
             ) : null}
 
-            <div style={{ display: 'flex', gap: 6, alignItems: 'flex-end' }}>
-              {/* Paperclip — attach a photo. */}
-              <button
-                type="button"
-                className="btn sm"
-                disabled={!connected || attaching || lockedActive}
-                onClick={() => fileInputRef.current?.click()}
-                title={connected ? (lockedActive ? 'Not a member of this group' : 'Attach a photo') : 'Not connected'}
-                aria-label="Attach a photo"
-                style={{ flexShrink: 0, padding: '5px 8px' }}
-              >
-                {attaching ? '…' : <PaperclipIcon />}
-              </button>
-              <textarea
-                ref={inputRef}
-                className="mono"
-                value={draft}
-                onChange={(e) => setDraft(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' && !e.shiftKey) {
-                    e.preventDefault();
-                    void doSend();
-                  }
-                }}
-                onPaste={(e) => {
-                  // Paste an image straight from the clipboard, like texting.
-                  const item = Array.from(e.clipboardData.items).find((it) =>
-                    it.type.startsWith('image/'),
-                  );
-                  if (item) {
-                    e.preventDefault();
-                    void attachFile(item.getAsFile());
-                  }
-                }}
-                placeholder={composerPlaceholder}
-                disabled={!connected || lockedActive}
-                rows={1}
-                maxLength={MAX_MESSAGE_CHARS + 64}
+            {voice.recording ? (
+              /* Recording strip — replaces the input while capturing a voice
+                 snippet. Auto-stops at MAX_VOICE_MS; Stop stages it for sending. */
+              <div
                 style={{
-                  flex: 1,
-                  resize: 'none',
-                  overflowY: 'auto',
-                  maxHeight: 90,
-                  minHeight: 28,
-                  padding: '5px 8px',
-                  boxSizing: 'border-box',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  padding: '6px 8px',
                   borderRadius: 'var(--r-sm)',
-                  border: composerBorder,
-                  background: connected ? '#0c0c10' : 'var(--bg-1)',
-                  color: '#d8d8dc',
-                  fontSize: 12,
-                  lineHeight: 1.4,
-                  outline: 'none',
-                  transition: `border-color var(--dur-fast) var(--ease-out)`,
+                  border: '1px solid var(--tx)',
+                  background: 'var(--tx-soft)',
                 }}
-              />
-              <button
-                type="button"
-                className={`btn sm${canSend ? ' active' : ''}`}
-                disabled={!canSend}
-                onClick={() => void doSend()}
-                title={connected ? 'Send (Enter)' : 'Not connected'}
               >
-                Send
-              </button>
-            </div>
+                <span
+                  aria-hidden
+                  style={{
+                    width: 9,
+                    height: 9,
+                    borderRadius: '50%',
+                    background: 'var(--tx)',
+                    boxShadow: '0 0 6px var(--tx)',
+                    flexShrink: 0,
+                  }}
+                />
+                <span style={{ fontSize: 11.5, fontWeight: 600, color: 'var(--tx)', flexShrink: 0 }}>
+                  Recording
+                </span>
+                <span className="mono" style={{ fontSize: 11.5, color: 'var(--fg-1)', flexShrink: 0 }}>
+                  {fmtDuration(voice.elapsedMs)} / {fmtDuration(MAX_VOICE_MS)}
+                </span>
+                <div style={{ flex: 1 }} />
+                <button
+                  type="button"
+                  className="btn sm"
+                  onClick={voice.cancel}
+                  title="Discard recording"
+                  style={{ flexShrink: 0 }}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className="btn sm active"
+                  onClick={voice.stop}
+                  title="Stop and attach the recording"
+                  style={{ flexShrink: 0 }}
+                >
+                  Stop
+                </button>
+              </div>
+            ) : (
+              <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                {/* Left action stack: mic on top, paperclip below. */}
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 4, flexShrink: 0 }}>
+                  {voice.supported && (
+                    <button
+                      type="button"
+                      className="btn sm"
+                      disabled={!connected || lockedActive || attaching || voice.preparing || pendingAttachment !== null}
+                      onClick={() => {
+                        setAttachError(null);
+                        voice.clearError();
+                        voice.start();
+                      }}
+                      title={
+                        !connected
+                          ? 'Not connected'
+                          : lockedActive
+                          ? 'Not a member of this group'
+                          : pendingAttachment !== null
+                          ? 'Remove the attachment first'
+                          : 'Record a voice message (max 60s)'
+                      }
+                      aria-label="Record a voice message"
+                      style={{ flexShrink: 0, padding: '5px 8px', color: 'var(--tx)' }}
+                    >
+                      {voice.preparing ? '…' : <MicIcon />}
+                    </button>
+                  )}
+                  {/* Paperclip — attach a photo. */}
+                  <button
+                    type="button"
+                    className="btn sm"
+                    disabled={!connected || attaching || lockedActive}
+                    onClick={() => fileInputRef.current?.click()}
+                    title={connected ? (lockedActive ? 'Not a member of this group' : 'Attach a photo') : 'Not connected'}
+                    aria-label="Attach a photo"
+                    style={{ flexShrink: 0, padding: '5px 8px' }}
+                  >
+                    {attaching ? '…' : <PaperclipIcon />}
+                  </button>
+                </div>
+                <textarea
+                  ref={inputRef}
+                  className="mono"
+                  value={draft}
+                  onChange={(e) => setDraft(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && !e.shiftKey) {
+                      e.preventDefault();
+                      void doSend();
+                    }
+                  }}
+                  onPaste={(e) => {
+                    // Paste an image straight from the clipboard, like texting.
+                    const item = Array.from(e.clipboardData.items).find((it) =>
+                      it.type.startsWith('image/'),
+                    );
+                    if (item) {
+                      e.preventDefault();
+                      void attachFile(item.getAsFile());
+                    }
+                  }}
+                  placeholder={composerPlaceholder}
+                  disabled={!connected || lockedActive}
+                  rows={1}
+                  maxLength={MAX_MESSAGE_CHARS + 64}
+                  style={{
+                    flex: 1,
+                    resize: 'none',
+                    overflowY: 'auto',
+                    maxHeight: 90,
+                    minHeight: 28,
+                    padding: '5px 8px',
+                    boxSizing: 'border-box',
+                    borderRadius: 'var(--r-sm)',
+                    border: composerBorder,
+                    background: connected ? '#0c0c10' : 'var(--bg-1)',
+                    color: '#d8d8dc',
+                    fontSize: 12,
+                    lineHeight: 1.4,
+                    outline: 'none',
+                    transition: `border-color var(--dur-fast) var(--ease-out)`,
+                  }}
+                />
+                {/* Send — vertically centered on the right edge. */}
+                <button
+                  type="button"
+                  className={`btn sm${canSend ? ' active' : ''}`}
+                  disabled={!canSend}
+                  onClick={() => void doSend()}
+                  title={connected ? 'Send (Enter)' : 'Not connected'}
+                  style={{ flexShrink: 0, alignSelf: 'center' }}
+                >
+                  Send
+                </button>
+              </div>
+            )}
             {/* Character counter when near limit */}
             {draft.length > MAX_MESSAGE_CHARS * 0.8 && (
               <div

--- a/zeus-web/src/state/chat-store.test.ts
+++ b/zeus-web/src/state/chat-store.test.ts
@@ -117,6 +117,39 @@ describe('chat-store ingest (0x35 live frames)', () => {
     expect(msgs.find((m) => m.id === 'img2')?.attachment).toBeNull();
   });
 
+  it('preserves a valid voice attachment and drops a mismatched one', () => {
+    const ing = useChatStore.getState().ingest;
+    const dataUrl = 'data:audio/webm;base64,GkXfAA==';
+    ing({
+      kind: 'message',
+      message: {
+        id: 'aud1',
+        ts: 300,
+        from: 'N9WAR',
+        text: '',
+        room: PUBLIC_ROOM,
+        attachment: { kind: 'audio', mime: 'audio/webm', dataUrl, name: 'voice-message.webm', size: 2048 },
+      },
+    });
+    // An audio MIME paired with an image data scheme must not survive.
+    ing({
+      kind: 'message',
+      message: {
+        id: 'aud2',
+        ts: 400,
+        from: 'N9WAR',
+        text: 'nope',
+        room: PUBLIC_ROOM,
+        attachment: { kind: 'audio', mime: 'audio/webm', dataUrl: 'data:image/png;base64,AAAA' },
+      },
+    });
+    const msgs = lobby();
+    const aud1 = msgs.find((m) => m.id === 'aud1')?.attachment;
+    expect(aud1?.dataUrl).toBe(dataUrl);
+    expect(aud1?.kind).toBe('audio');
+    expect(msgs.find((m) => m.id === 'aud2')?.attachment).toBeNull();
+  });
+
   it('routes messages to the correct room and counts unread for inactive rooms', () => {
     const ing = useChatStore.getState().ingest;
     ing({ kind: 'message', message: msg('g1', 100, 'hi', 'W1ABC', 'g123') });

--- a/zeus-web/src/util/chat-audio.ts
+++ b/zeus-web/src/util/chat-audio.ts
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version. See the LICENSE file at the root of this
+// repository for the full text, or https://www.gnu.org/licenses/.
+
+// Browser voice-snippet capture for ZeusChat inline audio attachments.
+//
+// A voice message rides inside the chat message exactly like an inline photo
+// (see util/chat-image.ts): the encoded bytes are carried as a base64 data URL
+// the relay persists in a single Durable-Object value (128 KiB cap). To stay
+// comfortably under MAX_ATTACHMENT_DATAURL_LEN for a full-length clip we record
+// Opus at a low voice-grade bitrate and hard-cap the duration at 60 s.
+//
+// MediaRecorder + getUserMedia require a secure context (https or localhost)
+// and a one-time mic grant. The hook surfaces a friendly message when either is
+// missing rather than throwing, so the composer can show it inline.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { MAX_ATTACHMENT_DATAURL_LEN, type ChatAttachment } from '../api/chat';
+
+export class ChatAudioError extends Error {}
+
+/** Hard cap on a single voice snippet (ms). The recorder auto-stops here. */
+export const MAX_VOICE_MS = 60_000;
+
+/**
+ * Encoder target bitrate (bits/s). 10 kbps Opus keeps an entire 60 s clip well
+ * under the data-URL cap (~75 KB decoded → ~100 k base64 chars) while staying
+ * intelligible for speech. Treated as a hint by the browser; the final size is
+ * re-checked against the cap before the attachment is staged.
+ */
+const VOICE_BITS_PER_SEC = 10_000;
+
+/** Candidate container/codec types, smallest-first (Opus), then Safari's mp4. */
+const MIME_CANDIDATES = [
+  'audio/webm;codecs=opus',
+  'audio/webm',
+  'audio/ogg;codecs=opus',
+  'audio/ogg',
+  'audio/mp4',
+];
+
+/** Whether this browser can capture a voice snippet at all. */
+export function isVoiceRecordingSupported(): boolean {
+  return (
+    typeof navigator !== 'undefined' &&
+    !!navigator.mediaDevices &&
+    typeof navigator.mediaDevices.getUserMedia === 'function' &&
+    typeof MediaRecorder !== 'undefined'
+  );
+}
+
+/** Best supported recorder MIME type, or undefined to let the browser choose. */
+function pickMimeType(): string | undefined {
+  if (typeof MediaRecorder === 'undefined' || typeof MediaRecorder.isTypeSupported !== 'function') {
+    return undefined;
+  }
+  for (const t of MIME_CANDIDATES) {
+    if (MediaRecorder.isTypeSupported(t)) return t;
+  }
+  return undefined;
+}
+
+/** Friendly download/display name for a recorded clip's container type. */
+function nameForMime(mime: string): string {
+  if (mime.includes('mp4')) return 'voice-message.m4a';
+  if (mime.includes('ogg')) return 'voice-message.ogg';
+  return 'voice-message.webm';
+}
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(typeof reader.result === 'string' ? reader.result : '');
+    reader.onerror = () => reject(new ChatAudioError("Couldn't read that recording."));
+    reader.readAsDataURL(blob);
+  });
+}
+
+export interface VoiceRecorderController {
+  /** True when the platform can record at all (gate the mic button on this). */
+  supported: boolean;
+  /** Acquiring the mic / spinning up the recorder. */
+  preparing: boolean;
+  /** Actively capturing. */
+  recording: boolean;
+  /** Elapsed capture time (ms), updated ~10×/s while recording. */
+  elapsedMs: number;
+  /** Last user-facing error, or null. */
+  error: string | null;
+  /** Begin capture (prompts for mic permission the first time). */
+  start: () => void;
+  /** Stop and finalize — invokes onComplete with the staged attachment. */
+  stop: () => void;
+  /** Stop and discard the in-progress recording. */
+  cancel: () => void;
+  /** Dismiss the current error. */
+  clearError: () => void;
+}
+
+/**
+ * Microphone capture lifecycle for a single voice snippet. `onComplete` fires
+ * once with the encoded attachment when {@link VoiceRecorderController.stop} is
+ * called (not on cancel). All native resources (recorder + mic tracks) are
+ * released on stop, cancel, and unmount so the OS mic indicator clears.
+ */
+export function useVoiceRecorder(
+  onComplete: (att: ChatAttachment) => void,
+): VoiceRecorderController {
+  const [preparing, setPreparing] = useState(false);
+  const [recording, setRecording] = useState(false);
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const chunksRef = useRef<BlobPart[]>([]);
+  const cancelledRef = useRef(false);
+  const timerRef = useRef<number | null>(null);
+  const autoStopRef = useRef<number | null>(null);
+  const startedAtRef = useRef(0);
+  const onCompleteRef = useRef(onComplete);
+  onCompleteRef.current = onComplete;
+
+  const clearTimers = useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+    if (autoStopRef.current !== null) {
+      window.clearTimeout(autoStopRef.current);
+      autoStopRef.current = null;
+    }
+  }, []);
+
+  const releaseStream = useCallback(() => {
+    streamRef.current?.getTracks().forEach((t) => t.stop());
+    streamRef.current = null;
+  }, []);
+
+  const finalize = useCallback(async (mime: string) => {
+    const blob = new Blob(chunksRef.current, { type: mime });
+    chunksRef.current = [];
+    try {
+      const dataUrl = await blobToDataUrl(blob);
+      if (!dataUrl || dataUrl.length > MAX_ATTACHMENT_DATAURL_LEN) {
+        throw new ChatAudioError('That recording is too long to send — keep it under a minute.');
+      }
+      onCompleteRef.current({
+        kind: 'audio',
+        mime,
+        dataUrl,
+        name: nameForMime(mime),
+        width: null,
+        height: null,
+        size: blob.size,
+      });
+    } catch (e) {
+      setError(e instanceof ChatAudioError ? e.message : "Couldn't process that recording.");
+    }
+  }, []);
+
+  const start = useCallback(async () => {
+    if (recorderRef.current || preparing) return;
+    if (!isVoiceRecordingSupported()) {
+      setError('Voice recording is not available in this browser.');
+      return;
+    }
+    setError(null);
+    setPreparing(true);
+    cancelledRef.current = false;
+    chunksRef.current = [];
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+      const mimeType = pickMimeType();
+      const recorder = new MediaRecorder(
+        stream,
+        mimeType ? { mimeType, audioBitsPerSecond: VOICE_BITS_PER_SEC } : { audioBitsPerSecond: VOICE_BITS_PER_SEC },
+      );
+      recorderRef.current = recorder;
+      recorder.ondataavailable = (e) => {
+        if (e.data && e.data.size > 0) chunksRef.current.push(e.data);
+      };
+      recorder.onstop = () => {
+        clearTimers();
+        releaseStream();
+        recorderRef.current = null;
+        setRecording(false);
+        setPreparing(false);
+        setElapsedMs(0);
+        if (!cancelledRef.current) void finalize(recorder.mimeType || mimeType || 'audio/webm');
+        else chunksRef.current = [];
+      };
+      startedAtRef.current = Date.now();
+      recorder.start();
+      setPreparing(false);
+      setRecording(true);
+      setElapsedMs(0);
+      timerRef.current = window.setInterval(() => {
+        setElapsedMs(Date.now() - startedAtRef.current);
+      }, 100);
+      // Auto-stop at the hard cap so a clip can never overflow the wire size.
+      autoStopRef.current = window.setTimeout(() => {
+        recorderRef.current?.stop();
+      }, MAX_VOICE_MS);
+    } catch (err) {
+      releaseStream();
+      recorderRef.current = null;
+      setPreparing(false);
+      setRecording(false);
+      const name = err instanceof DOMException ? err.name : '';
+      if (name === 'NotAllowedError' || name === 'SecurityError') {
+        setError('Microphone access was blocked. Allow mic access to send a voice message.');
+      } else if (name === 'NotFoundError') {
+        setError('No microphone was found.');
+      } else {
+        setError('Voice messages need a secure (https or localhost) connection and mic permission.');
+      }
+    }
+  }, [preparing, clearTimers, releaseStream, finalize]);
+
+  const stop = useCallback(() => {
+    cancelledRef.current = false;
+    recorderRef.current?.stop();
+  }, []);
+
+  const cancel = useCallback(() => {
+    cancelledRef.current = true;
+    recorderRef.current?.stop();
+  }, []);
+
+  const clearError = useCallback(() => setError(null), []);
+
+  // Release the mic + timers if the component unmounts mid-recording.
+  useEffect(() => {
+    return () => {
+      cancelledRef.current = true;
+      clearTimers();
+      try {
+        recorderRef.current?.stop();
+      } catch {
+        /* already stopped */
+      }
+      recorderRef.current = null;
+      streamRef.current?.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+    };
+  }, [clearTimers]);
+
+  return {
+    supported: isVoiceRecordingSupported(),
+    preparing,
+    recording,
+    elapsedMs,
+    error,
+    start: () => void start(),
+    stop,
+    cancel,
+    clearError,
+  };
+}
+
+/** Format an elapsed/total ms value as M:SS for the recording indicator. */
+export function fmtDuration(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}


### PR DESCRIPTION
## What

Adds **voice messages** to ZeusChat: a microphone button in the composer lets operators record and send a short voice snippet (max **60 s**), alongside the existing inline-photo support.

Voice rides the *same* path photos already use — the encoded bytes travel inside the chat message as a base64 data URL under the shared 120 000-char cap — so it reuses the entire attachment pipeline rather than adding a parallel one. **No wire-format shape change.**

## UI

- **Mic button stacked above the paperclip** in the composer (shown only where recording is supported).
- A red **recording strip** (live `M:SS / 1:00`, Cancel / Stop) replaces the input while capturing; auto-stops at 60 s.
- Stopping stages the clip like a photo — inline `<audio>` preview + optional caption — then **Send**.
- **Send button is now vertically centered** on the right edge.
- Received voice messages render as a compact mic-badged `<audio controls>` player in the bubble.

## Implementation

- New `useVoiceRecorder` hook (`zeus-web/src/util/chat-audio.ts`): `MediaRecorder` + `getUserMedia`, Opus at **10 kbps** (keeps a full 60 s clip well under the data-URL cap), hard-capped at 60 s with auto-stop, releases the mic on stop/cancel/unmount, and surfaces friendly messages for blocked-permission / no-mic / insecure-origin.
- Generalized the image-only attachment guards to also accept `audio/*` at **all four enforcement points** — web `normalizeAttachment`, C# `ValidateAttachment` / `ParseAttachment`, relay `sanitizeAttachment` — deriving `kind` from the MIME/scheme family so a mislabelled payload can't slip through.

## Tests / verification

- **C#**: `ParseMessage_ReadsAudioAttachment` + mismatched-family drop → ChatService tests **22/22**.
- **Web**: chat-store audio normalization round-trip → vitest **11/11**; `tsc -b` + ESLint clean.
- **Relay**: `tsc --noEmit` clean.

Note: the record→send→playback round-trip needs a live relay + QRZ login + a real mic grant, which the headless preview can't provide; verification here was static across all four layers.

## Notes for reviewers

- `Zeus.Contracts` change is **doc-comment only** — `ChatAttachment`'s shape (`Kind`/`Mime`/`DataUrl`/…) is unchanged; only the accepted *values* widened from image to image+audio.
- Branched off `develop`; isolated to the voice feature (9 files).