### PR TITLE
server-side credential admin auth

### DIFF
--- a/cloud/ADMIN_AUTH_DESIGN.md
+++ b/cloud/ADMIN_AUTH_DESIGN.md
@@ -1,0 +1,135 @@
+# Server-side admin auth (D1) — Phase 2 design
+
+Part of the remote-diagnostics epic (beads `zeus-87ca`, issue `zeus-d0yr`). Replaces
+the hardcoded `env.ADMINS` callsign list with a credential-based, server-side admin
+store shared by the broker and the chat relay, so "admin" has one secure source of
+truth and an automated agent can authenticate non-interactively.
+
+## Threat model
+- QRZ login proves a caller **owns** a callsign. It does NOT prove **authorization**.
+  Today admin = "your verified callsign is on a static env list" — anyone who can be
+  added to that list (or any future bug that lets a callsign be asserted) is admin.
+- New rule: admin = **owns the callsign (QRZ)** AND **holds an admin credential**
+  (password for interactive login, or a minted API token for non-interactive/agent
+  use). Both verified server-side. Nothing about admin status is client-asserted.
+
+## Store: one D1 database `zeus-admin`, bound to BOTH Workers
+```sql
+CREATE TABLE admins (
+  callsign     TEXT PRIMARY KEY,        -- uppercased
+  pw_hash      TEXT,                    -- PBKDF2 derived key, base64; NULL = no interactive login yet
+  pw_salt      TEXT,                    -- base64; NULL iff pw_hash NULL
+  pw_iter      INTEGER,                 -- PBKDF2 iterations used (for future cost bumps)
+  disabled     INTEGER NOT NULL DEFAULT 0,
+  created_at   INTEGER NOT NULL,        -- unix ms
+  created_by   TEXT                     -- callsign of the admin who added them, or 'bootstrap'
+);
+CREATE TABLE admin_tokens (
+  id           TEXT PRIMARY KEY,        -- random public id (safe to list)
+  token_hash   TEXT NOT NULL,           -- SHA-256 hex of the secret token; the secret is shown once
+  callsign     TEXT NOT NULL,
+  label        TEXT,                    -- e.g. 'agent', 'dashboard'
+  created_at   INTEGER NOT NULL,
+  last_used_at INTEGER,
+  revoked      INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE admin_audit (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts           INTEGER NOT NULL,
+  actor        TEXT,                    -- who did it
+  action       TEXT NOT NULL,           -- login | token.mint | token.revoke | admin.add | admin.disable | ...
+  target       TEXT,                    -- subject callsign / token id
+  detail       TEXT
+);
+CREATE INDEX admin_tokens_callsign ON admin_tokens(callsign);
+```
+
+## Crypto (WebCrypto only — runs in Workers AND Node, no WASM)
+- **Password**: PBKDF2-HMAC-SHA256, 210_000 iterations, 16-byte random salt, 32-byte
+  derived key. Store `pw_hash`/`pw_salt` base64 + `pw_iter`. Verify with a
+  constant-time compare of derived bytes.
+- **API token**: 32 random bytes → base64url, presented to the caller as
+  `zsa_<base64url>` exactly once. Persist only `SHA-256(token)` hex. Verify by
+  hashing the presented token and constant-time-comparing to stored hash; on match,
+  bump `last_used_at`. Tokens do not expire but are revocable.
+- **Interactive session token**: same token mechanism, label `session`, short TTL
+  enforced by the caller storing `created_at` and the API rejecting old session
+  tokens (TTL ~12h). (Agent tokens, label `agent`, never expire.)
+
+## Auth surfaces (broker, all under `/admin/*`, JSON)
+- `POST /admin/login` — body `{password}`, plus `X-QRZ-Session`+`X-QRZ-Callsign`
+  headers. Verify QRZ (owns callsign) AND password for that callsign. On success
+  mint a `session` token → `{token, callsign, expiresAt}`. Audit `login`.
+- `POST /admin/tokens` — auth required. body `{label}`. Mint an API token (e.g.
+  `agent`). Returns `{id, token}` (token shown once). Audit `token.mint`.
+- `GET /admin/tokens` — auth. List token metadata (id/label/created/last_used/revoked) — never the secret.
+- `DELETE /admin/tokens/:id` — auth. Revoke. Audit `token.revoke`.
+- `GET /admin/admins` — auth. List admins (callsign/disabled/created).
+- `POST /admin/admins` — auth. body `{callsign, password?}`. Add/seed an admin. Audit `admin.add`.
+- `POST /admin/admins/:callsign/password` — auth (self, or any admin). Set/replace password. Audit `admin.setpw`.
+- `DELETE /admin/admins/:callsign` — auth. Disable (never hard-delete; keep audit trail). Audit `admin.disable`.
+- `GET /admin/presence` — auth. List online support-available users (callsigns) from the PRESENCE DO.
+- `POST /admin/request` — auth. body `{callsign}`. Request a diagnostics session (STUB in P2; wired in P3).
+
+**Auth on protected routes:** `Authorization: Bearer zsa_…`. Resolve token → admin
+callsign; reject if revoked / unknown / (session) expired / admin disabled.
+Constant-time everywhere; generic 401s (no oracle on which factor failed).
+
+## Bootstrap & migration (idempotent, on first admin request / a setup call)
+1. If `admins` is empty AND `ADMIN_BOOTSTRAP_CALLSIGN`+`ADMIN_BOOTSTRAP_PASSWORD`
+   secrets are set, create that admin (created_by `bootstrap`).
+2. Seed any callsigns in legacy `env.ADMINS` as **password-less** admin rows
+   (chat-admin keeps working immediately; they set a password later to use the
+   diagnostics API). One-time; never demotes/removes.
+
+## Relay migration (chat-admin → same store)
+- Add the same `ADMIN_DB` D1 binding to the relay.
+- `ChatRoom` keeps its in-memory `this.admins: Set<string>` (no call-site churn) but
+  repopulates it from `SELECT callsign FROM admins WHERE disabled=0` during
+  `ensureLoaded()`, refreshing on a ~60s TTL so dashboard add/remove propagates
+  without redeploy. Fall back to the `env.ADMINS` seed when D1 is empty/unreachable
+  (nothing breaks pre-migration). All existing admin behavior (gold render, see-all,
+  moderation) is unchanged — only the SOURCE of the set changes.
+
+## Presence (broker)
+- `PresenceRoom` single Durable Object: a map of `callsign → {since, lastSeen}` for
+  operators whose sidecar has registered as support-available (operator L1 switch on).
+  Endpoints (internal): `register`/`heartbeat`/`drop` (sidecar, wired in P3) and
+  `list` (admin API). Entries expire if `lastSeen` is older than ~90s.
+
+## Security hardening applied (post independent review)
+- **Rate limiting**: all `/admin/*` is per-IP rate-limited (shared RateLimiter DO, mirrors `/turn`); `/admin/login` adds a second per-callsign throttle. Closes the unthrottled online password-guess / PBKDF2 CPU-exhaustion vector.
+- **CORS fails closed**: the admin API never emits `Access-Control-Allow-Origin: *`. If `WEB_APP_ORIGIN` is unset, no allow-origin header is sent (browsers can't read `/admin` cross-origin). Only `/turn` (public) keeps the `*` fallback.
+- **Token expiry at the data layer**: `admin_tokens.expires_at` column; `getTokenByHash` filters `revoked=0 AND (expires_at IS NULL OR expires_at>now)`. Session tokens get a 12h `expires_at`; agent tokens get NULL (revoke-only). Expiry no longer depends on a single app-level `if`.
+- **No peer account takeover**: an admin may set their own password or onboard a *password-less* admin, but may NOT reset a peer's existing password.
+- **No self-lockout**: disabling the last enabled admin is refused (409).
+- **No hardcoded admins in source**: the relay's `env.ADMINS` default is now `''` (was `'N9WAR,KB2UKA'`). Set the seed as a wrangler var, never in code.
+- **No secret caching**: `Cache-Control: no-store` on the login + token-mint responses (the only bodies carrying a secret). Token `label` capped at 64 chars.
+
+## Out of scope here (later phases)
+- Sidecar↔broker presence registration wiring and the actual diagnostics session
+  relay (P3). `POST /admin/request` is a stub. The agent CLI is `zeus-azji` (P4b).
+
+## Deploy (maintainer runs)
+Order matters: provision + seed D1 BEFORE the relay starts trusting it (the relay
+no longer has a hardcoded admin default — until D1 is seeded or `ADMINS` is set as
+a var, there are simply no admins, which is the intended fail-closed posture).
+```bash
+cd cloud/zeus-remote-broker
+wrangler d1 create zeus-admin            # copy database_id into BOTH wrangler.toml files
+wrangler d1 migrations apply zeus-admin  # applies migrations/0001_admin.sql
+# First admin (REQUIRED — there is no baked-in admin anymore):
+wrangler secret put ADMIN_BOOTSTRAP_CALLSIGN
+wrangler secret put ADMIN_BOOTSTRAP_PASSWORD
+# OPTIONAL legacy chat-admins seeded as password-less rows — set as a VAR, not in
+# source, on BOTH workers if you want them immediately (e.g. ADMINS="N9WAR,KB2UKA"):
+#   wrangler deploy --var ADMINS:"N9WAR,KB2UKA"   (or add to [vars])
+npm run deploy
+# then in cloud/zeuschat-relay: add the same [[d1_databases]] binding + deploy
+# First /admin call seeds bootstrap+legacy into D1. Then mint an agent token:
+#   curl -sX POST https://remote.openhpsdrzeus.com/admin/login \
+#     -H 'X-QRZ-Session: <key>' -H 'X-QRZ-Callsign: <CALL>' \
+#     -d '{"password":"<bootstrap-pw>"}'                       # -> session token
+#   curl -sX POST .../admin/tokens -H 'Authorization: Bearer <session>' \
+#     -d '{"label":"agent"}'                                   # -> agent token (shown once)
+```

--- a/cloud/zeus-remote-broker/migrations/0001_admin.sql
+++ b/cloud/zeus-remote-broker/migrations/0001_admin.sql
@@ -1,0 +1,37 @@
+-- Phase 2 of the remote-diagnostics epic (beads zeus-87ca / issue zeus-d0yr).
+-- One D1 database `zeus-admin`, bound to BOTH Workers (broker + chat relay), so
+-- "admin" has a single credential-based source of truth. See ADMIN_AUTH_DESIGN.md.
+
+CREATE TABLE admins (
+  callsign     TEXT PRIMARY KEY,        -- uppercased
+  pw_hash      TEXT,                    -- PBKDF2 derived key, base64; NULL = no interactive login yet
+  pw_salt      TEXT,                    -- base64; NULL iff pw_hash NULL
+  pw_iter      INTEGER,                 -- PBKDF2 iterations used (for future cost bumps)
+  disabled     INTEGER NOT NULL DEFAULT 0,
+  created_at   INTEGER NOT NULL,        -- unix ms
+  created_by   TEXT                     -- callsign of the admin who added them, or 'bootstrap'
+);
+
+CREATE TABLE admin_tokens (
+  id           TEXT PRIMARY KEY,        -- random public id (safe to list)
+  token_hash   TEXT NOT NULL,           -- SHA-256 hex of the secret token; the secret is shown once
+  callsign     TEXT NOT NULL,
+  label        TEXT,                    -- e.g. 'agent', 'dashboard', 'session'
+  created_at   INTEGER NOT NULL,
+  expires_at   INTEGER,                 -- unix ms; NULL = never expires (agent token). Enforced in getTokenByHash.
+  last_used_at INTEGER,
+  revoked      INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE admin_audit (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts           INTEGER NOT NULL,
+  actor        TEXT,                    -- who did it
+  action       TEXT NOT NULL,           -- login | token.mint | token.revoke | admin.add | admin.disable | ...
+  target       TEXT,                    -- subject callsign / token id
+  detail       TEXT
+);
+
+CREATE INDEX admin_tokens_callsign ON admin_tokens(callsign);
+-- Fast token auth lookups (hash equality) and expiry-aware filtering.
+CREATE INDEX admin_tokens_hash ON admin_tokens(token_hash);

--- a/cloud/zeus-remote-broker/package-lock.json
+++ b/cloud/zeus-remote-broker/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250109.0",
+        "tsx": "^4.19.0",
         "typescript": "^5.7.0",
         "wrangler": "^4.0.0"
       }
@@ -1433,6 +1434,25 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/cloud/zeus-remote-broker/package.json
+++ b/cloud/zeus-remote-broker/package.json
@@ -8,10 +8,12 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
     "typecheck": "tsc --noEmit",
+    "test": "node --import tsx --test test/admin-auth.test.ts",
     "cf-typegen": "wrangler types"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250109.0",
+    "tsx": "^4.19.0",
     "typescript": "^5.7.0",
     "wrangler": "^4.0.0"
   }

--- a/cloud/zeus-remote-broker/src/admin-api.ts
+++ b/cloud/zeus-remote-broker/src/admin-api.ts
@@ -1,0 +1,434 @@
+/**
+ * /admin/* API: credential-based admin auth backed by the `zeus-admin` D1 store.
+ *
+ * Auth model (ADMIN_AUTH_DESIGN.md): QRZ proves callsign *ownership*; the admin
+ * store proves *authorization*. Interactive callers POST /admin/login with a
+ * password (plus QRZ headers) to mint a short-lived `session` token; agents hold
+ * a non-expiring `agent` token. Protected routes require `Authorization: Bearer
+ * zsa_…`. Failures return generic 401s — no oracle on which factor failed.
+ */
+
+import type { Env } from './types';
+import { verifyQrzSessionCached } from './qrz';
+import {
+  hashPassword,
+  verifyPassword,
+  mintToken,
+  hashToken,
+  looksLikeToken,
+  SESSION_TTL_MS,
+  type PasswordHash,
+} from './admin-auth';
+import {
+  getAdmin,
+  listAdmins,
+  insertAdmin,
+  setAdminPassword,
+  disableAdmin,
+  insertToken,
+  getTokenByHash,
+  touchToken,
+  revokeToken,
+  listTokens,
+  getTokenOwner,
+  insertAudit,
+  countAdmins,
+  countEnabledAdmins,
+} from './admin-db';
+
+/** Resolved identity of an authenticated caller. */
+interface AuthCtx {
+  callsign: string;
+  tokenId: string;
+  label: string;
+}
+
+/** Module-scoped guard so the (idempotent) bootstrap+migration runs at most once per isolate. */
+let bootstrapped = false;
+
+export async function handleAdmin(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+): Promise<Response> {
+  const cors = corsHeaders(env);
+  if (request.method === 'OPTIONS') return new Response(null, { status: 204, headers: cors });
+
+  const url = new URL(request.url);
+  const path = url.pathname.replace(/\/+$/, ''); // tolerate trailing slash
+
+  // Seed bootstrap admin + migrate legacy env.ADMINS lazily on the first /admin
+  // call (guarded so it never touches the signaling hot-path).
+  await ensureBootstrap(env);
+
+  try {
+    // --- public: interactive login (mints a session token) -------------------
+    if (path === '/admin/login' && request.method === 'POST') {
+      return await handleLogin(request, env, ctx, cors);
+    }
+
+    // --- everything else is Bearer-token protected ---------------------------
+    const auth = await authenticate(request, env);
+    if (!auth) return json({ error: 'unauthorized' }, 401, cors);
+
+    // tokens
+    if (path === '/admin/tokens' && request.method === 'POST') {
+      return await handleMintToken(request, env, auth, cors);
+    }
+    if (path === '/admin/tokens' && request.method === 'GET') {
+      return json({ tokens: await listTokens(env.ADMIN_DB, auth.callsign) }, 200, cors);
+    }
+    const tokDel = /^\/admin\/tokens\/([^/]+)$/.exec(path);
+    if (tokDel && request.method === 'DELETE') {
+      return await handleRevokeToken(decodeURIComponent(tokDel[1]), env, auth, cors);
+    }
+
+    // admins
+    if (path === '/admin/admins' && request.method === 'GET') {
+      const admins = (await listAdmins(env.ADMIN_DB)).map((a) => ({
+        callsign: a.callsign,
+        disabled: a.disabled === 1,
+        hasPassword: a.pw_hash != null,
+        created_at: a.created_at,
+        created_by: a.created_by,
+      }));
+      return json({ admins }, 200, cors);
+    }
+    if (path === '/admin/admins' && request.method === 'POST') {
+      return await handleAddAdmin(request, env, auth, cors);
+    }
+    const setPw = /^\/admin\/admins\/([^/]+)\/password$/.exec(path);
+    if (setPw && request.method === 'POST') {
+      return await handleSetPassword(decodeURIComponent(setPw[1]), request, env, auth, cors);
+    }
+    const adminDel = /^\/admin\/admins\/([^/]+)$/.exec(path);
+    if (adminDel && request.method === 'DELETE') {
+      return await handleDisableAdmin(decodeURIComponent(adminDel[1]), env, auth, cors);
+    }
+
+    // presence
+    if (path === '/admin/presence' && request.method === 'GET') {
+      const id = env.PRESENCE.idFromName('global');
+      const res = await env.PRESENCE.get(id).fetch('https://presence.internal/list');
+      const body = await res.json<{ operators: unknown[] }>();
+      return json(body, 200, cors);
+    }
+
+    // diagnostics-session request (STUB in P2; wired in P3)
+    if (path === '/admin/request' && request.method === 'POST') {
+      const target = norm(((await safeJson(request)).callsign as string) ?? '');
+      if (!target) return json({ error: 'callsign required' }, 400, cors);
+      await insertAudit(env.ADMIN_DB, { actor: auth.callsign, action: 'request', target });
+      return json({ ok: true, status: 'stub', note: 'diagnostics session wired in P3' }, 202, cors);
+    }
+
+    return json({ error: 'not found' }, 404, cors);
+  } catch {
+    // Never leak internals; never reveal which step failed.
+    return json({ error: 'error' }, 500, cors);
+  }
+}
+
+// --- login -----------------------------------------------------------------
+
+async function handleLogin(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+  cors: Record<string, string>,
+): Promise<Response> {
+  const body = await safeJson(request);
+  const password = typeof body.password === 'string' ? body.password : '';
+  const callsign = norm(request.headers.get('X-QRZ-Callsign') ?? '');
+  const sessionKey = request.headers.get('X-QRZ-Session') ?? '';
+
+  // Generic failure for ALL of: missing inputs, bad QRZ, unknown/disabled admin,
+  // wrong/absent password. No oracle on which factor failed.
+  const fail = () => json({ error: 'unauthorized' }, 401, cors);
+
+  if (!password || !callsign || !sessionKey) return fail();
+
+  // Per-callsign throttle on top of the per-IP gate in index.ts, so a botnet
+  // spread across many IPs still can't brute-force one admin's password (each
+  // PBKDF2 verify is also real server CPU). Soft limit (429), not a hard lock.
+  if (await loginRateLimited(env, callsign)) {
+    return json({ error: 'rate limited' }, 429, cors);
+  }
+
+  // 1) QRZ: caller owns the callsign.
+  const verify = (env.QRZ_VERIFY ?? 'on').toLowerCase() !== 'off';
+  if (verify && !(await verifyQrzSessionCached(sessionKey, callsign, ctx))) return fail();
+
+  // 2) Admin store: callsign is an enabled admin with a password set, and it matches.
+  const admin = await getAdmin(env.ADMIN_DB, callsign);
+  if (!admin || admin.disabled === 1 || !admin.pw_hash || !admin.pw_salt || admin.pw_iter == null) {
+    return fail();
+  }
+  const stored: PasswordHash = { hash: admin.pw_hash, salt: admin.pw_salt, iter: admin.pw_iter };
+  if (!(await verifyPassword(password, stored))) return fail();
+
+  // Success: mint a short-lived session token. Expiry is persisted (expires_at)
+  // so the data layer — not one app-level if — enforces it for every consumer.
+  const minted = await mintToken();
+  const id = crypto.randomUUID();
+  const expiresAt = Date.now() + SESSION_TTL_MS;
+  await insertToken(env.ADMIN_DB, {
+    id,
+    token_hash: minted.hash,
+    callsign,
+    label: 'session',
+    expires_at: expiresAt,
+  });
+  await insertAudit(env.ADMIN_DB, { actor: callsign, action: 'login', target: callsign });
+  // Secret in the body — never let an intermediary cache it.
+  return json({ token: minted.token, callsign, expiresAt }, 200, cors, { 'Cache-Control': 'no-store' });
+}
+
+// --- token endpoints -------------------------------------------------------
+
+async function handleMintToken(
+  request: Request,
+  env: Env,
+  auth: AuthCtx,
+  cors: Record<string, string>,
+): Promise<Response> {
+  const body = await safeJson(request);
+  const label = (typeof body.label === 'string' && body.label.trim() ? body.label.trim() : 'agent').slice(0, 64);
+  const minted = await mintToken();
+  const id = crypto.randomUUID();
+  // Agent/API tokens do not expire (expires_at null); they are revocable instead.
+  await insertToken(env.ADMIN_DB, { id, token_hash: minted.hash, callsign: auth.callsign, label, expires_at: null });
+  await insertAudit(env.ADMIN_DB, { actor: auth.callsign, action: 'token.mint', target: id, detail: label });
+  // token shown once — never cache the secret-bearing body.
+  return json({ id, token: minted.token }, 201, cors, { 'Cache-Control': 'no-store' });
+}
+
+async function handleRevokeToken(
+  id: string,
+  env: Env,
+  auth: AuthCtx,
+  cors: Record<string, string>,
+): Promise<Response> {
+  const owner = await getTokenOwner(env.ADMIN_DB, id);
+  // Any admin may revoke any token; but if the id is unknown, respond the same
+  // way (idempotent revoke) rather than 404 — no enumeration oracle.
+  await revokeToken(env.ADMIN_DB, id);
+  await insertAudit(env.ADMIN_DB, {
+    actor: auth.callsign,
+    action: 'token.revoke',
+    target: id,
+    detail: owner?.callsign ?? null,
+  });
+  return json({ ok: true }, 200, cors);
+}
+
+// --- admin endpoints -------------------------------------------------------
+
+async function handleAddAdmin(
+  request: Request,
+  env: Env,
+  auth: AuthCtx,
+  cors: Record<string, string>,
+): Promise<Response> {
+  const body = await safeJson(request);
+  const callsign = norm((body.callsign as string) ?? '');
+  if (!callsign) return json({ error: 'callsign required' }, 400, cors);
+
+  let pw: PasswordHash | null = null;
+  if (typeof body.password === 'string' && body.password) pw = await hashPassword(body.password);
+
+  await insertAdmin(env.ADMIN_DB, {
+    callsign,
+    pw_hash: pw?.hash ?? null,
+    pw_salt: pw?.salt ?? null,
+    pw_iter: pw?.iter ?? null,
+    created_by: auth.callsign,
+  });
+  await insertAudit(env.ADMIN_DB, { actor: auth.callsign, action: 'admin.add', target: callsign });
+  return json({ ok: true, callsign }, 201, cors);
+}
+
+async function handleSetPassword(
+  target: string,
+  request: Request,
+  env: Env,
+  auth: AuthCtx,
+  cors: Record<string, string>,
+): Promise<Response> {
+  const callsign = norm(target);
+  const body = await safeJson(request);
+  const password = typeof body.password === 'string' ? body.password : '';
+  if (!password) return json({ error: 'password required' }, 400, cors);
+
+  const admin = await getAdmin(env.ADMIN_DB, callsign);
+  if (!admin) return json({ error: 'not found' }, 404, cors);
+
+  // An admin may set a password on themselves, or ONBOARD a password-less admin
+  // (e.g. a legacy-seeded callsign), but may NOT reset a peer's EXISTING
+  // password — that would be silent account takeover between equals.
+  if (callsign !== auth.callsign && admin.pw_hash) {
+    return json({ error: 'forbidden' }, 403, cors);
+  }
+
+  const pw = await hashPassword(password);
+  await setAdminPassword(env.ADMIN_DB, callsign, pw.hash, pw.salt, pw.iter);
+  await insertAudit(env.ADMIN_DB, { actor: auth.callsign, action: 'admin.setpw', target: callsign });
+  return json({ ok: true }, 200, cors);
+}
+
+async function handleDisableAdmin(
+  target: string,
+  env: Env,
+  auth: AuthCtx,
+  cors: Record<string, string>,
+): Promise<Response> {
+  const callsign = norm(target);
+
+  // Never let the system be locked out: refuse to disable the last enabled
+  // admin. (This also stops a single rogue/compromised admin from disabling
+  // everyone else AND themselves into an unrecoverable state.)
+  const admin = await getAdmin(env.ADMIN_DB, callsign);
+  if (admin && admin.disabled === 0 && (await countEnabledAdmins(env.ADMIN_DB)) <= 1) {
+    return json({ error: 'cannot disable the last enabled admin' }, 409, cors);
+  }
+
+  await disableAdmin(env.ADMIN_DB, callsign);
+  await insertAudit(env.ADMIN_DB, {
+    actor: auth.callsign,
+    action: 'admin.disable',
+    target: callsign,
+    detail: admin ? 'existed' : 'absent',
+  });
+  return json({ ok: true }, 200, cors);
+}
+
+// --- auth -------------------------------------------------------------------
+
+/**
+ * Resolve a `Authorization: Bearer zsa_…` header to an admin identity, or null.
+ * Rejects (as null) on: missing/malformed token, unknown/revoked token, expired
+ * session token, or disabled admin. Bumps last_used_at on success.
+ */
+async function authenticate(request: Request, env: Env): Promise<AuthCtx | null> {
+  const header = request.headers.get('Authorization') ?? '';
+  const m = /^Bearer\s+(.+)$/i.exec(header.trim());
+  if (!m) return null;
+  const token = m[1].trim();
+  if (!looksLikeToken(token)) return null;
+
+  const tokenHash = await hashToken(token);
+  // getTokenByHash enforces revoked=0 AND not-expired at the data layer, so
+  // expiry holds for every consumer of the shared store, not just this call.
+  const row = await getTokenByHash(env.ADMIN_DB, tokenHash, Date.now());
+  if (!row) return null;
+
+  // The owning admin must still be enabled.
+  const admin = await getAdmin(env.ADMIN_DB, row.callsign);
+  if (!admin || admin.disabled === 1) return null;
+
+  await touchToken(env.ADMIN_DB, row.id);
+  return { callsign: row.callsign, tokenId: row.id, label: row.label ?? '' };
+}
+
+// --- bootstrap & migration --------------------------------------------------
+
+/**
+ * Idempotent: when `admins` is empty, seed the bootstrap admin (if the secrets
+ * are set) and migrate legacy env.ADMINS callsigns to password-less rows. Guarded
+ * by a module flag AND a count check so it costs at most one COUNT(*) per isolate
+ * after the first call.
+ */
+async function ensureBootstrap(env: Env): Promise<void> {
+  if (bootstrapped) return;
+  bootstrapped = true;
+  try {
+    if ((await countAdmins(env.ADMIN_DB)) > 0) return; // already provisioned
+
+    if (env.ADMIN_BOOTSTRAP_CALLSIGN && env.ADMIN_BOOTSTRAP_PASSWORD) {
+      const callsign = norm(env.ADMIN_BOOTSTRAP_CALLSIGN);
+      const pw = await hashPassword(env.ADMIN_BOOTSTRAP_PASSWORD);
+      await insertAdmin(env.ADMIN_DB, {
+        callsign,
+        pw_hash: pw.hash,
+        pw_salt: pw.salt,
+        pw_iter: pw.iter,
+        created_by: 'bootstrap',
+      });
+      await insertAudit(env.ADMIN_DB, { actor: 'bootstrap', action: 'admin.add', target: callsign });
+    }
+
+    // Seed legacy ADMINS list as password-less rows (never demote/remove).
+    for (const callsign of (env.ADMINS ?? '').split(',').map(norm).filter(Boolean)) {
+      await insertAdmin(env.ADMIN_DB, {
+        callsign,
+        pw_hash: null,
+        pw_salt: null,
+        pw_iter: null,
+        created_by: 'bootstrap',
+      });
+    }
+  } catch {
+    // If bootstrap fails (e.g. schema not yet applied), allow a later retry.
+    bootstrapped = false;
+  }
+}
+
+// --- helpers ----------------------------------------------------------------
+
+function norm(callsign: string): string {
+  return callsign.trim().toUpperCase();
+}
+
+async function safeJson(request: Request): Promise<Record<string, unknown>> {
+  try {
+    const v = await request.json();
+    return v && typeof v === 'object' ? (v as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function json(
+  body: unknown,
+  status: number,
+  cors: Record<string, string>,
+  extra?: Record<string, string>,
+): Response {
+  return Response.json(body, { status, headers: extra ? { ...cors, ...extra } : cors });
+}
+
+/**
+ * Per-callsign login throttle, reusing the shared per-IP RateLimiter DO keyed by
+ * `login:<callsign>`. Soft-limits password attempts against a single admin even
+ * when an attacker rotates source IPs. Fails OPEN (returns false) if the limiter
+ * is somehow unreachable — availability of login beats a hard dependency.
+ */
+async function loginRateLimited(env: Env, callsign: string): Promise<boolean> {
+  try {
+    const id = env.RATE_DO.idFromName(`login:${callsign}`);
+    const res = await env.RATE_DO.get(id).fetch('https://rl.internal/check');
+    return res.status === 429;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * CORS for the dashboard's cross-origin /admin fetches. The admin surface fails
+ * CLOSED: we name exactly the configured web-app origin and NEVER fall back to
+ * '*' (unlike /turn, which is public). If WEB_APP_ORIGIN is unset, no
+ * Allow-Origin header is emitted, so a browser cannot read /admin responses
+ * cross-origin — a misconfigured deploy can't silently expose the admin API to
+ * every site. Authorization + QRZ headers are allowed; no cookies, so no
+ * Allow-Credentials.
+ */
+function corsHeaders(env: Env): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+    'Access-Control-Allow-Headers': 'content-type, authorization, x-qrz-session, x-qrz-callsign',
+    'Access-Control-Max-Age': '86400',
+    Vary: 'Origin',
+  };
+  if (env.WEB_APP_ORIGIN) headers['Access-Control-Allow-Origin'] = env.WEB_APP_ORIGIN;
+  return headers;
+}

--- a/cloud/zeus-remote-broker/src/admin-auth.ts
+++ b/cloud/zeus-remote-broker/src/admin-auth.ts
@@ -1,0 +1,137 @@
+/**
+ * Admin-auth crypto core (WebCrypto only — runs in Workers AND Node 20+, no WASM
+ * or native deps). Pure functions so they're unit-testable under `node --test`.
+ *
+ * Two secret kinds:
+ *  - Passwords: PBKDF2-HMAC-SHA256, 210k iters, 16-byte salt, 32-byte key. We
+ *    store base64(hash)/base64(salt)/iter and verify with a constant-time
+ *    compare of the derived bytes.
+ *  - API/session tokens: 32 random bytes → base64url, presented once as
+ *    `zsa_<...>`. We persist only SHA-256(token) hex and verify by hashing the
+ *    presented token and constant-time-comparing to the stored hash.
+ *
+ * Never log or return secrets; only hashes leave this module.
+ */
+
+/** PBKDF2 cost. Stored per-row (pw_iter) so it can be bumped without a flag-day. */
+export const PBKDF2_ITER = 210_000;
+const SALT_BYTES = 16;
+const KEY_BYTES = 32;
+const TOKEN_BYTES = 32;
+
+/** Public prefix on the secret token string. The bytes after it are base64url. */
+export const TOKEN_PREFIX = 'zsa_';
+
+/** Session-token lifetime: interactive logins expire; agent tokens do not. */
+export const SESSION_TTL_MS = 12 * 60 * 60 * 1000; // ~12h
+
+const enc = new TextEncoder();
+
+// --- base64 helpers (standard + url-safe) ----------------------------------
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  return bytesToBase64(bytes).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+// --- password (PBKDF2) -----------------------------------------------------
+
+/** A derived password record ready to persist. */
+export interface PasswordHash {
+  hash: string; // base64(derived key)
+  salt: string; // base64(salt)
+  iter: number;
+}
+
+async function pbkdf2(password: string, salt: Uint8Array, iter: number): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey('raw', enc.encode(password), 'PBKDF2', false, [
+    'deriveBits',
+  ]);
+  const bits = await crypto.subtle.deriveBits(
+    { name: 'PBKDF2', hash: 'SHA-256', salt: salt as BufferSource, iterations: iter },
+    key,
+    KEY_BYTES * 8,
+  );
+  return new Uint8Array(bits);
+}
+
+/** Hash a new password with a fresh random salt at the current cost. */
+export async function hashPassword(password: string): Promise<PasswordHash> {
+  const salt = crypto.getRandomValues(new Uint8Array(SALT_BYTES));
+  const derived = await pbkdf2(password, salt, PBKDF2_ITER);
+  return { hash: bytesToBase64(derived), salt: bytesToBase64(salt), iter: PBKDF2_ITER };
+}
+
+/**
+ * Verify a candidate password against a stored record. Re-derives with the
+ * stored salt/iter and constant-time-compares the bytes. Returns false on any
+ * malformed input rather than throwing (generic auth failure, no oracle).
+ */
+export async function verifyPassword(password: string, stored: PasswordHash): Promise<boolean> {
+  try {
+    const salt = base64ToBytes(stored.salt);
+    const expected = base64ToBytes(stored.hash);
+    const derived = await pbkdf2(password, salt, stored.iter);
+    return constantTimeEqual(derived, expected);
+  } catch {
+    return false;
+  }
+}
+
+// --- tokens (random secret → stored SHA-256 hex) ---------------------------
+
+/** A freshly minted token: the secret is returned ONCE, the hash is persisted. */
+export interface MintedToken {
+  token: string; // secret, shown to the caller once (`zsa_...`)
+  hash: string; // SHA-256 hex of the secret, stored
+}
+
+/** Mint a new opaque token: 32 random bytes, base64url, `zsa_`-prefixed. */
+export async function mintToken(): Promise<MintedToken> {
+  const raw = crypto.getRandomValues(new Uint8Array(TOKEN_BYTES));
+  const token = TOKEN_PREFIX + bytesToBase64Url(raw);
+  const hash = await hashToken(token);
+  return { token, hash };
+}
+
+/** SHA-256 hex of a token string (the only form we persist). */
+export async function hashToken(token: string): Promise<string> {
+  const buf = await crypto.subtle.digest('SHA-256', enc.encode(token));
+  return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/** Cheap shape check before hashing — a presented Bearer must look like ours. */
+export function looksLikeToken(token: string): boolean {
+  return typeof token === 'string' && token.startsWith(TOKEN_PREFIX) && token.length > TOKEN_PREFIX.length;
+}
+
+// --- constant-time compare -------------------------------------------------
+
+/**
+ * Constant-time equality for two byte arrays. Length is compared first (lengths
+ * are not secret here — both sides are fixed-width digests/keys), then every
+ * byte is XOR-accumulated so timing does not leak where a mismatch occurred.
+ */
+export function constantTimeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i];
+  return diff === 0;
+}
+
+/** Constant-time compare of two hex/ascii strings (e.g. stored vs presented token hash). */
+export function constantTimeEqualHex(a: string, b: string): boolean {
+  return constantTimeEqual(enc.encode(a), enc.encode(b));
+}

--- a/cloud/zeus-remote-broker/src/admin-db.ts
+++ b/cloud/zeus-remote-broker/src/admin-db.ts
@@ -1,0 +1,183 @@
+/**
+ * Typed D1 query wrappers for the `zeus-admin` store. Parameterized queries
+ * ONLY — never interpolate caller input into SQL. Rows mirror 0001_admin.sql.
+ *
+ * This is the broker's full admin data layer; the chat relay carries only a
+ * tiny read-only helper (it needs just the enabled-admin callsign list).
+ */
+
+/** A row in `admins`. pw_* are NULL for password-less (legacy-seeded) admins. */
+export interface AdminRow {
+  callsign: string;
+  pw_hash: string | null;
+  pw_salt: string | null;
+  pw_iter: number | null;
+  disabled: number;
+  created_at: number;
+  created_by: string | null;
+}
+
+/** A row in `admin_tokens`. token_hash is never returned to clients. */
+export interface TokenRow {
+  id: string;
+  token_hash: string;
+  callsign: string;
+  label: string | null;
+  created_at: number;
+  expires_at: number | null; // null = never expires (agent/API token); set for session tokens
+  last_used_at: number | null;
+  revoked: number;
+}
+
+// --- admins ----------------------------------------------------------------
+
+export async function getAdmin(db: D1Database, callsign: string): Promise<AdminRow | null> {
+  return db.prepare('SELECT * FROM admins WHERE callsign = ?').bind(callsign).first<AdminRow>();
+}
+
+export async function listAdmins(db: D1Database): Promise<AdminRow[]> {
+  const res = await db
+    .prepare('SELECT * FROM admins ORDER BY callsign')
+    .all<AdminRow>();
+  return res.results ?? [];
+}
+
+/** Callsigns of all enabled admins — the chat relay's only need (also reused here). */
+export async function listEnabledAdminCallsigns(db: D1Database): Promise<string[]> {
+  const res = await db
+    .prepare('SELECT callsign FROM admins WHERE disabled = 0')
+    .all<{ callsign: string }>();
+  return (res.results ?? []).map((r) => r.callsign);
+}
+
+export async function countAdmins(db: D1Database): Promise<number> {
+  const row = await db.prepare('SELECT COUNT(*) AS n FROM admins').first<{ n: number }>();
+  return row?.n ?? 0;
+}
+
+/** Enabled (non-disabled) admin count — used to refuse disabling the last admin. */
+export async function countEnabledAdmins(db: D1Database): Promise<number> {
+  const row = await db
+    .prepare('SELECT COUNT(*) AS n FROM admins WHERE disabled = 0')
+    .first<{ n: number }>();
+  return row?.n ?? 0;
+}
+
+/**
+ * Insert an admin if absent (idempotent — never demotes/overwrites an existing
+ * row). pw_* may all be null for a password-less seed.
+ */
+export async function insertAdmin(
+  db: D1Database,
+  row: {
+    callsign: string;
+    pw_hash: string | null;
+    pw_salt: string | null;
+    pw_iter: number | null;
+    created_by: string;
+  },
+): Promise<void> {
+  await db
+    .prepare(
+      'INSERT OR IGNORE INTO admins (callsign, pw_hash, pw_salt, pw_iter, disabled, created_at, created_by) ' +
+        'VALUES (?, ?, ?, ?, 0, ?, ?)',
+    )
+    .bind(row.callsign, row.pw_hash, row.pw_salt, row.pw_iter, Date.now(), row.created_by)
+    .run();
+}
+
+export async function setAdminPassword(
+  db: D1Database,
+  callsign: string,
+  pw_hash: string,
+  pw_salt: string,
+  pw_iter: number,
+): Promise<void> {
+  await db
+    .prepare('UPDATE admins SET pw_hash = ?, pw_salt = ?, pw_iter = ? WHERE callsign = ?')
+    .bind(pw_hash, pw_salt, pw_iter, callsign)
+    .run();
+}
+
+/** Disable (soft-delete) an admin; never hard-delete, to keep the audit trail. */
+export async function disableAdmin(db: D1Database, callsign: string): Promise<void> {
+  await db.prepare('UPDATE admins SET disabled = 1 WHERE callsign = ?').bind(callsign).run();
+}
+
+// --- tokens ----------------------------------------------------------------
+
+export async function insertToken(
+  db: D1Database,
+  row: { id: string; token_hash: string; callsign: string; label: string; expires_at: number | null },
+): Promise<void> {
+  await db
+    .prepare(
+      'INSERT INTO admin_tokens (id, token_hash, callsign, label, created_at, expires_at, revoked) ' +
+        'VALUES (?, ?, ?, ?, ?, ?, 0)',
+    )
+    .bind(row.id, row.token_hash, row.callsign, row.label, Date.now(), row.expires_at)
+    .run();
+}
+
+/**
+ * Look a token up by its stored SHA-256 hex. Enforces revoked=0 AND not-expired
+ * at the DATA layer (pass the current unix-ms), so expiry holds for every
+ * consumer rather than depending on an app-level check. A null expires_at never
+ * expires (agent tokens).
+ */
+export async function getTokenByHash(
+  db: D1Database,
+  tokenHash: string,
+  now: number,
+): Promise<TokenRow | null> {
+  return db
+    .prepare(
+      'SELECT * FROM admin_tokens WHERE token_hash = ? AND revoked = 0 ' +
+        'AND (expires_at IS NULL OR expires_at > ?)',
+    )
+    .bind(tokenHash, now)
+    .first<TokenRow>();
+}
+
+export async function touchToken(db: D1Database, id: string): Promise<void> {
+  await db
+    .prepare('UPDATE admin_tokens SET last_used_at = ? WHERE id = ?')
+    .bind(Date.now(), id)
+    .run();
+}
+
+export async function revokeToken(db: D1Database, id: string): Promise<void> {
+  await db.prepare('UPDATE admin_tokens SET revoked = 1 WHERE id = ?').bind(id).run();
+}
+
+/** Token metadata for a callsign — never the secret/hash. */
+export async function listTokens(
+  db: D1Database,
+  callsign: string,
+): Promise<Array<Omit<TokenRow, 'token_hash'>>> {
+  const res = await db
+    .prepare(
+      'SELECT id, callsign, label, created_at, expires_at, last_used_at, revoked FROM admin_tokens ' +
+        'WHERE callsign = ? ORDER BY created_at DESC',
+    )
+    .bind(callsign)
+    .all<Omit<TokenRow, 'token_hash'>>();
+  return res.results ?? [];
+}
+
+/** The id of the token referenced by a hash (so we can authorize a revoke). */
+export async function getTokenOwner(db: D1Database, id: string): Promise<TokenRow | null> {
+  return db.prepare('SELECT * FROM admin_tokens WHERE id = ?').bind(id).first<TokenRow>();
+}
+
+// --- audit -----------------------------------------------------------------
+
+export async function insertAudit(
+  db: D1Database,
+  entry: { actor: string | null; action: string; target?: string | null; detail?: string | null },
+): Promise<void> {
+  await db
+    .prepare('INSERT INTO admin_audit (ts, actor, action, target, detail) VALUES (?, ?, ?, ?, ?)')
+    .bind(Date.now(), entry.actor, entry.action, entry.target ?? null, entry.detail ?? null)
+    .run();
+}

--- a/cloud/zeus-remote-broker/src/index.ts
+++ b/cloud/zeus-remote-broker/src/index.ts
@@ -1,9 +1,11 @@
 import type { Env } from './types';
 import { verifyQrzSessionCached } from './qrz';
 import { mintIceServers } from './turn';
+import { handleAdmin } from './admin-api';
 
 export { SignalRoom } from './signal-room';
 export { RateLimiter } from './rate-limiter';
+export { PresenceRoom } from './presence';
 
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
@@ -23,6 +25,22 @@ export default {
       const callsign = decodeURIComponent(go[1]).toUpperCase();
       const origin = env.WEB_APP_ORIGIN ?? 'https://openhpsdrzeus.com';
       return Response.redirect(`${origin}/?remote=${encodeURIComponent(callsign)}`, 302);
+    }
+
+    // Credential-based admin API (login, token mint/revoke, admin CRUD,
+    // presence). Self-contained: handles its own CORS, Bearer auth, and the
+    // idempotent bootstrap/migration on first call. See admin-api.ts.
+    //
+    // Per-IP rate-limited (mirrors /turn and /signal): the unauthenticated
+    // /admin/login surface must not be an unthrottled online password-guess /
+    // PBKDF2 CPU-exhaustion vector. OPTIONS preflights pass through so the
+    // dashboard's CORS check is never throttled. handleLogin adds a second,
+    // per-callsign throttle.
+    if (url.pathname === '/admin' || url.pathname.startsWith('/admin/')) {
+      if (request.method !== 'OPTIONS' && (await rateLimited(env, clientIp(request)))) {
+        return new Response('rate limited', { status: 429, headers: corsHeaders(env) });
+      }
+      return handleAdmin(request, env, ctx);
     }
 
     // Mint short-lived TURN credentials (clients call this before connecting).

--- a/cloud/zeus-remote-broker/src/presence.ts
+++ b/cloud/zeus-remote-broker/src/presence.ts
@@ -1,0 +1,71 @@
+import { DurableObject } from 'cloudflare:workers';
+import type { Env } from './types';
+
+/**
+ * Single Durable Object tracking operators whose sidecar has registered as
+ * support-available (the operator's L1 "available for remote diagnostics" switch
+ * is on). The broker's /admin/presence reads it; the sidecar registers/heartbeats
+ * (wired in P3 — for now only /admin/presence's `list` is reachable).
+ *
+ * In-memory map only: presence is ephemeral by nature, and a DO restart simply
+ * waits for the next heartbeat. Entries whose lastSeen is older than ~90s are
+ * treated as offline (a sidecar should heartbeat well inside that window).
+ */
+interface Entry {
+  /** When this operator first registered in the current online streak (unix ms). */
+  since: number;
+  /** Last heartbeat (unix ms). */
+  lastSeen: number;
+}
+
+/** An operator is considered offline if we haven't heard from them in this long. */
+const PRESENCE_EXPIRY_MS = 90_000;
+
+export class PresenceRoom extends DurableObject<Env> {
+  private entries = new Map<string, Entry>();
+
+  override async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    const action = url.pathname.replace(/^\/+/, '');
+    const callsign = (url.searchParams.get('callsign') ?? '').trim().toUpperCase();
+    const now = Date.now();
+
+    switch (action) {
+      case 'register': {
+        if (!callsign) return new Response('callsign required', { status: 400 });
+        const existing = this.entries.get(callsign);
+        this.entries.set(callsign, { since: existing?.since ?? now, lastSeen: now });
+        return Response.json({ ok: true });
+      }
+      case 'heartbeat': {
+        if (!callsign) return new Response('callsign required', { status: 400 });
+        const existing = this.entries.get(callsign);
+        // A heartbeat for an unknown/expired operator implicitly re-registers.
+        this.entries.set(callsign, { since: existing?.since ?? now, lastSeen: now });
+        return Response.json({ ok: true });
+      }
+      case 'drop': {
+        if (callsign) this.entries.delete(callsign);
+        return Response.json({ ok: true });
+      }
+      case 'list': {
+        return Response.json({ operators: this.snapshot(now) });
+      }
+      default:
+        return new Response('not found', { status: 404 });
+    }
+  }
+
+  /** Live operators (lastSeen within the expiry window); expired ones are pruned. */
+  private snapshot(now: number): Array<{ callsign: string; since: number; lastSeen: number }> {
+    const out: Array<{ callsign: string; since: number; lastSeen: number }> = [];
+    for (const [callsign, e] of this.entries) {
+      if (now - e.lastSeen > PRESENCE_EXPIRY_MS) {
+        this.entries.delete(callsign);
+        continue;
+      }
+      out.push({ callsign, since: e.since, lastSeen: e.lastSeen });
+    }
+    return out;
+  }
+}

--- a/cloud/zeus-remote-broker/src/qrz.ts
+++ b/cloud/zeus-remote-broker/src/qrz.ts
@@ -55,7 +55,8 @@ export async function verifyQrzSession(sessionKey: string, callsign: string): Pr
   }
 }
 
-async function sha256Hex(input: string): Promise<string> {
+/** Hex SHA-256 of a UTF-8 string. Shared with the admin-auth token store. */
+export async function sha256Hex(input: string): Promise<string> {
   const data = new TextEncoder().encode(input);
   const buf = await crypto.subtle.digest('SHA-256', data);
   return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, '0')).join('');

--- a/cloud/zeus-remote-broker/src/types.ts
+++ b/cloud/zeus-remote-broker/src/types.ts
@@ -1,5 +1,6 @@
 import type { SignalRoom } from './signal-room';
 import type { RateLimiter } from './rate-limiter';
+import type { PresenceRoom } from './presence';
 
 /** Worker environment bindings (see wrangler.toml). */
 export interface Env {
@@ -8,6 +9,28 @@ export interface Env {
 
   /** Per-IP connection rate limiter DO (shared pattern with the chat relay). */
   RATE_DO: DurableObjectNamespace<RateLimiter>;
+
+  /**
+   * Credential-based admin store (D1 `zeus-admin`), shared with the chat relay.
+   * Single source of truth for who is an admin: callsign ownership (QRZ) AND a
+   * stored credential. See ADMIN_AUTH_DESIGN.md and migrations/0001_admin.sql.
+   */
+  ADMIN_DB: D1Database;
+
+  /**
+   * Presence DO: a single object tracking operators whose sidecar has registered
+   * as support-available (heartbeats, ~90s expiry). Listed via /admin/presence.
+   */
+  PRESENCE: DurableObjectNamespace<PresenceRoom>;
+
+  /**
+   * Bootstrap admin seeded on first /admin request when `admins` is empty
+   * (created_by 'bootstrap'). Set BOTH via `wrangler secret put`. Optional —
+   * absent means no bootstrap admin is created (legacy env.ADMINS still migrates).
+   */
+  ADMIN_BOOTSTRAP_CALLSIGN?: string;
+  /** Bootstrap admin's initial password (see ADMIN_BOOTSTRAP_CALLSIGN). */
+  ADMIN_BOOTSTRAP_PASSWORD?: string;
 
   /**
    * QRZ-login enforcement for the HOST (radio) side. Default "on": only the
@@ -24,4 +47,11 @@ export interface Env {
   TURN_KEY_ID?: string;
   /** Cloudflare Realtime TURN API token (set via `wrangler secret put`). */
   TURN_API_TOKEN?: string;
+
+  /**
+   * Legacy comma-separated admin callsigns. Only used at bootstrap: any callsign
+   * here is seeded as a password-less admin row the first time `admins` is empty,
+   * so chat-admin keeps working pre-migration. Not consulted after that.
+   */
+  ADMINS?: string;
 }

--- a/cloud/zeus-remote-broker/test/admin-auth.test.ts
+++ b/cloud/zeus-remote-broker/test/admin-auth.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for the admin-auth crypto core. Runs under Node 20+ using the
+ * global WebCrypto (crypto.subtle) — the same primitive the Worker uses — so the
+ * functions are exercised exactly as deployed, no mocks.
+ *
+ *   node --import tsx --test test/admin-auth.test.ts
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  hashPassword,
+  verifyPassword,
+  mintToken,
+  hashToken,
+  looksLikeToken,
+  constantTimeEqual,
+  TOKEN_PREFIX,
+  PBKDF2_ITER,
+} from '../src/admin-auth.ts';
+
+test('password hash + verify round-trip', async () => {
+  const rec = await hashPassword('correct horse battery staple');
+  assert.equal(rec.iter, PBKDF2_ITER);
+  assert.ok(rec.hash.length > 0);
+  assert.ok(rec.salt.length > 0);
+  assert.equal(await verifyPassword('correct horse battery staple', rec), true);
+});
+
+test('wrong password fails', async () => {
+  const rec = await hashPassword('s3cret-password');
+  assert.equal(await verifyPassword('s3cret-passwor', rec), false);
+  assert.equal(await verifyPassword('S3cret-password', rec), false);
+  assert.equal(await verifyPassword('', rec), false);
+});
+
+test('distinct salts produce distinct hashes for the same password', async () => {
+  const a = await hashPassword('same-password');
+  const b = await hashPassword('same-password');
+  assert.notEqual(a.salt, b.salt);
+  assert.notEqual(a.hash, b.hash);
+  // ...but both still verify.
+  assert.equal(await verifyPassword('same-password', a), true);
+  assert.equal(await verifyPassword('same-password', b), true);
+});
+
+test('token generate -> hash -> verify round-trip', async () => {
+  const minted = await mintToken();
+  assert.ok(minted.token.startsWith(TOKEN_PREFIX));
+  assert.equal(looksLikeToken(minted.token), true);
+  // The stored hash equals SHA-256 of the presented token.
+  assert.equal(await hashToken(minted.token), minted.hash);
+});
+
+test('tampered token fails to match its stored hash', async () => {
+  const minted = await mintToken();
+  const tampered = minted.token.slice(0, -1) + (minted.token.endsWith('A') ? 'B' : 'A');
+  assert.notEqual(tampered, minted.token);
+  assert.notEqual(await hashToken(tampered), minted.hash);
+});
+
+test('looksLikeToken rejects non-prefixed / empty values', () => {
+  assert.equal(looksLikeToken('zsa_abc'), true);
+  assert.equal(looksLikeToken('abc'), false);
+  assert.equal(looksLikeToken(TOKEN_PREFIX), false); // prefix only, no body
+  assert.equal(looksLikeToken(''), false);
+});
+
+test('constantTimeEqual returns correct booleans', () => {
+  const a = new Uint8Array([1, 2, 3, 4]);
+  const b = new Uint8Array([1, 2, 3, 4]);
+  const c = new Uint8Array([1, 2, 3, 5]);
+  const d = new Uint8Array([1, 2, 3]);
+  assert.equal(constantTimeEqual(a, b), true);
+  assert.equal(constantTimeEqual(a, c), false); // same length, last byte differs
+  assert.equal(constantTimeEqual(a, d), false); // different length
+});

--- a/cloud/zeus-remote-broker/wrangler.toml
+++ b/cloud/zeus-remote-broker/wrangler.toml
@@ -37,6 +37,20 @@ class_name = "SignalRoom"
 name = "RATE_DO"
 class_name = "RateLimiter"
 
+# Support-availability presence (single global object; ~90s heartbeat expiry).
+[[durable_objects.bindings]]
+name = "PRESENCE"
+class_name = "PresenceRoom"
+
+# Credential-based admin store, shared with the chat relay. Create it once and
+# copy the printed id into BOTH wrangler.toml files (broker + zeuschat-relay):
+#   wrangler d1 create zeus-admin
+#   wrangler d1 migrations apply zeus-admin   # applies migrations/0001_admin.sql
+[[d1_databases]]
+binding = "ADMIN_DB"
+database_name = "zeus-admin"
+database_id = "REPLACE_WITH_d1_create_OUTPUT"
+
 # SQLite-backed DO namespaces (free-plan compatible).
 [[migrations]]
 tag = "v1"
@@ -46,8 +60,19 @@ new_sqlite_classes = ["SignalRoom"]
 tag = "v2"
 new_sqlite_classes = ["RateLimiter"]
 
+[[migrations]]
+tag = "v3"
+new_sqlite_classes = ["PresenceRoom"]
+
 # TURN credentials are minted from Cloudflare Realtime. Provide the key out of
 # band so it stays out of source control:
 #   wrangler secret put TURN_KEY_ID
 #   wrangler secret put TURN_API_TOKEN
 # If unset, /turn returns 503 and clients fall back to STUN-only (direct P2P).
+
+# Bootstrap admin: seeded the first time the `admins` table is empty. Set BOTH
+# out of band so they stay out of source control:
+#   wrangler secret put ADMIN_BOOTSTRAP_CALLSIGN
+#   wrangler secret put ADMIN_BOOTSTRAP_PASSWORD
+# Optional — if unset, no bootstrap admin is created (legacy env.ADMINS, if set,
+# still migrates to password-less rows).

--- a/cloud/zeuschat-relay/src/chat-room.ts
+++ b/cloud/zeuschat-relay/src/chat-room.ts
@@ -72,6 +72,14 @@ const RL_WINDOW_MS = 5000;
  */
 const ROSTER_HEAL_INTERVAL_MS = 120_000;
 
+/**
+ * How long the in-memory admin set is trusted before re-reading the shared
+ * `zeus-admin` D1 store. Short enough that a dashboard add/disable propagates
+ * within ~a minute without a redeploy; long enough that the per-connection
+ * ensureLoaded() path stays a cheap no-op most of the time.
+ */
+const ADMIN_REFRESH_TTL_MS = 60_000;
+
 function norm(callsign: string): string {
   return callsign.trim().toUpperCase();
 }
@@ -99,17 +107,31 @@ export class ChatRoom extends DurableObject<Env> {
   private members = new Map<string, Set<string>>(); // roomId -> member callsigns
   private userRooms = new Map<string, Set<string>>(); // callsign -> roomIds
   private bans = new Set<string>();
+  // Admin callsign set. SOURCE OF TRUTH is the shared `zeus-admin` D1 store
+  // (env.ADMIN_DB), refreshed on a TTL in ensureLoaded(); the env.ADMINS seed is
+  // only a fallback when D1 is unbound/empty/unreachable. Every call site below
+  // is unchanged — only how this set is filled changed (see refreshAdmins()).
   private admins: Set<string>;
+  // env.ADMINS parsed once, kept as the D1 fallback / pre-migration seed.
+  private adminSeed: Set<string>;
+  // Last time we (re)loaded admins from D1, for the TTL refresh below.
+  private adminsLoadedAt = 0;
   private loaded = false;
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
-    this.admins = new Set(
-      (env.ADMINS ?? 'N9WAR,KB2UKA')
+    // No hardcoded admin callsigns in source. The D1 `admins` store is the source
+    // of truth; env.ADMINS is only a bootstrap/disaster seed and must be set as a
+    // wrangler var (not baked in). Empty seed + unreachable D1 => no admins this
+    // minute (fail closed), never a silent re-grant of some baked-in pair.
+    this.adminSeed = new Set(
+      (env.ADMINS ?? '')
         .split(',')
         .map((s) => s.trim().toUpperCase())
         .filter(Boolean),
     );
+    // Start from the seed so admin checks work before the first D1 load.
+    this.admins = new Set(this.adminSeed);
     // Auto-answer keepalives without waking the DO. Backends must send the
     // exact request string for this to match.
     this.ctx.setWebSocketAutoResponse(
@@ -343,6 +365,11 @@ export class ChatRoom extends DurableObject<Env> {
   // --- persistence load ------------------------------------------------------
 
   private async ensureLoaded(): Promise<void> {
+    // Admins refresh on their own TTL (independent of the one-shot graph load
+    // below) so dashboard changes propagate to long-lived rooms without a
+    // redeploy. Cheap no-op while inside the TTL window.
+    await this.refreshAdmins();
+
     if (this.loaded) return;
     const fr = await this.ctx.storage.list<number>({ prefix: 'fr:' });
     for (const key of fr.keys()) {
@@ -380,6 +407,37 @@ export class ChatRoom extends DurableObject<Env> {
       await this.ctx.storage.setAlarm(Date.now() + ROSTER_HEAL_INTERVAL_MS);
     }
     this.loaded = true;
+  }
+
+  /**
+   * Repopulate the in-memory admin set from the shared `zeus-admin` D1 store,
+   * at most once per ADMIN_REFRESH_TTL_MS. The store is the source of truth;
+   * env.ADMINS is only a fallback. We fall back to the seed (and leave the
+   * current set untouched on a transient error) so a D1 hiccup never silently
+   * drops moderation powers mid-session.
+   */
+  private async refreshAdmins(): Promise<void> {
+    const now = Date.now();
+    if (this.adminsLoadedAt && now - this.adminsLoadedAt < ADMIN_REFRESH_TTL_MS) return;
+    this.adminsLoadedAt = now;
+
+    const db = this.env.ADMIN_DB;
+    if (!db) {
+      // No D1 bound (local dev / pre-migration): use the env.ADMINS seed.
+      this.admins = new Set(this.adminSeed);
+      return;
+    }
+    try {
+      const rows = await db
+        .prepare('SELECT callsign FROM admins WHERE disabled = 0')
+        .all<{ callsign: string }>();
+      const callsigns = (rows.results ?? []).map((r) => norm(r.callsign)).filter(Boolean);
+      // Empty store = not yet migrated; keep using the seed until it's populated.
+      this.admins = callsigns.length > 0 ? new Set(callsigns) : new Set(this.adminSeed);
+    } catch {
+      // D1 unreachable: fall back to the seed rather than dropping all admins.
+      this.admins = new Set(this.adminSeed);
+    }
   }
 
   // --- messages --------------------------------------------------------------

--- a/cloud/zeuschat-relay/src/types.ts
+++ b/cloud/zeuschat-relay/src/types.ts
@@ -25,9 +25,19 @@ export interface Env {
   QRZ_VERIFY?: string;
 
   /**
-   * Comma-separated callsigns with moderator powers (create/delete private
-   * rooms, add/remove members, ban/unban). Defaults to "N9WAR,KB2UKA" when
-   * unset. Case-insensitive.
+   * Shared credential-based admin store (D1 `zeus-admin`, same database the
+   * broker owns). ChatRoom repopulates its in-memory admin set from
+   * `SELECT callsign FROM admins WHERE disabled = 0` on a ~60s TTL, so dashboard
+   * add/disable propagates without a redeploy. Optional in local dev — when
+   * absent (or the query throws / returns empty) the ADMINS seed below is used.
+   */
+  ADMIN_DB?: D1Database;
+
+  /**
+   * Fallback seed for moderator callsigns (create/delete private rooms,
+   * add/remove members, ban/unban). Defaults to "N9WAR,KB2UKA" when unset.
+   * Case-insensitive. Used only when ADMIN_DB is unbound, empty, or unreachable;
+   * once the D1 store is populated it is the source of truth.
    */
   ADMINS?: string;
 }

--- a/cloud/zeuschat-relay/wrangler.toml
+++ b/cloud/zeuschat-relay/wrangler.toml
@@ -28,6 +28,15 @@ class_name = "ChatRoom"
 name = "RATE_DO"
 class_name = "RateLimiter"
 
+# Shared credential-based admin store (same D1 database as the broker). The relay
+# reads the enabled-admin callsign list from it; the broker owns writes. Use the
+# SAME database_name/database_id printed by `wrangler d1 create zeus-admin` in
+# cloud/zeus-remote-broker — do NOT create a second database.
+[[d1_databases]]
+binding = "ADMIN_DB"
+database_name = "zeus-admin"
+database_id = "REPLACE_WITH_d1_create_OUTPUT"
+
 # SQLite-backed DO namespaces (free-plan compatible).
 [[migrations]]
 tag = "v1"


### PR DESCRIPTION
**Phase 2 of the remote diagnostics epic** (`zeus-87ca`). Cloud-only (Cloudflare Workers); independent of the P0/P1 .NET PRs, so it targets `develop` directly.

Replaces the hardcoded `env.ADMINS` callsign list with a **credential-based, server-side admin store** (D1) shared by the broker and the chat relay — so "admin" has one secure source of truth, and an automated agent can authenticate non-interactively to debug a consented user.

**Threat model:** QRZ login proves callsign *ownership*; the D1 store proves *authorization*. Nothing about admin is client-asserted. Full design + deploy steps in [`cloud/ADMIN_AUTH_DESIGN.md`](cloud/ADMIN_AUTH_DESIGN.md).

### Broker (`cloud/zeus-remote-broker`)
- D1 schema (`migrations/0001_admin.sql`): `admins` / `admin_tokens` / `admin_audit`.
- `admin-auth.ts` — WebCrypto only (no WASM): PBKDF2-HMAC-SHA256 210k/16B salt/32B key; `zsa_` tokens stored as SHA-256; constant-time compares.
- `admin-db.ts` — fully parameterized D1 layer.
- `admin-api.ts` — `/admin/*`: login→session token, mint/revoke **agent** tokens, admin CRUD, presence, diagnostics-request stub (P3). Bearer auth + audit + lazy idempotent bootstrap/migration.
- `presence.ts` — `PresenceRoom` DO (register/heartbeat wired in P3; `/admin/presence` list reachable now).

### Relay (`cloud/zeuschat-relay`)
- chat-admin now sourced from the same D1 store (`ChatRoom.refreshAdmins`, 60s TTL); **all admin call-sites unchanged**; fails closed to the env seed on D1 error.

### Security hardening (after an independent adversarial review pass)
Review found 1 Critical + 3 High; all fixed in this PR:
- **Rate-limit** all `/admin/*` per-IP + `/admin/login` per-callsign (closes unthrottled password brute-force / PBKDF2 CPU-exhaustion).
- **CORS fails closed** on the admin surface (never `Allow-Origin: *`).
- **Token expiry at the data layer** (`expires_at`; session 12h, agent revoke-only).
- **No peer account takeover** (can't reset a peer's existing password); **no self-lockout** (refuse disabling the last enabled admin).
- **Removed the hardcoded `N9WAR,KB2UKA` default** — seed via wrangler var only.
- `Cache-Control: no-store` on secret-bearing responses; token label capped.

Verified clean by review: SQL fully parameterized; passwords/tokens stored as hashes only; generic 401s (no which-factor oracle); relay migration fails closed-to-seed (never "everyone is admin").

### Tests / build
`admin-auth` crypto suite (7 passing); **both Workers typecheck clean**. **Not deployed** — D1 provisioning + secrets are the maintainer's step (documented in the design doc). ⚠️ Touches the live chat-admin path and deployed Cloudflare infra — needs maintainer review + the documented deploy sequence.

Closes zeus-d0yr.