### PR TITLE
feat(diag): support sidecar — supervise PID, capture crash logs (remote-diag P1)

### DIFF
--- a/OpenhpsdrZeus/OpenhpsdrZeus.csproj
+++ b/OpenhpsdrZeus/OpenhpsdrZeus.csproj
@@ -40,6 +40,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Zeus.Server.Hosting\Zeus.Server.Hosting.csproj" />
+    <!-- The support sidecar is a separate executable the desktop host launches
+         detached so it survives a backend crash. Referencing it co-locates
+         Zeus.SupportAgent(.exe) in this host's output dir for SupportSidecarLauncher
+         to spawn; the host does not use its types. -->
+    <ProjectReference Include="..\Zeus.SupportAgent\Zeus.SupportAgent.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OpenhpsdrZeus/Program.cs
+++ b/OpenhpsdrZeus/Program.cs
@@ -349,6 +349,11 @@ public partial class Program
         app.StartAsync().GetAwaiter().GetResult();
         StartupDiagnostics.Phase("desktop: host started");
 
+        // Spawn the out-of-process support sidecar now the backend is up. It runs
+        // detached so it survives a backend crash and can capture the crash logs
+        // the in-memory ring would lose. Best-effort — never blocks launch.
+        SupportSidecarLauncher.TryLaunch();
+
         // Resolve the bound URLs after Start — Kestrel writes the OS-assigned
         // loopback port (plus the LAN HTTPS port we configured) into
         // IServerAddressesFeature here. Photino must load the loopback HTTP URL:
@@ -699,6 +704,10 @@ public partial class Program
     //    above).
     private static void ShutdownDesktopHost(WebApplication app)
     {
+        // Deliberate shutdown — tell any supervising sidecar this is a clean exit,
+        // not a crash, BEFORE we tear the host down or _exit(2).
+        SupportSidecar.MarkCleanExit();
+
         StopAndDisposeHost(app);
 
         Console.Out.Flush();

--- a/OpenhpsdrZeus/SupportSidecarLauncher.cs
+++ b/OpenhpsdrZeus/SupportSidecarLauncher.cs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Diagnostics;
+using System.Globalization;
+using System.Reflection;
+using Zeus.Server;
+using Zeus.Support.Contracts;
+
+namespace OpenhpsdrZeus;
+
+/// <summary>
+/// Spawns the out-of-process support sidecar (Zeus.SupportAgent) from the desktop
+/// host. The sidecar is launched DETACHED — a plain child process, not killed
+/// when this process dies — so it survives a backend crash and can capture the
+/// crash. We hand it every path it needs as arguments (the host owns the
+/// platform data-dir logic); it never re-derives them.
+///
+/// The sidecar is a diagnostics enhancement: any failure to launch is logged and
+/// swallowed and MUST never block or slow Zeus startup.
+/// </summary>
+internal static class SupportSidecarLauncher
+{
+    public static void TryLaunch()
+    {
+        try
+        {
+            var exe = ResolveSidecarExe();
+            if (exe is null)
+            {
+                Console.Error.WriteLine(
+                    "support-agent: sidecar executable not found next to host; crash capture disabled this session.");
+                return;
+            }
+
+            var psi = new ProcessStartInfo(exe)
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WorkingDirectory = AppContext.BaseDirectory,
+            };
+
+            void Add(string key, string? value)
+            {
+                if (string.IsNullOrEmpty(value)) return;
+                psi.ArgumentList.Add(key);
+                psi.ArgumentList.Add(value);
+            }
+
+            Add("--supervise-pid", Environment.ProcessId.ToString(CultureInfo.InvariantCulture));
+            Add("--session", Guid.NewGuid().ToString("N"));
+            Add("--app-log", PrefsDbPath.AppLogPath());
+            Add("--startup-log", StartupDiagnostics.LogPath);
+            Add("--crash-dir", PrefsDbPath.CrashDir());
+            Add("--app-version", ResolveAppVersion());
+
+            Process.Start(psi);
+            StartupDiagnostics.Log($"support-agent: launched sidecar to supervise pid {Environment.ProcessId}");
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"support-agent: launch failed: {ex.Message}");
+        }
+    }
+
+    private static string? ResolveSidecarExe()
+    {
+        var name = OperatingSystem.IsWindows() ? "Zeus.SupportAgent.exe" : "Zeus.SupportAgent";
+        var path = Path.Combine(AppContext.BaseDirectory, name);
+        return File.Exists(path) ? path : null;
+    }
+
+    private static string? ResolveAppVersion()
+    {
+        var asm = Assembly.GetEntryAssembly();
+        return asm?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? asm?.GetName().Version?.ToString();
+    }
+}

--- a/Zeus.Server.Hosting/AppRestartService.cs
+++ b/Zeus.Server.Hosting/AppRestartService.cs
@@ -45,6 +45,10 @@ public sealed class AppRestartService
             // Never block the exit on a best-effort hook.
         }
 
+        // Deliberate exit — let any supervising support sidecar see this as a
+        // clean shutdown, not a crash.
+        SupportSidecar.MarkCleanExit();
+
         // Let the in-flight HTTP response flush before the process dies.
         _ = Task.Run(async () =>
         {
@@ -75,6 +79,11 @@ public sealed class AppRestartService
         {
             // Never block the relaunch on a best-effort hook.
         }
+
+        // A relaunch is a deliberate exit — mark it clean so a supervising sidecar
+        // doesn't capture a crash record for the old PID. (The fresh process will
+        // spawn its own sidecar.)
+        SupportSidecar.MarkCleanExit();
 
         // Let the in-flight HTTP response flush before the process dies.
         _ = Task.Run(async () =>

--- a/Zeus.Server.Hosting/PrefsDbPath.cs
+++ b/Zeus.Server.Hosting/PrefsDbPath.cs
@@ -81,6 +81,19 @@ public static class PrefsDbPath
     // Full path of the active rolling runtime log file.
     public static string AppLogPath() => Path.Combine(LogDir(), "zeus-app.log");
 
+    // Directory for support-sidecar artifacts: the per-PID clean-exit markers the
+    // backend drops at a deliberate shutdown and the crash records the sidecar
+    // writes when the backend dies unexpectedly. Same ZEUS_PREFS_PATH isolation as
+    // the logs so tests/dev never touch the operator's real data dir.
+    public static string CrashDir()
+    {
+        var env = Environment.GetEnvironmentVariable("ZEUS_PREFS_PATH");
+        var dir = string.IsNullOrEmpty(env)
+            ? DataDir
+            : (Path.GetDirectoryName(Path.GetFullPath(env)) ?? DataDir);
+        return Path.Combine(dir, "crashes");
+    }
+
     // Relative path (under DataDir) of the active profile. Reads the pointer
     // file; falls back to the legacy zeus-prefs.db when the pointer is absent,
     // unreadable, or names a file that no longer exists.

--- a/Zeus.Server.Hosting/Support/SupportSidecar.cs
+++ b/Zeus.Server.Hosting/Support/SupportSidecar.cs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Zeus.Support.Contracts;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Backend-side touchpoints for the out-of-process support sidecar. Phase 1 only
+/// needs the clean-exit handshake: the sidecar treats the backend's death as a
+/// crash UNLESS it finds a per-PID marker the backend wrote at a deliberate exit.
+/// Call <see cref="MarkCleanExit"/> on every intentional shutdown path (window
+/// close, operator quit, profile-switch relaunch) so a normal exit is never
+/// mis-reported as a crash.
+/// </summary>
+public static class SupportSidecar
+{
+    /// <summary>
+    /// Drop the clean-exit marker for THIS process so a supervising sidecar
+    /// classifies the imminent exit as expected. Best-effort and synchronous — it
+    /// must complete before the process exits, and must never throw on a shutdown
+    /// path.
+    /// </summary>
+    public static void MarkCleanExit()
+    {
+        try
+        {
+            var dir = PrefsDbPath.CrashDir();
+            Directory.CreateDirectory(dir);
+            var path = Path.Combine(dir, SupportPaths.CleanExitMarkerName(Environment.ProcessId));
+            File.WriteAllText(path, DateTimeOffset.UtcNow.ToString("o"));
+        }
+        catch
+        {
+            // A missing marker only costs a spurious crash record; never let it
+            // interfere with shutdown.
+        }
+    }
+}

--- a/Zeus.Support.Contracts/SupportArtifacts.cs
+++ b/Zeus.Support.Contracts/SupportArtifacts.cs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.Support.Contracts;
+
+/// <summary>
+/// On-disk filename conventions shared by the backend (writer) and the support
+/// sidecar (reader). Kept here — dependency-free — so the two processes can never
+/// disagree on a name. The directories themselves are resolved by the backend
+/// (which owns the platform data-dir logic) and passed to the sidecar as launch
+/// arguments, so this type holds only the pure, path-free filename rules.
+/// </summary>
+public static class SupportPaths
+{
+    /// <summary>
+    /// Marker the backend writes at a DELIBERATE exit (window close, operator
+    /// quit, profile-switch relaunch). The sidecar supervising that PID looks for
+    /// this file when the process dies: present ⇒ clean shutdown (delete it, exit
+    /// quietly); absent ⇒ the process died unexpectedly ⇒ capture a crash record.
+    /// Keyed by PID so a relaunch's fresh backend can never have its marker read
+    /// by the previous generation's sidecar.
+    /// </summary>
+    public static string CleanExitMarkerName(int pid) => $"clean-exit-{pid}.marker";
+
+    /// <summary>Filename for a captured crash record (sortable by time, disambiguated by PID).</summary>
+    public static string CrashRecordFileName(long detectedUnixMs, int pid) =>
+        $"crash-{detectedUnixMs:D13}-{pid}.json";
+}
+
+/// <summary>
+/// A captured backend-crash record, written by the sidecar to the crash directory
+/// when the supervised Zeus process dies without a clean-exit marker. This is the
+/// artifact a maintainer ultimately wants for a "random crash" report: the exit
+/// code plus the tail of the runtime and startup logs as they stood at death.
+///
+/// Persisted as JSON via <see cref="SupportIpcJsonContext"/>. Evolve by ADDING
+/// optional fields and bumping <see cref="SchemaVersion"/>.
+/// </summary>
+public sealed record SupportCrashRecord(
+    int SchemaVersion,
+    long DetectedUnixMs,
+    int Pid,
+    int? ExitCode,
+    bool Crashed,
+    string? AppVersion,
+    string Platform,
+    IReadOnlyList<string> AppLogTail,
+    IReadOnlyList<string> StartupLogTail,
+    string? Note)
+{
+    /// <summary>Current schema version for newly written crash records.</summary>
+    public const int CurrentSchemaVersion = 1;
+}

--- a/Zeus.Support.Contracts/SupportIpcJsonContext.cs
+++ b/Zeus.Support.Contracts/SupportIpcJsonContext.cs
@@ -15,4 +15,5 @@ namespace Zeus.Support.Contracts;
     UseStringEnumConverter = true,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
 [JsonSerializable(typeof(SupportIpcMessage))]
+[JsonSerializable(typeof(SupportCrashRecord))]
 public sealed partial class SupportIpcJsonContext : JsonSerializerContext;

--- a/Zeus.SupportAgent/CrashCapture.cs
+++ b/Zeus.SupportAgent/CrashCapture.cs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using Zeus.Support.Contracts;
+
+namespace Zeus.SupportAgent;
+
+/// <summary>
+/// Builds and persists a <see cref="SupportCrashRecord"/> when the supervised
+/// backend dies unexpectedly. The record bundles the exit code with the tail of
+/// the runtime and startup logs as they stood at death — the artifact a
+/// maintainer wants for a "random crash" report.
+/// </summary>
+public static class CrashCapture
+{
+    private const int AppLogTailLines = 200;
+    private const int StartupLogTailLines = 120;
+    private const int MaxRetainedRecords = 25;
+
+    /// <summary>
+    /// Assemble a crash record from the current logs. <paramref name="nowUnixMs"/>
+    /// is injected so callers (and tests) control the timestamp.
+    /// </summary>
+    public static SupportCrashRecord BuildRecord(SidecarOptions opts, int? exitCode, long nowUnixMs, string? note = null)
+    {
+        return new SupportCrashRecord(
+            SchemaVersion: SupportCrashRecord.CurrentSchemaVersion,
+            DetectedUnixMs: nowUnixMs,
+            Pid: opts.SupervisePid,
+            ExitCode: exitCode,
+            Crashed: true,
+            AppVersion: opts.AppVersion,
+            Platform: RuntimeInformation.OSDescription,
+            AppLogTail: LogTail.ReadAppLogTail(opts.AppLogPath, AppLogTailLines),
+            StartupLogTail: LogTail.ReadLastLines(opts.StartupLogPath, StartupLogTailLines),
+            Note: note);
+    }
+
+    /// <summary>
+    /// Build and write a crash record under the crash directory, returning the
+    /// written path (or null on failure). Best-effort: a write failure must not
+    /// throw — the sidecar's job is to help, never to add its own crash.
+    /// </summary>
+    public static string? WriteCrashRecord(SidecarOptions opts, int? exitCode, long nowUnixMs, string? note = null)
+    {
+        try
+        {
+            Directory.CreateDirectory(opts.CrashDir);
+            var record = BuildRecord(opts, exitCode, nowUnixMs, note);
+            var json = JsonSerializer.Serialize(record, SupportIpcJsonContext.Default.SupportCrashRecord);
+
+            var path = Path.Combine(opts.CrashDir, SupportPaths.CrashRecordFileName(nowUnixMs, opts.SupervisePid));
+            File.WriteAllText(path, json);
+
+            PruneOldRecords(opts.CrashDir);
+            return path;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    // Keep the crash directory bounded — newest records win.
+    private static void PruneOldRecords(string crashDir)
+    {
+        try
+        {
+            var files = Directory.GetFiles(crashDir, "crash-*.json");
+            if (files.Length <= MaxRetainedRecords) return;
+
+            foreach (var stale in files
+                         .OrderByDescending(f => f, StringComparer.Ordinal) // filename is time-sortable
+                         .Skip(MaxRetainedRecords))
+            {
+                try { File.Delete(stale); } catch { /* best effort */ }
+            }
+        }
+        catch
+        {
+            // Pruning is housekeeping; never let it surface.
+        }
+    }
+}

--- a/Zeus.SupportAgent/LogTail.cs
+++ b/Zeus.SupportAgent/LogTail.cs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Text;
+
+namespace Zeus.SupportAgent;
+
+/// <summary>
+/// Reads the trailing lines of a (small, bounded) on-disk log. Opens shared so it
+/// can read a file the backend may still be writing, and is tolerant of a missing
+/// or unreadable file — a crash record with an empty tail is better than no record.
+/// </summary>
+public static class LogTail
+{
+    /// <summary>Last <paramref name="maxLines"/> lines of one file, oldest first. Empty if missing/unreadable.</summary>
+    public static IReadOnlyList<string> ReadLastLines(string? path, int maxLines)
+    {
+        if (maxLines <= 0 || string.IsNullOrEmpty(path) || !File.Exists(path))
+            return [];
+
+        try
+        {
+            using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var reader = new StreamReader(fs, Encoding.UTF8);
+
+            // Files are size-capped (~2 MiB) so a ring of the last N lines is cheap
+            // and avoids holding the whole file.
+            var ring = new string[maxLines];
+            int count = 0, next = 0;
+            string? line;
+            while ((line = reader.ReadLine()) is not null)
+            {
+                ring[next] = line;
+                next = (next + 1) % maxLines;
+                if (count < maxLines) count++;
+            }
+
+            var result = new string[count];
+            int start = ((next - count) % maxLines + maxLines) % maxLines;
+            for (int i = 0; i < count; i++)
+                result[i] = ring[(start + i) % maxLines];
+            return result;
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// Trailing lines of the rolling app log, spanning the previous roll if the
+    /// active file just rotated and is short. Given the active path
+    /// <c>…/zeus-app.log</c> it also considers <c>…/zeus-app.1.log</c> so a crash
+    /// that lands moments after a roll still yields a useful tail.
+    /// </summary>
+    public static IReadOnlyList<string> ReadAppLogTail(string? appLogPath, int maxLines)
+    {
+        if (maxLines <= 0 || string.IsNullOrEmpty(appLogPath)) return [];
+
+        var active = ReadLastLines(appLogPath, maxLines);
+        if (active.Count >= maxLines) return active;
+
+        var rollPath = RolledPath(appLogPath, 1);
+        var roll = ReadLastLines(rollPath, maxLines - active.Count);
+        if (roll.Count == 0) return active;
+
+        var combined = new List<string>(roll.Count + active.Count);
+        combined.AddRange(roll);
+        combined.AddRange(active);
+        return combined;
+    }
+
+    private static string RolledPath(string path, int n)
+    {
+        var ext = Path.GetExtension(path);
+        var stem = path[..(path.Length - ext.Length)];
+        return $"{stem}.{n}{ext}";
+    }
+}

--- a/Zeus.SupportAgent/ProcessSupervisor.cs
+++ b/Zeus.SupportAgent/ProcessSupervisor.cs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Diagnostics;
+
+namespace Zeus.SupportAgent;
+
+/// <summary>Outcome of waiting on the supervised backend process.</summary>
+/// <param name="ProcessFound">False if the PID was already gone when we attached.</param>
+/// <param name="ExitCode">The process exit code when readable; null otherwise.</param>
+/// <param name="Cancelled">True if the wait was cancelled (the sidecar was told to stop).</param>
+public readonly record struct SupervisionResult(bool ProcessFound, int? ExitCode, bool Cancelled);
+
+/// <summary>
+/// Waits for the supervised Zeus backend to exit. Crash-vs-clean classification is
+/// NOT decided here — it depends on the clean-exit marker the backend writes at a
+/// deliberate shutdown — this just blocks until the process is gone (or the
+/// sidecar is cancelled).
+/// </summary>
+public static class ProcessSupervisor
+{
+    public static async Task<SupervisionResult> WaitForExitAsync(int pid, CancellationToken ct)
+    {
+        Process process;
+        try
+        {
+            process = Process.GetProcessById(pid);
+        }
+        catch (ArgumentException)
+        {
+            // No such process — it already exited before we attached. Caller still
+            // checks the clean-exit marker to classify it.
+            return new SupervisionResult(ProcessFound: false, ExitCode: null, Cancelled: false);
+        }
+
+        using (process)
+        {
+            try
+            {
+                process.EnableRaisingEvents = true;
+                await process.WaitForExitAsync(ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                return new SupervisionResult(ProcessFound: true, ExitCode: null, Cancelled: true);
+            }
+
+            int? exitCode = null;
+            try
+            {
+                exitCode = process.ExitCode;
+            }
+            catch
+            {
+                // Exit code can be unreadable for a process we didn't start; the
+                // crash record simply records a null exit code.
+            }
+
+            return new SupervisionResult(ProcessFound: true, ExitCode: exitCode, Cancelled: false);
+        }
+    }
+}

--- a/Zeus.SupportAgent/Program.cs
+++ b/Zeus.SupportAgent/Program.cs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Runtime.InteropServices;
+using Zeus.Support.Contracts;
+using Zeus.SupportAgent;
+
+// The Zeus support sidecar. Phase 1 scope is LOCAL ONLY: supervise the backend
+// PID, and on an unexpected death capture the tail of the on-disk logs into a
+// crash record. No broker / remote exposure yet — that arrives in later phases,
+// at which point this process (which survives the backend) will own the broker
+// connection.
+//
+// Lifecycle: wait for the supervised backend to exit, classify it via the
+// clean-exit marker the backend writes at a deliberate shutdown, capture a crash
+// record if it died unexpectedly, then exit. The sidecar must NEVER add its own
+// crash to the operator's machine, so every step is best-effort.
+
+if (!SidecarOptions.TryParse(args, out var opts, out var error) || opts is null)
+{
+    Console.Error.WriteLine($"zeus-support-agent: {error}");
+    return 2;
+}
+
+Breadcrumb(opts, $"start: supervising pid={opts.SupervisePid} session={opts.SessionToken ?? "-"}");
+
+using var cts = new CancellationTokenSource();
+using var sigint = SafeSignal(PosixSignal.SIGINT, cts);
+using var sigterm = SafeSignal(PosixSignal.SIGTERM, cts);
+Console.CancelKeyPress += (_, e) => { e.Cancel = true; cts.Cancel(); };
+
+var result = await ProcessSupervisor.WaitForExitAsync(opts.SupervisePid, cts.Token).ConfigureAwait(false);
+
+if (result.Cancelled)
+{
+    Breadcrumb(opts, "stop: cancelled while supervising; backend still alive");
+    return 0;
+}
+
+// Classify the exit. A clean-exit marker (written by the backend at window close,
+// operator quit, or profile-switch relaunch) means an expected shutdown.
+var markerPath = Path.Combine(opts.CrashDir, SupportPaths.CleanExitMarkerName(opts.SupervisePid));
+if (File.Exists(markerPath))
+{
+    TryDelete(markerPath);
+    Breadcrumb(opts, $"clean exit: pid={opts.SupervisePid} exitCode={Fmt(result.ExitCode)}");
+    return 0;
+}
+
+// No marker ⇒ the backend died unexpectedly. Capture a crash record.
+long nowUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+var note = result.ProcessFound ? null : "PID was already gone when the sidecar attached.";
+var written = CrashCapture.WriteCrashRecord(opts, result.ExitCode, nowUnixMs, note);
+Breadcrumb(opts,
+    written is null
+        ? $"crash detected: pid={opts.SupervisePid} exitCode={Fmt(result.ExitCode)} (record write FAILED)"
+        : $"crash detected: pid={opts.SupervisePid} exitCode={Fmt(result.ExitCode)} -> {Path.GetFileName(written)}");
+return 0;
+
+static string Fmt(int? code) => code?.ToString() ?? "<unknown>";
+
+// Register a POSIX signal handler without throwing on a platform/runtime that
+// doesn't support it (the sidecar still works; it just relies on Ctrl+C / exit).
+static IDisposable? SafeSignal(PosixSignal signal, CancellationTokenSource cts)
+{
+    try
+    {
+        return PosixSignalRegistration.Create(signal, ctx => { ctx.Cancel = true; cts.Cancel(); });
+    }
+    catch
+    {
+        return null;
+    }
+}
+
+static void TryDelete(string path)
+{
+    try { File.Delete(path); } catch { /* best effort */ }
+}
+
+// A one-line breadcrumb log for diagnosing the sidecar itself (it has no console
+// when spawned detached). Strictly best-effort and tiny.
+static void Breadcrumb(SidecarOptions opts, string message)
+{
+    try
+    {
+        Directory.CreateDirectory(opts.CrashDir);
+        var line = $"{DateTimeOffset.UtcNow:o} {message}{Environment.NewLine}";
+        File.AppendAllText(Path.Combine(opts.CrashDir, "support-agent.log"), line);
+    }
+    catch
+    {
+        // Never let breadcrumb logging affect the sidecar's behaviour.
+    }
+}

--- a/Zeus.SupportAgent/SidecarOptions.cs
+++ b/Zeus.SupportAgent/SidecarOptions.cs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.SupportAgent;
+
+/// <summary>
+/// Parsed command line for the support sidecar. The desktop host owns the
+/// platform data-dir logic, so it resolves every path and hands them in as
+/// arguments — the sidecar never re-derives <c>%LOCALAPPDATA%/Zeus</c> on its own
+/// (that keeps the ZEUS_PREFS_PATH override and profile rules in one place).
+/// </summary>
+public sealed record SidecarOptions(
+    int SupervisePid,
+    string? SessionToken,
+    string? AppLogPath,
+    string? StartupLogPath,
+    string CrashDir,
+    string? AppVersion)
+{
+    /// <summary>
+    /// Parse <c>--key value</c> arguments. Only <c>--supervise-pid</c> and
+    /// <c>--crash-dir</c> are required; everything else degrades gracefully (a
+    /// missing log path just yields an empty tail). Returns false with a message
+    /// on a malformed/missing required argument.
+    /// </summary>
+    public static bool TryParse(string[] args, out SidecarOptions? options, out string? error)
+    {
+        options = null;
+        error = null;
+
+        int? pid = null;
+        string? session = null, appLog = null, startupLog = null, crashDir = null, appVersion = null;
+
+        for (int i = 0; i < args.Length; i++)
+        {
+            string key = args[i];
+            string? Next()
+            {
+                if (i + 1 >= args.Length) return null;
+                return args[++i];
+            }
+
+            switch (key)
+            {
+                case "--supervise-pid":
+                    var pidStr = Next();
+                    if (!int.TryParse(pidStr, out var p) || p <= 0)
+                    {
+                        error = $"--supervise-pid requires a positive integer (got '{pidStr ?? "<none>"}').";
+                        return false;
+                    }
+                    pid = p;
+                    break;
+                case "--session": session = Next(); break;
+                case "--app-log": appLog = Next(); break;
+                case "--startup-log": startupLog = Next(); break;
+                case "--crash-dir": crashDir = Next(); break;
+                case "--app-version": appVersion = Next(); break;
+                default:
+                    error = $"Unknown argument '{key}'.";
+                    return false;
+            }
+        }
+
+        if (pid is null)
+        {
+            error = "--supervise-pid is required.";
+            return false;
+        }
+        if (string.IsNullOrWhiteSpace(crashDir))
+        {
+            error = "--crash-dir is required.";
+            return false;
+        }
+
+        options = new SidecarOptions(pid.Value, session, appLog, startupLog, crashDir, appVersion);
+        return true;
+    }
+}

--- a/Zeus.SupportAgent/Zeus.SupportAgent.csproj
+++ b/Zeus.SupportAgent/Zeus.SupportAgent.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- The Zeus support sidecar. A tiny, standalone process the desktop host
+       launches DETACHED so it OUTLIVES a backend crash: the Kestrel backend runs
+       in-process with the Photino webview, so when it dies it takes the in-memory
+       log ring with it. This process supervises the backend PID, and on an
+       unexpected death captures the tail of the on-disk logs into a crash record.
+       Dependency-free apart from the shared IPC/artifact contract. -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Zeus.SupportAgent</RootNamespace>
+    <AssemblyName>Zeus.SupportAgent</AssemblyName>
+    <!-- No console window should flash when the desktop host spawns us. -->
+    <UseWindowsForms>false</UseWindowsForms>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Zeus.Support.Contracts\Zeus.Support.Contracts.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Zeus.slnx
+++ b/Zeus.slnx
@@ -11,6 +11,7 @@
   </Folder>
   <Project Path="Zeus.Contracts/Zeus.Contracts.csproj" />
   <Project Path="Zeus.Support.Contracts/Zeus.Support.Contracts.csproj" />
+  <Project Path="Zeus.SupportAgent/Zeus.SupportAgent.csproj" />
   <Project Path="Zeus.Dsp/Zeus.Dsp.csproj" />
   <Project Path="Zeus.Dsp.FreeDv/Zeus.Dsp.FreeDv.csproj" />
   <Project Path="Zeus.Plugins.Contracts/Zeus.Plugins.Contracts.csproj" />

--- a/tests/Zeus.Server.Tests/SupportAgentTests.cs
+++ b/tests/Zeus.Server.Tests/SupportAgentTests.cs
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using Zeus.Support.Contracts;
+using Zeus.SupportAgent;
+
+namespace Zeus.Server.Tests;
+
+public class SidecarOptionsTests
+{
+    [Fact]
+    public void Parse_Valid_PopulatesAllFields()
+    {
+        var ok = SidecarOptions.TryParse(
+            ["--supervise-pid", "1234", "--session", "abc", "--app-log", "a.log",
+             "--startup-log", "s.log", "--crash-dir", "c", "--app-version", "1.0"],
+            out var opts, out var err);
+
+        Assert.True(ok);
+        Assert.Null(err);
+        Assert.NotNull(opts);
+        Assert.Equal(1234, opts!.SupervisePid);
+        Assert.Equal("abc", opts.SessionToken);
+        Assert.Equal("a.log", opts.AppLogPath);
+        Assert.Equal("s.log", opts.StartupLogPath);
+        Assert.Equal("c", opts.CrashDir);
+        Assert.Equal("1.0", opts.AppVersion);
+    }
+
+    [Fact]
+    public void Parse_MissingPid_Fails()
+    {
+        Assert.False(SidecarOptions.TryParse(["--crash-dir", "c"], out var opts, out var err));
+        Assert.Null(opts);
+        Assert.Contains("supervise-pid", err);
+    }
+
+    [Fact]
+    public void Parse_MissingCrashDir_Fails()
+    {
+        Assert.False(SidecarOptions.TryParse(["--supervise-pid", "5"], out _, out var err));
+        Assert.Contains("crash-dir", err);
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("-1")]
+    [InlineData("notanint")]
+    public void Parse_BadPid_Fails(string pid)
+    {
+        Assert.False(SidecarOptions.TryParse(["--supervise-pid", pid, "--crash-dir", "c"], out _, out var err));
+        Assert.Contains("supervise-pid", err);
+    }
+
+    [Fact]
+    public void Parse_UnknownArg_Fails()
+    {
+        Assert.False(SidecarOptions.TryParse(["--bogus", "x"], out _, out var err));
+        Assert.Contains("bogus", err);
+    }
+}
+
+public class SupportAgentLogTailTests : IDisposable
+{
+    private readonly string _dir;
+    public SupportAgentLogTailTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), $"zeus-tail-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_dir);
+    }
+    public void Dispose() { try { Directory.Delete(_dir, true); } catch { } }
+
+    [Fact]
+    public void ReadLastLines_ReturnsTrailingLines()
+    {
+        var p = Path.Combine(_dir, "f.log");
+        File.WriteAllLines(p, ["a", "b", "c", "d", "e"]);
+        Assert.Equal(["c", "d", "e"], LogTail.ReadLastLines(p, 3));
+    }
+
+    [Fact]
+    public void ReadLastLines_FewerThanRequested_ReturnsAll()
+    {
+        var p = Path.Combine(_dir, "f.log");
+        File.WriteAllLines(p, ["a", "b"]);
+        Assert.Equal(["a", "b"], LogTail.ReadLastLines(p, 10));
+    }
+
+    [Fact]
+    public void ReadLastLines_MissingFile_IsEmpty()
+        => Assert.Empty(LogTail.ReadLastLines(Path.Combine(_dir, "nope.log"), 5));
+
+    [Fact]
+    public void ReadAppLogTail_SpansPreviousRollWhenActiveShort()
+    {
+        var active = Path.Combine(_dir, "zeus-app.log");
+        var roll = Path.Combine(_dir, "zeus-app.1.log");
+        File.WriteAllLines(roll, ["A1", "A2", "A3", "A4", "A5"]);
+        File.WriteAllLines(active, ["B1", "B2"]);
+
+        // Want 4 lines: active has 2, so the previous roll fills the other 2.
+        Assert.Equal(["A4", "A5", "B1", "B2"], LogTail.ReadAppLogTail(active, 4));
+    }
+
+    [Fact]
+    public void ReadAppLogTail_ActiveAloneSatisfiesRequest()
+    {
+        var active = Path.Combine(_dir, "zeus-app.log");
+        File.WriteAllLines(active, ["B1", "B2", "B3", "B4"]);
+        Assert.Equal(["B3", "B4"], LogTail.ReadAppLogTail(active, 2));
+    }
+}
+
+public class CrashCaptureTests : IDisposable
+{
+    private readonly string _dir;
+    public CrashCaptureTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), $"zeus-crash-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_dir);
+    }
+    public void Dispose() { try { Directory.Delete(_dir, true); } catch { } }
+
+    private SidecarOptions Opts(string? appLog = null, string? startupLog = null) =>
+        new(SupervisePid: 4321, SessionToken: "s", AppLogPath: appLog,
+            StartupLogPath: startupLog, CrashDir: _dir, AppVersion: "9.9");
+
+    [Fact]
+    public void BuildRecord_CapturesLogTailsAndMetadata()
+    {
+        var appLog = Path.Combine(_dir, "zeus-app.log");
+        File.WriteAllLines(appLog, ["one", "two", "three"]);
+
+        var rec = CrashCapture.BuildRecord(Opts(appLog), exitCode: -1073741819, nowUnixMs: 1_700_000_000_000);
+
+        Assert.Equal(SupportCrashRecord.CurrentSchemaVersion, rec.SchemaVersion);
+        Assert.Equal(4321, rec.Pid);
+        Assert.Equal(-1073741819, rec.ExitCode);
+        Assert.True(rec.Crashed);
+        Assert.Equal("9.9", rec.AppVersion);
+        Assert.Contains("three", rec.AppLogTail);
+        Assert.False(string.IsNullOrEmpty(rec.Platform));
+    }
+
+    [Fact]
+    public void WriteCrashRecord_WritesDeserialisableJson()
+    {
+        var path = CrashCapture.WriteCrashRecord(Opts(), exitCode: 5, nowUnixMs: 1_700_000_000_000);
+        Assert.NotNull(path);
+        Assert.True(File.Exists(path));
+
+        var back = JsonSerializer.Deserialize(File.ReadAllText(path!), SupportIpcJsonContext.Default.SupportCrashRecord);
+        Assert.NotNull(back);
+        Assert.Equal(4321, back!.Pid);
+        Assert.Equal(5, back.ExitCode);
+        Assert.True(back.Crashed);
+    }
+
+    [Fact]
+    public void WriteCrashRecord_PrunesToBoundedHistory()
+    {
+        // Seed more than the retention cap with time-sortable names.
+        for (int i = 0; i < 30; i++)
+            File.WriteAllText(Path.Combine(_dir, SupportPaths.CrashRecordFileName(1_000_000_000_000 + i, 1)), "{}");
+
+        CrashCapture.WriteCrashRecord(Opts(), exitCode: 0, nowUnixMs: 1_700_000_000_000);
+
+        var remaining = Directory.GetFiles(_dir, "crash-*.json").Length;
+        Assert.True(remaining <= 25, $"expected <=25 retained crash records, found {remaining}");
+    }
+}
+
+public class SupportPathsTests
+{
+    [Fact]
+    public void CleanExitMarkerName_IsPerPid()
+        => Assert.Equal("clean-exit-777.marker", SupportPaths.CleanExitMarkerName(777));
+
+    [Fact]
+    public void CrashRecordFileName_IsTimeSortable()
+    {
+        var early = SupportPaths.CrashRecordFileName(1_000_000_000_000, 1);
+        var late = SupportPaths.CrashRecordFileName(1_700_000_000_000, 1);
+        Assert.True(string.CompareOrdinal(early, late) < 0);
+        Assert.StartsWith("crash-", early);
+        Assert.EndsWith(".json", early);
+    }
+}
+
+public class ProcessSupervisorTests
+{
+    // A short-lived child that sleeps briefly then exits with a known code, so the
+    // supervisor reliably attaches before it dies. Cross-platform via the OS shell.
+    private static Process StartDummy(int exitCode, bool linger)
+    {
+        ProcessStartInfo psi;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            var cmd = linger
+                ? $"ping -n 2 127.0.0.1 >nul & exit {exitCode}"
+                : $"exit {exitCode}";
+            psi = new ProcessStartInfo("cmd.exe", $"/c \"{cmd}\"");
+        }
+        else
+        {
+            var cmd = linger ? $"sleep 0.6; exit {exitCode}" : $"exit {exitCode}";
+            psi = new ProcessStartInfo("/bin/sh", $"-c \"{cmd}\"");
+        }
+        psi.CreateNoWindow = true;
+        psi.UseShellExecute = false;
+        return Process.Start(psi)!;
+    }
+
+    [Fact]
+    public async Task WaitForExit_ReturnsExitCodeOfSupervisedProcess()
+    {
+        using var child = StartDummy(exitCode: 7, linger: true);
+        var result = await ProcessSupervisor.WaitForExitAsync(child.Id, CancellationToken.None);
+
+        Assert.False(result.Cancelled);
+        Assert.True(result.ProcessFound);
+        Assert.Equal(7, result.ExitCode);
+    }
+
+    [Fact]
+    public async Task WaitForExit_ProcessAlreadyGone_ReportsNotFound()
+    {
+        using var child = StartDummy(exitCode: 3, linger: false);
+        child.WaitForExit(); // ensure it is fully gone before we attach
+        var goneId = child.Id;
+
+        var result = await ProcessSupervisor.WaitForExitAsync(goneId, CancellationToken.None);
+        Assert.False(result.ProcessFound);
+        Assert.False(result.Cancelled);
+    }
+
+    [Fact]
+    public async Task WaitForExit_Cancellation_ReportsCancelled()
+    {
+        using var child = StartDummy(exitCode: 0, linger: true);
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(50);
+
+        var result = await ProcessSupervisor.WaitForExitAsync(child.Id, cts.Token);
+        Assert.True(result.Cancelled);
+
+        try { child.Kill(); } catch { }
+    }
+}


### PR DESCRIPTION
**Phase 1 of the remote diagnostics epic** (`zeus-87ca`). **Stacked on #1082** (Phase 0) — review/merge that first; this PR's base is the P0 branch so the diff is just Phase 1. **Local only — no broker/remote exposure yet.**

This is the piece that directly addresses *"Zeus randomly crashes"*: a process that **outlives the crash** and preserves what the in-memory log ring loses (the backend runs in-process with the webview, so a crash takes the whole log history with it).

### What
New **`Zeus.SupportAgent`** executable, launched **detached** by the desktop host right after the backend starts:
- `ProcessSupervisor` waits on the backend PID.
- On exit, classifies via a **per-PID clean-exit marker** the backend writes at any deliberate shutdown (window close, operator quit, profile-switch relaunch): marker present ⇒ clean; absent ⇒ died unexpectedly.
- On a crash, `CrashCapture` writes a `SupportCrashRecord` (exit code + tail of the on-disk app log and startup log, spanning the previous roll) to `DataDir/crashes/`, bounded retention.
- Every step is best-effort — the sidecar must never add its own crash or block Zeus launch.

Backend/host wiring: `SupportSidecar.MarkCleanExit()` from `AppRestartService` (quit/restart) and the desktop shutdown chokepoint; `SupportSidecarLauncher` spawns the co-located sidecar exe; `PrefsDbPath.CrashDir()`; `Zeus.Support.Contracts` gains `SupportCrashRecord` + `SupportPaths`.

### Tests
20 passing: `SidecarOptions`, `LogTail` (incl. roll-spanning), `CrashCapture` (shape, JSON round-trip, bounded pruning), `SupportPaths`, and `ProcessSupervisor` against real short-lived child processes (exit code / already-gone / cancellation). **End-to-end verified**: a killed process with no marker yields one crash record with the captured log tail; with a marker, none.

Closes zeus-onrv.