### PR TITLE
DO NOT MERGE: Zeus Digital Logging v1 — full WSJT-X UDP + GridTracker live

### DIFF
--- a/Zeus.Contracts/WsjtxDtos.cs
+++ b/Zeus.Contracts/WsjtxDtos.cs
@@ -22,7 +22,22 @@ public sealed record WsjtxRuntimeConfig(
     bool Enabled = false,
     string Host = "127.0.0.1",
     int Port = 2237,
-    string InstanceId = "WSJT-X");
+    string InstanceId = "WSJT-X",
+    // Transport: "unicast" (one logger) or "multicast" (many loggers receive the
+    // same stream). Unicast is the back-compatible default; with unicast only the
+    // first binder on the port gets datagrams. Multicast uses MulticastGroup +
+    // MulticastTtl. All new fields default to today's behaviour (egress OFF, plain
+    // unicast) so existing persisted rows and clients are unaffected.
+    string Transport = "unicast",
+    string MulticastGroup = "224.0.0.73",
+    int MulticastTtl = 1,
+    // Also emit a structured QSOLogged (type 5) alongside the LoggedADIF (type 12)
+    // on each logged QSO. Some tools prefer the structured form.
+    bool SendQsoLogged = false,
+    // Emit the live stream GridTracker/JTAlert need for map/roster/alerts:
+    // Heartbeat (0) ~15 s, Status (1) on change + periodic, Decode (2) per FT8/FT4
+    // decode, WSPRDecode (10) per spot. OFF by default — pure additional egress.
+    bool SendLiveDecodes = false);
 
 /// <summary>Status/config view for the WSJT-X broadcaster. UDP has no listener,
 /// so config applies live — there is no RequiresRestart, unlike CAT/TCI.</summary>
@@ -30,4 +45,9 @@ public sealed record WsjtxStatus(
     bool Enabled,
     string Host,
     int Port,
-    string InstanceId);
+    string InstanceId,
+    string Transport = "unicast",
+    string MulticastGroup = "224.0.0.73",
+    int MulticastTtl = 1,
+    bool SendQsoLogged = false,
+    bool SendLiveDecodes = false);

--- a/Zeus.Server.Hosting/Wsjtx/WsjtxLiveEmitter.cs
+++ b/Zeus.Server.Hosting/Wsjtx/WsjtxLiveEmitter.cs
@@ -1,0 +1,368 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// WsjtxLiveEmitter — the live WSJT-X UDP stream GridTracker / JTAlert need for
+// map / roster / alerts: Heartbeat (0) ~15 s, Status (1) on MOX change + a slow
+// periodic tick, Decode (2) one per decoded FT8/FT4 line, WSPRDecode (10) one per
+// WSPR spot.
+//
+// Same proven leaf-subscriber seam as PskReporterReporter / WsprnetReporter: the
+// decode/spot handlers ONLY read existing events + a Snapshot() and ENQUEUE a
+// UDP send — they never call back into the radio/DSP/TX path, and they swallow
+// their own errors, so a reporter fault can never disturb decode or TX.
+//
+// SAFETY: SEND-ONLY (the broadcaster has no listener). Gated on
+// cfg.Enabled && cfg.SendLiveDecodes — the disabled-default path never pays for a
+// Snapshot() on the decode thread. PureSignal / drive / power are never touched.
+
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Hosting;
+using Zeus.Contracts;
+using Zeus.Dsp.Ft8;
+
+namespace Zeus.Server.Wsjtx;
+
+public sealed partial class WsjtxLiveEmitter : BackgroundService
+{
+    private static readonly TimeSpan HeartbeatInterval = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan StatusInterval = TimeSpan.FromSeconds(5);
+    private static readonly string ZeusVersion = BuildVersion();
+
+    private readonly ILogger<WsjtxLiveEmitter> _log;
+    private readonly WsjtxManagementService _mgmt;
+    private readonly Func<byte[], CancellationToken, Task> _send;
+    private readonly Ft8Service? _ft8;
+    private readonly WsprService? _wspr;
+    private readonly RadioService? _radio;
+    private readonly Ft8TxService? _tx;
+    private readonly SpottingManagementService? _operator;
+
+    public WsjtxLiveEmitter(
+        ILogger<WsjtxLiveEmitter> log,
+        WsjtxManagementService mgmt,
+        WsjtxUdpBroadcaster broadcaster,
+        Ft8Service ft8,
+        WsprService wspr,
+        RadioService radio,
+        Ft8TxService tx,
+        SpottingManagementService operatorIdentity)
+    {
+        _log = log;
+        _mgmt = mgmt;
+        _send = broadcaster.SendDatagramAsync;
+        _ft8 = ft8;
+        _wspr = wspr;
+        _radio = radio;
+        _tx = tx;
+        _operator = operatorIdentity;
+
+        _ft8.DecodesReady += OnDecodes;
+        _wspr.SpotsReady += OnSpots;
+        _radio.MoxChanged += OnMoxChanged;
+    }
+
+    // Test seam: no DSP/radio wiring. Drives the gate + field mapping via the
+    // OnDecodes/OnSpots handlers and a captured send delegate.
+    internal WsjtxLiveEmitter(
+        ILogger<WsjtxLiveEmitter> log,
+        WsjtxManagementService mgmt,
+        Func<byte[], CancellationToken, Task> send)
+    {
+        _log = log;
+        _mgmt = mgmt;
+        _send = send;
+        _ft8 = null;
+        _wspr = null;
+        _radio = null;
+        _tx = null;
+        _operator = null;
+    }
+
+    public override void Dispose()
+    {
+        if (_ft8 is not null) _ft8.DecodesReady -= OnDecodes;
+        if (_wspr is not null) _wspr.SpotsReady -= OnSpots;
+        if (_radio is not null) _radio.MoxChanged -= OnMoxChanged;
+        base.Dispose();
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken ct)
+    {
+        var lastHeartbeat = DateTime.MinValue;
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                var cfg = _mgmt.GetConfig();
+                if (cfg.Enabled && cfg.SendLiveDecodes)
+                {
+                    var now = DateTime.UtcNow;
+                    if (now - lastHeartbeat >= HeartbeatInterval)
+                    {
+                        lastHeartbeat = now;
+                        await SendHeartbeatAsync(cfg, ct).ConfigureAwait(false);
+                    }
+                    await SendStatusAsync(cfg, ct).ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex)
+            {
+                _log.LogDebug(ex, "wsjtx.live periodic tick failed");
+            }
+
+            try { await Task.Delay(StatusInterval, ct).ConfigureAwait(false); }
+            catch (OperationCanceledException) { break; }
+        }
+    }
+
+    // ---- event handlers (decode worker / state thread) -----------------------
+
+    private void OnDecodes(Ft8DecodeBatch batch) => HandleDecodes(batch);
+
+    private void OnSpots(WsprSpotBatch batch) => HandleSpots(batch);
+
+    // Gate (enable + live flag) then build + send. Internal so the gating is
+    // unit-testable without a DSP graph: disabled => nothing sent, live-flag off
+    // => nothing sent, enabled+live => one datagram per decoded line.
+    internal void HandleDecodes(Ft8DecodeBatch batch)
+    {
+        try
+        {
+            var cfg = _mgmt.GetConfig();
+            if (!cfg.Enabled || !cfg.SendLiveDecodes) return; // zero cost on the default path
+            foreach (var d in BuildDecodeDatagrams(cfg.InstanceId, batch))
+                _ = _send(d, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            _log.LogDebug(ex, "wsjtx.live decode emit failed");
+        }
+    }
+
+    internal void HandleSpots(WsprSpotBatch batch)
+    {
+        try
+        {
+            var cfg = _mgmt.GetConfig();
+            if (!cfg.Enabled || !cfg.SendLiveDecodes) return;
+            foreach (var d in BuildWsprDatagrams(cfg.InstanceId, batch))
+                _ = _send(d, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            _log.LogDebug(ex, "wsjtx.live wspr emit failed");
+        }
+    }
+
+    private void OnMoxChanged(bool mox)
+    {
+        try
+        {
+            var cfg = _mgmt.GetConfig();
+            if (!cfg.Enabled || !cfg.SendLiveDecodes) return;
+            _ = SendStatusAsync(cfg, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            _log.LogDebug(ex, "wsjtx.live mox status failed");
+        }
+    }
+
+    // ---- senders -------------------------------------------------------------
+
+    private Task SendHeartbeatAsync(WsjtxRuntimeConfig cfg, CancellationToken ct)
+    {
+        var dg = WsjtxMessage.EncodeHeartbeat(cfg.InstanceId, maxSchema: 3, version: ZeusVersion, revision: "");
+        return _send(dg, ct);
+    }
+
+    private Task SendStatusAsync(WsjtxRuntimeConfig cfg, CancellationToken ct)
+    {
+        if (_radio is null) return Task.CompletedTask;
+
+        var snap = _radio.Snapshot();
+        var (deCall, deGrid) = _operator?.ResolveOperator() ?? ("", "");
+
+        string mode;
+        uint trPeriodMs;
+        if (_wspr?.IsEnabled == true)
+        {
+            mode = "WSPR";
+            trPeriodMs = 120_000;
+        }
+        else if (_ft8?.IsEnabled == true)
+        {
+            mode = _ft8.ActiveProtocol == Ft8Protocol.Ft4 ? "FT4" : "FT8";
+            trPeriodMs = _ft8.ActiveProtocol == Ft8Protocol.Ft4 ? 7_500u : 15_000u;
+        }
+        else
+        {
+            mode = snap.Mode.ToString().ToUpperInvariant();
+            trPeriodMs = 0;
+        }
+
+        var txStatus = _tx?.Status();
+        bool txEnabled = txStatus?.Armed ?? false;
+        bool transmitting = txStatus?.Transmitting ?? false;
+        string txMessage = txStatus?.Message ?? "";
+        uint txDf = (uint)Math.Max(0, txStatus?.AudioHz ?? 0);
+        string dxCall = ParseDxCall(txMessage, deCall);
+
+        var dg = WsjtxMessage.EncodeStatus(
+            instanceId: cfg.InstanceId,
+            dialFrequencyHz: (ulong)Math.Max(0, snap.VfoHz),
+            mode: mode,
+            dxCall: dxCall,
+            report: "",
+            txMode: mode,
+            txEnabled: txEnabled,
+            transmitting: transmitting,
+            decoding: (_ft8?.IsEnabled ?? false) || (_wspr?.IsEnabled ?? false),
+            rxDf: 0,
+            txDf: txDf,
+            deCall: deCall,
+            deGrid: deGrid,
+            dxGrid: "",
+            txWatchdog: false,
+            subMode: "",
+            fastMode: false,
+            specialOperationMode: 0,
+            frequencyTolerance: 0,
+            trPeriod: trPeriodMs,
+            configurationName: "Zeus",
+            txMessage: txMessage);
+        return _send(dg, ct);
+    }
+
+    // ---- pure field mappers (unit-tested directly) ---------------------------
+
+    /// <summary>Map an FT8/FT4 decode batch to one Decode (type 2) datagram per line.</summary>
+    internal static IReadOnlyList<byte[]> BuildDecodeDatagrams(string instanceId, Ft8DecodeBatch batch)
+    {
+        uint timeMs = MsSinceUtcMidnight(batch.SlotStartUtc);
+        string mode = batch.Protocol == Ft8Protocol.Ft4 ? "FT4" : "FT8";
+        var list = new List<byte[]>(batch.Decodes.Count);
+        foreach (var d in batch.Decodes)
+        {
+            uint df = (uint)Math.Clamp((int)Math.Round(d.FreqHz), 0, int.MaxValue);
+            list.Add(WsjtxMessage.EncodeDecode(
+                instanceId,
+                isNew: true,
+                timeMsSinceMidnight: timeMs,
+                snr: (int)Math.Round(d.SnrDb),
+                deltaTimeSec: d.DtSec,
+                deltaFrequencyHz: df,
+                mode: mode,
+                message: d.Text ?? "",
+                lowConfidence: false,
+                offAir: false));
+        }
+        return list;
+    }
+
+    /// <summary>Map a WSPR spot batch to one WSPRDecode (type 10) datagram per spot.</summary>
+    internal static IReadOnlyList<byte[]> BuildWsprDatagrams(string instanceId, WsprSpotBatch batch)
+    {
+        uint timeMs = MsSinceUtcMidnight(batch.SlotStartUtc);
+        var list = new List<byte[]>(batch.Spots.Count);
+        foreach (var sp in batch.Spots)
+        {
+            ParseWsprMessage(sp.Message, out string call, out string grid, out int power);
+            ulong freqHz = sp.FreqMhz > 0 ? (ulong)Math.Round(sp.FreqMhz * 1_000_000.0) : 0UL;
+            list.Add(WsjtxMessage.EncodeWsprDecode(
+                instanceId,
+                isNew: true,
+                timeMsSinceMidnight: timeMs,
+                snr: (int)Math.Round(sp.SnrDb),
+                deltaTimeSec: sp.DtSec,
+                frequencyHz: freqHz,
+                drift: sp.DriftHz,
+                callsign: call,
+                grid: grid,
+                power: power,
+                offAir: false));
+        }
+        return list;
+    }
+
+    internal static uint MsSinceUtcMidnight(DateTime slotStart)
+    {
+        var utc = slotStart.Kind switch
+        {
+            DateTimeKind.Utc => slotStart,
+            DateTimeKind.Local => slotStart.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(slotStart, DateTimeKind.Utc),
+        };
+        return (uint)(((utc.Hour * 60 + utc.Minute) * 60 + utc.Second) * 1000 + utc.Millisecond);
+    }
+
+    [GeneratedRegex(@"^[A-R]{2}[0-9]{2}([A-X]{2})?$")]
+    private static partial Regex GridRegex();
+
+    // Tokenise a WSPR message ("CALL GRID DBM", "PFX/CALL DBM", "<CALL> GRID6 DBM").
+    // call = first token (hash markers stripped), grid = a Maidenhead token if
+    // present, power = the trailing integer (dBm) if present. Never throws.
+    internal static void ParseWsprMessage(string? message, out string call, out string grid, out int power)
+    {
+        call = "";
+        grid = "";
+        power = 0;
+        if (string.IsNullOrWhiteSpace(message)) return;
+
+        var tokens = message.Trim().ToUpperInvariant()
+            .Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+        if (tokens.Length == 0) return;
+
+        call = tokens[0].Trim('<', '>');
+
+        if (tokens.Length >= 2 && int.TryParse(tokens[^1], out int p))
+            power = p;
+
+        foreach (var t in tokens)
+        {
+            if (GridRegex().IsMatch(t)) { grid = t; break; }
+        }
+    }
+
+    // Extract the DX (target) call from OUR staged TX message: the first token
+    // that looks like a callsign and is not our own. Returns "" when none.
+    internal static string ParseDxCall(string? txMessage, string deCall)
+    {
+        if (string.IsNullOrWhiteSpace(txMessage)) return "";
+        var tokens = txMessage.Trim().ToUpperInvariant()
+            .Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+        foreach (var t in tokens)
+        {
+            if (t == "CQ" || t == "DE") continue;
+            var core = t.Trim('<', '>');
+            if (LooksLikeCall(core) && !string.Equals(core, deCall, StringComparison.OrdinalIgnoreCase))
+                return core;
+        }
+        return "";
+    }
+
+    private static bool LooksLikeCall(string s)
+    {
+        if (s.Length < 3) return false;
+        bool hasLetter = false, hasDigit = false;
+        foreach (var c in s)
+        {
+            if (c is >= 'A' and <= 'Z') hasLetter = true;
+            else if (c is >= '0' and <= '9') hasDigit = true;
+            else if (c != '/') return false;
+        }
+        if (!hasLetter || !hasDigit) return false;
+        return !GridRegex().IsMatch(s); // a bare locator is not a call
+    }
+
+    private static string BuildVersion()
+    {
+        var v = Assembly.GetExecutingAssembly().GetName().Version;
+        return v is null ? "Zeus" : $"Zeus {v.Major}.{v.Minor}.{v.Build}";
+    }
+}

--- a/Zeus.Server.Hosting/Wsjtx/WsjtxMessage.cs
+++ b/Zeus.Server.Hosting/Wsjtx/WsjtxMessage.cs
@@ -15,14 +15,23 @@ namespace Zeus.Server.Wsjtx;
 
 /// <summary>
 /// Encoder for the WSJT-X UDP "NetworkMessage" wire format — the de-facto
-/// protocol that JTAlert / Log4OM / GridTracker / N1MM consume. We emit ONE
-/// message type: 12 (LoggedADIF). The wire format is a Qt QDataStream: all
-/// integers big-endian, and each string is a UTF-8 QByteArray written as a
-/// 4-byte big-endian length followed by the bytes (length 0xFFFFFFFF = null).
+/// protocol that JTAlert / Log4OM / GridTracker / N1MM / JTDX consume. The wire
+/// format is a Qt QDataStream: byte order big-endian, all integers big-endian,
+/// floating point ALWAYS serialised as 8-byte IEEE-754 doubles (Qt's default
+/// QDataStream::DoublePrecision — WSJT-X never overrides it, so even fields
+/// declared <c>float</c> in NetworkMessage.hpp go on the wire as 8 bytes), bool =
+/// one byte, and each string is a UTF-8 QByteArray written as a 4-byte big-endian
+/// length followed by the bytes (length 0xFFFFFFFF = null, 0 = empty).
 ///
 /// Common header (every message): magic uint32 0xADBCCBDA, schema uint32,
-/// message-type uint32, then the instance id (utf8). LoggedADIF appends a single
-/// utf8 string: the ADIF record text.
+/// message-type uint32, then the instance id (utf8). Each message type appends
+/// its own fields IN THE EXACT ORDER WSJT-X declares them (see NetworkMessage.hpp)
+/// — field order is load-bearing; a single wrong-width field shifts everything
+/// after it.
+///
+/// SEND-ONLY. Zeus emits these; it never parses inbound WSJT-X messages (no
+/// listener anywhere in this namespace — Reply(4)/HaltTx(8)/FreeText(9) are
+/// network TX-triggers into a real PA and are intentionally unsupported).
 ///
 /// Pure + allocation-light so it is trivially unit-testable; no I/O lives here
 /// (see WsjtxUdpBroadcaster for the send).
@@ -32,8 +41,13 @@ public static class WsjtxMessage
     /// <summary>WSJT-X NetworkMessage magic number.</summary>
     public const uint Magic = 0xADBCCBDA;
 
-    /// <summary>LoggedADIF message type id.</summary>
+    // Message type ids (WSJT-X NetworkMessage::MessageType).
+    public const uint HeartbeatType = 0;
+    public const uint StatusType = 1;
+    public const uint DecodeType = 2;
+    public const uint QsoLoggedType = 5;
     public const uint LoggedAdifType = 12;
+    public const uint WsprDecodeType = 10;
 
     /// <summary>
     /// Schema number written into the header. WSJT-X has used schema 2 across the
@@ -43,23 +57,227 @@ public static class WsjtxMessage
     /// </summary>
     public const uint DefaultSchema = 2;
 
+    // ---- message encoders ----------------------------------------------------
+
     /// <summary>Encode a LoggedADIF (type 12) datagram for the given ADIF text.</summary>
     public static byte[] EncodeLoggedAdif(string instanceId, string adif, uint schema = DefaultSchema)
     {
         using var ms = new MemoryStream(64 + (adif?.Length ?? 0));
-        WriteUInt32(ms, Magic);
-        WriteUInt32(ms, schema);
-        WriteUInt32(ms, LoggedAdifType);
-        WriteUtf8(ms, instanceId);
+        WriteHeader(ms, schema, LoggedAdifType, instanceId);
         WriteUtf8(ms, adif);
         return ms.ToArray();
     }
+
+    /// <summary>Encode a Heartbeat (type 0). GridTracker uses this to discover the
+    /// running instance; emit it ~every 15 s while live decodes are enabled.</summary>
+    public static byte[] EncodeHeartbeat(
+        string instanceId, uint maxSchema, string version, string revision, uint schema = DefaultSchema)
+    {
+        using var ms = new MemoryStream(64);
+        WriteHeader(ms, schema, HeartbeatType, instanceId);
+        WriteUInt32(ms, maxSchema);
+        WriteUtf8(ms, version);
+        WriteUtf8(ms, revision);
+        return ms.ToArray();
+    }
+
+    /// <summary>Encode a Status (type 1) — the rig/keyer state GridTracker and
+    /// JTAlert track (dial freq, mode, TX/RX, DE/DX). Field order matches
+    /// NetworkMessage.hpp Status.</summary>
+    public static byte[] EncodeStatus(
+        string instanceId,
+        ulong dialFrequencyHz,
+        string mode,
+        string dxCall,
+        string report,
+        string txMode,
+        bool txEnabled,
+        bool transmitting,
+        bool decoding,
+        uint rxDf,
+        uint txDf,
+        string deCall,
+        string deGrid,
+        string dxGrid,
+        bool txWatchdog,
+        string subMode,
+        bool fastMode,
+        byte specialOperationMode,
+        uint frequencyTolerance,
+        uint trPeriod,
+        string configurationName,
+        string txMessage,
+        uint schema = DefaultSchema)
+    {
+        using var ms = new MemoryStream(192);
+        WriteHeader(ms, schema, StatusType, instanceId);
+        WriteUInt64(ms, dialFrequencyHz);
+        WriteUtf8(ms, mode);
+        WriteUtf8(ms, dxCall);
+        WriteUtf8(ms, report);
+        WriteUtf8(ms, txMode);
+        WriteBool(ms, txEnabled);
+        WriteBool(ms, transmitting);
+        WriteBool(ms, decoding);
+        WriteUInt32(ms, rxDf);
+        WriteUInt32(ms, txDf);
+        WriteUtf8(ms, deCall);
+        WriteUtf8(ms, deGrid);
+        WriteUtf8(ms, dxGrid);
+        WriteBool(ms, txWatchdog);
+        WriteUtf8(ms, subMode);
+        WriteBool(ms, fastMode);
+        WriteUInt8(ms, specialOperationMode);
+        WriteUInt32(ms, frequencyTolerance);
+        WriteUInt32(ms, trPeriod);
+        WriteUtf8(ms, configurationName);
+        WriteUtf8(ms, txMessage);
+        return ms.ToArray();
+    }
+
+    /// <summary>Encode a Decode (type 2) — one decoded FT8/FT4 line. <paramref
+    /// name="timeMsSinceMidnight"/> is a QTime (ms since UTC midnight), NOT a
+    /// QDateTime. <paramref name="deltaTimeSec"/> goes on the wire as a double.</summary>
+    public static byte[] EncodeDecode(
+        string instanceId,
+        bool isNew,
+        uint timeMsSinceMidnight,
+        int snr,
+        double deltaTimeSec,
+        uint deltaFrequencyHz,
+        string mode,
+        string message,
+        bool lowConfidence,
+        bool offAir,
+        uint schema = DefaultSchema)
+    {
+        using var ms = new MemoryStream(96);
+        WriteHeader(ms, schema, DecodeType, instanceId);
+        WriteBool(ms, isNew);
+        WriteUInt32(ms, timeMsSinceMidnight);
+        WriteInt32(ms, snr);
+        WriteDouble(ms, deltaTimeSec);
+        WriteUInt32(ms, deltaFrequencyHz);
+        WriteUtf8(ms, mode);
+        WriteUtf8(ms, message);
+        WriteBool(ms, lowConfidence);
+        WriteBool(ms, offAir);
+        return ms.ToArray();
+    }
+
+    /// <summary>Encode a WSPRDecode (type 10) — one WSPR spot. Frequency is a u64
+    /// in Hz (the absolute spot frequency), matching NetworkMessage.hpp.</summary>
+    public static byte[] EncodeWsprDecode(
+        string instanceId,
+        bool isNew,
+        uint timeMsSinceMidnight,
+        int snr,
+        double deltaTimeSec,
+        ulong frequencyHz,
+        int drift,
+        string callsign,
+        string grid,
+        int power,
+        bool offAir,
+        uint schema = DefaultSchema)
+    {
+        using var ms = new MemoryStream(96);
+        WriteHeader(ms, schema, WsprDecodeType, instanceId);
+        WriteBool(ms, isNew);
+        WriteUInt32(ms, timeMsSinceMidnight);
+        WriteInt32(ms, snr);
+        WriteDouble(ms, deltaTimeSec);
+        WriteUInt64(ms, frequencyHz);
+        WriteInt32(ms, drift);
+        WriteUtf8(ms, callsign);
+        WriteUtf8(ms, grid);
+        WriteInt32(ms, power);
+        WriteBool(ms, offAir);
+        return ms.ToArray();
+    }
+
+    /// <summary>Encode a QSOLogged (type 5) — the structured logged-QSO message
+    /// some tools prefer over (or alongside) the LoggedADIF type 12. Field order
+    /// matches NetworkMessage.hpp QSOLogged. The two QDateTimes are written UTC
+    /// (timespec byte = 1).</summary>
+    public static byte[] EncodeQsoLogged(
+        string instanceId,
+        DateTime dateTimeOffUtc,
+        string dxCall,
+        string dxGrid,
+        ulong txFrequencyHz,
+        string mode,
+        string reportSent,
+        string reportReceived,
+        string txPower,
+        string comments,
+        string name,
+        DateTime dateTimeOnUtc,
+        string operatorCall,
+        string myCall,
+        string myGrid,
+        string exchangeSent,
+        string exchangeReceived,
+        string adifPropagationMode,
+        uint schema = DefaultSchema)
+    {
+        using var ms = new MemoryStream(256);
+        WriteHeader(ms, schema, QsoLoggedType, instanceId);
+        WriteQDateTimeUtc(ms, dateTimeOffUtc);
+        WriteUtf8(ms, dxCall);
+        WriteUtf8(ms, dxGrid);
+        WriteUInt64(ms, txFrequencyHz);
+        WriteUtf8(ms, mode);
+        WriteUtf8(ms, reportSent);
+        WriteUtf8(ms, reportReceived);
+        WriteUtf8(ms, txPower);
+        WriteUtf8(ms, comments);
+        WriteUtf8(ms, name);
+        WriteQDateTimeUtc(ms, dateTimeOnUtc);
+        WriteUtf8(ms, operatorCall);
+        WriteUtf8(ms, myCall);
+        WriteUtf8(ms, myGrid);
+        WriteUtf8(ms, exchangeSent);
+        WriteUtf8(ms, exchangeReceived);
+        WriteUtf8(ms, adifPropagationMode);
+        return ms.ToArray();
+    }
+
+    // ---- QDataStream primitives ----------------------------------------------
+
+    private static void WriteHeader(Stream s, uint schema, uint messageType, string instanceId)
+    {
+        WriteUInt32(s, Magic);
+        WriteUInt32(s, schema);
+        WriteUInt32(s, messageType);
+        WriteUtf8(s, instanceId);
+    }
+
+    private static void WriteUInt8(Stream s, byte value) => s.WriteByte(value);
+
+    private static void WriteBool(Stream s, bool value) => s.WriteByte(value ? (byte)1 : (byte)0);
 
     private static void WriteUInt32(Stream s, uint value)
     {
         Span<byte> b = stackalloc byte[4];
         BinaryPrimitives.WriteUInt32BigEndian(b, value);
         s.Write(b);
+    }
+
+    private static void WriteInt32(Stream s, int value) => WriteUInt32(s, unchecked((uint)value));
+
+    private static void WriteUInt64(Stream s, ulong value)
+    {
+        Span<byte> b = stackalloc byte[8];
+        BinaryPrimitives.WriteUInt64BigEndian(b, value);
+        s.Write(b);
+    }
+
+    private static void WriteDouble(Stream s, double value)
+    {
+        // Qt QDataStream defaults to DoublePrecision: floating point is always 8
+        // bytes, big-endian (round-tripped through the IEEE-754 bit pattern).
+        WriteUInt64(s, unchecked((ulong)BitConverter.DoubleToInt64Bits(value)));
     }
 
     private static void WriteUtf8(Stream s, string? value)
@@ -74,5 +292,40 @@ public static class WsjtxMessage
         var bytes = Encoding.UTF8.GetBytes(value);
         WriteUInt32(s, (uint)bytes.Length);
         s.Write(bytes);
+    }
+
+    /// <summary>
+    /// Write a QDateTime in the Qt_5_2+ QDataStream layout (which schema 2 uses):
+    /// QDate as a qint64 Julian Day Number, QTime as a quint32 ms-since-midnight,
+    /// then a quint8 timespec. We always emit UTC (timespec = 1), so no trailing
+    /// offset/zone bytes are written. The input is normalised to UTC first.
+    /// </summary>
+    private static void WriteQDateTimeUtc(Stream s, DateTime dt)
+    {
+        var utc = dt.Kind switch
+        {
+            DateTimeKind.Utc => dt,
+            DateTimeKind.Local => dt.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(dt, DateTimeKind.Utc),
+        };
+
+        long julianDay = ToJulianDay(utc.Year, utc.Month, utc.Day);
+        uint msSinceMidnight = (uint)(((utc.Hour * 60 + utc.Minute) * 60 + utc.Second) * 1000 + utc.Millisecond);
+
+        WriteInt64(s, julianDay);     // QDate
+        WriteUInt32(s, msSinceMidnight); // QTime
+        WriteUInt8(s, 1);             // Qt::TimeSpec::UTC
+    }
+
+    private static void WriteInt64(Stream s, long value) => WriteUInt64(s, unchecked((ulong)value));
+
+    // Gregorian-calendar Julian Day Number, matching QDate::toJulianDay().
+    // 2000-01-01 -> 2451545.
+    internal static long ToJulianDay(int year, int month, int day)
+    {
+        long a = (14 - month) / 12;
+        long y = year + 4800 - a;
+        long m = month + 12 * a - 3;
+        return day + (153 * m + 2) / 5 + 365 * y + y / 4 - y / 100 + y / 400 - 32045;
     }
 }

--- a/Zeus.Server.Hosting/Wsjtx/WsjtxUdpBroadcaster.cs
+++ b/Zeus.Server.Hosting/Wsjtx/WsjtxUdpBroadcaster.cs
@@ -8,36 +8,71 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
+using System.Net;
 using System.Net.Sockets;
 using Zeus.Contracts;
 
 namespace Zeus.Server.Wsjtx;
 
 /// <summary>
-/// Emits a single WSJT-X NetworkMessage type 12 (LoggedADIF) datagram when a QSO
-/// is logged, so third-party loggers (JTAlert / Log4OM / GridTracker / N1MM)
-/// pick up Zeus's native FT8/FT4 QSOs. The ADIF for the single entry is reused
-/// from <see cref="LogService.ExportToAdifAsync"/>.
+/// Sends WSJT-X NetworkMessage datagrams so third-party loggers (JTAlert / Log4OM
+/// / GridTracker / N1MM / JTDX) pick up Zeus's native FT8/FT4/WSPR activity.
 ///
-/// Wired ONLY at /api/log/entry (live + manual QSOs); ADIF bulk import does NOT
-/// route through here, so re-importing a log never re-broadcasts. No-ops when
-/// disabled (the default) — new network egress is opt-in. Cross-platform: pure
+/// Two egress paths share one transport:
+///   * <see cref="BroadcastLoggedQsoAsync"/> — a LoggedADIF (type 12), and
+///     optionally a structured QSOLogged (type 5), on each logged QSO. Wired ONLY
+///     at /api/log/entry (live + manual QSOs); ADIF bulk import does NOT route
+///     here, so re-importing a log never re-broadcasts.
+///   * <see cref="SendDatagramAsync"/> — used by <see cref="WsjtxLiveEmitter"/>
+///     for the live Heartbeat/Status/Decode/WSPRDecode stream.
+///
+/// SEND-ONLY: there is no inbound socket anywhere in this namespace. Zeus never
+/// honours Reply(4)/HaltTx(8)/FreeText(9) — those are network TX-triggers into a
+/// real PA. No-ops when disabled (the default) — new network egress is opt-in.
+/// Transport is unicast by default, or multicast (group + TTL) when configured so
+/// MULTIPLE loggers can receive the same stream. Cross-platform: pure
 /// <see cref="UdpClient"/>, no native deps.
+///
+/// One long-lived send socket is cached for the broadcaster's lifetime (registered
+/// singleton). <see cref="UdpClient.SendAsync(byte[],int,string,int)"/> takes the
+/// destination per call, so the SAME socket serves unicast and multicast and every
+/// host/port change without re-allocation — the only per-config state is the
+/// multicast TTL, which is (re)applied lazily only when it actually changes. Sends
+/// are serialised through a semaphore so the fire-and-forget live stream (tens of
+/// Decode datagrams per FT8 slot, plus Status/Heartbeat) never issues concurrent
+/// SendAsync on a single socket. This removes the per-datagram ephemeral-socket
+/// churn the old throwaway-per-send model incurred on the live hot path.
 /// </summary>
-public sealed class WsjtxUdpBroadcaster
+public sealed class WsjtxUdpBroadcaster : IDisposable
 {
     private readonly ILogger<WsjtxUdpBroadcaster> _log;
     private readonly WsjtxManagementService _mgmt;
     private readonly LogService _logService;
+    private readonly SpottingManagementService? _operator;
+
+    // One cached send socket for the broadcaster's lifetime. Created lazily on the
+    // first enabled send so the disabled-default path allocates no socket at all.
+    // _sendGate serialises sends (a shared socket must not see concurrent SendAsync
+    // from the fire-and-forget live stream); _appliedTtl tracks the multicast TTL
+    // currently set on the socket so we only call SetSocketOption on change.
+    private readonly SemaphoreSlim _sendGate = new(1, 1);
+    private UdpClient? _udp;
+    private int _appliedTtl = -1;
+    private bool _disposed;
 
     public WsjtxUdpBroadcaster(
         ILogger<WsjtxUdpBroadcaster> log,
         WsjtxManagementService mgmt,
-        LogService logService)
+        LogService logService,
+        // Optional so the existing broadcaster tests (which exercise the type-12
+        // path only) keep their 3-arg construction. Supplies operator call/grid for
+        // the MY_* fields of the optional QSOLogged (type 5) message.
+        SpottingManagementService? operatorIdentity = null)
     {
         _log = log;
         _mgmt = mgmt;
         _logService = logService;
+        _operator = operatorIdentity;
     }
 
     /// <summary>Broadcast one logged QSO. No-op when the broadcaster is disabled;
@@ -51,17 +86,112 @@ public sealed class WsjtxUdpBroadcaster
         {
             var adif = await _logService.ExportToAdifAsync(new[] { entry.Id }, ct);
             var datagram = WsjtxMessage.EncodeLoggedAdif(cfg.InstanceId, adif);
+            await SendInternalAsync(cfg, datagram, ct).ConfigureAwait(false);
 
-            using var udp = new UdpClient();
-            await udp.SendAsync(datagram, datagram.Length, cfg.Host, cfg.Port).ConfigureAwait(false);
+            if (cfg.SendQsoLogged)
+            {
+                var (call, grid) = _operator?.ResolveOperator() ?? ("", "");
+                var qso = WsjtxMessage.EncodeQsoLogged(
+                    instanceId: cfg.InstanceId,
+                    dateTimeOffUtc: entry.QsoDateTimeUtc,
+                    dxCall: entry.Callsign ?? "",
+                    dxGrid: entry.Grid ?? "",
+                    txFrequencyHz: entry.FrequencyMhz is { } mhz && mhz > 0
+                        ? (ulong)Math.Round(mhz * 1_000_000.0)
+                        : 0UL,
+                    mode: entry.Mode ?? "",
+                    reportSent: entry.RstSent ?? "",
+                    reportReceived: entry.RstRcvd ?? "",
+                    txPower: "",
+                    comments: entry.Comment ?? "",
+                    name: entry.Name ?? "",
+                    dateTimeOnUtc: entry.QsoDateTimeUtc,
+                    operatorCall: call,
+                    myCall: call,
+                    myGrid: grid,
+                    exchangeSent: "",
+                    exchangeReceived: "",
+                    adifPropagationMode: "");
+                await SendInternalAsync(cfg, qso, ct).ConfigureAwait(false);
+            }
 
             _log.LogInformation(
-                "wsjtx.broadcast call={Call} -> {Host}:{Port} bytes={Bytes}",
-                entry.Callsign, cfg.Host, cfg.Port, datagram.Length);
+                "wsjtx.broadcast call={Call} -> {Transport} {Host}:{Port} bytes={Bytes} type5={T5}",
+                entry.Callsign, cfg.Transport, TargetHost(cfg), cfg.Port, datagram.Length, cfg.SendQsoLogged);
         }
         catch (Exception ex)
         {
             _log.LogWarning(ex, "wsjtx.broadcast failed call={Call}", entry.Callsign);
         }
+    }
+
+    /// <summary>Send a pre-encoded datagram on the live stream (Heartbeat / Status
+    /// / Decode / WSPRDecode). No-op when disabled; never throws. The caller has
+    /// already gated on <see cref="WsjtxRuntimeConfig.SendLiveDecodes"/>.</summary>
+    public async Task SendDatagramAsync(byte[] datagram, CancellationToken ct = default)
+    {
+        var cfg = _mgmt.GetConfig();
+        if (!cfg.Enabled) return;
+        try
+        {
+            await SendInternalAsync(cfg, datagram, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _log.LogDebug(ex, "wsjtx.live send failed bytes={Bytes}", datagram.Length);
+        }
+    }
+
+    private static string TargetHost(WsjtxRuntimeConfig cfg) =>
+        IsMulticast(cfg) ? cfg.MulticastGroup : cfg.Host;
+
+    private static bool IsMulticast(WsjtxRuntimeConfig cfg) =>
+        string.Equals(cfg.Transport, "multicast", StringComparison.OrdinalIgnoreCase);
+
+    // One cached transport for both egress paths. The socket is destination-agnostic
+    // (the endpoint is passed per SendAsync), so it is reused across unicast/multicast
+    // and every host/port change; only the multicast TTL is reapplied on change. Sends
+    // are serialised so a shared socket never sees concurrent SendAsync.
+    private async Task SendInternalAsync(WsjtxRuntimeConfig cfg, byte[] datagram, CancellationToken ct)
+    {
+        await _sendGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var udp = _udp ??= new UdpClient();
+            if (IsMulticast(cfg))
+            {
+                // Scope the multicast TTL (hop limit). Send-only multicast needs no
+                // JoinMulticastGroup — the group address is just the destination.
+                // Apply only when it changes; the option persists on the socket.
+                int ttl = Math.Clamp(cfg.MulticastTtl, 1, 255);
+                if (ttl != _appliedTtl)
+                {
+                    udp.Client.SetSocketOption(
+                        SocketOptionLevel.IP,
+                        SocketOptionName.MulticastTimeToLive,
+                        ttl);
+                    _appliedTtl = ttl;
+                }
+                await udp.SendAsync(datagram, datagram.Length, cfg.MulticastGroup, cfg.Port)
+                    .WaitAsync(TimeSpan.FromSeconds(5), ct).ConfigureAwait(false);
+            }
+            else
+            {
+                await udp.SendAsync(datagram, datagram.Length, cfg.Host, cfg.Port)
+                    .WaitAsync(TimeSpan.FromSeconds(5), ct).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            _sendGate.Release();
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _udp?.Dispose();
+        _sendGate.Dispose();
     }
 }

--- a/Zeus.Server.Hosting/WsjtxConfigStore.cs
+++ b/Zeus.Server.Hosting/WsjtxConfigStore.cs
@@ -48,7 +48,15 @@ public sealed class WsjtxConfigStore : IDisposable
                 Enabled: e.Enabled,
                 Host: e.Host,
                 Port: e.Port,
-                InstanceId: string.IsNullOrWhiteSpace(e.InstanceId) ? "WSJT-X" : e.InstanceId);
+                InstanceId: string.IsNullOrWhiteSpace(e.InstanceId) ? "WSJT-X" : e.InstanceId,
+                // LiteDB returns the type default for columns absent from older rows
+                // (Transport="" / Group="" / Ttl=0) — coalesce to the documented
+                // defaults so a pre-multicast row reads back as plain unicast.
+                Transport: string.IsNullOrWhiteSpace(e.Transport) ? "unicast" : e.Transport,
+                MulticastGroup: string.IsNullOrWhiteSpace(e.MulticastGroup) ? "224.0.0.73" : e.MulticastGroup,
+                MulticastTtl: e.MulticastTtl <= 0 ? 1 : e.MulticastTtl,
+                SendQsoLogged: e.SendQsoLogged,
+                SendLiveDecodes: e.SendLiveDecodes);
         }
     }
 
@@ -65,6 +73,11 @@ public sealed class WsjtxConfigStore : IDisposable
                     Host = config.Host,
                     Port = config.Port,
                     InstanceId = config.InstanceId,
+                    Transport = config.Transport,
+                    MulticastGroup = config.MulticastGroup,
+                    MulticastTtl = config.MulticastTtl,
+                    SendQsoLogged = config.SendQsoLogged,
+                    SendLiveDecodes = config.SendLiveDecodes,
                     UpdatedUtc = DateTime.UtcNow,
                 });
             }
@@ -74,6 +87,11 @@ public sealed class WsjtxConfigStore : IDisposable
                 existing.Host = config.Host;
                 existing.Port = config.Port;
                 existing.InstanceId = config.InstanceId;
+                existing.Transport = config.Transport;
+                existing.MulticastGroup = config.MulticastGroup;
+                existing.MulticastTtl = config.MulticastTtl;
+                existing.SendQsoLogged = config.SendQsoLogged;
+                existing.SendLiveDecodes = config.SendLiveDecodes;
                 existing.UpdatedUtc = DateTime.UtcNow;
                 _entries.Update(existing);
             }
@@ -90,5 +108,10 @@ public sealed class WsjtxConfigEntry
     public string Host { get; set; } = "127.0.0.1";
     public int Port { get; set; } = 2237;
     public string InstanceId { get; set; } = "WSJT-X";
+    public string Transport { get; set; } = "unicast";
+    public string MulticastGroup { get; set; } = "224.0.0.73";
+    public int MulticastTtl { get; set; } = 1;
+    public bool SendQsoLogged { get; set; }
+    public bool SendLiveDecodes { get; set; }
     public DateTime UpdatedUtc { get; set; }
 }

--- a/Zeus.Server.Hosting/WsjtxManagementService.cs
+++ b/Zeus.Server.Hosting/WsjtxManagementService.cs
@@ -8,6 +8,7 @@
 // Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
 // License for details.
 
+using System.Net;
 using Zeus.Contracts;
 
 namespace Zeus.Server;
@@ -42,16 +43,35 @@ public sealed class WsjtxManagementService
     public WsjtxStatus GetStatus()
     {
         var c = GetConfig();
-        return new WsjtxStatus(c.Enabled, c.Host, c.Port, c.InstanceId);
+        return new WsjtxStatus(
+            c.Enabled, c.Host, c.Port, c.InstanceId,
+            c.Transport, c.MulticastGroup, c.MulticastTtl, c.SendQsoLogged, c.SendLiveDecodes);
     }
 
     public WsjtxStatus SetConfig(WsjtxRuntimeConfig config)
     {
+        bool multicast = string.Equals(config.Transport?.Trim(), "multicast", StringComparison.OrdinalIgnoreCase);
+
+        // Validate the multicast group: must parse as an IPv4 address in
+        // 224.0.0.0–239.255.255.255. A bad/empty group falls back to 224.0.0.73 so
+        // a typo can never silently send to a unicast/garbage host as if multicast.
+        string group = "224.0.0.73";
+        if (!string.IsNullOrWhiteSpace(config.MulticastGroup) &&
+            IsMulticastIPv4(config.MulticastGroup.Trim()))
+        {
+            group = config.MulticastGroup.Trim();
+        }
+
         var normalized = new WsjtxRuntimeConfig(
             Enabled: config.Enabled,
             Host: string.IsNullOrWhiteSpace(config.Host) ? "127.0.0.1" : config.Host.Trim(),
             Port: config.Port is > 0 and < 65536 ? config.Port : 2237,
-            InstanceId: string.IsNullOrWhiteSpace(config.InstanceId) ? "WSJT-X" : config.InstanceId.Trim());
+            InstanceId: string.IsNullOrWhiteSpace(config.InstanceId) ? "WSJT-X" : config.InstanceId.Trim(),
+            Transport: multicast ? "multicast" : "unicast",
+            MulticastGroup: group,
+            MulticastTtl: Math.Clamp(config.MulticastTtl, 1, 255),
+            SendQsoLogged: config.SendQsoLogged,
+            SendLiveDecodes: config.SendLiveDecodes);
 
         lock (_sync) _config = normalized;
 
@@ -65,9 +85,20 @@ public sealed class WsjtxManagementService
         }
 
         _log.LogInformation(
-            "wsjtx.config.updated enabled={Enabled} host={Host} port={Port}",
-            normalized.Enabled, normalized.Host, normalized.Port);
+            "wsjtx.config.updated enabled={Enabled} transport={Transport} host={Host} port={Port} group={Group} ttl={Ttl} type5={T5} live={Live}",
+            normalized.Enabled, normalized.Transport, normalized.Host, normalized.Port,
+            normalized.MulticastGroup, normalized.MulticastTtl, normalized.SendQsoLogged, normalized.SendLiveDecodes);
 
         return GetStatus();
+    }
+
+    // True iff the string parses as an IPv4 address in the multicast range
+    // 224.0.0.0–239.255.255.255 (first octet 224..239).
+    internal static bool IsMulticastIPv4(string address)
+    {
+        if (!IPAddress.TryParse(address, out var ip)) return false;
+        if (ip.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork) return false;
+        byte first = ip.GetAddressBytes()[0];
+        return first is >= 224 and <= 239;
     }
 }

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -3448,7 +3448,10 @@ public static class ZeusEndpoints
 
         app.MapPost("/api/wsjtx/config", (WsjtxRuntimeConfig req, WsjtxManagementService wsjtx, HttpContext ctx) =>
         {
-            log.LogInformation("api.wsjtx.config enabled={En} host={Host} port={Port}", req.Enabled, req.Host, req.Port);
+            log.LogInformation(
+                "api.wsjtx.config enabled={En} transport={Tr} host={Host} port={Port} group={Grp} ttl={Ttl} type5={T5} live={Live}",
+                req.Enabled, req.Transport, req.Host, req.Port, req.MulticastGroup, req.MulticastTtl,
+                req.SendQsoLogged, req.SendLiveDecodes);
             var status = wsjtx.SetConfig(req);
             return Results.Ok(status);
         });

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -913,6 +913,12 @@ public static class ZeusHost
         builder.Services.AddSingleton<WsjtxConfigStore>();
         builder.Services.AddSingleton<WsjtxManagementService>();
         builder.Services.AddSingleton<Wsjtx.WsjtxUdpBroadcaster>();
+        // WsjtxLiveEmitter — the optional live WSJT-X stream (Heartbeat/Status/
+        // Decode/WSPRDecode) GridTracker / JTAlert consume. Leaf subscriber to
+        // Ft8Service/WsprService/RadioService; gated on Enabled && SendLiveDecodes
+        // so the default path emits nothing. SEND-ONLY via the broadcaster.
+        builder.Services.AddSingleton<Wsjtx.WsjtxLiveEmitter>();
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<Wsjtx.WsjtxLiveEmitter>());
 
         // Digital-mode spotting uploaders — FT8/FT4 decodes to PSK Reporter and
         // WSPR spots to WSPRnet. NEW network egress; both DISABLED by default and

--- a/tests/Zeus.Server.Tests/Wsjtx/WsjtxLiveEmitterTests.cs
+++ b/tests/Zeus.Server.Tests/Wsjtx/WsjtxLiveEmitterTests.cs
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Pins the live WSJT-X emitter's safety gate and field mapping:
+//   - DISABLED, or live-decodes flag OFF ⇒ no datagram is built/sent (the
+//     opt-in-egress invariant the whole subsystem rests on);
+//   - ENABLED + live ⇒ exactly one Decode/WSPRDecode datagram per line/spot,
+//     with the FT8/FT4 fields mapped correctly.
+
+using System.Buffers.Binary;
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Dsp.Ft8;
+using Zeus.Server;
+using Zeus.Server.Wsjtx;
+
+namespace Zeus.Server.Tests;
+
+public sealed class WsjtxLiveEmitterTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-wsjtxlive-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+    }
+
+    private (WsjtxLiveEmitter emitter, List<byte[]> sent, WsjtxManagementService mgmt) Build()
+    {
+        var store = new WsjtxConfigStore(NullLogger<WsjtxConfigStore>.Instance, _dbPath);
+        var mgmt = new WsjtxManagementService(NullLogger<WsjtxManagementService>.Instance, store);
+        var sent = new List<byte[]>();
+        var emitter = new WsjtxLiveEmitter(
+            NullLogger<WsjtxLiveEmitter>.Instance,
+            mgmt,
+            (dg, _) => { sent.Add(dg); return Task.CompletedTask; });
+        return (emitter, sent, mgmt);
+    }
+
+    private static Ft8DecodeBatch SampleFt8Batch() => new(
+        Receiver: 0,
+        SlotStartUtc: new DateTime(2024, 6, 15, 12, 30, 0, DateTimeKind.Utc),
+        Protocol: Ft8Protocol.Ft8,
+        Decodes: new[]
+        {
+            new Ft8DecodeResult(SnrDb: -7.4f, DtSec: 0.2f, FreqHz: 1500.6f, Score: 50, LdpcErrors: 0, Text: "CQ K1ABC FN42"),
+            new Ft8DecodeResult(SnrDb: -15f, DtSec: -0.1f, FreqHz: 800f, Score: 10, LdpcErrors: 1, Text: "KB2UKA W1AW -05"),
+        });
+
+    private static WsprSpotBatch SampleWsprBatch() => new(
+        Receiver: 0,
+        SlotStartUtc: new DateTime(2024, 6, 15, 12, 0, 0, DateTimeKind.Utc),
+        DialFreqMhz: 14.0956,
+        Spots: new[] { new WsprSpot(SnrDb: -24f, DtSec: 1.5f, FreqMhz: 14.0971f, DriftHz: -1, Message: "KB2UKA FN12 30") });
+
+    [Fact]
+    public void Disabled_Emits_Nothing()
+    {
+        var (emitter, sent, mgmt) = Build();
+        using (emitter)
+        {
+            mgmt.SetConfig(new WsjtxRuntimeConfig(Enabled: false, SendLiveDecodes: true));
+            emitter.HandleDecodes(SampleFt8Batch());
+            emitter.HandleSpots(SampleWsprBatch());
+            Assert.Empty(sent);
+        }
+    }
+
+    [Fact]
+    public void Enabled_But_Live_Flag_Off_Emits_Nothing()
+    {
+        var (emitter, sent, mgmt) = Build();
+        using (emitter)
+        {
+            mgmt.SetConfig(new WsjtxRuntimeConfig(Enabled: true, SendLiveDecodes: false));
+            emitter.HandleDecodes(SampleFt8Batch());
+            emitter.HandleSpots(SampleWsprBatch());
+            Assert.Empty(sent);
+        }
+    }
+
+    [Fact]
+    public void Enabled_And_Live_Emits_One_Datagram_Per_Line()
+    {
+        var (emitter, sent, mgmt) = Build();
+        using (emitter)
+        {
+            mgmt.SetConfig(new WsjtxRuntimeConfig(Enabled: true, SendLiveDecodes: true));
+            emitter.HandleDecodes(SampleFt8Batch()); // 2 lines
+            emitter.HandleSpots(SampleWsprBatch());   // 1 spot
+            Assert.Equal(3, sent.Count);
+            // Each is a well-formed WSJT-X datagram (magic header).
+            foreach (var dg in sent)
+                Assert.Equal(new byte[] { 0xAD, 0xBC, 0xCB, 0xDA }, dg[..4]);
+        }
+    }
+
+    [Fact]
+    public void BuildDecodeDatagrams_Maps_Type_And_Fields()
+    {
+        var dgs = WsjtxLiveEmitter.BuildDecodeDatagrams("Zeus", SampleFt8Batch());
+        Assert.Equal(2, dgs.Count);
+
+        // Decode type (2) in the header.
+        Assert.Equal(WsjtxMessage.DecodeType, BinaryPrimitives.ReadUInt32BigEndian(dgs[0].AsSpan(8, 4)));
+
+        // 12:30:00 UTC == 45_000_000 ms since midnight.
+        Assert.Equal(45_000_000u, WsjtxLiveEmitter.MsSinceUtcMidnight(SampleFt8Batch().SlotStartUtc));
+    }
+
+    [Fact]
+    public void BuildWsprDatagrams_Sets_Type_10()
+    {
+        var dgs = WsjtxLiveEmitter.BuildWsprDatagrams("Zeus", SampleWsprBatch());
+        Assert.Single(dgs);
+        Assert.Equal(WsjtxMessage.WsprDecodeType, BinaryPrimitives.ReadUInt32BigEndian(dgs[0].AsSpan(8, 4)));
+    }
+
+    [Theory]
+    [InlineData("KB2UKA FN12 30", "KB2UKA", "FN12", 30)]
+    [InlineData("VK7/KB2UKA 27", "VK7/KB2UKA", "", 27)]
+    [InlineData("<KB2UKA> FN12AB 23", "KB2UKA", "FN12AB", 23)]
+    [InlineData("", "", "", 0)]
+    public void ParseWsprMessage_Tokenizes(string msg, string call, string grid, int power)
+    {
+        WsjtxLiveEmitter.ParseWsprMessage(msg, out var c, out var g, out var p);
+        Assert.Equal(call, c);
+        Assert.Equal(grid, g);
+        Assert.Equal(power, p);
+    }
+
+    [Theory]
+    [InlineData("K1ABC KB2UKA FN12", "KB2UKA", "K1ABC")]    // standard reply: DX is the target
+    [InlineData("CQ KB2UKA FN12", "KB2UKA", "")]            // calling CQ: no DX
+    [InlineData("", "KB2UKA", "")]
+    public void ParseDxCall_Extracts_Target(string txMsg, string deCall, string expected)
+    {
+        Assert.Equal(expected, WsjtxLiveEmitter.ParseDxCall(txMsg, deCall));
+    }
+}

--- a/tests/Zeus.Server.Tests/Wsjtx/WsjtxManagementServiceTests.cs
+++ b/tests/Zeus.Server.Tests/Wsjtx/WsjtxManagementServiceTests.cs
@@ -112,4 +112,94 @@ public sealed class WsjtxManagementServiceTests : IDisposable
         Assert.Equal(2333, reloaded.Port);
         Assert.Equal("Shack", reloaded.InstanceId);
     }
+
+    [Fact]
+    public void Defaults_Transport_Is_Plain_Unicast()
+    {
+        using var store = NewStore();
+        var cfg = NewService(store).GetConfig();
+        Assert.Equal("unicast", cfg.Transport);
+        Assert.Equal("224.0.0.73", cfg.MulticastGroup);
+        Assert.Equal(1, cfg.MulticastTtl);
+        Assert.False(cfg.SendQsoLogged);
+        Assert.False(cfg.SendLiveDecodes);
+    }
+
+    [Theory]
+    [InlineData("multicast", "multicast")]
+    [InlineData("MULTICAST", "multicast")]
+    [InlineData("unicast", "unicast")]
+    [InlineData("garbage", "unicast")]
+    [InlineData("", "unicast")]
+    public void SetConfig_Normalizes_Transport(string input, string expected)
+    {
+        using var store = NewStore();
+        var status = NewService(store).SetConfig(new WsjtxRuntimeConfig(Enabled: true, Transport: input));
+        Assert.Equal(expected, status.Transport);
+    }
+
+    [Theory]
+    [InlineData("224.0.0.73", true)]
+    [InlineData("239.255.255.255", true)]
+    [InlineData("224.0.0.0", true)]
+    [InlineData("223.255.255.255", false)]
+    [InlineData("240.0.0.0", false)]
+    [InlineData("192.168.1.1", false)]
+    [InlineData("not-an-ip", false)]
+    public void IsMulticastIPv4_Recognizes_The_Class_D_Range(string addr, bool expected)
+    {
+        Assert.Equal(expected, WsjtxManagementService.IsMulticastIPv4(addr));
+    }
+
+    [Fact]
+    public void SetConfig_Falls_Back_On_Bad_Multicast_Group()
+    {
+        using var store = NewStore();
+        var status = NewService(store).SetConfig(
+            new WsjtxRuntimeConfig(Enabled: true, Transport: "multicast", MulticastGroup: "10.0.0.1"));
+        Assert.Equal("224.0.0.73", status.MulticastGroup); // unicast/garbage group rejected
+    }
+
+    [Fact]
+    public void SetConfig_Keeps_Valid_Multicast_Group()
+    {
+        using var store = NewStore();
+        var status = NewService(store).SetConfig(
+            new WsjtxRuntimeConfig(Enabled: true, Transport: "multicast", MulticastGroup: "239.1.2.3"));
+        Assert.Equal("239.1.2.3", status.MulticastGroup);
+    }
+
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(-5, 1)]
+    [InlineData(1, 1)]
+    [InlineData(32, 32)]
+    [InlineData(255, 255)]
+    [InlineData(999, 255)]
+    public void SetConfig_Clamps_Ttl(int input, int expected)
+    {
+        using var store = NewStore();
+        var status = NewService(store).SetConfig(
+            new WsjtxRuntimeConfig(Enabled: true, MulticastTtl: input));
+        Assert.Equal(expected, status.MulticastTtl);
+    }
+
+    [Fact]
+    public void SetConfig_Persists_New_Fields_Across_Store_Instances()
+    {
+        using (var store = NewStore())
+        {
+            NewService(store).SetConfig(new WsjtxRuntimeConfig(
+                Enabled: true, Transport: "multicast", MulticastGroup: "239.5.6.7",
+                MulticastTtl: 8, SendQsoLogged: true, SendLiveDecodes: true));
+        }
+
+        using var reopened = NewStore();
+        var reloaded = NewService(reopened).GetConfig();
+        Assert.Equal("multicast", reloaded.Transport);
+        Assert.Equal("239.5.6.7", reloaded.MulticastGroup);
+        Assert.Equal(8, reloaded.MulticastTtl);
+        Assert.True(reloaded.SendQsoLogged);
+        Assert.True(reloaded.SendLiveDecodes);
+    }
 }

--- a/tests/Zeus.Server.Tests/Wsjtx/WsjtxMessageTests.cs
+++ b/tests/Zeus.Server.Tests/Wsjtx/WsjtxMessageTests.cs
@@ -26,6 +26,41 @@ public sealed class WsjtxMessageTests
             return v;
         }
 
+        public int Int32() => unchecked((int)UInt32());
+
+        public ulong UInt64()
+        {
+            var v = BinaryPrimitives.ReadUInt64BigEndian(buf.AsSpan(_pos, 8));
+            _pos += 8;
+            return v;
+        }
+
+        public long Int64() => unchecked((long)UInt64());
+
+        public double Double() => BitConverter.Int64BitsToDouble(Int64());
+
+        public bool Bool()
+        {
+            var b = buf[_pos];
+            _pos += 1;
+            return b != 0;
+        }
+
+        public byte UInt8()
+        {
+            var b = buf[_pos];
+            _pos += 1;
+            return b;
+        }
+
+        public (long JulianDay, uint MsSinceMidnight, byte TimeSpec) QDateTime()
+        {
+            var jd = Int64();
+            var ms = UInt32();
+            var spec = UInt8();
+            return (jd, ms, spec);
+        }
+
         public string? Utf8()
         {
             var len = UInt32();
@@ -36,6 +71,17 @@ public sealed class WsjtxMessageTests
         }
 
         public int Remaining => buf.Length - _pos;
+    }
+
+    // Read past the common header (magic, schema, type, instance id) and assert it.
+    private static Reader AfterHeader(byte[] bytes, uint expectedType, string expectedId)
+    {
+        var r = new Reader(bytes);
+        Assert.Equal(0xADBCCBDAu, r.UInt32());
+        Assert.Equal(WsjtxMessage.DefaultSchema, r.UInt32());
+        Assert.Equal(expectedType, r.UInt32());
+        Assert.Equal(expectedId, r.Utf8());
+        return r;
     }
 
     [Fact]
@@ -80,5 +126,172 @@ public sealed class WsjtxMessageTests
         var r = new Reader(bytes);
         r.UInt32();
         Assert.Equal(3u, r.UInt32());
+    }
+
+    [Fact]
+    public void EncodeHeartbeat_WritesFieldsInOrder()
+    {
+        var bytes = WsjtxMessage.EncodeHeartbeat("Zeus", maxSchema: 3, version: "1.2.3", revision: "");
+        var r = AfterHeader(bytes, WsjtxMessage.HeartbeatType, "Zeus");
+        Assert.Equal(3u, r.UInt32());      // max schema
+        Assert.Equal("1.2.3", r.Utf8());   // version
+        Assert.Equal("", r.Utf8());        // revision (empty, not null)
+        Assert.Equal(0, r.Remaining);
+    }
+
+    [Fact]
+    public void EncodeStatus_WritesEveryFieldInDeclaredOrder()
+    {
+        var bytes = WsjtxMessage.EncodeStatus(
+            instanceId: "Zeus",
+            dialFrequencyHz: 14_074_000,
+            mode: "FT8",
+            dxCall: "K1ABC",
+            report: "-12",
+            txMode: "FT8",
+            txEnabled: true,
+            transmitting: false,
+            decoding: true,
+            rxDf: 1500,
+            txDf: 1234,
+            deCall: "KB2UKA",
+            deGrid: "FN12",
+            dxGrid: "FN42",
+            txWatchdog: false,
+            subMode: "",
+            fastMode: false,
+            specialOperationMode: 0,
+            frequencyTolerance: 0,
+            trPeriod: 15000,
+            configurationName: "Zeus",
+            txMessage: "K1ABC KB2UKA FN12");
+
+        var r = AfterHeader(bytes, WsjtxMessage.StatusType, "Zeus");
+        Assert.Equal(14_074_000UL, r.UInt64());
+        Assert.Equal("FT8", r.Utf8());
+        Assert.Equal("K1ABC", r.Utf8());
+        Assert.Equal("-12", r.Utf8());
+        Assert.Equal("FT8", r.Utf8());
+        Assert.True(r.Bool());   // txEnabled
+        Assert.False(r.Bool());  // transmitting
+        Assert.True(r.Bool());   // decoding
+        Assert.Equal(1500u, r.UInt32());
+        Assert.Equal(1234u, r.UInt32());
+        Assert.Equal("KB2UKA", r.Utf8());
+        Assert.Equal("FN12", r.Utf8());
+        Assert.Equal("FN42", r.Utf8());
+        Assert.False(r.Bool());  // txWatchdog
+        Assert.Equal("", r.Utf8());
+        Assert.False(r.Bool());  // fastMode
+        Assert.Equal(0, r.UInt8());
+        Assert.Equal(0u, r.UInt32());
+        Assert.Equal(15000u, r.UInt32());
+        Assert.Equal("Zeus", r.Utf8());
+        Assert.Equal("K1ABC KB2UKA FN12", r.Utf8());
+        Assert.Equal(0, r.Remaining);
+    }
+
+    [Fact]
+    public void EncodeDecode_WritesDeltaTimeAsDouble_AndTimeAsMsU32()
+    {
+        var bytes = WsjtxMessage.EncodeDecode(
+            "Zeus", isNew: true, timeMsSinceMidnight: 45_296_789, snr: -7,
+            deltaTimeSec: 0.2, deltaFrequencyHz: 1500, mode: "FT4",
+            message: "CQ K1ABC FN42", lowConfidence: false, offAir: false);
+
+        var r = AfterHeader(bytes, WsjtxMessage.DecodeType, "Zeus");
+        Assert.True(r.Bool());                       // new
+        Assert.Equal(45_296_789u, r.UInt32());       // time (ms since midnight)
+        Assert.Equal(-7, r.Int32());                 // snr
+        Assert.Equal(0.2, r.Double(), 9);            // dt — 8-byte double
+        Assert.Equal(1500u, r.UInt32());             // df
+        Assert.Equal("FT4", r.Utf8());
+        Assert.Equal("CQ K1ABC FN42", r.Utf8());
+        Assert.False(r.Bool());                      // low confidence
+        Assert.False(r.Bool());                      // off air
+        Assert.Equal(0, r.Remaining);
+    }
+
+    [Fact]
+    public void EncodeWsprDecode_WritesFrequencyAsU64Hz()
+    {
+        var bytes = WsjtxMessage.EncodeWsprDecode(
+            "Zeus", isNew: true, timeMsSinceMidnight: 60_000, snr: -24,
+            deltaTimeSec: 1.5, frequencyHz: 14_097_100, drift: -1,
+            callsign: "KB2UKA", grid: "FN12", power: 30, offAir: false);
+
+        var r = AfterHeader(bytes, WsjtxMessage.WsprDecodeType, "Zeus");
+        Assert.True(r.Bool());
+        Assert.Equal(60_000u, r.UInt32());
+        Assert.Equal(-24, r.Int32());
+        Assert.Equal(1.5, r.Double(), 9);
+        Assert.Equal(14_097_100UL, r.UInt64());
+        Assert.Equal(-1, r.Int32());
+        Assert.Equal("KB2UKA", r.Utf8());
+        Assert.Equal("FN12", r.Utf8());
+        Assert.Equal(30, r.Int32());
+        Assert.False(r.Bool());
+        Assert.Equal(0, r.Remaining);
+    }
+
+    [Fact]
+    public void EncodeQsoLogged_WritesQDateTimeAsJulianMsTimespec()
+    {
+        var off = new DateTime(2024, 6, 15, 12, 34, 56, 789, DateTimeKind.Utc);
+        var on = new DateTime(2024, 6, 15, 12, 33, 0, 0, DateTimeKind.Utc);
+        var bytes = WsjtxMessage.EncodeQsoLogged(
+            instanceId: "Zeus",
+            dateTimeOffUtc: off,
+            dxCall: "K1ABC",
+            dxGrid: "FN42",
+            txFrequencyHz: 14_074_000,
+            mode: "FT8",
+            reportSent: "-12",
+            reportReceived: "-07",
+            txPower: "",
+            comments: "",
+            name: "",
+            dateTimeOnUtc: on,
+            operatorCall: "KB2UKA",
+            myCall: "KB2UKA",
+            myGrid: "FN12",
+            exchangeSent: "",
+            exchangeReceived: "",
+            adifPropagationMode: "");
+
+        var r = AfterHeader(bytes, WsjtxMessage.QsoLoggedType, "Zeus");
+
+        var (jd, ms, spec) = r.QDateTime();
+        Assert.Equal(WsjtxMessage.ToJulianDay(2024, 6, 15), jd);
+        Assert.Equal(45_296_789u, ms);  // 12:34:56.789
+        Assert.Equal(1, spec);          // UTC
+        Assert.Equal("K1ABC", r.Utf8());
+        Assert.Equal("FN42", r.Utf8());
+        Assert.Equal(14_074_000UL, r.UInt64());
+        Assert.Equal("FT8", r.Utf8());
+        Assert.Equal("-12", r.Utf8());
+        Assert.Equal("-07", r.Utf8());
+        Assert.Equal("", r.Utf8());     // tx power
+        Assert.Equal("", r.Utf8());     // comments
+        Assert.Equal("", r.Utf8());     // name
+
+        var (jd2, ms2, spec2) = r.QDateTime();
+        Assert.Equal(WsjtxMessage.ToJulianDay(2024, 6, 15), jd2);
+        Assert.Equal((uint)((12 * 60 + 33) * 60) * 1000u, ms2);
+        Assert.Equal(1, spec2);
+        Assert.Equal("KB2UKA", r.Utf8());  // operator
+        Assert.Equal("KB2UKA", r.Utf8());  // my call
+        Assert.Equal("FN12", r.Utf8());    // my grid
+        Assert.Equal("", r.Utf8());        // exchange sent
+        Assert.Equal("", r.Utf8());        // exchange recv
+        Assert.Equal("", r.Utf8());        // adif prop mode
+        Assert.Equal(0, r.Remaining);
+    }
+
+    [Fact]
+    public void ToJulianDay_MatchesQtAnchor()
+    {
+        // QDate(2000,1,1).toJulianDay() == 2451545.
+        Assert.Equal(2451545L, WsjtxMessage.ToJulianDay(2000, 1, 1));
     }
 }

--- a/tests/Zeus.Server.Tests/Wsjtx/WsjtxUdpBroadcasterTests.cs
+++ b/tests/Zeus.Server.Tests/Wsjtx/WsjtxUdpBroadcasterTests.cs
@@ -89,6 +89,46 @@ public sealed class WsjtxUdpBroadcasterTests : IDisposable
     }
 
     [Fact]
+    public async Task SendQsoLogged_Emits_Type5_Alongside_Type12()
+    {
+        using var listener = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        var port = ((IPEndPoint)listener.Client.LocalEndPoint!).Port;
+
+        using var store = new WsjtxConfigStore(NullLogger<WsjtxConfigStore>.Instance, _prefsDbPath);
+        var (bc, mgmt, entry, _) = await BuildAsync(store);
+        mgmt.SetConfig(new WsjtxRuntimeConfig(
+            Enabled: true, Host: "127.0.0.1", Port: port, SendQsoLogged: true));
+
+        await bc.BroadcastLoggedQsoAsync(entry);
+
+        // Two datagrams must arrive: a type-12 LoggedADIF and a type-5 QSOLogged
+        // (order not asserted). Both carry the WSJT-X magic.
+        var types = new List<uint>();
+        for (int i = 0; i < 2; i++)
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            var result = await listener.ReceiveAsync(cts.Token);
+            Assert.Equal(new byte[] { 0xAD, 0xBC, 0xCB, 0xDA }, result.Buffer[..4]);
+            types.Add(System.Buffers.Binary.BinaryPrimitives.ReadUInt32BigEndian(result.Buffer.AsSpan(8, 4)));
+        }
+        Assert.Contains(WsjtxMessage.LoggedAdifType, types);
+        Assert.Contains(WsjtxMessage.QsoLoggedType, types);
+    }
+
+    [Fact]
+    public async Task Multicast_Broadcast_Never_Throws()
+    {
+        using var store = new WsjtxConfigStore(NullLogger<WsjtxConfigStore>.Instance, _prefsDbPath);
+        var (bc, mgmt, entry, _) = await BuildAsync(store);
+        mgmt.SetConfig(new WsjtxRuntimeConfig(
+            Enabled: true, Transport: "multicast", MulticastGroup: "224.0.0.73", MulticastTtl: 1, Port: 2237));
+
+        // A multicast send must complete without surfacing an exception into the
+        // log POST path, regardless of whether anything is joined to the group.
+        await bc.BroadcastLoggedQsoAsync(entry);
+    }
+
+    [Fact]
     public async Task Enabled_Send_To_Dead_Endpoint_Never_Throws()
     {
         // Reserve a loopback port, then close it so nothing is listening. A UDP

--- a/zeus-web/src/api/wsjtx.ts
+++ b/zeus-web/src/api/wsjtx.ts
@@ -14,28 +14,58 @@
 
 import { ApiError } from './client';
 
+// "unicast" → one logger on Host:Port. "multicast" → many loggers receive the
+// same stream via MulticastGroup/MulticastTtl (the only way to feed e.g.
+// GridTracker AND Log4OM at once, since unicast hands the port to a single
+// binder). Mirrors WsjtxRuntimeConfig.Transport in Zeus.Contracts.
+export type WsjtxTransport = 'unicast' | 'multicast';
+
 export type WsjtxStatus = {
   enabled: boolean;
   host: string;
   port: number;
   instanceId: string;
+  transport: WsjtxTransport;
+  multicastGroup: string;
+  multicastTtl: number;
+  sendQsoLogged: boolean;
+  sendLiveDecodes: boolean;
 };
 
 export type WsjtxConfig = {
   enabled: boolean;
   host: string;
   port: number;
+  instanceId: string;
+  transport: WsjtxTransport;
+  multicastGroup: string;
+  multicastTtl: number;
+  sendQsoLogged: boolean;
+  sendLiveDecodes: boolean;
 };
 
-const DEFAULT_PORT = 2237;
+export const WSJTX_DEFAULT_PORT = 2237;
+export const WSJTX_DEFAULT_GROUP = '224.0.0.73';
+export const WSJTX_DEFAULT_TTL = 1;
+export const WSJTX_DEFAULT_INSTANCE = 'WSJT-X';
+
+function normalizeTransport(v: unknown): WsjtxTransport {
+  return v === 'multicast' ? 'multicast' : 'unicast';
+}
 
 function normalizeStatus(raw: unknown): WsjtxStatus {
   const r = (raw ?? {}) as Record<string, unknown>;
   return {
     enabled: Boolean(r.enabled),
     host: typeof r.host === 'string' ? r.host : '127.0.0.1',
-    port: typeof r.port === 'number' ? r.port : DEFAULT_PORT,
-    instanceId: typeof r.instanceId === 'string' ? r.instanceId : 'WSJT-X',
+    port: typeof r.port === 'number' ? r.port : WSJTX_DEFAULT_PORT,
+    instanceId: typeof r.instanceId === 'string' ? r.instanceId : WSJTX_DEFAULT_INSTANCE,
+    transport: normalizeTransport(r.transport),
+    multicastGroup:
+      typeof r.multicastGroup === 'string' ? r.multicastGroup : WSJTX_DEFAULT_GROUP,
+    multicastTtl: typeof r.multicastTtl === 'number' ? r.multicastTtl : WSJTX_DEFAULT_TTL,
+    sendQsoLogged: Boolean(r.sendQsoLogged),
+    sendLiveDecodes: Boolean(r.sendLiveDecodes),
   };
 }
 

--- a/zeus-web/src/components/WsjtxSettingsPanel.tsx
+++ b/zeus-web/src/components/WsjtxSettingsPanel.tsx
@@ -38,7 +38,11 @@ export function WsjtxSettingsPanel() {
     try {
       const portNum = Number(port);
       if (!Number.isFinite(portNum) || portNum <= 0 || portNum >= 65536) return;
-      await saveConfig({ enabled, host: host.trim() || '127.0.0.1', port: portNum });
+      // Spread the current config so the additive fields (transport, multicast
+      // group/TTL, instance-id, type-5, live decodes) configured in the Zeus
+      // Digital "Logging" group are preserved — this Network-tab form only edits
+      // enable/host/port.
+      await saveConfig({ ...config, enabled, host: host.trim() || '127.0.0.1', port: portNum });
     } finally {
       setSaving(false);
     }

--- a/zeus-web/src/components/ZeusDigitalSettingsPanel.test.tsx
+++ b/zeus-web/src/components/ZeusDigitalSettingsPanel.test.tsx
@@ -87,16 +87,64 @@ vi.mock('../api/spotting', () => ({
 }));
 
 vi.mock('../api/wsjtx', () => ({
-  getWsjtxStatus: vi.fn(async () => ({ enabled: false, host: '127.0.0.1', port: 2237 })),
-  postWsjtxConfig: vi.fn(async (c: unknown) => c),
+  WSJTX_DEFAULT_PORT: 2237,
+  WSJTX_DEFAULT_GROUP: '224.0.0.73',
+  WSJTX_DEFAULT_TTL: 1,
+  WSJTX_DEFAULT_INSTANCE: 'WSJT-X',
+  getWsjtxStatus: vi.fn(async () => ({
+    enabled: false,
+    host: '127.0.0.1',
+    port: 2237,
+    instanceId: 'WSJT-X',
+    transport: 'unicast',
+    multicastGroup: '224.0.0.73',
+    multicastTtl: 1,
+    sendQsoLogged: false,
+    sendLiveDecodes: false,
+  })),
+  postWsjtxConfig: vi.fn(async (c: Record<string, unknown>) => ({ ...c })),
 }));
 
 import { ZeusDigitalSettingsPanel } from './ZeusDigitalSettingsPanel';
 import { useFt8Store } from '../state/ft8-store';
 import { useFt8SettingsStore } from '../state/ft8-settings-store';
 import { useLayoutStore } from '../state/layout-store';
+import { useWsjtxStore } from '../state/wsjtx-store';
+import type { WsjtxConfig } from '../api/wsjtx';
 import * as operatorApi from '../api/operator';
 import * as ft8SettingsApi from '../api/ft8-settings';
+import * as wsjtxApi from '../api/wsjtx';
+
+const WSJTX_BASE_CONFIG: WsjtxConfig = {
+  enabled: false,
+  host: '127.0.0.1',
+  port: 2237,
+  instanceId: 'WSJT-X',
+  transport: 'unicast',
+  multicastGroup: '224.0.0.73',
+  multicastTtl: 1,
+  sendQsoLogged: false,
+  sendLiveDecodes: false,
+};
+
+function setSelectValue(select: HTMLSelectElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLSelectElement.prototype,
+    'value',
+  )!.set!;
+  act(() => {
+    setter.call(select, value);
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+}
+
+function clickSwitch(container: HTMLElement, label: string) {
+  const btn = container.querySelector(
+    `button[aria-label="${label}"]`,
+  ) as HTMLButtonElement | null;
+  expect(btn, `switch "${label}"`).toBeTruthy();
+  act(() => btn!.click());
+}
 
 function setInputValue(input: HTMLInputElement, value: string) {
   const setter = Object.getOwnPropertyDescriptor(
@@ -126,6 +174,9 @@ describe('ZeusDigitalSettingsPanel', () => {
       hydrated: { FT8: true, FT4: true, WSPR: true },
     });
     useLayoutStore.setState({ settingsViewOpen: false, settingsInitialTab: undefined });
+    // Reset the (singleton) WSJT-X store to a known disabled baseline so the
+    // external-logging form starts clean in every test.
+    useWsjtxStore.setState({ config: { ...WSJTX_BASE_CONFIG }, status: { ...WSJTX_BASE_CONFIG } });
   });
 
   it('renders the GLOBAL Station identity fields and the mode selector', () => {
@@ -225,10 +276,76 @@ describe('ZeusDigitalSettingsPanel', () => {
     const { container, unmount } = render(createElement(ZeusDigitalSettingsPanel));
     expect(container.textContent).toContain('PSK Reporter');
     expect(container.textContent).toContain('WSPRnet');
-    expect(container.textContent).toContain('WSJT-X UDP');
     clickByText(container, 'Open Network settings →');
     expect(useLayoutStore.getState().settingsViewOpen).toBe(true);
     expect(useLayoutStore.getState().settingsInitialTab).toBe('network');
+    unmount();
+  });
+
+  it('Logging group frames external logging as ADDITIVE to the internal logbook (default off)', () => {
+    const { container, unmount } = render(createElement(ZeusDigitalSettingsPanel));
+    expect(container.textContent).toContain('Zeus internal logbook');
+    expect(container.textContent).toContain('Also send to an external logger');
+    // Default off — the preset/host/port form is hidden until the operator opts in.
+    expect(container.textContent).not.toContain('Logger preset');
+    unmount();
+  });
+
+  it('opting in reveals the external-logger form and surfaces the multicast option', () => {
+    const { container, unmount } = render(createElement(ZeusDigitalSettingsPanel));
+    clickSwitch(container, 'Also send to an external logger');
+    expect(container.textContent).toContain('Logger preset');
+    expect(container.textContent).toContain('Host');
+    expect(container.textContent).toContain('Transport');
+    // Multicast group/TTL only show once Multicast transport is selected.
+    expect(container.textContent).not.toContain('Multicast group');
+    clickByText(container, 'Multicast');
+    expect(container.textContent).toContain('Multicast group');
+    expect(container.textContent).toContain('Multicast TTL');
+    unmount();
+  });
+
+  it('GridTracker preset turns on the live decode/status stream', () => {
+    const { container, unmount } = render(createElement(ZeusDigitalSettingsPanel));
+    clickSwitch(container, 'Also send to an external logger');
+    const presetSelect = container.querySelector(
+      'select[aria-label="Logger preset"]',
+    ) as HTMLSelectElement;
+    expect(presetSelect).toBeTruthy();
+    setSelectValue(presetSelect, 'gridtracker');
+    const liveSwitch = container.querySelector(
+      'button[aria-label="Send live decodes & status (for GridTracker)"]',
+    ) as HTMLButtonElement;
+    expect(liveSwitch.getAttribute('aria-checked')).toBe('true');
+    unmount();
+  });
+
+  it('SAVE persists the full external-logger config (transport/multicast/live) to the backend', async () => {
+    const { container, unmount } = render(createElement(ZeusDigitalSettingsPanel));
+    clickSwitch(container, 'Also send to an external logger');
+    clickByText(container, 'Multicast');
+    clickSwitch(container, 'Send live decodes & status (for GridTracker)');
+    clickByText(container, 'SAVE');
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(wsjtxApi.postWsjtxConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: true,
+        transport: 'multicast',
+        multicastGroup: '224.0.0.73',
+        sendLiveDecodes: true,
+      }),
+    );
+    unmount();
+  });
+
+  it('surfaces QRZ cloud logging and deep-links to the QRZ tab', () => {
+    const { container, unmount } = render(createElement(ZeusDigitalSettingsPanel));
+    expect(container.textContent).toContain('QRZ Logbook (cloud)');
+    clickByText(container, 'Open QRZ settings →');
+    expect(useLayoutStore.getState().settingsViewOpen).toBe(true);
+    expect(useLayoutStore.getState().settingsInitialTab).toBe('qrz');
     unmount();
   });
 });

--- a/zeus-web/src/components/ZeusDigitalSettingsPanel.tsx
+++ b/zeus-web/src/components/ZeusDigitalSettingsPanel.tsx
@@ -18,8 +18,13 @@
 //
 // MESSAGE EDITING (CQ / CQ DX / free-text macros) is NOT here — it stays in the
 // digital pop-out (the macros still persist per-mode in the same store). This
-// panel only links out to it. Reporting (PSK / WSPRnet / WSJT-X UDP) is SURFACED
-// and deep-linked to the Network tab, never duplicated.
+// panel only links out to it. Spotting (PSK Reporter / WSPRnet) is SURFACED and
+// deep-linked to the Network tab, never duplicated. LOGGING, by contrast, is
+// owned here: the Zeus internal logbook is the always-on default and an ADDITIVE
+// external logger (WSJT-X UDP — the universal contract Log4OM / N1MM+ /
+// GridTracker / JTAlert all speak) plus QRZ cloud upload only ADD copies. The
+// external-logger form reuses the same wsjtx-store/api the Network tab uses (not
+// a fork); egress is OFF until the operator opts in and SAVES.
 //
 // Styling is HUD-token-only (ft8-theme.css --hud-*) — no raw hex.
 
@@ -29,7 +34,9 @@ import { useFt8SettingsStore } from '../state/ft8-settings-store';
 import { useFt8Store } from '../state/ft8-store';
 import { useSpottingStore } from '../state/spotting-store';
 import { useWsjtxStore } from '../state/wsjtx-store';
+import { useQrzStore } from '../state/qrz-store';
 import { useLayoutStore } from '../state/layout-store';
+import type { WsjtxConfig } from '../api/wsjtx';
 import {
   DIGITAL_MODES,
   WF_PALETTES,
@@ -46,6 +53,7 @@ import {
   Chip,
   NumberRow,
   SegRow,
+  SelectRow,
   TextRow,
   ToggleRow,
 } from '../layout/ft8/ft8-settings-controls';
@@ -91,8 +99,10 @@ export function ZeusDigitalSettingsPanel({
   // Reporting status (read-only chips — owned by the Network tab, surfaced here).
   const spotStatus = useSpottingStore((s) => s.status);
   const refreshSpotting = useSpottingStore((s) => s.refreshStatus);
-  const wsjtxStatus = useWsjtxStore((s) => s.status);
   const refreshWsjtx = useWsjtxStore((s) => s.refreshStatus);
+  // QRZ logbook (cloud) availability — surfaced as a logging option. Publishing
+  // QSOs to QRZ needs a logbook API key; the QRZ tab owns the credential.
+  const qrzHasApiKey = useQrzStore((s) => s.hasApiKey);
 
   // Freshen identity + reporting + the selected mode's settings on open / mode
   // switch so the panel always reflects the server (QRZ home may resolve late).
@@ -108,6 +118,7 @@ export function ZeusDigitalSettingsPanel({
   // Deep-link to the Network settings tab (PSK / WSPRnet / WSJT-X UDP live there).
   const setSettingsView = useLayoutStore((s) => s.setSettingsView);
   const openNetworkSettings = () => setSettingsView(true, 'network');
+  const openQrzSettings = () => setSettingsView(true, 'qrz');
 
   const isWspr = mode === 'WSPR';
 
@@ -366,29 +377,41 @@ export function ZeusDigitalSettingsPanel({
         </div>
       </section>
 
-      {/* § Reporting & Logging — surface/deep-link reporting, own logging. */}
+      {/* § Reporting — spotting networks (owned by the Network tab, surfaced). */}
       <section className="ft8-region ft8-set-section">
-        <div className="ft8-region__head">Reporting &amp; Logging</div>
+        <div className="ft8-region__head">Reporting</div>
         <div className="ft8-set-body">
           <div className="ft8-set-chips">
             <Chip label="PSK Reporter" on={!!spotStatus?.pskReporterEnabled} />
             <Chip label="WSPRnet" on={!!spotStatus?.wsprnetEnabled} />
-            <Chip label="WSJT-X UDP" on={!!wsjtxStatus?.enabled} />
           </div>
           <button type="button" className="ft8-set-link" onClick={openNetworkSettings}>
             Open Network settings →
           </button>
           <p className="ft8-set-note">
-            PSK Reporter, WSPRnet and WSJT-X UDP push are configured on the Network tab.
+            PSK Reporter and WSPRnet automatic spotting are configured on the Network tab.
+          </p>
+        </div>
+      </section>
+
+      {/* § Logging — Zeus internal logbook (ALWAYS on) + ADDITIVE external copies.
+          The internal logbook is the default and is never bypassed; the external
+          logger (WSJT-X UDP) and QRZ cloud upload only ADD copies. */}
+      <section className="ft8-region ft8-set-section">
+        <div className="ft8-region__head">Logging</div>
+        <div className="ft8-set-body">
+          <div className="ft8-set-chips">
+            <Chip label="Zeus internal logbook" on />
+          </div>
+          <p className="ft8-set-note">
+            Every QSO is always saved to the Zeus internal logbook. The options below ADD
+            external copies — they never replace it.
           </p>
 
-          {/* QSO logging is a non-WSPR concept — WSPR is a beacon mode with no
-              QSO/logbook path, so these toggles are hidden for WSPR (the WSPR
-              pop-out consumes none of them). */}
+          {/* Internal QSO-logging behaviour — non-WSPR (WSPR is a beacon mode
+              with no QSO/logbook path, so these toggles are hidden for it). */}
           {!isWspr && (
             <>
-              <div className="ft8-set-divider" />
-
               <ToggleRow
                 label="Auto-log QSO"
                 hint="Write completed QSOs to the logbook automatically."
@@ -420,8 +443,222 @@ export function ZeusDigitalSettingsPanel({
               </p>
             </>
           )}
+
+          <div className="ft8-set-divider" />
+
+          {/* Additive external logger over the WSJT-X UDP protocol. */}
+          <ExternalLoggingGroup />
+
+          <div className="ft8-set-divider" />
+
+          {/* QRZ cloud logbook — credential lives on the QRZ tab. */}
+          <div className="ft8-set-chips">
+            <Chip label="QRZ Logbook (cloud)" on={qrzHasApiKey} />
+          </div>
+          <button type="button" className="ft8-set-link" onClick={openQrzSettings}>
+            Open QRZ settings →
+          </button>
+          <p className="ft8-set-note">
+            Push logged QSOs to your QRZ.com logbook from the Logbook panel. Requires a QRZ
+            logbook API key, set on the QRZ tab.
+          </p>
         </div>
       </section>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// External logging over the WSJT-X UDP protocol — the universal contract every
+// modern logger speaks (Log4OM, N1MM+, GridTracker, JTAlert, …). This is the
+// SAME wsjtx-store/api the Network tab's WsjtxSettingsPanel uses (not a fork):
+// the additive fields (transport, multicast group/TTL, instance-id, type-5,
+// live decodes) are edited here, basic enable/host/port can be edited in either
+// place, and both POST through saveConfig so they stay coherent. Egress is OFF
+// by default and nothing leaves the machine until the operator hits SAVE.
+//
+// SEND-ONLY: Zeus never opens an inbound WSJT-X listener, so external loggers
+// cannot key the radio — there is no Reply/HaltTx/FreeText path. (Mirrored from
+// the backend safety note.)
+// ---------------------------------------------------------------------------
+
+type LoggerPreset = 'log4om' | 'n1mm' | 'gridtracker' | 'jtalert' | 'custom';
+
+const LOGGER_PRESETS: ReadonlyArray<{ value: LoggerPreset; label: string }> = [
+  { value: 'log4om', label: 'Log4OM' },
+  { value: 'n1mm', label: 'N1MM+' },
+  { value: 'gridtracker', label: 'GridTracker' },
+  { value: 'jtalert', label: 'JTAlert' },
+  { value: 'custom', label: 'Custom (raw WSJT-X UDP)' },
+];
+
+// Per-preset sensible defaults. Host/port match the WSJT-X convention
+// (127.0.0.1:2237) for every preset and stay fully editable; the meaningful
+// difference is which extra streams a tool wants — GridTracker needs the live
+// decode/status stream for its map & roster, Log4OM prefers the structured
+// type-5 QSOLogged. All additive, all overridable.
+const PRESET_DEFAULTS: Record<
+  Exclude<LoggerPreset, 'custom'>,
+  Pick<WsjtxConfig, 'host' | 'port' | 'transport' | 'sendQsoLogged' | 'sendLiveDecodes'>
+> = {
+  log4om: { host: '127.0.0.1', port: 2237, transport: 'unicast', sendQsoLogged: true, sendLiveDecodes: false },
+  n1mm: { host: '127.0.0.1', port: 2237, transport: 'unicast', sendQsoLogged: false, sendLiveDecodes: false },
+  gridtracker: { host: '127.0.0.1', port: 2237, transport: 'unicast', sendQsoLogged: false, sendLiveDecodes: true },
+  jtalert: { host: '127.0.0.1', port: 2237, transport: 'unicast', sendQsoLogged: false, sendLiveDecodes: false },
+};
+
+export function ExternalLoggingGroup() {
+  const config = useWsjtxStore((s) => s.config);
+  const status = useWsjtxStore((s) => s.status);
+  const saveConfig = useWsjtxStore((s) => s.saveConfig);
+
+  // Local form state — nothing is committed (no egress) until SAVE. Seeded from
+  // the server-backed config and re-seeded whenever it changes.
+  const [form, setForm] = useState<WsjtxConfig>(config);
+  const [preset, setPreset] = useState<LoggerPreset>('custom');
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setForm(config);
+  }, [config]);
+
+  const patch = (p: Partial<WsjtxConfig>) => setForm((f) => ({ ...f, ...p }));
+  // Any manual field edit drops the preset back to Custom — the values no longer
+  // match a named tool's profile.
+  const editField = (p: Partial<WsjtxConfig>) => {
+    patch(p);
+    setPreset('custom');
+  };
+  const applyPreset = (p: LoggerPreset) => {
+    setPreset(p);
+    if (p !== 'custom') patch(PRESET_DEFAULTS[p]);
+  };
+
+  async function onSave() {
+    setSaving(true);
+    try {
+      const port =
+        Number.isFinite(form.port) && form.port > 0 && form.port < 65536 ? form.port : 2237;
+      await saveConfig({
+        ...form,
+        port,
+        host: form.host.trim() || '127.0.0.1',
+        instanceId: form.instanceId.trim() || 'WSJT-X',
+        multicastGroup: form.multicastGroup.trim() || '224.0.0.73',
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const live = status?.enabled ?? false;
+  const isMulticast = form.transport === 'multicast';
+
+  return (
+    <div aria-label="External logging (WSJT-X UDP)">
+      <ToggleRow
+        label="Also send to an external logger"
+        hint="Mirror each logged QSO out over the WSJT-X UDP protocol. Additive — Zeus keeps the internal copy."
+        checked={form.enabled}
+        onChange={(v) => patch({ enabled: v })}
+      />
+
+      {form.enabled && (
+        <>
+          <SelectRow<LoggerPreset>
+            label="Logger preset"
+            hint="Sets sensible host/port and stream defaults — all fields stay editable."
+            value={preset}
+            options={LOGGER_PRESETS}
+            onChange={applyPreset}
+          />
+          <TextRow
+            label="Host"
+            hint="127.0.0.1 for a logger on this machine; otherwise the logger's LAN IP."
+            value={form.host}
+            placeholder="127.0.0.1"
+            onChange={(v) => editField({ host: v })}
+          />
+          <NumberRow
+            label="Port"
+            hint="WSJT-X default is 2237 — match your logger's UDP input."
+            value={form.port}
+            min={1}
+            max={65535}
+            onChange={(v) => editField({ port: v })}
+          />
+          <SegRow
+            label="Transport"
+            hint="Multicast lets several loggers receive the same stream at once."
+            value={form.transport}
+            options={[
+              { value: 'unicast', label: 'Unicast' },
+              { value: 'multicast', label: 'Multicast' },
+            ]}
+            onChange={(v) => editField({ transport: v })}
+          />
+          {isMulticast && (
+            <>
+              <TextRow
+                label="Multicast group"
+                hint="IPv4 multicast address (224.0.0.0–239.255.255.255). WSJT-X uses 224.0.0.73."
+                value={form.multicastGroup}
+                placeholder="224.0.0.73"
+                onChange={(v) => editField({ multicastGroup: v })}
+              />
+              <NumberRow
+                label="Multicast TTL"
+                hint="Hop limit. 1 keeps the stream on the local subnet."
+                value={form.multicastTtl}
+                min={1}
+                max={255}
+                onChange={(v) => editField({ multicastTtl: v })}
+              />
+            </>
+          )}
+          <TextRow
+            label="Instance id"
+            hint='Identifies this sender to the logger. Leave "WSJT-X" for maximum compatibility.'
+            value={form.instanceId}
+            placeholder="WSJT-X"
+            onChange={(v) => editField({ instanceId: v })}
+          />
+          <ToggleRow
+            label="Send structured QSO (type 5) too"
+            hint="Emit QSOLogged alongside the ADIF record. Some loggers (e.g. Log4OM) prefer it."
+            checked={form.sendQsoLogged}
+            onChange={(v) => editField({ sendQsoLogged: v })}
+          />
+          <ToggleRow
+            label="Send live decodes & status (for GridTracker)"
+            hint="Stream Decode/WSPRDecode/Status/Heartbeat so map & roster tools stay live."
+            checked={form.sendLiveDecodes}
+            onChange={(v) => editField({ sendLiveDecodes: v })}
+          />
+        </>
+      )}
+
+      <div className="ft8-set-row ft8-set-row--readonly">
+        <span className="ft8-set-row__text">
+          <span className="ft8-set-row__label">
+            <span
+              className="ft8-set-chip__dot"
+              style={{ background: live ? 'var(--hud-cq)' : 'var(--hud-text-dim)' }}
+            />{' '}
+            External logger
+          </span>
+          <span className="ft8-set-row__hint">
+            {live
+              ? status?.transport === 'multicast'
+                ? `Sending to multicast ${status?.multicastGroup}:${status?.port}`
+                : `Sending to ${status?.host}:${status?.port}`
+              : 'Disabled — no QSO data leaves this machine.'}
+          </span>
+        </span>
+        <button type="button" className="ft8-set-link" disabled={saving} onClick={() => void onSave()}>
+          {saving ? 'SAVING…' : 'SAVE'}
+        </button>
+      </div>
     </div>
   );
 }

--- a/zeus-web/src/layout/ft8/ft8-settings-controls.tsx
+++ b/zeus-web/src/layout/ft8/ft8-settings-controls.tsx
@@ -82,6 +82,37 @@ export function SegRow<T extends string>(props: {
   );
 }
 
+export function SelectRow<T extends string>(props: {
+  label: string;
+  hint?: string;
+  value: T;
+  options: ReadonlyArray<{ value: T; label: string }>;
+  disabled?: boolean;
+  onChange: (v: T) => void;
+}) {
+  return (
+    <div className={`ft8-set-row${props.disabled ? ' is-disabled' : ''}`}>
+      <span className="ft8-set-row__text">
+        <span className="ft8-set-row__label">{props.label}</span>
+        {props.hint && <span className="ft8-set-row__hint">{props.hint}</span>}
+      </span>
+      <select
+        className="ft8-set-input"
+        aria-label={props.label}
+        value={props.value}
+        disabled={props.disabled}
+        onChange={(e) => props.onChange(e.target.value as T)}
+      >
+        {props.options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
 export function TextRow(props: {
   label: string;
   hint?: string;

--- a/zeus-web/src/state/wsjtx-store.test.ts
+++ b/zeus-web/src/state/wsjtx-store.test.ts
@@ -4,20 +4,39 @@ import { describe, expect, it, vi } from 'vitest';
 // Mock the REST layer BEFORE the store imports it — the store fires a one-shot
 // status probe on module load.
 vi.mock('../api/wsjtx', () => ({
+  WSJTX_DEFAULT_PORT: 2237,
+  WSJTX_DEFAULT_GROUP: '224.0.0.73',
+  WSJTX_DEFAULT_TTL: 1,
+  WSJTX_DEFAULT_INSTANCE: 'WSJT-X',
   getWsjtxStatus: vi.fn(async () => ({
     enabled: false,
     host: '127.0.0.1',
     port: 2237,
     instanceId: 'WSJT-X',
+    transport: 'unicast',
+    multicastGroup: '224.0.0.73',
+    multicastTtl: 1,
+    sendQsoLogged: false,
+    sendLiveDecodes: false,
   })),
-  postWsjtxConfig: vi.fn(async (cfg: { enabled: boolean; host: string; port: number }) => ({
-    ...cfg,
-    instanceId: 'WSJT-X',
-  })),
+  postWsjtxConfig: vi.fn(async (cfg: Record<string, unknown>) => ({ ...cfg })),
 }));
 
 import { useWsjtxStore } from './wsjtx-store';
+import type { WsjtxConfig } from '../api/wsjtx';
 import * as api from '../api/wsjtx';
+
+const FULL_CONFIG: WsjtxConfig = {
+  enabled: true,
+  host: '127.0.0.1',
+  port: 2237,
+  instanceId: 'WSJT-X',
+  transport: 'multicast',
+  multicastGroup: '224.0.0.73',
+  multicastTtl: 1,
+  sendQsoLogged: true,
+  sendLiveDecodes: true,
+};
 
 describe('wsjtx-store', () => {
   it('defaults to disabled egress (opt-in)', () => {
@@ -28,11 +47,12 @@ describe('wsjtx-store', () => {
     expect(api.postWsjtxConfig).not.toHaveBeenCalled();
   });
 
-  it('saveConfig pushes the operator choice to the backend', async () => {
-    const cfg = { enabled: true, host: '127.0.0.1', port: 2237 };
-    const status = await useWsjtxStore.getState().saveConfig(cfg);
-    expect(api.postWsjtxConfig).toHaveBeenCalledWith(cfg);
+  it('saveConfig pushes the full operator choice (incl. transport/multicast) to the backend', async () => {
+    const status = await useWsjtxStore.getState().saveConfig(FULL_CONFIG);
+    expect(api.postWsjtxConfig).toHaveBeenCalledWith(FULL_CONFIG);
     expect(status.enabled).toBe(true);
+    expect(status.transport).toBe('multicast');
     expect(useWsjtxStore.getState().config.enabled).toBe(true);
+    expect(useWsjtxStore.getState().config.sendLiveDecodes).toBe(true);
   });
 });

--- a/zeus-web/src/state/wsjtx-store.ts
+++ b/zeus-web/src/state/wsjtx-store.ts
@@ -12,6 +12,10 @@ import { create } from 'zustand';
 import {
   getWsjtxStatus,
   postWsjtxConfig,
+  WSJTX_DEFAULT_GROUP,
+  WSJTX_DEFAULT_INSTANCE,
+  WSJTX_DEFAULT_PORT,
+  WSJTX_DEFAULT_TTL,
   type WsjtxConfig,
   type WsjtxStatus,
 } from '../api/wsjtx';
@@ -22,8 +26,31 @@ import {
 const DEFAULT_CONFIG: WsjtxConfig = {
   enabled: false,
   host: '127.0.0.1',
-  port: 2237,
+  port: WSJTX_DEFAULT_PORT,
+  instanceId: WSJTX_DEFAULT_INSTANCE,
+  transport: 'unicast',
+  multicastGroup: WSJTX_DEFAULT_GROUP,
+  multicastTtl: WSJTX_DEFAULT_TTL,
+  sendQsoLogged: false,
+  sendLiveDecodes: false,
 };
+
+// Project a status snapshot onto a config, coalescing any field a (possibly
+// older / mocked) backend omits to the back-compatible default so the form
+// never holds an undefined.
+function configFromStatus(status: WsjtxStatus): WsjtxConfig {
+  return {
+    enabled: status.enabled,
+    host: status.host ?? DEFAULT_CONFIG.host,
+    port: status.port ?? DEFAULT_CONFIG.port,
+    instanceId: status.instanceId ?? DEFAULT_CONFIG.instanceId,
+    transport: status.transport ?? DEFAULT_CONFIG.transport,
+    multicastGroup: status.multicastGroup ?? DEFAULT_CONFIG.multicastGroup,
+    multicastTtl: status.multicastTtl ?? DEFAULT_CONFIG.multicastTtl,
+    sendQsoLogged: status.sendQsoLogged ?? DEFAULT_CONFIG.sendQsoLogged,
+    sendLiveDecodes: status.sendLiveDecodes ?? DEFAULT_CONFIG.sendLiveDecodes,
+  };
+}
 
 export type WsjtxStoreState = {
   config: WsjtxConfig;
@@ -41,16 +68,18 @@ export const useWsjtxStore = create<WsjtxStoreState>((set, get) => ({
     try {
       const status = await getWsjtxStatus();
       const current = get().config;
+      const incoming = configFromStatus(status);
       const synced =
-        current.enabled === status.enabled &&
-        current.host === status.host &&
-        current.port === status.port;
-      set({
-        status,
-        config: synced
-          ? current
-          : { enabled: status.enabled, host: status.host, port: status.port },
-      });
+        current.enabled === incoming.enabled &&
+        current.host === incoming.host &&
+        current.port === incoming.port &&
+        current.instanceId === incoming.instanceId &&
+        current.transport === incoming.transport &&
+        current.multicastGroup === incoming.multicastGroup &&
+        current.multicastTtl === incoming.multicastTtl &&
+        current.sendQsoLogged === incoming.sendQsoLogged &&
+        current.sendLiveDecodes === incoming.sendLiveDecodes;
+      set({ status, config: synced ? current : incoming });
     } catch {
       /* transient — next refresh recovers */
     }


### PR DESCRIPTION
## ⛔ DO NOT MERGE — bench + Contracts sign-off required

**Stack: on top of `ft8/zeus-digital-menu` (#1081).** Zeus Digital **Logging v1** — internal logbook (default) + additive external over the **full WSJT-X UDP protocol**.

### Why this is high-leverage
The WSJT-X UDP protocol is the universal contract — emitting it once serves **Log4OM, N1MM+, JTAlert, GridTracker, MacLoggerDX, DXKeeper** simultaneously (JTDX-compatible), all additive over the internal logbook.

### What's in it
- **Full message set:** byte-correct `Heartbeat(0)/Status(1)/Decode(2)/QSOLogged(5)/WSPRDecode(10)` added to the existing type-12 envelope (QDateTime + QDataStream primitives), unit-tested field-by-field.
- **`WsjtxLiveEmitter`** leaf-subscribes the decode/spot events and emits Decode/WSPRDecode + periodic Heartbeat/Status → **GridTracker's live map / call roster / alerts work**, not just logged QSOs. Never touches RX/TX/DSP.
- **Multicast** (224.0.0.73 + TTL) so several loggers share the stream; **instance-id** surfaced; optional **type-5**. Single cached `UdpClient` (audit fix for per-datagram socket churn).
- **Zeus Digital "Logging" UI:** internal (default) + "also send to external" → preset dropdown (Log4OM/N1MM+/GridTracker/JTAlert/Custom) with host/port/transport/group/TTL/instance-id/type-5/live-decodes; **QRZ** cloud option surfaced. Operator call/grid stamped on outgoing ADIF.

### Safety
**Send-only** — no inbound UDP listener, no `Reply`/`HaltTx`/`FreeText` honored (no network TX-trigger into the PA). Egress **OFF** by default.

### Red-light / bench
- **Contracts:** extends `Zeus.Contracts/WsjtxDtos.cs` — needs **Christian (N9WAR)** sign-off.
- **Bench:** verify a real **GridTracker** parses the live stream (a couple of minor wire-field choices — e.g. Decode `mode` string, Status dial source — are flagged for live confirmation).

### Status
Build 0/0; **60 backend + 16 FE** tests green. PureSignal untouched; tokens only.
