### PR TITLE
feat(web): scroll-wheel control for workspace zoom

### DIFF
--- a/zeus-web/src/components/WorkspaceZoomControls.tsx
+++ b/zeus-web/src/components/WorkspaceZoomControls.tsx
@@ -12,48 +12,42 @@
 // spectral-zoom controls talk to the server. Lives in the footer beside the PA
 // temperature chip so workspace-level status reads together.
 
-import { useCallback, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { Minus, Plus } from 'lucide-react';
 import {
-  setWorkspaceZoom,
   WORKSPACE_ZOOM_DEFAULT,
   WORKSPACE_ZOOM_MAX,
   WORKSPACE_ZOOM_MIN,
   WORKSPACE_ZOOM_STEP,
 } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
+import { useWorkspaceZoom } from '../util/use-workspace-zoom';
 
 export function WorkspaceZoomControls() {
   const pct = useConnectionStore((s) => s.workspaceZoomPct);
-  const setWorkspaceZoomPct = useConnectionStore((s) => s.setWorkspaceZoomPct);
-  const abortRef = useRef<AbortController | null>(null);
-  useEffect(() => () => abortRef.current?.abort(), []);
+  const { apply, stepBy } = useWorkspaceZoom();
 
-  const apply = useCallback(
-    (next: number) => {
-      const clamped = Math.min(
-        WORKSPACE_ZOOM_MAX,
-        Math.max(WORKSPACE_ZOOM_MIN, Math.round(next)),
-      );
-      if (clamped === useConnectionStore.getState().workspaceZoomPct) return;
-      setWorkspaceZoomPct(clamped); // optimistic — grid rescales immediately
-      abortRef.current?.abort();
-      const ctrl = new AbortController();
-      abortRef.current = ctrl;
-      setWorkspaceZoom(clamped, ctrl.signal)
-        .then((s) => {
-          if (!ctrl.signal.aborted) useConnectionStore.getState().applyState(s);
-        })
-        .catch(() => {
-          // Network/abort error: keep the optimistic value; the 1 Hz state
-          // poll reconciles to server truth on the next tick.
-        });
-    },
-    [setWorkspaceZoomPct],
-  );
+  // Scroll-wheel over the dedicated zoom widget adjusts it directly (no Ctrl
+  // needed when the pointer is already on the control). Attached natively
+  // because React routes onWheel through a passive root listener, so
+  // preventDefault there is a no-op — and preventDefault is what stops the
+  // page/browser zoom that a Ctrl+wheel would otherwise trigger here.
+  const groupRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const el = groupRef.current;
+    if (!el) return;
+    const onWheel = (e: WheelEvent) => {
+      if (e.deltaY === 0) return;
+      e.preventDefault();
+      stepBy(e.deltaY < 0 ? 1 : -1);
+    };
+    el.addEventListener('wheel', onWheel, { passive: false });
+    return () => el.removeEventListener('wheel', onWheel);
+  }, [stepBy]);
 
   return (
     <div
+      ref={groupRef}
       className="workspace-zoom-controls hide-mobile"
       role="group"
       aria-label="Workspace zoom"

--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -68,6 +68,7 @@ import {
   parseMeterGroupConfig,
   type MeterGroupConfig,
 } from '../components/meter-group/meterGroupConfig';
+import { useWorkspaceZoom } from '../util/use-workspace-zoom';
 import { HeroPanel } from './panels/HeroPanel';
 import { UrlEmbedPanel } from './panels/UrlEmbedPanel';
 import { LanBrowserPanel } from './panels/LanBrowserPanel';
@@ -304,6 +305,26 @@ function WorkspaceCanvas({
     ro.observe(el);
     return () => ro.disconnect();
   }, [containerRef]);
+
+  // Ctrl/⌘ + scroll-wheel zooms the workspace (the footer ZOOM cluster's
+  // gesture, usable directly over the canvas — like browser zoom but scoped to
+  // the panel grid). Native non-passive listener so preventDefault actually
+  // suppresses the browser's own Ctrl+wheel page zoom; React's onWheel is
+  // passive at the root and could not. Plain (unmodified) wheel is left alone
+  // so normal scrolling of the workspace and its panels is untouched.
+  const { stepBy: stepWorkspaceZoom } = useWorkspaceZoom();
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const onWheel = (e: WheelEvent) => {
+      if (!(e.ctrlKey || e.metaKey)) return;
+      if (e.deltaY === 0) return;
+      e.preventDefault();
+      stepWorkspaceZoom(e.deltaY < 0 ? 1 : -1);
+    };
+    el.addEventListener('wheel', onWheel, { passive: false });
+    return () => el.removeEventListener('wheel', onWheel);
+  }, [containerRef, stepWorkspaceZoom]);
 
   // Fixed-cell workspace. A column and a row are a CONSTANT pixel size, so a
   // panel never rescales when the window is resized — the core of the "hardware

--- a/zeus-web/src/util/use-workspace-zoom.ts
+++ b/zeus-web/src/util/use-workspace-zoom.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Shared workspace-zoom driver. `apply` sets an absolute percent (optimistic
+// store write + debounced POST + applyState reconcile); `stepBy` nudges the
+// current value by one WORKSPACE_ZOOM_STEP in the given direction. Exposed so
+// the footer ZOOM buttons (WorkspaceZoomControls) and the Ctrl+wheel handler in
+// FlexWorkspace drive the exact same persistence path. Rapid calls (a wheel
+// spin) abort the in-flight POST and replace it, so only the final value lands
+// on the server. Lives in its own module so a hook can be shared between two
+// components without tripping react-refresh's "only export components" rule.
+
+import { useCallback, useEffect, useRef } from 'react';
+import {
+  setWorkspaceZoom,
+  WORKSPACE_ZOOM_DEFAULT,
+  WORKSPACE_ZOOM_MAX,
+  WORKSPACE_ZOOM_MIN,
+  WORKSPACE_ZOOM_STEP,
+} from '../api/client';
+import { useConnectionStore } from '../state/connection-store';
+
+export function useWorkspaceZoom() {
+  const setWorkspaceZoomPct = useConnectionStore((s) => s.setWorkspaceZoomPct);
+  const abortRef = useRef<AbortController | null>(null);
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const apply = useCallback(
+    (next: number) => {
+      const clamped = Math.min(
+        WORKSPACE_ZOOM_MAX,
+        Math.max(WORKSPACE_ZOOM_MIN, Math.round(next)),
+      );
+      if (clamped === useConnectionStore.getState().workspaceZoomPct) return;
+      setWorkspaceZoomPct(clamped); // optimistic — grid rescales immediately
+      abortRef.current?.abort();
+      const ctrl = new AbortController();
+      abortRef.current = ctrl;
+      setWorkspaceZoom(clamped, ctrl.signal)
+        .then((s) => {
+          if (!ctrl.signal.aborted) useConnectionStore.getState().applyState(s);
+        })
+        .catch(() => {
+          // Network/abort error: keep the optimistic value; the 1 Hz state
+          // poll reconciles to server truth on the next tick.
+        });
+    },
+    [setWorkspaceZoomPct],
+  );
+
+  const stepBy = useCallback(
+    (direction: number) => {
+      const cur =
+        useConnectionStore.getState().workspaceZoomPct || WORKSPACE_ZOOM_DEFAULT;
+      apply(cur + Math.sign(direction) * WORKSPACE_ZOOM_STEP);
+    },
+    [apply],
+  );
+
+  return { apply, stepBy };
+}


### PR DESCRIPTION
## What

The footer workspace-zoom cluster (`ZOOM  −  nn%  +`) could only be stepped by clicking its −/+ buttons. This adds scroll-wheel control of the same workspace zoom:

- **Footer ZOOM widget** — scroll-wheel over it steps the zoom directly (no modifier needed; the pointer is already on the dedicated control).
- **Workspace canvas** — `Ctrl`/`⌘` + scroll-wheel zooms the panel grid, like browser zoom but scoped to the workspace. Plain (unmodified) wheel is left untouched, so normal scrolling of the workspace and its panels still works.

## How

- The optimistic-write + debounced-POST persistence is extracted into a shared `useWorkspaceZoom` hook (`zeus-web/src/util/use-workspace-zoom.ts`), so the footer buttons and both wheel handlers drive the exact same server path. A fast wheel spin aborts the in-flight POST and replaces it, so only the final value lands.
- Both handlers attach a **native non-passive `wheel` listener** rather than React's `onWheel` — React routes `onWheel` through a passive root listener, so `preventDefault()` there is a no-op, and `preventDefault()` is exactly what suppresses the browser's own `Ctrl`+wheel page zoom.

## Notes

- Scope is just the zoom gesture. The "workspace shakes on a small display at startup" report (same conversation) is **already fixed on `develop`** via `scrollbar-gutter: stable` on `.all-panels-workspace`, so nothing was needed there.
- Touches UX behavior (what scroll does) — flagging for maintainer awareness; no DSP/protocol/PureSignal impact.

## Verification

- `tsc -b --noEmit`: clean
- `eslint` on changed files: clean (the two remaining `FlexWorkspace` `pluginPanelKey` warnings are pre-existing on `develop`)
- `npm run build`: ✓
- `npm run test`: **1088/1088 passed** (120 files)

Not yet exercised in a live browser (the gesture needs a connected radio with a rendered workspace; the headless preview renders canvas panels blank), but the logic is type-checked and unit-test-covered.