### PR TITLE
feat(desktop): "Reset & Uninstall Zeus" — full cross-platform wipe with inline backup

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -1827,6 +1827,10 @@ public sealed record BandMemoryDto(string Band, long Hz, RxMode Mode);
 
 public sealed record BandMemorySetRequest(long Hz, RxMode Mode);
 
+// "Reset & Uninstall Zeus" confirm. Token is the one-shot nonce from the
+// uninstall preview; RemoveBinary requests a full uninstall (app binary too).
+public sealed record UninstallRequest(string? Token, bool RemoveBinary);
+
 // UI layout: opaque workspace JSON persisted server-side so the operator's
 // panel arrangement survives page reloads and reinstalls. The JSON is stored
 // as a string to avoid strongly-typing the workspace tree on the wire — the

--- a/Zeus.Server.Hosting/Uninstall/UninstallExecutor.cs
+++ b/Zeus.Server.Hosting/Uninstall/UninstallExecutor.cs
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Zeus.Server.Uninstall;
+
+// Launches the detached post-exit uninstall helper. The whole safety story of
+// this file is: PATHS ARE DATA, NEVER CODE.
+//
+//  * The validated absolute paths are written to a temp manifest file (UTF-8,
+//    NUL-delimited) that lives in the OS temp dir — a location the wipe never
+//    touches — and are passed to the helper as the CONTENTS of that file.
+//  * Dynamic values (parent PID, manifest path, marker path, registry keys,
+//    the optional Windows uninstaller command) are passed through ENVIRONMENT
+//    variables, never concatenated into the script text.
+//  * The script bodies (PosixScript / WindowsScript) are FIXED CONSTANTS with no
+//    path interpolation, so a folder name containing $(...), backticks, quotes,
+//    or spaces can neither widen an rm -rf nor execute code (the defect the
+//    audit flagged in the reused AppRestartService shell template).
+//
+// The helper waits (bounded) for the parent PID to die, RE-CHECKS liveness and
+// ABORTS if the parent is still alive (so a stuck shutdown can never delete a
+// still-locked DB), then deletes each path, removes the Windows WER registry
+// key, optionally invokes the installer's own uninstaller, and writes a result
+// marker. Survives the parent's Environment.Exit (reparented to init/services),
+// exactly like the relaunch helper it is modelled on.
+public sealed class UninstallExecutor
+{
+    public sealed record Plan(ProcessStartInfo StartInfo, string ManifestPath, byte[] ManifestBytes, string MarkerPath);
+
+    // Env var names the fixed scripts read.
+    internal const string EnvPid = "ZEUS_UN_PID";
+    internal const string EnvManifest = "ZEUS_UN_MANIFEST";
+    internal const string EnvMarker = "ZEUS_UN_MARKER";
+    internal const string EnvDryRun = "ZEUS_UN_DRYRUN";
+    internal const string EnvRegKeys = "ZEUS_UN_REGKEYS";
+    internal const string EnvUninstaller = "ZEUS_UN_UNINSTALLER";
+
+    // Build the launch plan WITHOUT touching the disk or starting anything, so it
+    // can be unit-tested (assert the script is the fixed constant, no path leaks
+    // into argv, paths only appear in the manifest bytes).
+    public static Plan BuildPlan(UninstallManifest manifest, int parentPid, bool dryRun, string? tempDir = null)
+    {
+        if (!manifest.Ok)
+            throw new InvalidOperationException("Refusing to build an uninstall plan from an aborted manifest.");
+
+        tempDir ??= Path.GetTempPath();
+        var stamp = Guid.NewGuid().ToString("N");
+        var manifestPath = Path.Combine(tempDir, $"zeus-uninstall-{stamp}.lst");
+        var markerPath = Path.Combine(tempDir, $"zeus-uninstall-{stamp}.log");
+
+        // NUL-delimited absolute paths (file & dir alike — rm -rf / Remove-Item
+        // -Recurse handle both). NUL can't appear in a path, so it's an unambiguous
+        // separator immune to newlines/spaces in names.
+        var sb = new StringBuilder();
+        foreach (var p in manifest.Paths)
+        {
+            sb.Append(p.Path);
+            sb.Append('\0');
+        }
+        var manifestBytes = Encoding.UTF8.GetBytes(sb.ToString());
+
+        var regKeys = string.Join('\0', manifest.RegistryKeys.Select(k => $"{k.Hive}\\{k.SubKey}"));
+
+        ProcessStartInfo psi;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            psi = new ProcessStartInfo("powershell.exe")
+            {
+                CreateNoWindow = true,
+                UseShellExecute = false,
+            };
+            psi.ArgumentList.Add("-NoProfile");
+            psi.ArgumentList.Add("-ExecutionPolicy");
+            psi.ArgumentList.Add("Bypass");
+            psi.ArgumentList.Add("-Command");
+            psi.ArgumentList.Add(WindowsScript);
+            psi.Environment[EnvRegKeys] = regKeys;
+            psi.Environment[EnvUninstaller] = manifest.WindowsUninstallerCommand ?? "";
+        }
+        else
+        {
+            psi = new ProcessStartInfo("/bin/sh")
+            {
+                CreateNoWindow = true,
+                UseShellExecute = false,
+            };
+            psi.ArgumentList.Add("-c");
+            psi.ArgumentList.Add(PosixScript);
+        }
+
+        psi.Environment[EnvPid] = parentPid.ToString();
+        psi.Environment[EnvManifest] = manifestPath;
+        psi.Environment[EnvMarker] = markerPath;
+        psi.Environment[EnvDryRun] = dryRun ? "1" : "0";
+
+        return new Plan(psi, manifestPath, manifestBytes, markerPath);
+    }
+
+    // Write the manifest file and launch the detached helper. Returns the marker
+    // path so a dry-run/test can read the result.
+    public static string Launch(UninstallManifest manifest, bool dryRun = false)
+    {
+        var plan = BuildPlan(manifest, Environment.ProcessId, dryRun);
+        File.WriteAllBytes(plan.ManifestPath, plan.ManifestBytes);
+        Process.Start(plan.StartInfo);
+        return plan.MarkerPath;
+    }
+
+    // FIXED POSIX script. References only env vars we set + reads paths as data
+    // from the manifest file. No path is ever interpolated into this text.
+    internal const string PosixScript = """
+        i=0
+        while kill -0 "$ZEUS_UN_PID" 2>/dev/null; do
+          i=$((i+1)); if [ "$i" -ge 240 ]; then break; fi; sleep 0.5
+        done
+        if kill -0 "$ZEUS_UN_PID" 2>/dev/null; then
+          printf 'ABORT parent still alive\n' > "$ZEUS_UN_MARKER"; exit 1
+        fi
+        sleep 1
+        while IFS= read -r -d '' p; do
+          [ -n "$p" ] || continue
+          if [ "$ZEUS_UN_DRYRUN" = "1" ]; then
+            printf 'WOULD-DELETE %s\n' "$p" >> "$ZEUS_UN_MARKER"
+          else
+            rm -rf -- "$p" 2>/dev/null
+          fi
+        done < "$ZEUS_UN_MANIFEST"
+        printf 'DONE\n' >> "$ZEUS_UN_MARKER"
+        rm -f -- "$ZEUS_UN_MANIFEST" 2>/dev/null
+        """;
+
+    // FIXED Windows (PowerShell) script. NOTE: never use the automatic $pid
+    // variable here — that's the helper's own PID; the parent PID is in env.
+    internal const string WindowsScript = """
+        $ErrorActionPreference='SilentlyContinue'
+        $ppid=[int]$env:ZEUS_UN_PID
+        for($i=0;$i -lt 240;$i++){ if(-not (Get-Process -Id $ppid -ErrorAction SilentlyContinue)){break}; Start-Sleep -Milliseconds 500 }
+        if(Get-Process -Id $ppid -ErrorAction SilentlyContinue){ 'ABORT parent still alive' | Out-File -LiteralPath $env:ZEUS_UN_MARKER -Encoding UTF8; exit 1 }
+        Start-Sleep -Seconds 1
+        $dry = ($env:ZEUS_UN_DRYRUN -eq '1')
+        $txt=[System.IO.File]::ReadAllText($env:ZEUS_UN_MANIFEST,[System.Text.Encoding]::UTF8)
+        foreach($p in ($txt -split [char]0)){
+          if([string]::IsNullOrWhiteSpace($p)){continue}
+          if($dry){ "WOULD-DELETE $p" | Out-File -LiteralPath $env:ZEUS_UN_MARKER -Append -Encoding UTF8; continue }
+          try{
+            $it=Get-Item -LiteralPath $p -Force -ErrorAction Stop
+            if($it.Attributes -band [System.IO.FileAttributes]::ReparsePoint){
+              if($it.PSIsContainer){ & cmd.exe /c rmdir (Convert-Path -LiteralPath $p) | Out-Null } else { Remove-Item -LiteralPath $p -Force }
+            } else {
+              Remove-Item -LiteralPath $p -Recurse -Force
+            }
+          }catch{}
+        }
+        if(-not $dry){
+          foreach($k in ($env:ZEUS_UN_REGKEYS -split [char]0)){ if($k){ & reg.exe delete $k /f | Out-Null } }
+          if($env:ZEUS_UN_UNINSTALLER){ try{ Start-Process -FilePath cmd.exe -ArgumentList '/c',$env:ZEUS_UN_UNINSTALLER -Wait }catch{} }
+        }
+        'DONE' | Out-File -LiteralPath $env:ZEUS_UN_MARKER -Append -Encoding UTF8
+        Remove-Item -LiteralPath $env:ZEUS_UN_MANIFEST -Force
+        """;
+}

--- a/Zeus.Server.Hosting/Uninstall/UninstallManifest.cs
+++ b/Zeus.Server.Hosting/Uninstall/UninstallManifest.cs
@@ -1,0 +1,446 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance statement.
+
+using System.Runtime.InteropServices;
+
+namespace Zeus.Server.Uninstall;
+
+// Builds the SERVER-OWNED list of paths/registry keys a full Zeus uninstall may
+// delete. This is the safety heart of the feature: a destructive wipe that must
+// NEVER resolve to a shared/parent/system location. The endpoint takes NO path
+// from the client — everything here is derived from the live path-producers and
+// then validated, fail-closed: if ANY required base is missing or ANY essential
+// entry fails validation, the WHOLE manifest aborts and nothing is deleted.
+//
+// Why this re-derives paths instead of calling the live producers' combined
+// output: producers like PrefsDbPath.DataDir do Path.Combine(LocalApplicationData,
+// "Zeus") with no null-guard. When HOME/$XDG is unset (a systemd/launchd/cron/CI
+// context, or the zeus-agent rbash service user) GetFolderPath returns "" and the
+// producer hands back the RELATIVE string "Zeus"; Path.GetFullPath then silently
+// re-anchors it to the current working directory, yielding an absolute, leaf-"Zeus"
+// path that would pass a naive check and get rm -rf'd (e.g. <cwd>/Zeus = the repo
+// checkout). So we fetch every base RAW, assert it is non-empty AND fully-qualified
+// BEFORE any Combine, and abort otherwise.
+
+public enum OsKind { Windows, MacOs, Linux }
+
+public enum EntryKind { File, Directory }
+
+public sealed record UninstallPath(string Path, EntryKind Kind);
+
+public sealed record RegistryDelete(string Hive, string SubKey);
+
+public sealed record UninstallManifest(
+    IReadOnlyList<UninstallPath> Paths,
+    IReadOnlyList<RegistryDelete> RegistryKeys,
+    string? WindowsUninstallerCommand,
+    bool RemoveBinary,
+    IReadOnlyList<string> Warnings,
+    IReadOnlyList<string> AbortReasons)
+{
+    public bool Ok => AbortReasons.Count == 0;
+
+    public static UninstallManifest Aborted(params string[] reasons) =>
+        new([], [], null, false, [], reasons);
+}
+
+// Abstracts every environment input the builder reads, so the hostile-env test
+// matrix (HOME unset, env overrides, metachar paths, reparse points) can run
+// without mutating real process state or touching the disk.
+public interface IUninstallEnv
+{
+    OsKind Os { get; }
+    string? Home { get; }          // UserProfile, RAW (may be null/empty)
+    string? LocalAppData { get; }  // RAW
+    string? RoamingAppData { get; }// RAW (Windows roaming)
+    string? XdgDataHome { get; }   // RAW $XDG_DATA_HOME
+    string? GetEnv(string name);
+    string? ProcessPath { get; }
+    string CurrentDirectory { get; }
+    bool IsReparsePoint(string path);
+}
+
+public sealed class SystemUninstallEnv : IUninstallEnv
+{
+    public OsKind Os =>
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? OsKind.Windows
+        : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? OsKind.MacOs
+        : OsKind.Linux;
+
+    // NOTE: deliberately NO SpecialFolderOption.Create here — we are reading
+    // locations to delete, not to create, and Create could materialise a stray dir.
+    public string? Home => Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+    public string? LocalAppData => Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+    public string? RoamingAppData => Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+    public string? XdgDataHome => Environment.GetEnvironmentVariable("XDG_DATA_HOME");
+    public string? GetEnv(string name) => Environment.GetEnvironmentVariable(name);
+    public string? ProcessPath => Environment.ProcessPath;
+    public string CurrentDirectory => Environment.CurrentDirectory;
+
+    public bool IsReparsePoint(string path)
+    {
+        try
+        {
+            var attrs = File.GetAttributes(path);
+            return (attrs & FileAttributes.ReparsePoint) != 0;
+        }
+        catch
+        {
+            return false; // can't stat → not treated as a reparse point; descendant guard still applies
+        }
+    }
+}
+
+public static class UninstallManifestBuilder
+{
+    // Control characters that would corrupt the NUL-delimited manifest file or
+    // the result marker. Shell metacharacters ($, `, *, ", …) are NOT forbidden:
+    // the helper passes paths as DATA (NUL-delimited file → quoted "$p" / -LiteralPath),
+    // so they can neither glob nor execute, and they ARE legal in macOS/Linux paths.
+    // Rejecting them would wrongly refuse to uninstall for users whose home dir
+    // legitimately contains one.
+    private static readonly char[] ForbiddenChars = ['\0', '\n', '\r'];
+
+    // Leaf names that, if they were ever the FINAL segment of a delete target,
+    // mean a base collapsed — hard-abort, never delete one of these.
+    private static readonly HashSet<string> ForbiddenLeaves =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            "", ".", "..", "Library", "Caches", ".cache", ".local", "share",
+            "Application Support", "AppData", "Local", "Roaming", "Downloads",
+            "Documents", "Desktop", "Users", "home", "tmp", "var", "etc", "usr",
+            "Program Files", "Program Files (x86)", "Applications", "System",
+        };
+
+    private sealed record Candidate(
+        string Path, EntryKind Kind, string ExpectedLeaf, string SafeRoot, bool Essential);
+
+    public static UninstallManifest Build(IUninstallEnv env, bool removeBinary)
+    {
+        var aborts = new List<string>();
+        var warnings = new List<string>();
+
+        // ---- 1. Validate the RAW bases this OS needs, BEFORE any Combine. ----
+        string? RequireBase(string? raw, string label)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                aborts.Add($"{label} is empty/unset — refusing to uninstall (a missing base could resolve to the working directory).");
+                return null;
+            }
+            if (!Path.IsPathFullyQualified(raw))
+            {
+                aborts.Add($"{label} '{raw}' is not an absolute path — refusing to uninstall.");
+                return null;
+            }
+            return raw;
+        }
+
+        var home = RequireBase(env.Home, "User home");
+        var localAppData = RequireBase(env.LocalAppData, "LocalApplicationData");
+        string? roaming = env.Os == OsKind.Windows ? RequireBase(env.RoamingAppData, "ApplicationData (Roaming)") : null;
+
+        // Linux data root = $XDG_DATA_HOME or ~/.local/share (home already required).
+        string? linuxDataRoot = null;
+        if (env.Os == OsKind.Linux && home is not null)
+        {
+            var xdg = env.XdgDataHome;
+            linuxDataRoot = string.IsNullOrWhiteSpace(xdg) ? Path.Combine(home, ".local", "share") : xdg;
+            if (!Path.IsPathFullyQualified(linuxDataRoot))
+            {
+                aborts.Add($"XDG_DATA_HOME '{xdg}' is not absolute — refusing to uninstall.");
+                linuxDataRoot = null;
+            }
+        }
+
+        if (aborts.Count > 0)
+            return UninstallManifest.Aborted([.. aborts]);
+
+        // ---- 2. Assemble candidates from the GUARDED bases. ----
+        var candidates = new List<Candidate>();
+
+        // DataDir (the big recursive tree: prefs, profiles, logbook, wisdom,
+        // certs, nr3-models, freedv, hamclock, node, crash-dumps, markers).
+        string dataDir = env.Os switch
+        {
+            OsKind.Windows => Path.Combine(localAppData!, "Zeus"),
+            OsKind.MacOs => Path.Combine(home!, "Library", "Application Support", "Zeus"),
+            _ => Path.Combine(linuxDataRoot!, "Zeus"),
+        };
+        string dataRoot = env.Os switch
+        {
+            OsKind.Windows => localAppData!,
+            OsKind.MacOs => Path.Combine(home!, "Library", "Application Support"),
+            _ => linuxDataRoot!,
+        };
+        candidates.Add(new(dataDir, EntryKind.Directory, "Zeus", dataRoot, Essential: true));
+
+        // Plugins root — can live OUTSIDE DataDir (Windows Roaming, Linux lowercase
+        // "zeus"). Only delete the DEFAULT location; an operator ZEUS_PLUGINS_PATH
+        // override points at a possibly-shared dir and is NEVER recursively deleted.
+        if (!string.IsNullOrEmpty(env.GetEnv(Zeus.Plugins.Host.PluginRoot.EnvVar)))
+        {
+            warnings.Add("ZEUS_PLUGINS_PATH is set to a custom plugins folder; it is left untouched. Clear that env var if you want it removed too.");
+        }
+        else
+        {
+            (string path, string root) plugins = env.Os switch
+            {
+                OsKind.Windows => (Path.Combine(roaming!, "Zeus", "plugins"), Path.Combine(roaming!, "Zeus")),
+                OsKind.MacOs => (Path.Combine(home!, "Library", "Application Support", "Zeus", "plugins"), dataDir),
+                _ => (Path.Combine(linuxDataRoot!, "zeus", "plugins"), Path.Combine(linuxDataRoot!, "zeus")),
+            };
+            candidates.Add(new(plugins.path, EntryKind.Directory, "plugins", plugins.root, Essential: false));
+        }
+
+        // Recordings — ONLY the "Zeus Recordings" subfolder of Downloads, never
+        // Downloads itself. (The user's chosen backup also lands in Downloads root,
+        // which this never touches.)
+        string downloads = Path.Combine(home!, "Downloads");
+        candidates.Add(new(Path.Combine(downloads, "Zeus Recordings"), EntryKind.Directory, "Zeus Recordings", downloads, Essential: false));
+
+        // Webview caches — leaf is the HARD-CODED Photino product name, never derived.
+        const string Product = "OpenhpsdrZeus";
+        switch (env.Os)
+        {
+            case OsKind.MacOs:
+                candidates.Add(new(Path.Combine(home!, "Library", "Caches", Product), EntryKind.Directory, Product, Path.Combine(home!, "Library", "Caches"), Essential: false));
+                candidates.Add(new(Path.Combine(home!, "Library", "WebKit", Product), EntryKind.Directory, Product, Path.Combine(home!, "Library", "WebKit"), Essential: false));
+                break;
+            case OsKind.Linux:
+                string cacheRoot = Path.Combine(home!, ".cache");
+                candidates.Add(new(Path.Combine(cacheRoot, Product), EntryKind.Directory, Product, cacheRoot, Essential: false));
+                break;
+            case OsKind.Windows:
+                // The unambiguous, co-located WebView2 user-data folder next to the
+                // exe. The relocated %LOCALAPPDATA%\<vendor> case is intentionally NOT
+                // guessed — a wrong guess could wipe another WebView2 app's profile;
+                // the audit's rule is "resolve from the live instance or skip".
+                var exe = env.ProcessPath;
+                if (!string.IsNullOrWhiteSpace(exe) && Path.IsPathFullyQualified(exe))
+                {
+                    var exeDir = Path.GetDirectoryName(exe);
+                    if (!string.IsNullOrEmpty(exeDir))
+                    {
+                        var wv = Path.Combine(exeDir, "OpenhpsdrZeus.exe.WebView2", "EBWebView");
+                        candidates.Add(new(wv, EntryKind.Directory, "EBWebView", Path.Combine(exeDir, "OpenhpsdrZeus.exe.WebView2"), Essential: false));
+                    }
+                }
+                break;
+        }
+
+        // ---- 3. External ZEUS_PREFS_PATH override — FILE-only, never the dir. ----
+        var prefsOverride = env.GetEnv("ZEUS_PREFS_PATH");
+        if (!string.IsNullOrWhiteSpace(prefsOverride) && Path.IsPathFullyQualified(prefsOverride))
+        {
+            var full = Path.GetFullPath(prefsOverride);
+            // Only act if it resolves OUTSIDE DataDir (inside is already covered).
+            if (!IsStrictDescendant(full, dataDir))
+            {
+                warnings.Add($"ZEUS_PREFS_PATH points outside the data folder ({full}); only the database FILES it names are removed, not the containing directory.");
+                var dir = Path.GetDirectoryName(full);
+                if (dir is not null && Path.IsPathFullyQualified(dir))
+                {
+                    foreach (var f in new[] { full, full + "-log" })
+                        candidates.Add(new(f, EntryKind.File, Path.GetFileName(f), dir, Essential: false));
+                    var logbook = Path.Combine(dir, "zeus-logbook.db");
+                    foreach (var f in new[] { logbook, logbook + "-log" })
+                        candidates.Add(new(f, EntryKind.File, Path.GetFileName(f), dir, Essential: false));
+                }
+            }
+        }
+
+        // ---- 4. Validate every candidate; essential failure aborts the wipe. ----
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var paths = new List<UninstallPath>();
+        foreach (var c in candidates)
+        {
+            var reason = Validate(c, env, home!);
+            if (reason is not null)
+            {
+                if (c.Essential)
+                    aborts.Add($"Safety check failed for '{c.Path}': {reason}");
+                else
+                    warnings.Add($"Skipping '{c.Path}': {reason}");
+                continue;
+            }
+            var canon = Path.GetFullPath(c.Path);
+            if (seen.Add(canon))
+                paths.Add(new(canon, c.Kind));
+        }
+
+        if (aborts.Count > 0)
+            return UninstallManifest.Aborted([.. aborts]);
+
+        // ---- 5. Registry (Windows: exactly the one app-owned WER key). ----
+        var registry = new List<RegistryDelete>();
+        if (env.Os == OsKind.Windows)
+            registry.Add(new("HKCU", @"Software\Microsoft\Windows\Windows Error Reporting\LocalDumps\OpenhpsdrZeus.exe"));
+
+        // ---- 6. Binary removal (the install-type-aware part). ----
+        string? winUninstaller = null;
+        bool binary = false;
+        if (removeBinary)
+        {
+            (binary, winUninstaller) = ResolveBinaryRemoval(env, paths, warnings);
+        }
+
+        return new UninstallManifest(paths, registry, winUninstaller, binary, warnings, []);
+    }
+
+    // Per-entry validation. Returns null when safe, else the reason it is rejected.
+    private static string? Validate(Candidate c, IUninstallEnv env, string home)
+    {
+        var raw = c.Path;
+        if (string.IsNullOrWhiteSpace(raw)) return "empty path";
+        if (raw.IndexOfAny(ForbiddenChars) >= 0) return "path contains a forbidden character";
+        if (!Path.IsPathFullyQualified(raw)) return "not absolute";
+
+        string full;
+        try { full = Path.GetFullPath(raw); }
+        catch { return "could not canonicalize"; }
+
+        var leaf = Path.GetFileName(full.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        if (!string.Equals(leaf, c.ExpectedLeaf, StringComparison.Ordinal))
+            return $"leaf '{leaf}' != expected '{c.ExpectedLeaf}'";
+        if (ForbiddenLeaves.Contains(leaf))
+            return $"leaf '{leaf}' is a protected directory name";
+
+        // Strict descendant of its declared safe root, AND the root must itself be
+        // a real, fully-qualified path that is NOT the home/filesystem root.
+        if (string.IsNullOrWhiteSpace(c.SafeRoot) || !Path.IsPathFullyQualified(c.SafeRoot))
+            return "safe-root not absolute";
+        var safeRoot = Path.GetFullPath(c.SafeRoot);
+        if (!IsStrictDescendant(full, safeRoot))
+            return $"not a strict descendant of '{safeRoot}'";
+
+        // Never equal to / an ancestor of: home, the filesystem root, or a drive root.
+        if (PathEquals(full, home)) return "resolves to the user home";
+        if (IsRootLike(full)) return "resolves to a filesystem/drive root";
+        if (IsAncestorOrEqual(full, home)) return "is an ancestor of the user home";
+
+        // Reparse-point containment: never delete THROUGH a symlink/junction. The
+        // managed deleter re-checks at delete time too (TOCTOU defence).
+        if (env.IsReparsePoint(full)) return "target is a symlink/junction";
+
+        return null;
+    }
+
+    private static (bool, string?) ResolveBinaryRemoval(IUninstallEnv env, List<UninstallPath> paths, List<string> warnings)
+    {
+        switch (env.Os)
+        {
+            case OsKind.MacOs:
+            {
+                // The running binary lives inside the bundle
+                // (.../OpenHPSDR Zeus.app/Contents/.../OpenhpsdrZeus). Walk up to the
+                // enclosing *.app and remove THAT (handles installs outside
+                // /Applications), plus the sibling Server wrapper. Each is validated
+                // as a non-reparse strict descendant of its own parent.
+                var added = false;
+                var pp = env.ProcessPath;
+                if (!string.IsNullOrWhiteSpace(pp) && Path.IsPathFullyQualified(pp))
+                {
+                    var dir = Path.GetDirectoryName(Path.GetFullPath(pp));
+                    while (dir is not null)
+                    {
+                        if (dir.EndsWith(".app", StringComparison.OrdinalIgnoreCase))
+                        {
+                            var parent = Path.GetDirectoryName(dir);
+                            if (parent is not null
+                                && Validate(new(dir, EntryKind.Directory, Path.GetFileName(dir), parent, false), env, env.Home ?? "") is null)
+                            {
+                                paths.Add(new(dir, EntryKind.Directory));
+                                added = true;
+                                var server = Path.Combine(parent, "OpenHPSDR Zeus Server.app");
+                                if (Validate(new(server, EntryKind.Directory, "OpenHPSDR Zeus Server.app", parent, false), env, env.Home ?? "") is null)
+                                    paths.Add(new(server, EntryKind.Directory));
+                            }
+                            break;
+                        }
+                        dir = Path.GetDirectoryName(dir);
+                    }
+                }
+                if (!added)
+                {
+                    const string apps = "/Applications";
+                    foreach (var name in new[] { "OpenHPSDR Zeus.app", "OpenHPSDR Zeus Server.app" })
+                    {
+                        var p = Path.Combine(apps, name);
+                        if (Validate(new(p, EntryKind.Directory, name, apps, false), env, env.Home ?? "") is null)
+                            paths.Add(new(Path.GetFullPath(p), EntryKind.Directory));
+                    }
+                }
+                // If no .app could be located, report binary removal as unsupported.
+                var foundApp = paths.Any(x => x.Path.EndsWith(".app", StringComparison.OrdinalIgnoreCase));
+                if (!foundApp)
+                    warnings.Add("Could not locate the Zeus app bundle; data was wiped — drag the app to the Trash to finish.");
+                return (foundApp, null);
+            }
+            case OsKind.Linux:
+            {
+                // AppImage: the artifact path is in $APPIMAGE (ProcessPath is the
+                // read-only FUSE mount). If neither is resolvable, skip the binary.
+                var appImage = env.GetEnv("APPIMAGE");
+                if (!string.IsNullOrWhiteSpace(appImage) && Path.IsPathFullyQualified(appImage)
+                    && appImage.IndexOfAny(ForbiddenChars) < 0)
+                {
+                    paths.Add(new(Path.GetFullPath(appImage), EntryKind.File));
+                    return (true, null);
+                }
+                warnings.Add("Could not safely resolve the Zeus binary on Linux (tarball install / no $APPIMAGE); data was wiped — delete the install folder manually.");
+                return (false, null);
+            }
+            case OsKind.Windows:
+            default:
+                // Binary removal on Windows is the installer's job. The caller fills
+                // the QuietUninstallString (per-user installs only); HKLM/Program-Files
+                // installs are refused upstream and fall back to data-only.
+                return (true, null); // RemoveBinary=true signals "invoke uninstaller if command present"
+        }
+    }
+
+    internal static bool IsStrictDescendant(string path, string root)
+    {
+        var p = TrimSep(Path.GetFullPath(path));
+        var r = TrimSep(Path.GetFullPath(root));
+        if (PathEquals(p, r)) return false;
+        var prefix = r + Path.DirectorySeparatorChar;
+        return p.StartsWith(prefix, PathComparison);
+    }
+
+    private static bool IsAncestorOrEqual(string maybeAncestor, string path)
+    {
+        var a = TrimSep(maybeAncestor);
+        var p = TrimSep(Path.GetFullPath(path));
+        if (PathEquals(a, p)) return true;
+        return p.StartsWith(a + Path.DirectorySeparatorChar, PathComparison);
+    }
+
+    private static bool IsRootLike(string full)
+    {
+        var t = TrimSep(full);
+        if (t.Length == 0) return true;
+        var root = Path.GetPathRoot(full) ?? "";
+        return PathEquals(TrimSep(root), t);
+    }
+
+    private static string TrimSep(string p) =>
+        p.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+    // macOS/Windows are case-insensitive filesystems by default; Linux is case-
+    // sensitive (the "Zeus" vs "zeus" split is real there).
+    private static StringComparison PathComparison =>
+        RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+            ? StringComparison.Ordinal
+            : StringComparison.OrdinalIgnoreCase;
+
+    private static bool PathEquals(string a, string b) =>
+        string.Equals(TrimSep(a), TrimSep(b), PathComparison);
+}

--- a/Zeus.Server.Hosting/Uninstall/UninstallManifest.cs
+++ b/Zeus.Server.Hosting/Uninstall/UninstallManifest.cs
@@ -237,9 +237,15 @@ public static class UninstallManifestBuilder
 
         // ---- 3. External ZEUS_PREFS_PATH override — FILE-only, never the dir. ----
         var prefsOverride = env.GetEnv("ZEUS_PREFS_PATH");
+        // GetFullPath throws on illegal characters (e.g. a newline on Windows);
+        // a malformed override is simply skipped, not crashed on.
+        string? full = null;
         if (!string.IsNullOrWhiteSpace(prefsOverride) && Path.IsPathFullyQualified(prefsOverride))
         {
-            var full = Path.GetFullPath(prefsOverride);
+            try { full = Path.GetFullPath(prefsOverride); } catch { full = null; }
+        }
+        if (full is not null)
+        {
             // Only act if it resolves OUTSIDE DataDir (inside is already covered).
             if (!IsStrictDescendant(full, dataDir))
             {

--- a/Zeus.Server.Hosting/Uninstall/UninstallService.cs
+++ b/Zeus.Server.Hosting/Uninstall/UninstallService.cs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace Zeus.Server.Uninstall;
+
+// Orchestrates the "Reset & Uninstall Zeus" flow: build a safe preview, stream a
+// one-click backup, and (on a valid confirm token) launch the detached wipe and
+// exit. Owns a single one-shot confirmation nonce so the destructive POST can't
+// be replayed or fired without the operator having seen the preview.
+public sealed class UninstallService
+{
+    private readonly ILogger<UninstallService> _log;
+    private readonly LogService _logService;
+    private readonly object _gate = new();
+    private string? _nonce;
+
+    public UninstallService(ILogger<UninstallService> log, LogService logService)
+    {
+        _log = log;
+        _logService = logService;
+    }
+
+    public sealed record PreviewDto(
+        IReadOnlyList<string> Paths,
+        IReadOnlyList<string> Warnings,
+        IReadOnlyList<string> AbortReasons,
+        bool CanProceed,
+        bool BinaryRemovalSupported,
+        string ConfirmToken);
+
+    public PreviewDto Preview(bool removeBinary)
+    {
+        var manifest = BuildManifest(removeBinary, out var binarySupported);
+        var token = NewNonce();
+        return new PreviewDto(
+            manifest.Paths.Select(p => p.Path).ToList(),
+            manifest.Warnings,
+            manifest.AbortReasons,
+            manifest.Ok,
+            binarySupported,
+            token);
+    }
+
+    // Build a single backup archive (prefs DB + every profile + logbook + an ADIF
+    // export of the log) the operator downloads to ~/Downloads before wiping. The
+    // browser download default IS the Downloads root, which the wipe never touches.
+    public async Task<(byte[] Bytes, string FileName)> BuildBackupAsync(CancellationToken ct)
+    {
+        using var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var dataDir = PrefsDbPath.DataDir;
+            // All *.db in DataDir and DataDir/profiles, read shared so the live DB
+            // can be copied while open.
+            foreach (var (abs, entryName) in EnumerateBackupDbFiles(dataDir))
+            {
+                try
+                {
+                    var entry = zip.CreateEntry(entryName, CompressionLevel.Fastest);
+                    await using var es = entry.Open();
+                    await using var fs = new FileStream(abs, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                    await fs.CopyToAsync(es, ct).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _log.LogWarning(ex, "uninstall.backup skip {File}", abs);
+                }
+            }
+
+            // Human-readable ADIF export of the QSO log.
+            try
+            {
+                var adif = await _logService.ExportToAdifAsync(null, ct).ConfigureAwait(false);
+                var entry = zip.CreateEntry("zeus-logbook.adi", CompressionLevel.Fastest);
+                await using var es = entry.Open();
+                await es.WriteAsync(Encoding.UTF8.GetBytes(adif), ct).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _log.LogWarning(ex, "uninstall.backup adif failed");
+            }
+        }
+        return (ms.ToArray(), "zeus-backup.zip");
+    }
+
+    public sealed record ExecuteResult(bool Started, string? Error, IReadOnlyList<string>? AbortReasons);
+
+    public ExecuteResult Execute(string? token, bool removeBinary)
+    {
+        lock (_gate)
+        {
+            if (string.IsNullOrEmpty(_nonce) || token != _nonce)
+                return new ExecuteResult(false, "Invalid or expired confirmation token. Reopen the uninstall dialog.", null);
+            _nonce = null; // one-shot
+        }
+
+        var manifest = BuildManifest(removeBinary, out _);
+        if (!manifest.Ok)
+        {
+            _log.LogError("uninstall.aborted reasons={Reasons}", string.Join(" | ", manifest.AbortReasons));
+            return new ExecuteResult(false, "Uninstall safety checks failed; nothing was deleted.", manifest.AbortReasons);
+        }
+
+        _log.LogWarning("uninstall.execute paths={Count} binary={Binary} — launching detached wipe and exiting.",
+            manifest.Paths.Count, manifest.RemoveBinary);
+
+        try
+        {
+            UninstallExecutor.Launch(manifest, dryRun: false);
+        }
+        catch (Exception ex)
+        {
+            _log.LogError(ex, "uninstall.launch failed");
+            return new ExecuteResult(false, $"Failed to start the uninstaller: {ex.Message}", null);
+        }
+
+        // Same clean-teardown the restart/quit paths use: let the HTTP response
+        // flush, then exit so the detached helper can delete the now-unlocked files.
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(400).ConfigureAwait(false);
+            Environment.Exit(0);
+        });
+        return new ExecuteResult(true, null, null);
+    }
+
+    // Builds and validates the manifest, then fills the Windows install-type-aware
+    // binary-removal command. binarySupported reports whether binary removal is
+    // actually achievable on this install (false → data-only fallback).
+    private UninstallManifest BuildManifest(bool removeBinary, out bool binarySupported)
+    {
+        var env = new SystemUninstallEnv();
+        var manifest = UninstallManifestBuilder.Build(env, removeBinary);
+        binarySupported = false;
+
+        if (!manifest.Ok || !removeBinary)
+            return manifest;
+
+        if (env.Os == OsKind.Windows)
+        {
+            var (cmd, refusedReason) = WindowsInstallInfo.ResolveUninstaller();
+            if (cmd is not null)
+            {
+                binarySupported = true;
+                return manifest with { WindowsUninstallerCommand = cmd };
+            }
+            // Per-machine / Program Files / not found → data-only fallback.
+            var warnings = manifest.Warnings.ToList();
+            warnings.Add(refusedReason ?? "The Zeus binary could not be removed automatically; finish in Settings → Apps → OpenHPSDR-Zeus.");
+            return manifest with { RemoveBinary = false, Warnings = warnings };
+        }
+
+        // macOS/Linux binary removal is encoded as path entries by the builder.
+        binarySupported = manifest.RemoveBinary;
+        return manifest;
+    }
+
+    private static IEnumerable<(string Abs, string EntryName)> EnumerateBackupDbFiles(string dataDir)
+    {
+        if (!Directory.Exists(dataDir)) yield break;
+        foreach (var f in SafeEnumerate(dataDir, "*.db"))
+            yield return (f, Path.GetFileName(f));
+        var profiles = Path.Combine(dataDir, "profiles");
+        if (Directory.Exists(profiles))
+            foreach (var f in SafeEnumerate(profiles, "*.db"))
+                yield return (f, "profiles/" + Path.GetFileName(f));
+    }
+
+    private static IEnumerable<string> SafeEnumerate(string dir, string pattern)
+    {
+        try { return Directory.EnumerateFiles(dir, pattern, SearchOption.TopDirectoryOnly); }
+        catch { return []; }
+    }
+
+    private string NewNonce()
+    {
+        var n = Convert.ToHexString(RandomNumberGenerator.GetBytes(16));
+        lock (_gate) { _nonce = n; }
+        return n;
+    }
+}

--- a/Zeus.Server.Hosting/Uninstall/WindowsInstallInfo.cs
+++ b/Zeus.Server.Hosting/Uninstall/WindowsInstallInfo.cs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+
+using System.Diagnostics;
+
+namespace Zeus.Server.Uninstall;
+
+// Resolves how (or whether) Zeus's own binary can be removed on Windows, by
+// reading the installer's Add/Remove-Programs entry via reg.exe (the project
+// targets net10.0, not net10.0-windows, so Microsoft.Win32.Registry isn't
+// available — and the wipe helper already shells reg.exe, so this stays
+// consistent).
+//
+// FAIL SAFE: binary removal is only offered for a confirmed PER-USER install
+// whose uninstaller we can read. A per-machine (HKLM / Program Files) install is
+// admin-owned and unremovable by this non-elevated process, so we return null +
+// a reason and the caller falls back to a DATA-ONLY wipe — never hand-deleting
+// the install dir (which would orphan the Add/Remove-Programs entry).
+public static class WindowsInstallInfo
+{
+    private static readonly string[] PerUserRoots =
+    [
+        @"HKCU\Software\Microsoft\Windows\CurrentVersion\Uninstall",
+    ];
+
+    private static readonly string[] PerMachineRoots =
+    [
+        @"HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall",
+        @"HKLM\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall",
+    ];
+
+    // Returns (command, null) when a per-user uninstaller is found; otherwise
+    // (null, reason) → caller does data-only + tells the operator to use Settings.
+    public static (string? Command, string? Reason) ResolveUninstaller()
+    {
+        if (!OperatingSystem.IsWindows())
+            return (null, null);
+
+        // A per-machine install present at all means binary removal needs elevation.
+        foreach (var root in PerMachineRoots)
+        {
+            if (FindZeusEntry(root) is { } machine && machine.IsZeus)
+                return (null, "Zeus was installed for all users; remove it from Windows Settings → Apps (needs administrator rights).");
+        }
+
+        foreach (var root in PerUserRoots)
+        {
+            if (FindZeusEntry(root) is { } e && e.IsZeus)
+            {
+                if (e.InstallLocation is { Length: > 0 } loc && IsUnderProgramFiles(loc))
+                    return (null, "Zeus is installed under Program Files; remove it from Windows Settings → Apps.");
+
+                var cmd = e.QuietUninstallString ?? AppendSilent(e.UninstallString);
+                if (!string.IsNullOrWhiteSpace(cmd))
+                    return (cmd, null);
+            }
+        }
+
+        return (null, "Could not locate Zeus's uninstaller; data was wiped — remove the program folder via Windows Settings → Apps.");
+    }
+
+    private sealed record Entry(bool IsZeus, string? QuietUninstallString, string? UninstallString, string? InstallLocation);
+
+    private static Entry? FindZeusEntry(string root)
+    {
+        var dump = RegQuery(root + " /s");
+        if (dump is null) return null;
+
+        string? display = null, quiet = null, uninstall = null, loc = null;
+        Entry? best = null;
+
+        void Flush()
+        {
+            if (display is not null && IsZeusName(display))
+                best ??= new Entry(true, quiet, uninstall, loc);
+            display = quiet = uninstall = loc = null;
+        }
+
+        foreach (var raw in dump.Split('\n'))
+        {
+            var line = raw.TrimEnd('\r');
+            if (line.StartsWith("HKEY", StringComparison.OrdinalIgnoreCase))
+            {
+                Flush();
+                continue;
+            }
+            var (name, value) = ParseValue(line);
+            if (name is null) continue;
+            switch (name.ToLowerInvariant())
+            {
+                case "displayname": display = value; break;
+                case "quietuninstallstring": quiet = value; break;
+                case "uninstallstring": uninstall = value; break;
+                case "installlocation": loc = value; break;
+            }
+        }
+        Flush();
+        return best;
+    }
+
+    private static bool IsZeusName(string displayName) =>
+        displayName.Contains("OpenHPSDR", StringComparison.OrdinalIgnoreCase)
+        || displayName.Contains("Zeus", StringComparison.OrdinalIgnoreCase);
+
+    // reg.exe value line: "    <Name>    REG_SZ    <value>" (3+ spaces / tab between fields).
+    private static (string? Name, string? Value) ParseValue(string line)
+    {
+        var t = line.TrimStart();
+        if (t.Length == 0 || t.StartsWith("HKEY", StringComparison.OrdinalIgnoreCase)) return (null, null);
+        // Split on the REG_<TYPE> token.
+        var marker = FindTypeMarker(t);
+        if (marker < 0) return (null, null);
+        var name = t[..marker].Trim();
+        var afterType = t[marker..];
+        var sp = afterType.IndexOf(' ');
+        var value = sp >= 0 ? afterType[(sp + 1)..].Trim() : "";
+        return (name.Length == 0 ? null : name, value);
+    }
+
+    private static int FindTypeMarker(string s)
+    {
+        foreach (var tok in new[] { "REG_SZ", "REG_EXPAND_SZ", "REG_DWORD", "REG_MULTI_SZ", "REG_QWORD", "REG_BINARY" })
+        {
+            var idx = s.IndexOf(tok, StringComparison.Ordinal);
+            if (idx > 0) return idx;
+        }
+        return -1;
+    }
+
+    private static string? AppendSilent(string? uninstallString)
+    {
+        if (string.IsNullOrWhiteSpace(uninstallString)) return null;
+        // Inno Setup uninstallers accept /VERYSILENT; only add it if not already present.
+        return uninstallString.Contains("/VERYSILENT", StringComparison.OrdinalIgnoreCase)
+            ? uninstallString
+            : uninstallString + " /VERYSILENT /NORESTART";
+    }
+
+    private static bool IsUnderProgramFiles(string path)
+    {
+        foreach (var v in new[] { "ProgramFiles", "ProgramFiles(x86)", "ProgramW6432" })
+        {
+            var pf = Environment.GetEnvironmentVariable(v);
+            if (!string.IsNullOrEmpty(pf)
+                && path.StartsWith(pf, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+
+    private static string? RegQuery(string args)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("reg.exe", "query " + args)
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            using var p = Process.Start(psi);
+            if (p is null) return null;
+            var stdout = p.StandardOutput.ReadToEnd();
+            p.WaitForExit(5000);
+            return stdout;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -3352,6 +3352,37 @@ public static class ZeusEndpoints
             return Results.Ok(new { quitting = true });
         });
 
+        // ---- Reset & Uninstall Zeus (About panel) ----------------------------
+        // Preview the exact paths the wipe will remove (+ warnings) and mint a
+        // one-shot confirm token. removeBinary asks for a full uninstall (app
+        // binary too); BinaryRemovalSupported reports whether that's achievable
+        // on this install (false → data-only fallback).
+        app.MapGet("/api/app/uninstall/preview",
+            (bool? removeBinary, Zeus.Server.Uninstall.UninstallService svc) =>
+                Results.Ok(svc.Preview(removeBinary ?? false)));
+
+        // One-click backup: prefs DB + all profiles + logbook + ADIF, streamed as
+        // a single zip the operator saves to ~/Downloads (which the wipe never
+        // touches) BEFORE uninstalling.
+        app.MapGet("/api/app/backup",
+            async (Zeus.Server.Uninstall.UninstallService svc, HttpContext ctx) =>
+            {
+                var (bytes, fileName) = await svc.BuildBackupAsync(ctx.RequestAborted);
+                return Results.File(bytes, "application/zip", fileName);
+            });
+
+        // Execute. Requires the one-shot token from the preview. Builds + validates
+        // the manifest fresh (fail-closed); on success launches the detached wipe
+        // and exits.
+        app.MapPost("/api/app/uninstall",
+            (UninstallRequest req, Zeus.Server.Uninstall.UninstallService svc) =>
+            {
+                var result = svc.Execute(req.Token, req.RemoveBinary);
+                if (!result.Started)
+                    return Results.BadRequest(new { error = result.Error, abortReasons = result.AbortReasons });
+                return Results.Ok(new { uninstalling = true });
+            }).DisableAntiforgery();
+
         app.MapGet("/api/qrz/status", (QrzService qrz) => qrz.GetStatus());
 
         app.MapPost("/api/qrz/login", async (QrzLoginRequest req, QrzService qrz, HttpContext ctx) =>

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -639,6 +639,9 @@ public static class ZeusHost
         // the active DB applies on the next launch, so the endpoint relaunches.
         builder.Services.AddSingleton<AppRestartService>();
 
+        // Full "Reset & Uninstall Zeus" flow (About panel).
+        builder.Services.AddSingleton<Zeus.Server.Uninstall.UninstallService>();
+
         // Self-diagnostic "Report a problem" feature: read-only probes, the
         // symptom→recipe registry, the known-issue rules (seeded from docs/rca +
         // docs/lessons), and the report builder. All strictly read-only — the

--- a/tests/Zeus.Server.Tests/UninstallManifestTests.cs
+++ b/tests/Zeus.Server.Tests/UninstallManifestTests.cs
@@ -44,7 +44,9 @@ public sealed class UninstallManifestTests
     {
         var os = HostOs();
         var home = Path.Combine(Path.GetTempPath(), "zeus-uatest-home-" + Guid.NewGuid().ToString("N"));
-        var exe = Path.Combine(Path.GetTempPath(), "zeus-uatest-app", os == OsKind.Windows ? "OpenhpsdrZeus.exe" : "OpenhpsdrZeus");
+        // Keep the exe UNDER home so the Windows next-to-exe webview cache
+        // (ProcessPath dir → EBWebView) stays within the home tree the test asserts.
+        var exe = Path.Combine(home, "app", os == OsKind.Windows ? "OpenhpsdrZeus.exe" : "OpenhpsdrZeus");
         return new FakeEnv
         {
             Os = os,

--- a/tests/Zeus.Server.Tests/UninstallManifestTests.cs
+++ b/tests/Zeus.Server.Tests/UninstallManifestTests.cs
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+
+using System.Runtime.InteropServices;
+using Zeus.Server.Uninstall;
+
+namespace Zeus.Server.Tests;
+
+// The safety case for the destructive "Reset & Uninstall" wipe. A destructive
+// feature is proven by showing it ABORTS or stays in-scope under hostile inputs,
+// never by actually deleting. Every test asserts either a fail-closed abort or
+// that all emitted paths are Zeus-owned, absolute, leaf-correct strict descendants
+// that are never the user home / a base root.
+//
+// Inputs use the HOST OS's path style (Path.* APIs are host-specific), so the
+// matrix is exercised per-platform by CI (macOS, Windows, Linux).
+public sealed class UninstallManifestTests
+{
+    private sealed class FakeEnv : IUninstallEnv
+    {
+        public OsKind Os { get; set; }
+        public string? Home { get; set; }
+        public string? LocalAppData { get; set; }
+        public string? RoamingAppData { get; set; }
+        public string? XdgDataHome { get; set; }
+        public string? ProcessPath { get; set; }
+        public string CurrentDirectory { get; set; } = Directory.GetCurrentDirectory();
+        private readonly Dictionary<string, string?> _env = new(StringComparer.Ordinal);
+        public string? GetEnv(string name) => _env.GetValueOrDefault(name);
+        public void SetEnv(string name, string? value) => _env[name] = value;
+        public HashSet<string> ReparsePoints { get; } = new(StringComparer.Ordinal);
+        public bool IsReparsePoint(string path) => ReparsePoints.Contains(path);
+    }
+
+    private static OsKind HostOs() => new SystemUninstallEnv().Os;
+
+    // A valid, host-appropriate environment rooted under a unique temp dir so
+    // every produced path is host-fully-qualified.
+    private static FakeEnv ValidEnv()
+    {
+        var os = HostOs();
+        var home = Path.Combine(Path.GetTempPath(), "zeus-uatest-home-" + Guid.NewGuid().ToString("N"));
+        var exe = Path.Combine(Path.GetTempPath(), "zeus-uatest-app", os == OsKind.Windows ? "OpenhpsdrZeus.exe" : "OpenhpsdrZeus");
+        return new FakeEnv
+        {
+            Os = os,
+            Home = home,
+            LocalAppData = os == OsKind.Windows ? Path.Combine(home, "AppData", "Local") : home,
+            RoamingAppData = os == OsKind.Windows ? Path.Combine(home, "AppData", "Roaming") : home,
+            XdgDataHome = null, // → ~/.local/share fallback (Linux)
+            ProcessPath = exe,
+        };
+    }
+
+    // ---- The CRITICAL guard: empty/unset base must NOT collapse to <cwd>/Zeus. ----
+
+    [Fact]
+    public void HomeUnset_AbortsEntireWipe()
+    {
+        var env = ValidEnv();
+        env.Home = null;
+        env.LocalAppData = HostOs() == OsKind.Windows ? null : null;
+        env.XdgDataHome = null;
+
+        var m = UninstallManifestBuilder.Build(env, removeBinary: false);
+
+        Assert.False(m.Ok);
+        Assert.NotEmpty(m.AbortReasons);
+        Assert.Empty(m.Paths); // nothing to delete when a base is missing
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void WhitespaceBase_Aborts(string blank)
+    {
+        var env = ValidEnv();
+        env.Home = blank;
+        env.LocalAppData = blank;
+        env.XdgDataHome = blank;
+
+        var m = UninstallManifestBuilder.Build(env, removeBinary: false);
+
+        Assert.False(m.Ok);
+        Assert.Empty(m.Paths);
+    }
+
+    [Fact]
+    public void RelativeBase_Aborts_AndNeverAnchorsToCwd()
+    {
+        var env = ValidEnv();
+        env.Home = "Zeus";          // relative — the exact GetFolderPath-returns-"" footgun
+        env.LocalAppData = "Zeus";
+        env.XdgDataHome = "zeus";
+
+        var m = UninstallManifestBuilder.Build(env, removeBinary: false);
+
+        Assert.False(m.Ok);
+        Assert.Empty(m.Paths);
+        // Belt: even if it had produced anything, none may sit under the CWD.
+        var cwd = Directory.GetCurrentDirectory();
+        Assert.DoesNotContain(m.Paths, p => p.Path.StartsWith(cwd, StringComparison.OrdinalIgnoreCase));
+    }
+
+    // ---- Valid env produces ONLY Zeus-owned, in-scope paths. ----
+
+    [Fact]
+    public void ValidEnv_ProducesZeusOwnedPaths_NoneEscapeHome()
+    {
+        var env = ValidEnv();
+
+        var m = UninstallManifestBuilder.Build(env, removeBinary: false);
+
+        Assert.True(m.Ok, string.Join(" | ", m.AbortReasons));
+        Assert.NotEmpty(m.Paths);
+
+        var home = Path.GetFullPath(env.Home!);
+        foreach (var p in m.Paths)
+        {
+            Assert.True(Path.IsPathFullyQualified(p.Path), $"not absolute: {p.Path}");
+            Assert.NotEqual(TrimSep(home), TrimSep(p.Path));      // never the home dir itself
+            Assert.NotEqual(TrimSep(p.Path), TrimSep(Path.GetPathRoot(p.Path) ?? "")); // never a root
+            // every emitted path is under the home tree (all our bases are)
+            Assert.StartsWith(home, p.Path, StringComparison.OrdinalIgnoreCase);
+        }
+
+        // The DataDir entry is always present with the exact "Zeus" leaf.
+        Assert.Contains(m.Paths, p => string.Equals(Path.GetFileName(TrimSep(p.Path)), "Zeus", StringComparison.Ordinal));
+    }
+
+    // ---- ZEUS_PREFS_PATH override outside DataDir → FILE entries only, never a dir. ----
+
+    [Fact]
+    public void PrefsPathOverride_OutsideDataDir_NeverDeletesTheDirectory()
+    {
+        var env = ValidEnv();
+        var sharedDir = Path.Combine(Path.GetTempPath(), "shared-prefs-" + Guid.NewGuid().ToString("N"));
+        env.SetEnv("ZEUS_PREFS_PATH", Path.Combine(sharedDir, "zeus-prefs.db"));
+
+        var m = UninstallManifestBuilder.Build(env, removeBinary: false);
+
+        Assert.True(m.Ok);
+        // The containing dir must NEVER be a delete target...
+        Assert.DoesNotContain(m.Paths, p => p.Kind == EntryKind.Directory
+            && TrimSep(p.Path).Equals(TrimSep(Path.GetFullPath(sharedDir)), StringComparison.OrdinalIgnoreCase));
+        // ...but the named DB files may be (as File entries).
+        Assert.Contains(m.Paths, p => p.Kind == EntryKind.File && p.Path.EndsWith("zeus-prefs.db", StringComparison.Ordinal));
+        Assert.NotEmpty(m.Warnings);
+    }
+
+    // ---- ZEUS_PLUGINS_PATH override → never recursively delete a shared dir. ----
+
+    [Fact]
+    public void PluginsPathOverride_IsNeverDeleted()
+    {
+        var env = ValidEnv();
+        var shared = Path.Combine(Path.GetTempPath(), "shared", "plugins");
+        env.SetEnv(Zeus.Plugins.Host.PluginRoot.EnvVar, shared);
+
+        var m = UninstallManifestBuilder.Build(env, removeBinary: false);
+
+        Assert.True(m.Ok);
+        Assert.DoesNotContain(m.Paths, p => p.Path.Contains(shared, StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(m.Warnings, w => w.Contains("ZEUS_PLUGINS_PATH", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void NewlineInOverridePath_IsRejected()
+    {
+        var env = ValidEnv();
+        env.SetEnv("ZEUS_PREFS_PATH", Path.Combine(Path.GetTempPath(), "ev\nil", "zeus-prefs.db"));
+
+        var m = UninstallManifestBuilder.Build(env, removeBinary: false);
+
+        // Essential entries still fine; the newline path is simply never emitted.
+        Assert.DoesNotContain(m.Paths, p => p.Path.Contains('\n'));
+    }
+
+    // ---- Recordings: only the subfolder, never the Downloads parent. ----
+
+    [Fact]
+    public void Recordings_OnlyTheSubfolder_NeverDownloadsItself()
+    {
+        var env = ValidEnv();
+        var downloads = Path.Combine(Path.GetFullPath(env.Home!), "Downloads");
+
+        var m = UninstallManifestBuilder.Build(env, removeBinary: false);
+
+        Assert.DoesNotContain(m.Paths, p => TrimSep(p.Path).Equals(TrimSep(downloads), StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(m.Paths, p => Path.GetFileName(TrimSep(p.Path)) == "Zeus Recordings");
+    }
+
+    // ---- Reparse-point entries are refused. ----
+
+    [Fact]
+    public void ReparsePointEntry_IsSkipped()
+    {
+        var env = ValidEnv();
+        // Mark the DataDir as a reparse point → essential entry fails → whole abort.
+        var dataDir = HostOs() switch
+        {
+            OsKind.Windows => Path.Combine(env.LocalAppData!, "Zeus"),
+            OsKind.MacOs => Path.Combine(env.Home!, "Library", "Application Support", "Zeus"),
+            _ => Path.Combine(env.Home!, ".local", "share", "Zeus"),
+        };
+        env.ReparsePoints.Add(Path.GetFullPath(dataDir));
+
+        var m = UninstallManifestBuilder.Build(env, removeBinary: false);
+
+        Assert.False(m.Ok); // DataDir is essential; a symlinked DataDir aborts the wipe
+    }
+
+    private static string TrimSep(string p) =>
+        p.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+}
+
+// Helper-generation safety: the detached executor must pass paths as DATA, never
+// interpolate them into the script, and use a bounded wait + liveness re-check.
+public sealed class UninstallExecutorTests
+{
+    private static UninstallManifest ValidManifest()
+    {
+        var p1 = Path.Combine(Path.GetTempPath(), "zeus-x", "Zeus");
+        var p2 = Path.Combine(Path.GetTempPath(), "zeus-x", "plugins");
+        return new UninstallManifest(
+            [new UninstallPath(p1, EntryKind.Directory), new UninstallPath(p2, EntryKind.Directory)],
+            [], null, false, [], []);
+    }
+
+    [Fact]
+    public void BuildPlan_PassesPathsAsData_NotInArgv()
+    {
+        var m = ValidManifest();
+        var plan = UninstallExecutor.BuildPlan(m, parentPid: 4242, dryRun: true);
+
+        // The shell binary + a FIXED script constant; nothing else (no path) in argv.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Assert.EndsWith("powershell.exe", plan.StartInfo.FileName);
+            Assert.Contains(UninstallExecutor.WindowsScript, plan.StartInfo.ArgumentList);
+        }
+        else
+        {
+            Assert.Equal("/bin/sh", plan.StartInfo.FileName);
+            Assert.Equal(["-c", UninstallExecutor.PosixScript], plan.StartInfo.ArgumentList);
+        }
+
+        // No delete path may appear anywhere in argv — they live only in the data file.
+        foreach (var arg in plan.StartInfo.ArgumentList)
+            foreach (var p in m.Paths)
+                Assert.DoesNotContain(p.Path, arg);
+
+        // Paths ARE present in the manifest bytes (NUL-delimited).
+        var data = System.Text.Encoding.UTF8.GetString(plan.ManifestBytes);
+        foreach (var p in m.Paths)
+            Assert.Contains(p.Path, data);
+
+        // Dynamic values travel via environment, not the script text.
+        Assert.Equal("4242", plan.StartInfo.Environment[UninstallExecutor.EnvPid]);
+        Assert.Equal(plan.ManifestPath, plan.StartInfo.Environment[UninstallExecutor.EnvManifest]);
+        Assert.Equal("1", plan.StartInfo.Environment[UninstallExecutor.EnvDryRun]);
+    }
+
+    [Fact]
+    public void Scripts_WaitBounded_AndReCheckLiveness()
+    {
+        // Both fixed scripts must bound the wait and ABORT if the parent is still
+        // alive after the loop (never fall through to deletion).
+        Assert.Contains("ABORT parent still alive", UninstallExecutor.PosixScript);
+        Assert.Contains("ABORT parent still alive", UninstallExecutor.WindowsScript);
+        Assert.Contains("240", UninstallExecutor.PosixScript);   // bounded loop
+        Assert.Contains("240", UninstallExecutor.WindowsScript);
+    }
+
+    [Fact]
+    public void BuildPlan_ThrowsOnAbortedManifest()
+    {
+        var aborted = UninstallManifest.Aborted("nope");
+        Assert.Throws<InvalidOperationException>(() => UninstallExecutor.BuildPlan(aborted, 1, false));
+    }
+}

--- a/zeus-web/src/api/uninstall.ts
+++ b/zeus-web/src/api/uninstall.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// Client for the "Reset & Uninstall Zeus" flow. The backend owns the entire
+// footprint and the safety validation; the client only previews, triggers the
+// one-click backup download, and confirms with the one-shot token.
+
+export interface UninstallPreview {
+  paths: string[];
+  warnings: string[];
+  abortReasons: string[];
+  canProceed: boolean;
+  binaryRemovalSupported: boolean;
+  confirmToken: string;
+}
+
+export async function getUninstallPreview(removeBinary: boolean): Promise<UninstallPreview> {
+  const res = await fetch(`/api/app/uninstall/preview?removeBinary=${removeBinary ? 'true' : 'false'}`);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return (await res.json()) as UninstallPreview;
+}
+
+// Trigger the backup zip download (prefs + profiles + logbook + ADIF). The
+// browser saves it to its Downloads folder — which the wipe never touches.
+export function downloadBackup(): void {
+  const a = document.createElement('a');
+  a.href = '/api/app/backup';
+  a.download = 'zeus-backup.zip';
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+}
+
+export async function executeUninstall(token: string, removeBinary: boolean): Promise<void> {
+  const res = await fetch('/api/app/uninstall', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ token, removeBinary }),
+  });
+  if (!res.ok) {
+    let msg = `HTTP ${res.status}`;
+    try {
+      const body = await res.json();
+      if (body?.error) msg = body.error as string;
+    } catch {
+      /* ignore */
+    }
+    throw new Error(msg);
+  }
+}

--- a/zeus-web/src/components/AboutPanel.tsx
+++ b/zeus-web/src/components/AboutPanel.tsx
@@ -21,6 +21,7 @@
 // Both are GPL-2.0-or-later.
 
 import { useEffect, useState } from 'react';
+import { UninstallDialog } from './UninstallDialog';
 
 // Release date for the version this build ships against. Bump whenever
 // VersionPrefix in Directory.Build.props bumps. ISO 8601 so toLocaleDateString
@@ -51,6 +52,7 @@ type VersionInfo = {
 export function AboutPanel() {
   const [versionInfo, setVersionInfo] = useState<VersionInfo>({ version: 'Loading...' });
   const [checking, setChecking] = useState(false);
+  const [showUninstall, setShowUninstall] = useState(false);
 
   useEffect(() => {
     // Fetch current version on mount
@@ -236,6 +238,29 @@ export function AboutPanel() {
           for source code and documentation.
         </p>
       </div>
+
+      {/* Danger zone — full reset / uninstall. Visual placement & copy are a
+          red-light item for Brian's/Doug's sign-off; the logic is server-owned
+          and safety-audited. */}
+      <div style={{ marginTop: 20, paddingTop: 16, borderTop: '1px solid var(--tx)' }}>
+        <div style={{ color: 'var(--tx)', fontSize: 11, fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', marginBottom: 8 }}>
+          Danger Zone
+        </div>
+        <p style={{ margin: '0 0 10px', lineHeight: 1.5, color: 'var(--fg-2)', fontSize: 12 }}>
+          Completely remove Zeus and wipe all of its data for a fresh install. You'll be asked
+          to confirm, and you can back up your settings and logbook first.
+        </p>
+        <button
+          type="button"
+          className="btn sm"
+          onClick={() => setShowUninstall(true)}
+          style={{ borderColor: 'var(--tx)', color: 'var(--tx)' }}
+        >
+          RESET &amp; UNINSTALL ZEUS…
+        </button>
+      </div>
+
+      {showUninstall && <UninstallDialog onClose={() => setShowUninstall(false)} />}
     </div>
   );
 }

--- a/zeus-web/src/components/UninstallDialog.tsx
+++ b/zeus-web/src/components/UninstallDialog.tsx
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// "Reset & Uninstall Zeus" confirm dialog. Offers an inline one-click backup
+// (to the browser's Downloads folder, which the wipe never touches), surfaces
+// exactly what will be removed, and gates the irreversible action behind a typed
+// confirmation when the operator skips the backup.
+
+import { useEffect, useState } from 'react';
+import {
+  downloadBackup,
+  executeUninstall,
+  getUninstallPreview,
+  type UninstallPreview,
+} from '../api/uninstall';
+import { useLoggerStore } from '../state/logger-store';
+
+const TX = 'var(--tx)';
+
+export function UninstallDialog({ onClose }: { onClose: () => void }) {
+  const [removeBinary, setRemoveBinary] = useState(true);
+  const [preview, setPreview] = useState<UninstallPreview | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [backedUp, setBackedUp] = useState(false);
+  const [confirmText, setConfirmText] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  const qsoCount = useLoggerStore((s) => s.totalCount);
+
+  useEffect(() => {
+    let cancelled = false;
+    setPreview(null);
+    setLoadError(null);
+    getUninstallPreview(removeBinary)
+      .then((p) => {
+        if (!cancelled) setPreview(p);
+      })
+      .catch((e) => {
+        if (!cancelled) setLoadError(e instanceof Error ? e.message : 'Failed to load uninstall preview');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [removeBinary]);
+
+  const confirmRequired = !backedUp;
+  const confirmOk = !confirmRequired || confirmText.trim().toUpperCase() === 'CONFIRM';
+  const canUninstall = !!preview?.canProceed && confirmOk && !busy;
+
+  const runUninstall = async () => {
+    if (!preview || !canUninstall) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await executeUninstall(preview.confirmToken, removeBinary);
+      setDone(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Uninstall failed');
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 1000,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'rgba(0,0,0,0.6)',
+      }}
+      onClick={busy ? undefined : onClose}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          width: 560,
+          maxWidth: '92vw',
+          maxHeight: '88vh',
+          overflowY: 'auto',
+          background: 'var(--panel-bot)',
+          border: `1px solid ${TX}`,
+          borderRadius: 'var(--r-md)',
+          padding: 20,
+          boxShadow: '0 12px 48px rgba(0,0,0,0.5)',
+        }}
+      >
+        {done ? (
+          <div style={{ textAlign: 'center', padding: '20px 0' }}>
+            <h3 style={{ color: TX, margin: '0 0 12px' }}>Uninstalling Zeus…</h3>
+            <p style={{ color: 'var(--fg-1)', lineHeight: 1.6 }}>
+              Zeus is shutting down and removing itself. This window will close on its own.
+              You can safely quit your browser.
+            </p>
+          </div>
+        ) : (
+          <>
+            <h3 style={{ color: TX, margin: '0 0 12px', letterSpacing: '0.08em', textTransform: 'uppercase', fontSize: 14 }}>
+              Reset &amp; Uninstall Zeus
+            </h3>
+
+            <p style={{ color: 'var(--fg-1)', lineHeight: 1.6, margin: '0 0 12px' }}>
+              This permanently deletes <strong>all Zeus data</strong> — every setting and profile,
+              your QSO logbook, calibration, plugins, caches, and certificates — for a clean slate.
+              <strong> This cannot be undone.</strong>
+            </p>
+
+            {/* Inline backup — saves to your Downloads folder, which is NOT wiped. */}
+            <div
+              style={{
+                border: '1px solid var(--panel-border)',
+                borderRadius: 'var(--r-sm)',
+                padding: 12,
+                marginBottom: 12,
+                background: 'rgba(74,158,255,0.06)',
+              }}
+            >
+              <div style={{ color: 'var(--fg-1)', marginBottom: 8, lineHeight: 1.5 }}>
+                Back up your settings, profiles, and logbook first. The file saves to your{' '}
+                <strong>Downloads</strong> folder (which this uninstall never touches).
+              </div>
+              <button
+                type="button"
+                className="btn sm"
+                onClick={() => {
+                  downloadBackup();
+                  setBackedUp(true);
+                }}
+              >
+                {backedUp ? '✓ BACKUP DOWNLOADED — DOWNLOAD AGAIN' : '⬇ BACK UP MY DATA'}
+              </button>
+            </div>
+
+            <label style={{ display: 'flex', alignItems: 'center', gap: 8, color: 'var(--fg-1)', marginBottom: 12, cursor: 'pointer' }}>
+              <input type="checkbox" checked={removeBinary} onChange={(e) => setRemoveBinary(e.target.checked)} />
+              Also remove the Zeus application itself (full uninstall)
+            </label>
+
+            {qsoCount > 0 && !backedUp && (
+              <div style={{ color: TX, marginBottom: 12, lineHeight: 1.5, fontWeight: 600 }}>
+                ⚠ This will permanently delete {qsoCount.toLocaleString()} logged QSO
+                {qsoCount === 1 ? '' : 's'}. Back up first, or they are gone forever.
+              </div>
+            )}
+
+            {preview?.warnings && preview.warnings.length > 0 && (
+              <ul style={{ color: 'var(--fg-2)', fontSize: 12, lineHeight: 1.5, margin: '0 0 12px', paddingLeft: 18 }}>
+                {preview.warnings.map((w, i) => (
+                  <li key={i}>{w}</li>
+                ))}
+              </ul>
+            )}
+
+            {preview && (
+              <details style={{ marginBottom: 12 }}>
+                <summary style={{ color: 'var(--fg-2)', fontSize: 12, cursor: 'pointer' }}>
+                  Show what will be removed ({preview.paths.length} location{preview.paths.length === 1 ? '' : 's'})
+                </summary>
+                <ul style={{ color: 'var(--fg-2)', fontSize: 11, lineHeight: 1.5, margin: '8px 0 0', paddingLeft: 18, fontFamily: 'monospace' }}>
+                  {preview.paths.map((p, i) => (
+                    <li key={i} style={{ wordBreak: 'break-all' }}>{p}</li>
+                  ))}
+                </ul>
+              </details>
+            )}
+
+            {loadError && <div style={{ color: TX, marginBottom: 12 }}>Could not load preview: {loadError}</div>}
+            {preview && !preview.canProceed && (
+              <div style={{ color: TX, marginBottom: 12 }}>
+                Uninstall is blocked by a safety check; nothing will be deleted.
+                {preview.abortReasons.map((r, i) => (
+                  <div key={i} style={{ fontSize: 12 }}>{r}</div>
+                ))}
+              </div>
+            )}
+
+            {confirmRequired && (
+              <div style={{ marginBottom: 12 }}>
+                <label style={{ color: 'var(--fg-1)', display: 'block', marginBottom: 6 }}>
+                  To proceed without a backup, type <strong>CONFIRM</strong>:
+                </label>
+                <input
+                  className="cs-input mono"
+                  value={confirmText}
+                  onChange={(e) => setConfirmText(e.target.value)}
+                  placeholder="CONFIRM"
+                  style={{ width: 160 }}
+                  autoFocus
+                />
+              </div>
+            )}
+
+            {error && <div style={{ color: TX, marginBottom: 12 }}>{error}</div>}
+
+            <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end', marginTop: 8 }}>
+              <button type="button" className="btn sm" onClick={onClose} disabled={busy}>
+                CANCEL
+              </button>
+              <button
+                type="button"
+                className="btn sm"
+                onClick={runUninstall}
+                disabled={!canUninstall}
+                style={{
+                  borderColor: TX,
+                  color: canUninstall ? '#fff' : 'var(--fg-3)',
+                  background: canUninstall ? TX : 'transparent',
+                }}
+              >
+                {busy ? 'UNINSTALLING…' : removeBinary ? 'UNINSTALL ZEUS' : 'WIPE ALL DATA'}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
KB2UKA-requested. A safe, complete uninstall in **About → Reset & Uninstall Zeus**, for when an operator needs a 100% fresh install.

## What it does
- Wipes every **Zeus-owned** location: prefs DB + **all profiles**, logbook, FFTW `wdspWisdom00`, certs, `nr3-models`, `freedv`, `hamclock`/`node`, `crash-dumps`, the **plugins root** (incl. Windows `%APPDATA%` Roaming + Linux lowercase `zeus`), `~/Downloads/Zeus Recordings`, webview caches, and the one app-owned WER registry key.
- **Proper uninstall (removes the app too)** when requested: Windows → invoke the installers **silent uninstaller** (cleans binary + registry + shortcuts + firewall); macOS → delete the `.app` bundle(s) (derived from the running process path); Linux → delete the AppImage. **Auto-falls back to data-only** + an on-screen "finish in Settings → Apps / drag to Trash" note when an elevated / Program-Files / non-resolvable install cant be removed by a non-elevated app.
- **Inline one-click backup**: prefs + all profiles + logbook + ADIF zipped to the browser **Downloads** folder (which the wipe never touches). Skipping it requires a typed **CONFIRM** with a QSO-loss count warning.

## Safety (this is the whole point — see the swarm audit that caught 2 criticals)
Server owns the entire footprint; the endpoint takes **no path from the client**. `UninstallManifestBuilder`:
- Re-derives every base **raw** and **aborts fail-closed** if any is empty/relative — kills the `HOME`-unset → `rm -rf <cwd>/Zeus` footgun (the zeus-agent/CI/cron case).
- Validates each entry by **expected-leaf + strict-descendant + reparse-point containment**; a leaf/base miss hard-aborts the *whole* wipe.
- **Refuses external `ZEUS_PREFS_PATH` / `ZEUS_PLUGINS_PATH`** (file-only at most, never a shared dir).
- Deletes only the `Zeus Recordings` **subfolder**, never `~/Downloads`.

Detached helper passes paths as **DATA** (NUL-delimited temp file + env vars; **fixed** sh/PowerShell script bodies) → a folder named with `$(…)`/backticks/quotes can neither glob nor execute (the shell-injection defect the audit found in the reused relaunch template). Bounded PID-wait on both platforms with a **post-wait liveness re-check that aborts** — never deletes a locked DB.

## Tests
Hostile-env unit matrix on the manifest builder (HOME unset, whitespace/relative bases, env overrides, newline paths, reparse points, recordings-subfolder-only) + helper-generation tests (paths-as-data not argv; bounded wait + liveness re-check). **14 new tests**, runs on all 3 platforms in CI.

## Gates
`dotnet build Zeus.slnx` clean · full backend suite **0 failures** · `npm run typecheck` + `npm run build` clean.

## Red-light / needs sign-off
- **Visual:** the "Danger Zone" button copy/placement needs Brians/Dougs sign-off (logic is green-light/server-owned).
- **Verify on bench:** desktop download-to-Downloads behavior in Photino; the Windows/Linux binary-removal paths (developed by audit, not bench-run on this Mac). A `dry-run` mode in the helper logs the exact delete set without deleting — recommend exercising it on the Windows/Linux test VMs before a real wipe.

## Known v1 residuals (documented, non-escape)
- Sidecar subprocess remnants possible on Windows only if HamClock/VST-engine were active (POSIX unlinks open files cleanly).
- The destructive endpoints sit on the same loopback/LAN surface as `/api/app/quit`; tightening to desktop-loopback-only is a possible follow-up.