### PR TITLE
feat(diag): on-disk rolling log sink + sidecar IPC contract (remote-diag P0)

### DIFF
--- a/OpenhpsdrZeus/OpenhpsdrZeus.csproj
+++ b/OpenhpsdrZeus/OpenhpsdrZeus.csproj
@@ -40,6 +40,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Zeus.Server.Hosting\Zeus.Server.Hosting.csproj" />
+    <!-- The support sidecar is a separate executable the desktop host launches
+         detached so it survives a backend crash. Referencing it co-locates
+         Zeus.SupportAgent(.exe) in this host's output dir for SupportSidecarLauncher
+         to spawn; the host does not use its types. -->
+    <ProjectReference Include="..\Zeus.SupportAgent\Zeus.SupportAgent.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OpenhpsdrZeus/Program.cs
+++ b/OpenhpsdrZeus/Program.cs
@@ -349,6 +349,11 @@ public partial class Program
         app.StartAsync().GetAwaiter().GetResult();
         StartupDiagnostics.Phase("desktop: host started");
 
+        // Spawn the out-of-process support sidecar now the backend is up. It runs
+        // detached so it survives a backend crash and can capture the crash logs
+        // the in-memory ring would lose. Best-effort — never blocks launch.
+        SupportSidecarLauncher.TryLaunch();
+
         // Resolve the bound URLs after Start — Kestrel writes the OS-assigned
         // loopback port (plus the LAN HTTPS port we configured) into
         // IServerAddressesFeature here. Photino must load the loopback HTTP URL:
@@ -699,6 +704,10 @@ public partial class Program
     //    above).
     private static void ShutdownDesktopHost(WebApplication app)
     {
+        // Deliberate shutdown — tell any supervising sidecar this is a clean exit,
+        // not a crash, BEFORE we tear the host down or _exit(2).
+        SupportSidecar.MarkCleanExit();
+
         StopAndDisposeHost(app);
 
         Console.Out.Flush();

--- a/OpenhpsdrZeus/SupportSidecarLauncher.cs
+++ b/OpenhpsdrZeus/SupportSidecarLauncher.cs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Diagnostics;
+using System.Globalization;
+using System.Reflection;
+using Zeus.Server;
+using Zeus.Support.Contracts;
+
+namespace OpenhpsdrZeus;
+
+/// <summary>
+/// Spawns the out-of-process support sidecar (Zeus.SupportAgent) from the desktop
+/// host. The sidecar is launched DETACHED — a plain child process, not killed
+/// when this process dies — so it survives a backend crash and can capture the
+/// crash. We hand it every path it needs as arguments (the host owns the
+/// platform data-dir logic); it never re-derives them.
+///
+/// The sidecar is a diagnostics enhancement: any failure to launch is logged and
+/// swallowed and MUST never block or slow Zeus startup.
+/// </summary>
+internal static class SupportSidecarLauncher
+{
+    public static void TryLaunch()
+    {
+        try
+        {
+            var exe = ResolveSidecarExe();
+            if (exe is null)
+            {
+                Console.Error.WriteLine(
+                    "support-agent: sidecar executable not found next to host; crash capture disabled this session.");
+                return;
+            }
+
+            var psi = new ProcessStartInfo(exe)
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WorkingDirectory = AppContext.BaseDirectory,
+            };
+
+            void Add(string key, string? value)
+            {
+                if (string.IsNullOrEmpty(value)) return;
+                psi.ArgumentList.Add(key);
+                psi.ArgumentList.Add(value);
+            }
+
+            Add("--supervise-pid", Environment.ProcessId.ToString(CultureInfo.InvariantCulture));
+            Add("--session", Guid.NewGuid().ToString("N"));
+            Add("--app-log", PrefsDbPath.AppLogPath());
+            Add("--startup-log", StartupDiagnostics.LogPath);
+            Add("--crash-dir", PrefsDbPath.CrashDir());
+            Add("--app-version", ResolveAppVersion());
+
+            Process.Start(psi);
+            StartupDiagnostics.Log($"support-agent: launched sidecar to supervise pid {Environment.ProcessId}");
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"support-agent: launch failed: {ex.Message}");
+        }
+    }
+
+    private static string? ResolveSidecarExe()
+    {
+        var name = OperatingSystem.IsWindows() ? "Zeus.SupportAgent.exe" : "Zeus.SupportAgent";
+        var path = Path.Combine(AppContext.BaseDirectory, name);
+        return File.Exists(path) ? path : null;
+    }
+
+    private static string? ResolveAppVersion()
+    {
+        var asm = Assembly.GetEntryAssembly();
+        return asm?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? asm?.GetName().Version?.ToString();
+    }
+}

--- a/Zeus.Server.Hosting/AppRestartService.cs
+++ b/Zeus.Server.Hosting/AppRestartService.cs
@@ -45,6 +45,10 @@ public sealed class AppRestartService
             // Never block the exit on a best-effort hook.
         }
 
+        // Deliberate exit — let any supervising support sidecar see this as a
+        // clean shutdown, not a crash.
+        SupportSidecar.MarkCleanExit();
+
         // Let the in-flight HTTP response flush before the process dies.
         _ = Task.Run(async () =>
         {
@@ -75,6 +79,11 @@ public sealed class AppRestartService
         {
             // Never block the relaunch on a best-effort hook.
         }
+
+        // A relaunch is a deliberate exit — mark it clean so a supervising sidecar
+        // doesn't capture a crash record for the old PID. (The fresh process will
+        // spawn its own sidecar.)
+        SupportSidecar.MarkCleanExit();
 
         // Let the in-flight HTTP response flush before the process dies.
         _ = Task.Run(async () =>

--- a/Zeus.Server.Hosting/Diagnostics/DiagnosticLogFileSink.cs
+++ b/Zeus.Server.Hosting/Diagnostics/DiagnosticLogFileSink.cs
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using System.Text;
+
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>
+/// Rolling on-disk log file. Writes the same formatted+redacted lines the
+/// in-memory <see cref="DiagnosticLogBuffer"/> holds, so the recent log persists
+/// across a backend crash for the support sidecar to tail.
+///
+/// Design notes:
+/// <list type="bullet">
+/// <item>Auto-flush on every write — crash freshness beats throughput here; the
+/// ring is Information+ only, so volume is modest and we want the last lines on
+/// disk <i>before</i> the process dies.</item>
+/// <item>Best-effort: any I/O failure is swallowed (the sink stays "down" until a
+/// later write succeeds). A diagnostic sink must never crash the app or throw
+/// into the logging pipeline.</item>
+/// <item>Rolling: when the active file passes <c>maxBytes</c> it is rotated to
+/// <c>{name}.1{ext}</c>, older rolls shift up, and the oldest beyond
+/// <c>maxRolls</c> is dropped — bounding disk use without losing the freshest
+/// lines.</item>
+/// </list>
+/// </summary>
+public sealed class DiagnosticLogFileSink : IDiagnosticLogFileSink, IDisposable
+{
+    private const int DefaultMaxBytes = 2 * 1024 * 1024; // 2 MiB active file
+    private const int DefaultMaxRolls = 3;               // keep .1 .2 .3 alongside the active file
+
+    private readonly object _sync = new();
+    private readonly string _path;
+    private readonly string _dir;
+    private readonly long _maxBytes;
+    private readonly int _maxRolls;
+
+    private StreamWriter? _writer;
+    private long _written;
+    private bool _disposed;
+
+    public DiagnosticLogFileSink(string path, long maxBytes = DefaultMaxBytes, int maxRolls = DefaultMaxRolls)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        _path = path;
+        _dir = Path.GetDirectoryName(Path.GetFullPath(path)) ?? ".";
+        _maxBytes = maxBytes > 0 ? maxBytes : DefaultMaxBytes;
+        _maxRolls = Math.Max(0, maxRolls);
+    }
+
+    public void Append(string line)
+    {
+        if (string.IsNullOrEmpty(line) || _disposed) return;
+        lock (_sync)
+        {
+            if (_disposed) return;
+            try
+            {
+                var w = EnsureWriter();
+                if (w is null) return; // sink is down; drop this line rather than throw
+
+                // +1 covers the newline; a byte estimate is fine for a roll threshold.
+                long lineBytes = Encoding.UTF8.GetByteCount(line) + 1;
+
+                // Roll BEFORE writing when this line would push the active file past
+                // the cap, so the active file always exists afterwards and holds the
+                // freshest line (a single oversized line on a fresh file is allowed
+                // through rather than rolling to an empty file).
+                if (_written > 0 && _written + lineBytes > _maxBytes)
+                {
+                    Roll();
+                    w = EnsureWriter();
+                    if (w is null) return;
+                }
+
+                w.WriteLine(line);
+                _written += lineBytes;
+            }
+            catch
+            {
+                // Best-effort: a transient I/O error must not break logging. Tear
+                // the writer down so the next Append re-opens from scratch.
+                TryCloseWriter();
+            }
+        }
+    }
+
+    private StreamWriter? EnsureWriter()
+    {
+        if (_writer is not null) return _writer;
+        try
+        {
+            if (!Directory.Exists(_dir))
+                Directory.CreateDirectory(_dir);
+
+            // Append + shared read so the sidecar (or a developer's `tail`) can read
+            // the file while the backend keeps writing it.
+            var fs = new FileStream(_path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
+            _writer = new StreamWriter(fs, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false))
+            {
+                AutoFlush = true,
+            };
+            _written = fs.Length;
+            return _writer;
+        }
+        catch
+        {
+            TryCloseWriter();
+            return null;
+        }
+    }
+
+    private void Roll()
+    {
+        TryCloseWriter();
+        try
+        {
+            var ext = Path.GetExtension(_path);                       // ".log"
+            var stem = _path[..(_path.Length - ext.Length)];          // "...\zeus-app"
+
+            if (_maxRolls == 0)
+            {
+                // No history retained — just truncate the active file.
+                if (File.Exists(_path)) File.Delete(_path);
+                return;
+            }
+
+            // Drop the oldest, then shift .{n-1} -> .{n} down to active -> .1.
+            var oldest = $"{stem}.{_maxRolls}{ext}";
+            if (File.Exists(oldest)) File.Delete(oldest);
+
+            for (int i = _maxRolls - 1; i >= 1; i--)
+            {
+                var src = $"{stem}.{i}{ext}";
+                var dst = $"{stem}.{i + 1}{ext}";
+                if (File.Exists(src)) File.Move(src, dst, overwrite: true);
+            }
+
+            if (File.Exists(_path)) File.Move(_path, $"{stem}.1{ext}", overwrite: true);
+        }
+        catch
+        {
+            // If rotation fails the next EnsureWriter just keeps appending to the
+            // (possibly oversized) active file — degraded, not fatal.
+        }
+        finally
+        {
+            _written = 0;
+        }
+    }
+
+    private void TryCloseWriter()
+    {
+        try { _writer?.Dispose(); } catch { /* best effort */ }
+        _writer = null;
+    }
+
+    public void Dispose()
+    {
+        lock (_sync)
+        {
+            if (_disposed) return;
+            _disposed = true;
+            TryCloseWriter();
+        }
+    }
+}

--- a/Zeus.Server.Hosting/Diagnostics/IDiagnosticLogFileSink.cs
+++ b/Zeus.Server.Hosting/Diagnostics/IDiagnosticLogFileSink.cs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+namespace Zeus.Server.Diagnostics;
+
+/// <summary>
+/// A durable sink for already-formatted, already-redacted log lines. Mirrors the
+/// in-memory <see cref="DiagnosticLogBuffer"/> to disk so the recent log SURVIVES
+/// a backend crash and can be tailed by the out-of-process support sidecar (the
+/// in-memory ring dies with the process — useless for diagnosing the crash that
+/// killed it). Implementations must be thread-safe and best-effort: a logging
+/// sink must never throw into the logging pipeline or block the app on an I/O
+/// hiccup.
+/// </summary>
+public interface IDiagnosticLogFileSink
+{
+    /// <summary>Append one formatted+redacted line. Cheap; safe from any thread; never throws.</summary>
+    void Append(string line);
+}

--- a/Zeus.Server.Hosting/Diagnostics/RingBufferLoggerProvider.cs
+++ b/Zeus.Server.Hosting/Diagnostics/RingBufferLoggerProvider.cs
@@ -10,6 +10,10 @@ namespace Zeus.Server.Diagnostics;
 /// host's logging pipeline means the "Report a problem" button can snapshot the
 /// recent log retroactively — the ring is always being filled.
 ///
+/// When an <see cref="IDiagnosticLogFileSink"/> is supplied, the SAME redacted
+/// line is also mirrored to disk (redaction is computed once and fanned out), so
+/// the recent log survives a backend crash for the support sidecar to tail.
+///
 /// Trace/Debug are intentionally dropped to keep the (capacity-bounded) ring
 /// signal-dense. Scopes are no-ops. The underlying buffer is thread-safe, so the
 /// provider holds no per-call lock of its own.
@@ -17,15 +21,17 @@ namespace Zeus.Server.Diagnostics;
 public sealed class RingBufferLoggerProvider : ILoggerProvider
 {
     private readonly DiagnosticLogBuffer _buffer;
+    private readonly IDiagnosticLogFileSink? _fileSink;
 
-    public RingBufferLoggerProvider(DiagnosticLogBuffer buffer)
+    public RingBufferLoggerProvider(DiagnosticLogBuffer buffer, IDiagnosticLogFileSink? fileSink = null)
     {
         ArgumentNullException.ThrowIfNull(buffer);
         _buffer = buffer;
+        _fileSink = fileSink;
     }
 
     public ILogger CreateLogger(string categoryName) =>
-        new RingBufferLogger(_buffer, ShortCategory(categoryName));
+        new RingBufferLogger(_buffer, _fileSink, ShortCategory(categoryName));
 
     public void Dispose() { /* buffer is owned elsewhere (singleton); nothing to release */ }
 
@@ -42,11 +48,13 @@ public sealed class RingBufferLoggerProvider : ILoggerProvider
         private static readonly IDisposable NoopScope = new NoopDisposable();
 
         private readonly DiagnosticLogBuffer _buffer;
+        private readonly IDiagnosticLogFileSink? _fileSink;
         private readonly string _shortCategory;
 
-        public RingBufferLogger(DiagnosticLogBuffer buffer, string shortCategory)
+        public RingBufferLogger(DiagnosticLogBuffer buffer, IDiagnosticLogFileSink? fileSink, string shortCategory)
         {
             _buffer = buffer;
+            _fileSink = fileSink;
             _shortCategory = shortCategory;
         }
 
@@ -75,7 +83,11 @@ public sealed class RingBufferLoggerProvider : ILoggerProvider
                 ? $"{ts} {Level(logLevel)} {_shortCategory} {message}"
                 : $"{ts} {Level(logLevel)} {_shortCategory} {message} {exception}";
 
-            _buffer.Add(Redaction.Scrub(line));
+            // Redact once, fan out to both the in-memory ring and (when present)
+            // the on-disk sink so the same scrubbed line lands in both.
+            string redacted = Redaction.Scrub(line);
+            _buffer.Add(redacted);
+            _fileSink?.Append(redacted);
         }
 
         private static string Level(LogLevel level) => level switch

--- a/Zeus.Server.Hosting/PrefsDbPath.cs
+++ b/Zeus.Server.Hosting/PrefsDbPath.cs
@@ -64,6 +64,23 @@ public static class PrefsDbPath
         return Path.Combine(dir, "zeus-logbook.db");
     }
 
+    // Directory for the rolling on-disk runtime log (DiagnosticLogFileSink). Lives
+    // under DataDir/logs so it can be tailed by the out-of-process support sidecar
+    // after a backend crash. Follows the same ZEUS_PREFS_PATH override as the
+    // logbook so dev `/run fresh`, CI, and tests write their logs into the
+    // throwaway data dir instead of the operator's real %LOCALAPPDATA%/Zeus.
+    public static string LogDir()
+    {
+        var env = Environment.GetEnvironmentVariable("ZEUS_PREFS_PATH");
+        var dir = string.IsNullOrEmpty(env)
+            ? DataDir
+            : (Path.GetDirectoryName(Path.GetFullPath(env)) ?? DataDir);
+        return Path.Combine(dir, "logs");
+    }
+
+    // Full path of the active rolling runtime log file.
+    public static string AppLogPath() => Path.Combine(LogDir(), "zeus-app.log");
+
     // Relative path (under DataDir) of the active profile. Reads the pointer
     // file; falls back to the legacy zeus-prefs.db when the pointer is absent,
     // unreadable, or names a file that no longer exists.

--- a/Zeus.Server.Hosting/PrefsDbPath.cs
+++ b/Zeus.Server.Hosting/PrefsDbPath.cs
@@ -81,6 +81,19 @@ public static class PrefsDbPath
     // Full path of the active rolling runtime log file.
     public static string AppLogPath() => Path.Combine(LogDir(), "zeus-app.log");
 
+    // Directory for support-sidecar artifacts: the per-PID clean-exit markers the
+    // backend drops at a deliberate shutdown and the crash records the sidecar
+    // writes when the backend dies unexpectedly. Same ZEUS_PREFS_PATH isolation as
+    // the logs so tests/dev never touch the operator's real data dir.
+    public static string CrashDir()
+    {
+        var env = Environment.GetEnvironmentVariable("ZEUS_PREFS_PATH");
+        var dir = string.IsNullOrEmpty(env)
+            ? DataDir
+            : (Path.GetDirectoryName(Path.GetFullPath(env)) ?? DataDir);
+        return Path.Combine(dir, "crashes");
+    }
+
     // Relative path (under DataDir) of the active profile. Reads the pointer
     // file; falls back to the legacy zeus-prefs.db when the pointer is absent,
     // unreadable, or names a file that no longer exists.

--- a/Zeus.Server.Hosting/Support/SupportSidecar.cs
+++ b/Zeus.Server.Hosting/Support/SupportSidecar.cs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Zeus.Support.Contracts;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Backend-side touchpoints for the out-of-process support sidecar. Phase 1 only
+/// needs the clean-exit handshake: the sidecar treats the backend's death as a
+/// crash UNLESS it finds a per-PID marker the backend wrote at a deliberate exit.
+/// Call <see cref="MarkCleanExit"/> on every intentional shutdown path (window
+/// close, operator quit, profile-switch relaunch) so a normal exit is never
+/// mis-reported as a crash.
+/// </summary>
+public static class SupportSidecar
+{
+    /// <summary>
+    /// Drop the clean-exit marker for THIS process so a supervising sidecar
+    /// classifies the imminent exit as expected. Best-effort and synchronous — it
+    /// must complete before the process exits, and must never throw on a shutdown
+    /// path.
+    /// </summary>
+    public static void MarkCleanExit()
+    {
+        try
+        {
+            var dir = PrefsDbPath.CrashDir();
+            Directory.CreateDirectory(dir);
+            var path = Path.Combine(dir, SupportPaths.CleanExitMarkerName(Environment.ProcessId));
+            File.WriteAllText(path, DateTimeOffset.UtcNow.ToString("o"));
+        }
+        catch
+        {
+            // A missing marker only costs a spurious crash record; never let it
+            // interfere with shutdown.
+        }
+    }
+}

--- a/Zeus.Server.Hosting/Zeus.Server.Hosting.csproj
+++ b/Zeus.Server.Hosting/Zeus.Server.Hosting.csproj
@@ -34,6 +34,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Zeus.Contracts\Zeus.Contracts.csproj" />
+    <ProjectReference Include="..\Zeus.Support.Contracts\Zeus.Support.Contracts.csproj" />
     <ProjectReference Include="..\Zeus.Plugins.Host\Zeus.Plugins.Host.csproj" />
     <ProjectReference Include="..\Zeus.Protocol1\Zeus.Protocol1.csproj" />
     <ProjectReference Include="..\Zeus.Protocol2\Zeus.Protocol2.csproj" />

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -150,7 +150,15 @@ public static class ZeusHost
         // report builder snapshots what the provider has been filling.
         var diagnosticLogBuffer = new DiagnosticLogBuffer();
         builder.Services.AddSingleton(diagnosticLogBuffer);
-        builder.Logging.AddProvider(new RingBufferLoggerProvider(diagnosticLogBuffer));
+        // Mirror the same redacted lines to a rolling on-disk file under
+        // DataDir/logs so the recent log SURVIVES a backend crash and the
+        // out-of-process support sidecar can tail it (the in-memory ring dies
+        // with the process). Best-effort: the sink never throws into logging, so
+        // an unwritable log dir degrades to in-memory-only rather than blocking
+        // launch.
+        var diagnosticLogFileSink = new DiagnosticLogFileSink(PrefsDbPath.AppLogPath());
+        builder.Services.AddSingleton<IDiagnosticLogFileSink>(diagnosticLogFileSink);
+        builder.Logging.AddProvider(new RingBufferLoggerProvider(diagnosticLogBuffer, diagnosticLogFileSink));
 
         // Resolve TCI bind settings from configuration before DI builds, because
         // Kestrel's listeners have to be declared now. TCI shares Kestrel (rather

--- a/Zeus.Support.Contracts/SupportArtifacts.cs
+++ b/Zeus.Support.Contracts/SupportArtifacts.cs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.Support.Contracts;
+
+/// <summary>
+/// On-disk filename conventions shared by the backend (writer) and the support
+/// sidecar (reader). Kept here — dependency-free — so the two processes can never
+/// disagree on a name. The directories themselves are resolved by the backend
+/// (which owns the platform data-dir logic) and passed to the sidecar as launch
+/// arguments, so this type holds only the pure, path-free filename rules.
+/// </summary>
+public static class SupportPaths
+{
+    /// <summary>
+    /// Marker the backend writes at a DELIBERATE exit (window close, operator
+    /// quit, profile-switch relaunch). The sidecar supervising that PID looks for
+    /// this file when the process dies: present ⇒ clean shutdown (delete it, exit
+    /// quietly); absent ⇒ the process died unexpectedly ⇒ capture a crash record.
+    /// Keyed by PID so a relaunch's fresh backend can never have its marker read
+    /// by the previous generation's sidecar.
+    /// </summary>
+    public static string CleanExitMarkerName(int pid) => $"clean-exit-{pid}.marker";
+
+    /// <summary>Filename for a captured crash record (sortable by time, disambiguated by PID).</summary>
+    public static string CrashRecordFileName(long detectedUnixMs, int pid) =>
+        $"crash-{detectedUnixMs:D13}-{pid}.json";
+}
+
+/// <summary>
+/// A captured backend-crash record, written by the sidecar to the crash directory
+/// when the supervised Zeus process dies without a clean-exit marker. This is the
+/// artifact a maintainer ultimately wants for a "random crash" report: the exit
+/// code plus the tail of the runtime and startup logs as they stood at death.
+///
+/// Persisted as JSON via <see cref="SupportIpcJsonContext"/>. Evolve by ADDING
+/// optional fields and bumping <see cref="SchemaVersion"/>.
+/// </summary>
+public sealed record SupportCrashRecord(
+    int SchemaVersion,
+    long DetectedUnixMs,
+    int Pid,
+    int? ExitCode,
+    bool Crashed,
+    string? AppVersion,
+    string Platform,
+    IReadOnlyList<string> AppLogTail,
+    IReadOnlyList<string> StartupLogTail,
+    string? Note)
+{
+    /// <summary>Current schema version for newly written crash records.</summary>
+    public const int CurrentSchemaVersion = 1;
+}

--- a/Zeus.Support.Contracts/SupportIpc.cs
+++ b/Zeus.Support.Contracts/SupportIpc.cs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Text.Json.Serialization;
+
+namespace Zeus.Support.Contracts;
+
+/// <summary>
+/// Local IPC contract between the in-process Zeus backend and the out-of-process
+/// support <b>sidecar</b> (Zeus.SupportAgent). The sidecar is launched detached
+/// by the desktop host so it OUTLIVES a backend crash; it owns the broker
+/// connection and persists crash/log state to disk. The two processes talk over
+/// a per-session named pipe (Windows) / Unix-domain-style local pipe using the
+/// length-prefixed JSON framing in <see cref="SupportIpcFraming"/>.
+///
+/// This is a same-machine, same-user channel only. It is NOT the server↔web wire
+/// format (that lives in Zeus.Contracts and is red-light). Evolve this contract
+/// by ADDING optional fields / new <see cref="SupportIpcMessage"/> subtypes and
+/// bumping <see cref="ProtocolVersion"/>; never repurpose an existing field.
+/// </summary>
+public static class SupportIpc
+{
+    /// <summary>
+    /// Contract version. The backend stamps it into <see cref="SupportHello"/> so a
+    /// mismatched sidecar can refuse to attach rather than misread later frames.
+    /// </summary>
+    public const int ProtocolVersion = 1;
+
+    /// <summary>
+    /// Hard ceiling on a single framed message (a diagnostics snapshot is the
+    /// largest payload). Anything bigger is treated as a desync / hostile peer and
+    /// the channel is dropped rather than allocating unbounded memory.
+    /// </summary>
+    public const int MaxFrameBytes = 4 * 1024 * 1024;
+
+    private const string PipePrefix = "zeus-support";
+
+    /// <summary>
+    /// Stable pipe name for a Zeus session. The desktop host mints a random
+    /// session token at launch, passes it to the sidecar (its listen name) and
+    /// exposes it to the backend (its connect target) so two Zeus instances on
+    /// one machine never collide. The token is sanitised to the pipe-safe
+    /// alphabet; a null/blank token falls back to the bare prefix (single-instance
+    /// dev default).
+    /// </summary>
+    public static string PipeNameForSession(string? sessionToken)
+    {
+        if (string.IsNullOrWhiteSpace(sessionToken)) return PipePrefix;
+        var sb = new System.Text.StringBuilder(PipePrefix.Length + 1 + sessionToken.Length);
+        sb.Append(PipePrefix).Append('-');
+        foreach (var ch in sessionToken)
+            sb.Append(char.IsLetterOrDigit(ch) ? ch : '_');
+        return sb.ToString();
+    }
+
+    /// <summary>Environment variable the desktop host uses to hand the session token to the backend.</summary>
+    public const string SessionTokenEnvVar = "ZEUS_SUPPORT_SESSION";
+}
+
+/// <summary>An operator's decision on an admin's request for a live support session.</summary>
+public enum SupportPromptDecision
+{
+    /// <summary>Operator explicitly approved a read-only diagnostics session.</summary>
+    Allow,
+    /// <summary>Operator explicitly declined.</summary>
+    Deny,
+    /// <summary>No answer within the prompt window — treated as a denial, fail-closed.</summary>
+    Timeout,
+    /// <summary>Backend could not show a prompt (no UI client connected). Fail-closed.</summary>
+    Unavailable,
+}
+
+/// <summary>
+/// Base type for every message on the support IPC channel. Polymorphic on a
+/// <c>kind</c> discriminator so the framing layer can round-trip any message
+/// without the reader knowing the concrete type in advance.
+/// </summary>
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "kind")]
+[JsonDerivedType(typeof(SupportHello), "hello")]
+[JsonDerivedType(typeof(SupportStateChanged), "state")]
+[JsonDerivedType(typeof(SupportHeartbeat), "heartbeat")]
+[JsonDerivedType(typeof(SupportPromptRequest), "prompt-request")]
+[JsonDerivedType(typeof(SupportPromptResult), "prompt-result")]
+[JsonDerivedType(typeof(SupportDiagnosticsPull), "diag-pull")]
+[JsonDerivedType(typeof(SupportDiagnosticsSnapshot), "diag-snapshot")]
+public abstract record SupportIpcMessage;
+
+/// <summary>
+/// Backend → sidecar. First message after the pipe connects, and re-sent if the
+/// backend reconnects. Carries identity + the operator's current opt-in posture
+/// and the on-disk log paths the sidecar will tail.
+/// </summary>
+public sealed record SupportHello(
+    int ProtocolVersion,
+    int BackendPid,
+    string AppVersion,
+    string Platform,
+    string? QrzCallsign,
+    bool RemoteDiagnosticsEnabled,
+    bool AutoShareOnCrash,
+    string AppLogPath,
+    string StartupLogPath) : SupportIpcMessage;
+
+/// <summary>
+/// Backend → sidecar. The operator changed an opt-in setting (the L1 master
+/// switch, the crash auto-share sub-toggle) or signed in/out of QRZ. The sidecar
+/// uses this to register/deregister with the broker and to gate crash sharing.
+/// </summary>
+public sealed record SupportStateChanged(
+    string? QrzCallsign,
+    bool RemoteDiagnosticsEnabled,
+    bool AutoShareOnCrash) : SupportIpcMessage;
+
+/// <summary>Either direction. Liveness ping; the peer is considered gone if these stop.</summary>
+public sealed record SupportHeartbeat(long UnixMs) : SupportIpcMessage;
+
+/// <summary>
+/// Sidecar → backend. An authenticated admin has requested a live read-only
+/// diagnostics session. The backend MUST surface an in-app Allow/Deny prompt and
+/// reply with a <see cref="SupportPromptResult"/> carrying the same
+/// <see cref="RequestId"/>. (When the backend is dead the sidecar never sees a
+/// reply and falls back to the separate crash-auto-share pre-authorisation.)
+/// </summary>
+public sealed record SupportPromptRequest(
+    string RequestId,
+    string AdminCallsign,
+    string? Reason) : SupportIpcMessage;
+
+/// <summary>Backend → sidecar. The operator's answer to a <see cref="SupportPromptRequest"/>.</summary>
+public sealed record SupportPromptResult(
+    string RequestId,
+    SupportPromptDecision Decision) : SupportIpcMessage;
+
+/// <summary>
+/// Sidecar → backend. Ask the live backend for a diagnostics snapshot. A null
+/// <see cref="RouteSegment"/> means the whole v2 index; otherwise a single
+/// provider's route segment (e.g. "dsp-live").
+/// </summary>
+public sealed record SupportDiagnosticsPull(
+    string RequestId,
+    string? RouteSegment) : SupportIpcMessage;
+
+/// <summary>
+/// Backend → sidecar. The JSON result of a <see cref="SupportDiagnosticsPull"/>.
+/// <see cref="Json"/> is the already-serialised diagnostics payload (redacted by
+/// the backend's existing diagnostics layer); the sidecar relays it verbatim.
+/// </summary>
+public sealed record SupportDiagnosticsSnapshot(
+    string RequestId,
+    bool Ok,
+    string Json) : SupportIpcMessage;

--- a/Zeus.Support.Contracts/SupportIpcFraming.cs
+++ b/Zeus.Support.Contracts/SupportIpcFraming.cs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using System.Buffers.Binary;
+using System.Text.Json;
+
+namespace Zeus.Support.Contracts;
+
+/// <summary>
+/// Length-prefixed JSON framing for the support IPC channel, transport-agnostic
+/// so it works over any duplex <see cref="Stream"/> (named pipe today, a loopback
+/// socket if that ever changes) and is unit-testable without a live pipe.
+///
+/// Wire shape per message: a 4-byte little-endian unsigned length, then exactly
+/// that many bytes of UTF-8 JSON (a <see cref="SupportIpcMessage"/> serialised via
+/// <see cref="SupportIpcJsonContext"/>). A length of 0 or one exceeding
+/// <see cref="SupportIpc.MaxFrameBytes"/> is a framing error: the channel is
+/// desynchronised or the peer is hostile, so the caller must drop the connection
+/// rather than trust the stream.
+/// </summary>
+public static class SupportIpcFraming
+{
+    /// <summary>Serialise and write one framed message. Concurrent writers must serialise externally.</summary>
+    public static async Task WriteAsync(Stream stream, SupportIpcMessage message, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentNullException.ThrowIfNull(message);
+
+        byte[] payload = JsonSerializer.SerializeToUtf8Bytes(
+            message, typeof(SupportIpcMessage), SupportIpcJsonContext.Default);
+
+        if (payload.Length == 0 || payload.Length > SupportIpc.MaxFrameBytes)
+            throw new InvalidOperationException(
+                $"Support IPC frame of {payload.Length} bytes is outside the 1..{SupportIpc.MaxFrameBytes} range.");
+
+        byte[] header = new byte[4];
+        BinaryPrimitives.WriteUInt32LittleEndian(header, (uint)payload.Length);
+
+        await stream.WriteAsync(header, ct).ConfigureAwait(false);
+        await stream.WriteAsync(payload, ct).ConfigureAwait(false);
+        await stream.FlushAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Read one framed message. Returns null on a clean end-of-stream (peer closed
+    /// the pipe between frames). Throws <see cref="InvalidDataException"/> on a
+    /// truncated or out-of-range frame so the caller tears the channel down.
+    /// </summary>
+    public static async Task<SupportIpcMessage?> ReadAsync(Stream stream, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        byte[] header = new byte[4];
+        if (!await TryReadExactAsync(stream, header, ct).ConfigureAwait(false))
+            return null; // clean EOF at a frame boundary
+
+        uint len = BinaryPrimitives.ReadUInt32LittleEndian(header);
+        if (len == 0 || len > SupportIpc.MaxFrameBytes)
+            throw new InvalidDataException(
+                $"Support IPC frame length {len} is outside the 1..{SupportIpc.MaxFrameBytes} range.");
+
+        byte[] payload = new byte[len];
+        if (!await TryReadExactAsync(stream, payload, ct).ConfigureAwait(false))
+            throw new InvalidDataException("Support IPC stream ended mid-frame (truncated payload).");
+
+        var message = JsonSerializer.Deserialize(
+            payload, typeof(SupportIpcMessage), SupportIpcJsonContext.Default) as SupportIpcMessage;
+        return message ?? throw new InvalidDataException("Support IPC frame did not deserialise to a known message.");
+    }
+
+    // Fill the whole buffer or fail. Returns false only when the stream ends
+    // before any byte of the buffer is read (clean EOF); a partial read followed
+    // by EOF is a truncation and surfaces to the caller as such.
+    private static async Task<bool> TryReadExactAsync(Stream stream, byte[] buffer, CancellationToken ct)
+    {
+        int offset = 0;
+        while (offset < buffer.Length)
+        {
+            int read = await stream.ReadAsync(buffer.AsMemory(offset), ct).ConfigureAwait(false);
+            if (read == 0)
+            {
+                if (offset == 0) return false;       // EOF exactly at a frame boundary
+                throw new InvalidDataException("Support IPC stream ended mid-frame.");
+            }
+            offset += read;
+        }
+        return true;
+    }
+}

--- a/Zeus.Support.Contracts/SupportIpcJsonContext.cs
+++ b/Zeus.Support.Contracts/SupportIpcJsonContext.cs
@@ -15,4 +15,5 @@ namespace Zeus.Support.Contracts;
     UseStringEnumConverter = true,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
 [JsonSerializable(typeof(SupportIpcMessage))]
+[JsonSerializable(typeof(SupportCrashRecord))]
 public sealed partial class SupportIpcJsonContext : JsonSerializerContext;

--- a/Zeus.Support.Contracts/SupportIpcJsonContext.cs
+++ b/Zeus.Support.Contracts/SupportIpcJsonContext.cs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using System.Text.Json.Serialization;
+
+namespace Zeus.Support.Contracts;
+
+/// <summary>
+/// Source-generated System.Text.Json metadata for the support IPC contract.
+/// Serialising through the base <see cref="SupportIpcMessage"/> emits the
+/// polymorphic <c>kind</c> discriminator, so a reader can deserialise back to the
+/// concrete subtype without knowing it ahead of time. CamelCase + string enums
+/// keep the framed JSON human-readable in a packet/pipe trace.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    UseStringEnumConverter = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(SupportIpcMessage))]
+public sealed partial class SupportIpcJsonContext : JsonSerializerContext;

--- a/Zeus.Support.Contracts/Zeus.Support.Contracts.csproj
+++ b/Zeus.Support.Contracts/Zeus.Support.Contracts.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- Wire contract for the local IPC channel between the in-process Zeus
+       backend (Zeus.Server.Hosting) and the out-of-process support sidecar
+       (Zeus.SupportAgent). Deliberately tiny and dependency-free so BOTH the
+       backend and a standalone sidecar can reference it without dragging in
+       ASP.NET, LiteDB, or the radio stack. Same-machine, same-user transport
+       only (named pipe / loopback) — this is NOT the server<->web wire format
+       (that is Zeus.Contracts). -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Zeus.SupportAgent/CrashCapture.cs
+++ b/Zeus.SupportAgent/CrashCapture.cs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using Zeus.Support.Contracts;
+
+namespace Zeus.SupportAgent;
+
+/// <summary>
+/// Builds and persists a <see cref="SupportCrashRecord"/> when the supervised
+/// backend dies unexpectedly. The record bundles the exit code with the tail of
+/// the runtime and startup logs as they stood at death — the artifact a
+/// maintainer wants for a "random crash" report.
+/// </summary>
+public static class CrashCapture
+{
+    private const int AppLogTailLines = 200;
+    private const int StartupLogTailLines = 120;
+    private const int MaxRetainedRecords = 25;
+
+    /// <summary>
+    /// Assemble a crash record from the current logs. <paramref name="nowUnixMs"/>
+    /// is injected so callers (and tests) control the timestamp.
+    /// </summary>
+    public static SupportCrashRecord BuildRecord(SidecarOptions opts, int? exitCode, long nowUnixMs, string? note = null)
+    {
+        return new SupportCrashRecord(
+            SchemaVersion: SupportCrashRecord.CurrentSchemaVersion,
+            DetectedUnixMs: nowUnixMs,
+            Pid: opts.SupervisePid,
+            ExitCode: exitCode,
+            Crashed: true,
+            AppVersion: opts.AppVersion,
+            Platform: RuntimeInformation.OSDescription,
+            AppLogTail: LogTail.ReadAppLogTail(opts.AppLogPath, AppLogTailLines),
+            StartupLogTail: LogTail.ReadLastLines(opts.StartupLogPath, StartupLogTailLines),
+            Note: note);
+    }
+
+    /// <summary>
+    /// Build and write a crash record under the crash directory, returning the
+    /// written path (or null on failure). Best-effort: a write failure must not
+    /// throw — the sidecar's job is to help, never to add its own crash.
+    /// </summary>
+    public static string? WriteCrashRecord(SidecarOptions opts, int? exitCode, long nowUnixMs, string? note = null)
+    {
+        try
+        {
+            Directory.CreateDirectory(opts.CrashDir);
+            var record = BuildRecord(opts, exitCode, nowUnixMs, note);
+            var json = JsonSerializer.Serialize(record, SupportIpcJsonContext.Default.SupportCrashRecord);
+
+            var path = Path.Combine(opts.CrashDir, SupportPaths.CrashRecordFileName(nowUnixMs, opts.SupervisePid));
+            File.WriteAllText(path, json);
+
+            PruneOldRecords(opts.CrashDir);
+            return path;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    // Keep the crash directory bounded — newest records win.
+    private static void PruneOldRecords(string crashDir)
+    {
+        try
+        {
+            var files = Directory.GetFiles(crashDir, "crash-*.json");
+            if (files.Length <= MaxRetainedRecords) return;
+
+            foreach (var stale in files
+                         .OrderByDescending(f => f, StringComparer.Ordinal) // filename is time-sortable
+                         .Skip(MaxRetainedRecords))
+            {
+                try { File.Delete(stale); } catch { /* best effort */ }
+            }
+        }
+        catch
+        {
+            // Pruning is housekeeping; never let it surface.
+        }
+    }
+}

--- a/Zeus.SupportAgent/LogTail.cs
+++ b/Zeus.SupportAgent/LogTail.cs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Text;
+
+namespace Zeus.SupportAgent;
+
+/// <summary>
+/// Reads the trailing lines of a (small, bounded) on-disk log. Opens shared so it
+/// can read a file the backend may still be writing, and is tolerant of a missing
+/// or unreadable file — a crash record with an empty tail is better than no record.
+/// </summary>
+public static class LogTail
+{
+    /// <summary>Last <paramref name="maxLines"/> lines of one file, oldest first. Empty if missing/unreadable.</summary>
+    public static IReadOnlyList<string> ReadLastLines(string? path, int maxLines)
+    {
+        if (maxLines <= 0 || string.IsNullOrEmpty(path) || !File.Exists(path))
+            return [];
+
+        try
+        {
+            using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var reader = new StreamReader(fs, Encoding.UTF8);
+
+            // Files are size-capped (~2 MiB) so a ring of the last N lines is cheap
+            // and avoids holding the whole file.
+            var ring = new string[maxLines];
+            int count = 0, next = 0;
+            string? line;
+            while ((line = reader.ReadLine()) is not null)
+            {
+                ring[next] = line;
+                next = (next + 1) % maxLines;
+                if (count < maxLines) count++;
+            }
+
+            var result = new string[count];
+            int start = ((next - count) % maxLines + maxLines) % maxLines;
+            for (int i = 0; i < count; i++)
+                result[i] = ring[(start + i) % maxLines];
+            return result;
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// Trailing lines of the rolling app log, spanning the previous roll if the
+    /// active file just rotated and is short. Given the active path
+    /// <c>…/zeus-app.log</c> it also considers <c>…/zeus-app.1.log</c> so a crash
+    /// that lands moments after a roll still yields a useful tail.
+    /// </summary>
+    public static IReadOnlyList<string> ReadAppLogTail(string? appLogPath, int maxLines)
+    {
+        if (maxLines <= 0 || string.IsNullOrEmpty(appLogPath)) return [];
+
+        var active = ReadLastLines(appLogPath, maxLines);
+        if (active.Count >= maxLines) return active;
+
+        var rollPath = RolledPath(appLogPath, 1);
+        var roll = ReadLastLines(rollPath, maxLines - active.Count);
+        if (roll.Count == 0) return active;
+
+        var combined = new List<string>(roll.Count + active.Count);
+        combined.AddRange(roll);
+        combined.AddRange(active);
+        return combined;
+    }
+
+    private static string RolledPath(string path, int n)
+    {
+        var ext = Path.GetExtension(path);
+        var stem = path[..(path.Length - ext.Length)];
+        return $"{stem}.{n}{ext}";
+    }
+}

--- a/Zeus.SupportAgent/ProcessSupervisor.cs
+++ b/Zeus.SupportAgent/ProcessSupervisor.cs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Diagnostics;
+
+namespace Zeus.SupportAgent;
+
+/// <summary>Outcome of waiting on the supervised backend process.</summary>
+/// <param name="ProcessFound">False if the PID was already gone when we attached.</param>
+/// <param name="ExitCode">The process exit code when readable; null otherwise.</param>
+/// <param name="Cancelled">True if the wait was cancelled (the sidecar was told to stop).</param>
+public readonly record struct SupervisionResult(bool ProcessFound, int? ExitCode, bool Cancelled);
+
+/// <summary>
+/// Waits for the supervised Zeus backend to exit. Crash-vs-clean classification is
+/// NOT decided here — it depends on the clean-exit marker the backend writes at a
+/// deliberate shutdown — this just blocks until the process is gone (or the
+/// sidecar is cancelled).
+/// </summary>
+public static class ProcessSupervisor
+{
+    public static async Task<SupervisionResult> WaitForExitAsync(int pid, CancellationToken ct)
+    {
+        Process process;
+        try
+        {
+            process = Process.GetProcessById(pid);
+        }
+        catch (ArgumentException)
+        {
+            // No such process — it already exited before we attached. Caller still
+            // checks the clean-exit marker to classify it.
+            return new SupervisionResult(ProcessFound: false, ExitCode: null, Cancelled: false);
+        }
+
+        using (process)
+        {
+            try
+            {
+                process.EnableRaisingEvents = true;
+                await process.WaitForExitAsync(ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                return new SupervisionResult(ProcessFound: true, ExitCode: null, Cancelled: true);
+            }
+
+            int? exitCode = null;
+            try
+            {
+                exitCode = process.ExitCode;
+            }
+            catch
+            {
+                // Exit code can be unreadable for a process we didn't start; the
+                // crash record simply records a null exit code.
+            }
+
+            return new SupervisionResult(ProcessFound: true, ExitCode: exitCode, Cancelled: false);
+        }
+    }
+}

--- a/Zeus.SupportAgent/Program.cs
+++ b/Zeus.SupportAgent/Program.cs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Runtime.InteropServices;
+using Zeus.Support.Contracts;
+using Zeus.SupportAgent;
+
+// The Zeus support sidecar. Phase 1 scope is LOCAL ONLY: supervise the backend
+// PID, and on an unexpected death capture the tail of the on-disk logs into a
+// crash record. No broker / remote exposure yet — that arrives in later phases,
+// at which point this process (which survives the backend) will own the broker
+// connection.
+//
+// Lifecycle: wait for the supervised backend to exit, classify it via the
+// clean-exit marker the backend writes at a deliberate shutdown, capture a crash
+// record if it died unexpectedly, then exit. The sidecar must NEVER add its own
+// crash to the operator's machine, so every step is best-effort.
+
+if (!SidecarOptions.TryParse(args, out var opts, out var error) || opts is null)
+{
+    Console.Error.WriteLine($"zeus-support-agent: {error}");
+    return 2;
+}
+
+Breadcrumb(opts, $"start: supervising pid={opts.SupervisePid} session={opts.SessionToken ?? "-"}");
+
+using var cts = new CancellationTokenSource();
+using var sigint = SafeSignal(PosixSignal.SIGINT, cts);
+using var sigterm = SafeSignal(PosixSignal.SIGTERM, cts);
+Console.CancelKeyPress += (_, e) => { e.Cancel = true; cts.Cancel(); };
+
+var result = await ProcessSupervisor.WaitForExitAsync(opts.SupervisePid, cts.Token).ConfigureAwait(false);
+
+if (result.Cancelled)
+{
+    Breadcrumb(opts, "stop: cancelled while supervising; backend still alive");
+    return 0;
+}
+
+// Classify the exit. A clean-exit marker (written by the backend at window close,
+// operator quit, or profile-switch relaunch) means an expected shutdown.
+var markerPath = Path.Combine(opts.CrashDir, SupportPaths.CleanExitMarkerName(opts.SupervisePid));
+if (File.Exists(markerPath))
+{
+    TryDelete(markerPath);
+    Breadcrumb(opts, $"clean exit: pid={opts.SupervisePid} exitCode={Fmt(result.ExitCode)}");
+    return 0;
+}
+
+// No marker ⇒ the backend died unexpectedly. Capture a crash record.
+long nowUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+var note = result.ProcessFound ? null : "PID was already gone when the sidecar attached.";
+var written = CrashCapture.WriteCrashRecord(opts, result.ExitCode, nowUnixMs, note);
+Breadcrumb(opts,
+    written is null
+        ? $"crash detected: pid={opts.SupervisePid} exitCode={Fmt(result.ExitCode)} (record write FAILED)"
+        : $"crash detected: pid={opts.SupervisePid} exitCode={Fmt(result.ExitCode)} -> {Path.GetFileName(written)}");
+return 0;
+
+static string Fmt(int? code) => code?.ToString() ?? "<unknown>";
+
+// Register a POSIX signal handler without throwing on a platform/runtime that
+// doesn't support it (the sidecar still works; it just relies on Ctrl+C / exit).
+static IDisposable? SafeSignal(PosixSignal signal, CancellationTokenSource cts)
+{
+    try
+    {
+        return PosixSignalRegistration.Create(signal, ctx => { ctx.Cancel = true; cts.Cancel(); });
+    }
+    catch
+    {
+        return null;
+    }
+}
+
+static void TryDelete(string path)
+{
+    try { File.Delete(path); } catch { /* best effort */ }
+}
+
+// A one-line breadcrumb log for diagnosing the sidecar itself (it has no console
+// when spawned detached). Strictly best-effort and tiny.
+static void Breadcrumb(SidecarOptions opts, string message)
+{
+    try
+    {
+        Directory.CreateDirectory(opts.CrashDir);
+        var line = $"{DateTimeOffset.UtcNow:o} {message}{Environment.NewLine}";
+        File.AppendAllText(Path.Combine(opts.CrashDir, "support-agent.log"), line);
+    }
+    catch
+    {
+        // Never let breadcrumb logging affect the sidecar's behaviour.
+    }
+}

--- a/Zeus.SupportAgent/SidecarOptions.cs
+++ b/Zeus.SupportAgent/SidecarOptions.cs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.SupportAgent;
+
+/// <summary>
+/// Parsed command line for the support sidecar. The desktop host owns the
+/// platform data-dir logic, so it resolves every path and hands them in as
+/// arguments — the sidecar never re-derives <c>%LOCALAPPDATA%/Zeus</c> on its own
+/// (that keeps the ZEUS_PREFS_PATH override and profile rules in one place).
+/// </summary>
+public sealed record SidecarOptions(
+    int SupervisePid,
+    string? SessionToken,
+    string? AppLogPath,
+    string? StartupLogPath,
+    string CrashDir,
+    string? AppVersion)
+{
+    /// <summary>
+    /// Parse <c>--key value</c> arguments. Only <c>--supervise-pid</c> and
+    /// <c>--crash-dir</c> are required; everything else degrades gracefully (a
+    /// missing log path just yields an empty tail). Returns false with a message
+    /// on a malformed/missing required argument.
+    /// </summary>
+    public static bool TryParse(string[] args, out SidecarOptions? options, out string? error)
+    {
+        options = null;
+        error = null;
+
+        int? pid = null;
+        string? session = null, appLog = null, startupLog = null, crashDir = null, appVersion = null;
+
+        for (int i = 0; i < args.Length; i++)
+        {
+            string key = args[i];
+            string? Next()
+            {
+                if (i + 1 >= args.Length) return null;
+                return args[++i];
+            }
+
+            switch (key)
+            {
+                case "--supervise-pid":
+                    var pidStr = Next();
+                    if (!int.TryParse(pidStr, out var p) || p <= 0)
+                    {
+                        error = $"--supervise-pid requires a positive integer (got '{pidStr ?? "<none>"}').";
+                        return false;
+                    }
+                    pid = p;
+                    break;
+                case "--session": session = Next(); break;
+                case "--app-log": appLog = Next(); break;
+                case "--startup-log": startupLog = Next(); break;
+                case "--crash-dir": crashDir = Next(); break;
+                case "--app-version": appVersion = Next(); break;
+                default:
+                    error = $"Unknown argument '{key}'.";
+                    return false;
+            }
+        }
+
+        if (pid is null)
+        {
+            error = "--supervise-pid is required.";
+            return false;
+        }
+        if (string.IsNullOrWhiteSpace(crashDir))
+        {
+            error = "--crash-dir is required.";
+            return false;
+        }
+
+        options = new SidecarOptions(pid.Value, session, appLog, startupLog, crashDir, appVersion);
+        return true;
+    }
+}

--- a/Zeus.SupportAgent/Zeus.SupportAgent.csproj
+++ b/Zeus.SupportAgent/Zeus.SupportAgent.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- The Zeus support sidecar. A tiny, standalone process the desktop host
+       launches DETACHED so it OUTLIVES a backend crash: the Kestrel backend runs
+       in-process with the Photino webview, so when it dies it takes the in-memory
+       log ring with it. This process supervises the backend PID, and on an
+       unexpected death captures the tail of the on-disk logs into a crash record.
+       Dependency-free apart from the shared IPC/artifact contract. -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Zeus.SupportAgent</RootNamespace>
+    <AssemblyName>Zeus.SupportAgent</AssemblyName>
+    <!-- No console window should flash when the desktop host spawns us. -->
+    <UseWindowsForms>false</UseWindowsForms>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Zeus.Support.Contracts\Zeus.Support.Contracts.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Zeus.slnx
+++ b/Zeus.slnx
@@ -11,6 +11,7 @@
   </Folder>
   <Project Path="Zeus.Contracts/Zeus.Contracts.csproj" />
   <Project Path="Zeus.Support.Contracts/Zeus.Support.Contracts.csproj" />
+  <Project Path="Zeus.SupportAgent/Zeus.SupportAgent.csproj" />
   <Project Path="Zeus.Dsp/Zeus.Dsp.csproj" />
   <Project Path="Zeus.Dsp.FreeDv/Zeus.Dsp.FreeDv.csproj" />
   <Project Path="Zeus.Plugins.Contracts/Zeus.Plugins.Contracts.csproj" />

--- a/Zeus.slnx
+++ b/Zeus.slnx
@@ -10,6 +10,7 @@
     <Project Path="tests/Zeus.Server.Tests/Zeus.Server.Tests.csproj" />
   </Folder>
   <Project Path="Zeus.Contracts/Zeus.Contracts.csproj" />
+  <Project Path="Zeus.Support.Contracts/Zeus.Support.Contracts.csproj" />
   <Project Path="Zeus.Dsp/Zeus.Dsp.csproj" />
   <Project Path="Zeus.Dsp.FreeDv/Zeus.Dsp.FreeDv.csproj" />
   <Project Path="Zeus.Plugins.Contracts/Zeus.Plugins.Contracts.csproj" />

--- a/tests/Zeus.Server.Tests/DiagnosticLogFileSinkTests.cs
+++ b/tests/Zeus.Server.Tests/DiagnosticLogFileSinkTests.cs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Zeus.Server.Diagnostics;
+
+namespace Zeus.Server.Tests;
+
+// Rolling on-disk log sink that mirrors the in-memory diagnostic ring so the
+// recent log survives a backend crash for the support sidecar to tail.
+public class DiagnosticLogFileSinkTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly string _path;
+
+    public DiagnosticLogFileSinkTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), $"zeus-logsink-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_dir);
+        _path = Path.Combine(_dir, "zeus-app.log");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+    }
+
+    private static string Rolled(string path, int n)
+    {
+        var ext = Path.GetExtension(path);
+        var stem = path[..(path.Length - ext.Length)];
+        return $"{stem}.{n}{ext}";
+    }
+
+    [Fact]
+    public void Append_WritesLinesToDisk()
+    {
+        using (var sink = new DiagnosticLogFileSink(_path))
+        {
+            sink.Append("12:00:00.000 INFO RadioService hello");
+            sink.Append("12:00:00.100 WARN RadioService world");
+        }
+
+        var lines = File.ReadAllLines(_path);
+        Assert.Equal(2, lines.Length);
+        Assert.Contains("hello", lines[0]);
+        Assert.Contains("world", lines[1]);
+    }
+
+    [Fact]
+    public void Append_CreatesParentDirectoryOnDemand()
+    {
+        // The host points the sink at DataDir/logs which may not exist yet.
+        var nested = Path.Combine(_dir, "logs", "zeus-app.log");
+        using var sink = new DiagnosticLogFileSink(nested);
+        sink.Append("line");
+
+        Assert.True(File.Exists(nested));
+    }
+
+    [Fact]
+    public void Append_RollsAndBoundsHistory()
+    {
+        // Tiny cap so a handful of lines forces several rolls; keep 2 rolls.
+        using (var sink = new DiagnosticLogFileSink(_path, maxBytes: 200, maxRolls: 2))
+        {
+            for (int i = 0; i < 200; i++)
+                sink.Append($"{i:D4} {new string('x', 60)}");
+        }
+
+        Assert.True(File.Exists(_path));            // active
+        Assert.True(File.Exists(Rolled(_path, 1))); // newest roll
+        Assert.True(File.Exists(Rolled(_path, 2))); // oldest retained roll
+        // History is bounded to maxRolls — nothing older is kept.
+        Assert.False(File.Exists(Rolled(_path, 3)));
+    }
+
+    [Fact]
+    public void Append_BadPath_DoesNotThrow()
+    {
+        // Point the sink at a path whose "directory" is actually an existing file,
+        // so the directory create fails. A logging sink must degrade silently, not
+        // throw into the logging pipeline.
+        var asFile = Path.Combine(_dir, "not-a-dir");
+        File.WriteAllText(asFile, "x");
+        var doomed = Path.Combine(asFile, "sub", "zeus-app.log");
+
+        using var sink = new DiagnosticLogFileSink(doomed);
+        var ex = Record.Exception(() => sink.Append("should be swallowed"));
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void Append_AfterDispose_IsNoOp()
+    {
+        var sink = new DiagnosticLogFileSink(_path);
+        sink.Append("before");
+        sink.Dispose();
+
+        var ex = Record.Exception(() => sink.Append("after"));
+        Assert.Null(ex);
+
+        var lines = File.ReadAllLines(_path);
+        Assert.Single(lines);
+        Assert.Contains("before", lines[0]);
+    }
+}

--- a/tests/Zeus.Server.Tests/SupportAgentTests.cs
+++ b/tests/Zeus.Server.Tests/SupportAgentTests.cs
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using Zeus.Support.Contracts;
+using Zeus.SupportAgent;
+
+namespace Zeus.Server.Tests;
+
+public class SidecarOptionsTests
+{
+    [Fact]
+    public void Parse_Valid_PopulatesAllFields()
+    {
+        var ok = SidecarOptions.TryParse(
+            ["--supervise-pid", "1234", "--session", "abc", "--app-log", "a.log",
+             "--startup-log", "s.log", "--crash-dir", "c", "--app-version", "1.0"],
+            out var opts, out var err);
+
+        Assert.True(ok);
+        Assert.Null(err);
+        Assert.NotNull(opts);
+        Assert.Equal(1234, opts!.SupervisePid);
+        Assert.Equal("abc", opts.SessionToken);
+        Assert.Equal("a.log", opts.AppLogPath);
+        Assert.Equal("s.log", opts.StartupLogPath);
+        Assert.Equal("c", opts.CrashDir);
+        Assert.Equal("1.0", opts.AppVersion);
+    }
+
+    [Fact]
+    public void Parse_MissingPid_Fails()
+    {
+        Assert.False(SidecarOptions.TryParse(["--crash-dir", "c"], out var opts, out var err));
+        Assert.Null(opts);
+        Assert.Contains("supervise-pid", err);
+    }
+
+    [Fact]
+    public void Parse_MissingCrashDir_Fails()
+    {
+        Assert.False(SidecarOptions.TryParse(["--supervise-pid", "5"], out _, out var err));
+        Assert.Contains("crash-dir", err);
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("-1")]
+    [InlineData("notanint")]
+    public void Parse_BadPid_Fails(string pid)
+    {
+        Assert.False(SidecarOptions.TryParse(["--supervise-pid", pid, "--crash-dir", "c"], out _, out var err));
+        Assert.Contains("supervise-pid", err);
+    }
+
+    [Fact]
+    public void Parse_UnknownArg_Fails()
+    {
+        Assert.False(SidecarOptions.TryParse(["--bogus", "x"], out _, out var err));
+        Assert.Contains("bogus", err);
+    }
+}
+
+public class SupportAgentLogTailTests : IDisposable
+{
+    private readonly string _dir;
+    public SupportAgentLogTailTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), $"zeus-tail-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_dir);
+    }
+    public void Dispose() { try { Directory.Delete(_dir, true); } catch { } }
+
+    [Fact]
+    public void ReadLastLines_ReturnsTrailingLines()
+    {
+        var p = Path.Combine(_dir, "f.log");
+        File.WriteAllLines(p, ["a", "b", "c", "d", "e"]);
+        Assert.Equal(["c", "d", "e"], LogTail.ReadLastLines(p, 3));
+    }
+
+    [Fact]
+    public void ReadLastLines_FewerThanRequested_ReturnsAll()
+    {
+        var p = Path.Combine(_dir, "f.log");
+        File.WriteAllLines(p, ["a", "b"]);
+        Assert.Equal(["a", "b"], LogTail.ReadLastLines(p, 10));
+    }
+
+    [Fact]
+    public void ReadLastLines_MissingFile_IsEmpty()
+        => Assert.Empty(LogTail.ReadLastLines(Path.Combine(_dir, "nope.log"), 5));
+
+    [Fact]
+    public void ReadAppLogTail_SpansPreviousRollWhenActiveShort()
+    {
+        var active = Path.Combine(_dir, "zeus-app.log");
+        var roll = Path.Combine(_dir, "zeus-app.1.log");
+        File.WriteAllLines(roll, ["A1", "A2", "A3", "A4", "A5"]);
+        File.WriteAllLines(active, ["B1", "B2"]);
+
+        // Want 4 lines: active has 2, so the previous roll fills the other 2.
+        Assert.Equal(["A4", "A5", "B1", "B2"], LogTail.ReadAppLogTail(active, 4));
+    }
+
+    [Fact]
+    public void ReadAppLogTail_ActiveAloneSatisfiesRequest()
+    {
+        var active = Path.Combine(_dir, "zeus-app.log");
+        File.WriteAllLines(active, ["B1", "B2", "B3", "B4"]);
+        Assert.Equal(["B3", "B4"], LogTail.ReadAppLogTail(active, 2));
+    }
+}
+
+public class CrashCaptureTests : IDisposable
+{
+    private readonly string _dir;
+    public CrashCaptureTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), $"zeus-crash-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_dir);
+    }
+    public void Dispose() { try { Directory.Delete(_dir, true); } catch { } }
+
+    private SidecarOptions Opts(string? appLog = null, string? startupLog = null) =>
+        new(SupervisePid: 4321, SessionToken: "s", AppLogPath: appLog,
+            StartupLogPath: startupLog, CrashDir: _dir, AppVersion: "9.9");
+
+    [Fact]
+    public void BuildRecord_CapturesLogTailsAndMetadata()
+    {
+        var appLog = Path.Combine(_dir, "zeus-app.log");
+        File.WriteAllLines(appLog, ["one", "two", "three"]);
+
+        var rec = CrashCapture.BuildRecord(Opts(appLog), exitCode: -1073741819, nowUnixMs: 1_700_000_000_000);
+
+        Assert.Equal(SupportCrashRecord.CurrentSchemaVersion, rec.SchemaVersion);
+        Assert.Equal(4321, rec.Pid);
+        Assert.Equal(-1073741819, rec.ExitCode);
+        Assert.True(rec.Crashed);
+        Assert.Equal("9.9", rec.AppVersion);
+        Assert.Contains("three", rec.AppLogTail);
+        Assert.False(string.IsNullOrEmpty(rec.Platform));
+    }
+
+    [Fact]
+    public void WriteCrashRecord_WritesDeserialisableJson()
+    {
+        var path = CrashCapture.WriteCrashRecord(Opts(), exitCode: 5, nowUnixMs: 1_700_000_000_000);
+        Assert.NotNull(path);
+        Assert.True(File.Exists(path));
+
+        var back = JsonSerializer.Deserialize(File.ReadAllText(path!), SupportIpcJsonContext.Default.SupportCrashRecord);
+        Assert.NotNull(back);
+        Assert.Equal(4321, back!.Pid);
+        Assert.Equal(5, back.ExitCode);
+        Assert.True(back.Crashed);
+    }
+
+    [Fact]
+    public void WriteCrashRecord_PrunesToBoundedHistory()
+    {
+        // Seed more than the retention cap with time-sortable names.
+        for (int i = 0; i < 30; i++)
+            File.WriteAllText(Path.Combine(_dir, SupportPaths.CrashRecordFileName(1_000_000_000_000 + i, 1)), "{}");
+
+        CrashCapture.WriteCrashRecord(Opts(), exitCode: 0, nowUnixMs: 1_700_000_000_000);
+
+        var remaining = Directory.GetFiles(_dir, "crash-*.json").Length;
+        Assert.True(remaining <= 25, $"expected <=25 retained crash records, found {remaining}");
+    }
+}
+
+public class SupportPathsTests
+{
+    [Fact]
+    public void CleanExitMarkerName_IsPerPid()
+        => Assert.Equal("clean-exit-777.marker", SupportPaths.CleanExitMarkerName(777));
+
+    [Fact]
+    public void CrashRecordFileName_IsTimeSortable()
+    {
+        var early = SupportPaths.CrashRecordFileName(1_000_000_000_000, 1);
+        var late = SupportPaths.CrashRecordFileName(1_700_000_000_000, 1);
+        Assert.True(string.CompareOrdinal(early, late) < 0);
+        Assert.StartsWith("crash-", early);
+        Assert.EndsWith(".json", early);
+    }
+}
+
+public class ProcessSupervisorTests
+{
+    // A short-lived child that sleeps briefly then exits with a known code, so the
+    // supervisor reliably attaches before it dies. Cross-platform via the OS shell.
+    private static Process StartDummy(int exitCode, bool linger)
+    {
+        ProcessStartInfo psi;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            var cmd = linger
+                ? $"ping -n 2 127.0.0.1 >nul & exit {exitCode}"
+                : $"exit {exitCode}";
+            psi = new ProcessStartInfo("cmd.exe", $"/c \"{cmd}\"");
+        }
+        else
+        {
+            var cmd = linger ? $"sleep 0.6; exit {exitCode}" : $"exit {exitCode}";
+            psi = new ProcessStartInfo("/bin/sh", $"-c \"{cmd}\"");
+        }
+        psi.CreateNoWindow = true;
+        psi.UseShellExecute = false;
+        return Process.Start(psi)!;
+    }
+
+    [Fact]
+    public async Task WaitForExit_ReturnsExitCodeOfSupervisedProcess()
+    {
+        using var child = StartDummy(exitCode: 7, linger: true);
+        var result = await ProcessSupervisor.WaitForExitAsync(child.Id, CancellationToken.None);
+
+        Assert.False(result.Cancelled);
+        Assert.True(result.ProcessFound);
+        Assert.Equal(7, result.ExitCode);
+    }
+
+    [Fact]
+    public async Task WaitForExit_ProcessAlreadyGone_ReportsNotFound()
+    {
+        using var child = StartDummy(exitCode: 3, linger: false);
+        child.WaitForExit(); // ensure it is fully gone before we attach
+        var goneId = child.Id;
+
+        var result = await ProcessSupervisor.WaitForExitAsync(goneId, CancellationToken.None);
+        Assert.False(result.ProcessFound);
+        Assert.False(result.Cancelled);
+    }
+
+    [Fact]
+    public async Task WaitForExit_Cancellation_ReportsCancelled()
+    {
+        using var child = StartDummy(exitCode: 0, linger: true);
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(50);
+
+        var result = await ProcessSupervisor.WaitForExitAsync(child.Id, cts.Token);
+        Assert.True(result.Cancelled);
+
+        try { child.Kill(); } catch { }
+    }
+}

--- a/tests/Zeus.Server.Tests/SupportAgentTests.cs
+++ b/tests/Zeus.Server.Tests/SupportAgentTests.cs
@@ -229,7 +229,17 @@ public class ProcessSupervisorTests
 
         Assert.False(result.Cancelled);
         Assert.True(result.ProcessFound);
-        Assert.Equal(7, result.ExitCode);
+
+        // The supervisor attaches by PID via Process.GetProcessById — it is NOT the
+        // process that started the child. On Windows the exit code is still readable
+        // through the open process handle; on Unix only the real parent can reap a
+        // child's status (waitpid), so ExitCode is unavailable and the production
+        // crash record records null. This mirrors the live sidecar, which always
+        // attaches to a backend PID it never started.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            Assert.Equal(7, result.ExitCode);
+        else
+            Assert.Null(result.ExitCode);
     }
 
     [Fact]

--- a/tests/Zeus.Server.Tests/SupportIpcFramingTests.cs
+++ b/tests/Zeus.Server.Tests/SupportIpcFramingTests.cs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Buffers.Binary;
+using System.Text;
+using Zeus.Support.Contracts;
+
+namespace Zeus.Server.Tests;
+
+// Length-prefixed JSON framing + DTO contract for the backend<->sidecar IPC.
+public class SupportIpcFramingTests
+{
+    private static async Task<SupportIpcMessage?> RoundTripAsync(SupportIpcMessage message)
+    {
+        using var ms = new MemoryStream();
+        await SupportIpcFraming.WriteAsync(ms, message);
+        ms.Position = 0;
+        return await SupportIpcFraming.ReadAsync(ms);
+    }
+
+    [Fact]
+    public async Task Hello_RoundTrips()
+    {
+        var hello = new SupportHello(
+            ProtocolVersion: SupportIpc.ProtocolVersion,
+            BackendPid: 4242,
+            AppVersion: "1.2.3",
+            Platform: "win32-x64",
+            QrzCallsign: "N9WAR",
+            RemoteDiagnosticsEnabled: true,
+            AutoShareOnCrash: false,
+            AppLogPath: @"C:\Users\x\AppData\Local\Zeus\logs\zeus-app.log",
+            StartupLogPath: @"C:\Users\x\AppData\Local\Zeus\zeus-startup.log");
+
+        var result = await RoundTripAsync(hello);
+
+        // Records have value equality, so a full round-trip must reproduce the
+        // concrete type and every field.
+        Assert.Equal(hello, result);
+        Assert.IsType<SupportHello>(result);
+    }
+
+    [Fact]
+    public async Task PromptResult_PreservesEnumDecision()
+    {
+        var msg = new SupportPromptResult("req-1", SupportPromptDecision.Timeout);
+        var result = await RoundTripAsync(msg);
+        Assert.Equal(msg, result);
+    }
+
+    [Theory]
+    [InlineData(SupportPromptDecision.Allow)]
+    [InlineData(SupportPromptDecision.Deny)]
+    [InlineData(SupportPromptDecision.Timeout)]
+    [InlineData(SupportPromptDecision.Unavailable)]
+    public async Task AllDecisions_RoundTrip(SupportPromptDecision decision)
+    {
+        var result = await RoundTripAsync(new SupportPromptResult("r", decision));
+        Assert.Equal(decision, Assert.IsType<SupportPromptResult>(result).Decision);
+    }
+
+    [Fact]
+    public async Task Sequence_OfMessages_RoundTripsInOrder()
+    {
+        SupportIpcMessage[] sent =
+        [
+            new SupportHeartbeat(123),
+            new SupportPromptRequest("req-9", "KB2UKA", "looking into a crash"),
+            new SupportDiagnosticsPull("req-10", "dsp-live"),
+            new SupportDiagnosticsSnapshot("req-10", Ok: true, Json: "{\"x\":1}"),
+        ];
+
+        using var ms = new MemoryStream();
+        foreach (var m in sent)
+            await SupportIpcFraming.WriteAsync(ms, m);
+        ms.Position = 0;
+
+        foreach (var expected in sent)
+            Assert.Equal(expected, await SupportIpcFraming.ReadAsync(ms));
+
+        // Stream is now exhausted exactly at a frame boundary → clean EOF.
+        Assert.Null(await SupportIpcFraming.ReadAsync(ms));
+    }
+
+    [Fact]
+    public async Task Read_OnEmptyStream_ReturnsNull()
+    {
+        using var ms = new MemoryStream();
+        Assert.Null(await SupportIpcFraming.ReadAsync(ms));
+    }
+
+    [Fact]
+    public async Task Read_ZeroLengthFrame_Throws()
+    {
+        using var ms = new MemoryStream(new byte[4]); // length prefix = 0
+        await Assert.ThrowsAsync<InvalidDataException>(() => SupportIpcFraming.ReadAsync(ms));
+    }
+
+    [Fact]
+    public async Task Read_OversizedFrame_Throws()
+    {
+        var header = new byte[4];
+        BinaryPrimitives.WriteUInt32LittleEndian(header, (uint)SupportIpc.MaxFrameBytes + 1);
+        using var ms = new MemoryStream(header);
+        await Assert.ThrowsAsync<InvalidDataException>(() => SupportIpcFraming.ReadAsync(ms));
+    }
+
+    [Fact]
+    public async Task Read_TruncatedPayload_Throws()
+    {
+        // Header promises 50 bytes; supply only 10 then EOF.
+        var header = new byte[4];
+        BinaryPrimitives.WriteUInt32LittleEndian(header, 50);
+        var buf = new byte[4 + 10];
+        header.CopyTo(buf, 0);
+        Encoding.UTF8.GetBytes("0123456789").CopyTo(buf, 4);
+
+        using var ms = new MemoryStream(buf);
+        await Assert.ThrowsAsync<InvalidDataException>(() => SupportIpcFraming.ReadAsync(ms));
+    }
+
+    [Fact]
+    public void PipeNameForSession_SanitisesAndIsStable()
+    {
+        Assert.Equal("zeus-support", SupportIpc.PipeNameForSession(null));
+        Assert.Equal("zeus-support", SupportIpc.PipeNameForSession("   "));
+        // Non-alphanumerics collapse to underscores; the same token is stable.
+        var a = SupportIpc.PipeNameForSession("ab/cd-12");
+        Assert.Equal("zeus-support-ab_cd_12", a);
+        Assert.Equal(a, SupportIpc.PipeNameForSession("ab/cd-12"));
+    }
+}


### PR DESCRIPTION
**Phase 0 of the remote diagnostics & maintainer support epic** (`zeus-87ca`). Foundations only — **no remote exposure** in this PR.

### Why
The desktop backend runs in-process with the Photino webview, so a crash takes the broker connection *and* the in-memory diagnostic log ring with it — useless for diagnosing the crash that killed the process. Anything that must outlive a crash has to live in a separate sidecar process and persist to disk. This PR lays that groundwork.

### What
- **`DiagnosticLogFileSink`** — rolling, size-capped, best-effort on-disk mirror of the diagnostic log at `DataDir/logs/zeus-app.log`. `RingBufferLogger` now redacts each line once and fans it to both the in-memory ring and the file sink, so the recent log survives a crash for a sidecar to tail. Rolls *before* writing so the active file always holds the freshest line.
- **`PrefsDbPath.LogDir()/AppLogPath()`** — cross-platform log path honouring the `ZEUS_PREFS_PATH` override (dev `/run fresh`, CI, tests stay isolated).
- **`Zeus.Support.Contracts`** — new dependency-free shared library defining the local backend↔sidecar IPC contract: polymorphic message DTOs, source-generated JSON, length-prefixed framing, per-session pipe naming. Same-machine transport only — **not** the `Zeus.Contracts` server↔web wire format.

### Tests
17 new tests (`DiagnosticLogFileSinkTests`, `SupportIpcFramingTests`): write/dir-create/rolling+bounded-history/bad-path tolerance/post-dispose no-op; framing round-trip of every message type, enum decisions, multi-message sequence + clean EOF, zero/oversized/truncated frame rejection, pipe-name sanitising. All green. `.NET` build clean.

Closes zeus-idf2.