### PR TITLE
DO NOT MERGE: Logging v2 (N1MM/Wavelog/Club Log) + HamClock DX-push

### DIFF
--- a/Zeus.Server.Hosting/CloudLog/CloudLogConfigStore.cs
+++ b/Zeus.Server.Hosting/CloudLog/CloudLogConfigStore.cs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using LiteDB;
+
+namespace Zeus.Server.CloudLog;
+
+// Non-secret config for the per-QSO HTTP cloud-log uploaders (Wavelog/Cloudlog
+// and Club Log realtime). These records live in Zeus.Server.Hosting (NOT
+// Zeus.Contracts) on purpose — they never cross the SignalR hub / StateDto wire,
+// only the /api/log/cloud/* REST endpoints and the frontend store consume them
+// as JSON. Keeping them out of Contracts avoids a red-light wire-format change.
+//
+// SECRETS DO NOT LIVE HERE. The Wavelog API key, Club Log application password
+// and Club Log API key go in the plaintext CredentialStore (service names
+// "wavelog-apikey" / "clublog-password" / "clublog-apikey"), exactly like the
+// QRZ key. This store holds only the non-secret, persistable settings.
+
+public sealed record CloudLogConfig(
+    WavelogConfig Wavelog,
+    ClubLogConfig ClubLog)
+{
+    public CloudLogConfig() : this(new WavelogConfig(), new ClubLogConfig()) { }
+}
+
+// Enabled defaults to false — new network egress is opt-in.
+public sealed record WavelogConfig(
+    bool Enabled = false,
+    string BaseUrl = "",
+    string StationProfileId = "");
+
+public sealed record ClubLogConfig(
+    bool Enabled = false,
+    string Email = "",
+    string Callsign = "");
+
+// Single-row LiteDB collection. Mirrors WsjtxConfigStore — same Connection=shared
+// pattern + Directory guard (no new exposure to the Linux LiteDB shared-mode
+// caveat, GH #682). Returns null when nothing is persisted so the caller falls
+// back to the default (egress OFF) config.
+public sealed class CloudLogConfigStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<CloudLogConfigEntry> _entries;
+    private readonly ILogger<CloudLogConfigStore> _log;
+    private readonly object _sync = new();
+
+    public CloudLogConfigStore(ILogger<CloudLogConfigStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _entries = _db.GetCollection<CloudLogConfigEntry>("cloudlog_config");
+
+        _log.LogInformation("CloudLogConfigStore initialized at {Path}", dbPath);
+    }
+
+    public CloudLogConfig? Get()
+    {
+        lock (_sync)
+        {
+            var e = _entries.FindAll().FirstOrDefault();
+            if (e is null) return null;
+            return new CloudLogConfig(
+                new WavelogConfig(
+                    Enabled: e.WavelogEnabled,
+                    BaseUrl: e.WavelogBaseUrl ?? "",
+                    StationProfileId: e.WavelogStationProfileId ?? ""),
+                new ClubLogConfig(
+                    Enabled: e.ClubLogEnabled,
+                    Email: e.ClubLogEmail ?? "",
+                    Callsign: e.ClubLogCallsign ?? ""));
+        }
+    }
+
+    public void Set(CloudLogConfig config)
+    {
+        lock (_sync)
+        {
+            var existing = _entries.FindAll().FirstOrDefault() ?? new CloudLogConfigEntry();
+            existing.WavelogEnabled = config.Wavelog.Enabled;
+            existing.WavelogBaseUrl = config.Wavelog.BaseUrl;
+            existing.WavelogStationProfileId = config.Wavelog.StationProfileId;
+            existing.ClubLogEnabled = config.ClubLog.Enabled;
+            existing.ClubLogEmail = config.ClubLog.Email;
+            existing.ClubLogCallsign = config.ClubLog.Callsign;
+            existing.UpdatedUtc = DateTime.UtcNow;
+            if (existing.Id == 0) _entries.Insert(existing);
+            else _entries.Update(existing);
+        }
+    }
+
+    public void Dispose() => _db.Dispose();
+}
+
+public sealed class CloudLogConfigEntry
+{
+    public int Id { get; set; }
+    public bool WavelogEnabled { get; set; }
+    public string? WavelogBaseUrl { get; set; }
+    public string? WavelogStationProfileId { get; set; }
+    public bool ClubLogEnabled { get; set; }
+    public string? ClubLogEmail { get; set; }
+    public string? ClubLogCallsign { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/CloudLog/CloudLogResult.cs
+++ b/Zeus.Server.Hosting/CloudLog/CloudLogResult.cs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+namespace Zeus.Server.CloudLog;
+
+/// <summary>
+/// Outcome of a single per-QSO cloud-log upload attempt.
+/// <para>
+/// <see cref="HardStop"/> is set only by Club Log on an HTTP 403 (auth failure):
+/// Club Log warns that repeated rejected auth can get the source IP blocked, so
+/// the publisher must stop sending and surface a warning rather than keep
+/// retrying. A normal failure (bad ADIF, network error, 500) is retryable and
+/// does NOT set HardStop.
+/// </para>
+/// </summary>
+public sealed record CloudLogResult(
+    string Provider,
+    bool Success,
+    bool HardStop,
+    string? RemoteId,
+    string? Message)
+{
+    public static CloudLogResult Ok(string provider, string? id = null, string? message = null) =>
+        new(provider, Success: true, HardStop: false, RemoteId: id, Message: message);
+
+    public static CloudLogResult Fail(string provider, string? message, bool hardStop = false) =>
+        new(provider, Success: false, HardStop: hardStop, RemoteId: null, Message: message);
+
+    public static CloudLogResult Skipped(string provider, string reason) =>
+        new(provider, Success: false, HardStop: false, RemoteId: null, Message: reason);
+}

--- a/Zeus.Server.Hosting/CloudLog/CloudLogService.cs
+++ b/Zeus.Server.Hosting/CloudLog/CloudLogService.cs
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using Zeus.Contracts;
+
+namespace Zeus.Server.CloudLog;
+
+/// <summary>
+/// Owns the live config + secrets for the HTTP cloud-log uploaders and fans a
+/// logged QSO out to every enabled provider. Like the WSJT-X broadcaster this is
+/// SEND-ONLY and applies config changes live (no listener, no restart).
+///
+/// Egress is OFF by default and additionally no-ops per provider when its
+/// credentials are missing. Each provider send is independent and failure
+/// tolerant — one provider failing (or a slow/blocked host) never blocks the
+/// operator's log confirmation or the other providers.
+/// </summary>
+public sealed class CloudLogService
+{
+    private readonly ILogger<CloudLogService> _log;
+    private readonly CloudLogConfigStore _store;
+    private readonly CredentialStore _creds;
+    private readonly WavelogClient _wavelog;
+    private readonly ClubLogClient _clubLog;
+    private readonly object _sync = new();
+    private CloudLogConfig _config;
+
+    public CloudLogService(
+        ILogger<CloudLogService> log,
+        CloudLogConfigStore store,
+        CredentialStore creds,
+        WavelogClient wavelog,
+        ClubLogClient clubLog)
+    {
+        _log = log;
+        _store = store;
+        _creds = creds;
+        _wavelog = wavelog;
+        _clubLog = clubLog;
+        _config = _store.Get() ?? new CloudLogConfig();
+    }
+
+    public CloudLogConfig GetConfig()
+    {
+        lock (_sync) return _config;
+    }
+
+    public async Task<CloudLogStatus> GetStatusAsync(CancellationToken ct = default)
+    {
+        var c = GetConfig();
+        bool wavelogKey = await HasCredAsync(WavelogClient.ServiceName, ct).ConfigureAwait(false);
+        bool clubLogPw = await HasCredAsync(ClubLogClient.PasswordServiceName, ct).ConfigureAwait(false);
+        bool clubLogApi = await HasCredAsync(ClubLogClient.ApiKeyServiceName, ct).ConfigureAwait(false);
+        return new CloudLogStatus(
+            Wavelog: new WavelogStatus(c.Wavelog.Enabled, c.Wavelog.BaseUrl, c.Wavelog.StationProfileId, wavelogKey),
+            ClubLog: new ClubLogStatus(c.ClubLog.Enabled, c.ClubLog.Email, c.ClubLog.Callsign, clubLogPw, clubLogApi));
+    }
+
+    public CloudLogConfig SetConfig(CloudLogConfig config)
+    {
+        var normalized = new CloudLogConfig(
+            new WavelogConfig(
+                Enabled: config.Wavelog.Enabled,
+                BaseUrl: (config.Wavelog.BaseUrl ?? "").Trim(),
+                StationProfileId: (config.Wavelog.StationProfileId ?? "").Trim()),
+            new ClubLogConfig(
+                Enabled: config.ClubLog.Enabled,
+                Email: (config.ClubLog.Email ?? "").Trim(),
+                Callsign: (config.ClubLog.Callsign ?? "").Trim().ToUpperInvariant()));
+
+        lock (_sync) _config = normalized;
+        try { _store.Set(normalized); }
+        catch (Exception ex) { _log.LogWarning(ex, "cloudlog.config.persist failed"); }
+
+        _log.LogInformation(
+            "cloudlog.config.updated wavelog={WlEn} clublog={ClEn}",
+            normalized.Wavelog.Enabled, normalized.ClubLog.Enabled);
+        return normalized;
+    }
+
+    public Task SetWavelogApiKeyAsync(string? apiKey, CancellationToken ct = default) =>
+        SetOrDeleteAsync(WavelogClient.ServiceName, "apikey", apiKey, ct);
+
+    public async Task SetClubLogCredentialsAsync(string? password, string? apiKey, CancellationToken ct = default)
+    {
+        var email = GetConfig().ClubLog.Email;
+        // Per-secret contract, matching the Wavelog path: a null field leaves
+        // that secret unchanged, an empty string clears it, a non-empty string
+        // replaces it. Club Log needs BOTH the application password and the API
+        // key, so a routine single-secret rotation must NOT clobber the other —
+        // guard each call independently rather than running both unconditionally.
+        if (password is not null)
+            await SetOrDeleteAsync(ClubLogClient.PasswordServiceName, email, password, ct).ConfigureAwait(false);
+        if (apiKey is not null)
+            await SetOrDeleteAsync(ClubLogClient.ApiKeyServiceName, email, apiKey, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>Fan a logged QSO out to every enabled provider. Never throws.
+    /// No-op when nothing is enabled.</summary>
+    public async Task PublishAsync(LogEntry entry, CancellationToken ct = default)
+    {
+        var cfg = GetConfig();
+        if (!cfg.Wavelog.Enabled && !cfg.ClubLog.Enabled) return;
+
+        // One ADIF record reused across providers (ends in <EOR>, which Club Log
+        // requires). Identical to the QRZ publish path.
+        string adif;
+        try { adif = QrzService.ConvertLogEntryToAdif(entry); }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "cloudlog.adif build failed call={Call}", entry.Callsign);
+            return;
+        }
+
+        var results = await PublishToAllAsync(cfg, adif, ct).ConfigureAwait(false);
+
+        // A Club Log 403 is a hard stop: disable it so we never keep hitting a
+        // forbidden auth and risk an IP block.
+        if (results.Any(r => r is { Provider: "clublog", HardStop: true }))
+        {
+            _log.LogWarning("cloudlog: disabling Club Log after a hard-stop (403) response");
+            SetConfig(cfg with { ClubLog = cfg.ClubLog with { Enabled = false } });
+        }
+
+        foreach (var r in results)
+            _log.LogInformation(
+                "cloudlog.publish provider={Provider} ok={Ok} call={Call} msg={Msg}",
+                r.Provider, r.Success, entry.Callsign, r.Message);
+    }
+
+    /// <summary>Publish a single entry on demand (batch endpoint). Same fan-out
+    /// as <see cref="PublishAsync"/> but returns the per-provider results.</summary>
+    public async Task<IReadOnlyList<CloudLogResult>> PublishOnceAsync(LogEntry entry, CancellationToken ct = default)
+    {
+        var cfg = GetConfig();
+        string adif;
+        try { adif = QrzService.ConvertLogEntryToAdif(entry); }
+        catch (Exception ex) { return new[] { CloudLogResult.Fail("cloudlog", ex.Message) }; }
+        return await PublishToAllAsync(cfg, adif, ct).ConfigureAwait(false);
+    }
+
+    private async Task<List<CloudLogResult>> PublishToAllAsync(
+        CloudLogConfig cfg, string adif, CancellationToken ct)
+    {
+        var results = new List<CloudLogResult>();
+
+        if (cfg.Wavelog.Enabled)
+        {
+            var key = await GetCredAsync(WavelogClient.ServiceName, ct).ConfigureAwait(false);
+            results.Add(await _wavelog.PublishAsync(cfg.Wavelog, key ?? "", adif, ct).ConfigureAwait(false));
+        }
+
+        if (cfg.ClubLog.Enabled)
+        {
+            var pw = await GetCredAsync(ClubLogClient.PasswordServiceName, ct).ConfigureAwait(false);
+            var api = await GetCredAsync(ClubLogClient.ApiKeyServiceName, ct).ConfigureAwait(false);
+            results.Add(await _clubLog.PublishAsync(cfg.ClubLog, pw ?? "", api ?? "", adif, ct).ConfigureAwait(false));
+        }
+
+        return results;
+    }
+
+    private async Task<string?> GetCredAsync(string service, CancellationToken ct)
+    {
+        var c = await _creds.GetAsync(service, ct).ConfigureAwait(false);
+        return string.IsNullOrWhiteSpace(c?.Password) ? null : c.Password;
+    }
+
+    private async Task<bool> HasCredAsync(string service, CancellationToken ct) =>
+        await GetCredAsync(service, ct).ConfigureAwait(false) is not null;
+
+    private async Task SetOrDeleteAsync(string service, string username, string? secret, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(secret))
+            await _creds.DeleteAsync(service, ct).ConfigureAwait(false);
+        else
+            await _creds.SetAsync(service, string.IsNullOrWhiteSpace(username) ? "secret" : username, secret, ct)
+                .ConfigureAwait(false);
+    }
+}
+
+// Status DTOs — server-side only (never on the SignalR/StateDto wire). Secrets
+// are reported as presence booleans, never echoed.
+public sealed record CloudLogStatus(WavelogStatus Wavelog, ClubLogStatus ClubLog);
+
+public sealed record WavelogStatus(bool Enabled, string BaseUrl, string StationProfileId, bool HasApiKey);
+
+public sealed record ClubLogStatus(bool Enabled, string Email, string Callsign, bool HasPassword, bool HasApiKey);
+
+// Write-only secret setter. Per-secret semantics applied uniformly across
+// Wavelog and both Club Log secrets: a null/omitted field leaves that secret
+// unchanged, an empty string clears it, a non-empty string replaces it. The
+// endpoint (see ZeusEndpoints) only calls a provider when at least one of its
+// fields is non-null; the service then guards each individual secret.
+public sealed record CloudLogCredentialsRequest(
+    string? WavelogApiKey = null,
+    string? ClubLogPassword = null,
+    string? ClubLogApiKey = null);

--- a/Zeus.Server.Hosting/CloudLog/ClubLogClient.cs
+++ b/Zeus.Server.Hosting/CloudLog/ClubLogClient.cs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using System.Net;
+
+namespace Zeus.Server.CloudLog;
+
+/// <summary>
+/// Per-QSO realtime uploader for Club Log. SEND-ONLY: POSTs exactly one ADIF
+/// record to the realtime endpoint and never reads the remote log back.
+///
+/// Wire contract (clublog.freshdesk.com art. 54906):
+///   POST https://clublog.org/realtime.php
+///   Content-Type: application/x-www-form-urlencoded
+///
+/// Host note: the legacy secure.clublog.org / www.clublog.org hosts were
+/// retired (DNS + certificates removed in December 2022). Per Club Log's
+/// "Using the right URLs" article (freshdesk art. 3000118796) the correct host
+/// for all web/iFrame/API requests — realtime.php included — is clublog.org.
+///   params: email (account email, NOT callsign), password (Club Log Application
+///           Password), callsign (target log — must belong to email), adif (ONE
+///           record ending in &lt;EOR&gt;), api (API key from the helpdesk).
+///
+/// Response mapping:
+///   200 "QSO OK" / "QSO Modified" / "QSO Duplicate"  -> success
+///   400 -> rejected (bad ADIF)            -> retryable failure
+///   403 -> auth failure                   -> HARD STOP (IP-block risk; stop sending)
+///   500 -> server error                   -> retryable failure
+///
+/// This endpoint is throttled and realtime-only. NEVER loop putlogs.php batch
+/// uploads through here.
+/// </summary>
+public sealed class ClubLogClient
+{
+    public const string PasswordServiceName = "clublog-password";
+    public const string ApiKeyServiceName = "clublog-apikey";
+    public const string RealtimeUrl = "https://clublog.org/realtime.php";
+
+    private readonly HttpClient _http;
+    private readonly ILogger<ClubLogClient> _log;
+
+    public ClubLogClient(IHttpClientFactory httpClientFactory, ILogger<ClubLogClient> log)
+    {
+        _http = httpClientFactory.CreateClient("ClubLog");
+        _log = log;
+    }
+
+    public async Task<CloudLogResult> PublishAsync(
+        ClubLogConfig cfg, string password, string apiKey, string adifRecord,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(cfg.Email))
+            return CloudLogResult.Skipped("clublog", "account email not configured");
+        if (string.IsNullOrWhiteSpace(cfg.Callsign))
+            return CloudLogResult.Skipped("clublog", "callsign not configured");
+        if (string.IsNullOrWhiteSpace(password))
+            return CloudLogResult.Skipped("clublog", "application password not configured");
+        if (string.IsNullOrWhiteSpace(apiKey))
+            return CloudLogResult.Skipped("clublog", "API key not configured");
+
+        var form = new FormUrlEncodedContent(new[]
+        {
+            new KeyValuePair<string, string>("email", cfg.Email.Trim()),
+            new KeyValuePair<string, string>("password", password),
+            new KeyValuePair<string, string>("callsign", cfg.Callsign.Trim().ToUpperInvariant()),
+            new KeyValuePair<string, string>("adif", adifRecord),
+            new KeyValuePair<string, string>("api", apiKey),
+        });
+
+        try
+        {
+            using var resp = await _http.PostAsync(RealtimeUrl, form, ct).ConfigureAwait(false);
+            var body = (await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false)).Trim();
+            return MapResponse(resp.StatusCode, body);
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "clublog publish failed");
+            return CloudLogResult.Fail("clublog", ex.Message);
+        }
+    }
+
+    internal CloudLogResult MapResponse(HttpStatusCode status, string body)
+    {
+        switch ((int)status)
+        {
+            case 200:
+                // "QSO OK" / "QSO Modified" / "QSO Duplicate" — all success.
+                return CloudLogResult.Ok("clublog", id: null,
+                    message: string.IsNullOrWhiteSpace(body) ? "QSO accepted" : body);
+            case 403:
+                _log.LogWarning(
+                    "clublog 403 forbidden (auth fail) — disabling to avoid IP block: {Body}", body);
+                return CloudLogResult.Fail("clublog",
+                    $"authentication failed (403): {body} — Club Log disabled to avoid an IP block; check email/password/API key.",
+                    hardStop: true);
+            case 400:
+                return CloudLogResult.Fail("clublog", $"rejected (400): {body}");
+            default:
+                // 500 and anything else — retryable, do not hard-stop.
+                return CloudLogResult.Fail("clublog", $"HTTP {(int)status}: {body}");
+        }
+    }
+}

--- a/Zeus.Server.Hosting/CloudLog/WavelogClient.cs
+++ b/Zeus.Server.Hosting/CloudLog/WavelogClient.cs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+
+namespace Zeus.Server.CloudLog;
+
+/// <summary>
+/// Per-QSO realtime uploader for Wavelog and Cloudlog (Wavelog is the Cloudlog
+/// fork — one wire shape covers both). SEND-ONLY: it POSTs a single ADIF record
+/// to {baseUrl}/api/qso and never reads the remote log back.
+///
+/// Wire contract (docs.wavelog.org / magicbug Cloudlog wiki, verified June 2026):
+///   POST {baseUrl}/api/qso
+///   Content-Type: application/json, Accept: application/json
+///   body: {"key":"&lt;api key&gt;","station_profile_id":"&lt;int&gt;",
+///          "type":"adif","string":"&lt;one ADIF record&gt;"}
+///   On 404 retry ONCE at {baseUrl}/index.php/api/qso (installs without URL
+///   rewriting expose the front controller path). The server dupe-checks on the
+///   fly; API submissions never re-post to QRZ or do a callbook lookup.
+///
+/// Stateless and side-effect-free apart from the HTTP call, so it unit-tests
+/// cleanly behind a fake <see cref="HttpMessageHandler"/>.
+/// </summary>
+public sealed class WavelogClient
+{
+    public const string ServiceName = "wavelog-apikey";
+
+    private readonly HttpClient _http;
+    private readonly ILogger<WavelogClient> _log;
+
+    public WavelogClient(IHttpClientFactory httpClientFactory, ILogger<WavelogClient> log)
+    {
+        _http = httpClientFactory.CreateClient("Wavelog");
+        _log = log;
+    }
+
+    public async Task<CloudLogResult> PublishAsync(
+        WavelogConfig cfg, string apiKey, string adifRecord, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(cfg.BaseUrl))
+            return CloudLogResult.Skipped("wavelog", "base URL not configured");
+        if (string.IsNullOrWhiteSpace(apiKey))
+            return CloudLogResult.Skipped("wavelog", "API key not configured");
+        if (string.IsNullOrWhiteSpace(cfg.StationProfileId))
+            return CloudLogResult.Skipped("wavelog", "station profile id not configured");
+
+        var payload = JsonSerializer.Serialize(new Dictionary<string, string>
+        {
+            ["key"] = apiKey,
+            ["station_profile_id"] = cfg.StationProfileId.Trim(),
+            ["type"] = "adif",
+            ["string"] = adifRecord,
+        });
+
+        var primary = BuildQsoUrl(cfg.BaseUrl, indexPhp: false);
+        try
+        {
+            var (status, body) = await PostAsync(primary, payload, ct).ConfigureAwait(false);
+
+            // Some installs only expose the front controller — retry once via index.php.
+            if (status == HttpStatusCode.NotFound)
+            {
+                var fallback = BuildQsoUrl(cfg.BaseUrl, indexPhp: true);
+                _log.LogDebug("wavelog 404 at {Url}, retrying {Fallback}", primary, fallback);
+                (status, body) = await PostAsync(fallback, payload, ct).ConfigureAwait(false);
+            }
+
+            return MapResponse(status, body);
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "wavelog publish failed");
+            return CloudLogResult.Fail("wavelog", ex.Message);
+        }
+    }
+
+    private async Task<(HttpStatusCode Status, string Body)> PostAsync(
+        string url, string json, CancellationToken ct)
+    {
+        using var req = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+        req.Headers.Accept.ParseAdd("application/json");
+        using var resp = await _http.SendAsync(req, ct).ConfigureAwait(false);
+        var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        return (resp.StatusCode, body);
+    }
+
+    private CloudLogResult MapResponse(HttpStatusCode status, string body)
+    {
+        // Wavelog returns 200 with a JSON object on success (the imported record)
+        // and a JSON object carrying error/messages on failure. Be lenient: treat
+        // a 2xx without an explicit error as success, and parse an "id" when present.
+        if ((int)status is >= 200 and < 300)
+        {
+            string? id = null;
+            string? message = null;
+            try
+            {
+                using var doc = JsonDocument.Parse(string.IsNullOrWhiteSpace(body) ? "{}" : body);
+                var root = doc.RootElement;
+                if (root.ValueKind == JsonValueKind.Object)
+                {
+                    if (root.TryGetProperty("adif_count", out var c)) id = c.ToString();
+                    if (root.TryGetProperty("id", out var idEl)) id = idEl.ToString();
+                    if (root.TryGetProperty("messages", out var m)) message = m.ToString();
+                    if (root.TryGetProperty("reason", out var r)) message = r.ToString();
+                    if (root.TryGetProperty("status", out var st) &&
+                        st.ValueKind == JsonValueKind.String &&
+                        string.Equals(st.GetString(), "failed", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return CloudLogResult.Fail("wavelog", message ?? "rejected by server");
+                    }
+                }
+            }
+            catch (JsonException)
+            {
+                // Non-JSON 2xx body — still treat as success (older Cloudlog builds
+                // return a bare string).
+            }
+            return CloudLogResult.Ok("wavelog", id, message ?? "QSO uploaded");
+        }
+
+        return CloudLogResult.Fail("wavelog", $"HTTP {(int)status}: {Truncate(body)}");
+    }
+
+    // Joins baseUrl + the api path without doubling slashes; optional index.php
+    // front-controller segment for installs without URL rewriting.
+    internal static string BuildQsoUrl(string baseUrl, bool indexPhp)
+    {
+        var b = baseUrl.Trim().TrimEnd('/');
+        return indexPhp ? $"{b}/index.php/api/qso" : $"{b}/api/qso";
+    }
+
+    private static string Truncate(string s) =>
+        string.IsNullOrEmpty(s) ? "" : (s.Length <= 200 ? s : s[..200]);
+}

--- a/Zeus.Server.Hosting/HamClockPushConfigStore.cs
+++ b/Zeus.Server.Hosting/HamClockPushConfigStore.cs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using LiteDB;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Live config + persistence for the outbound "push worked station to HamClock"
+/// feature. SEND-ONLY (HamClockService only issues an HTTP GET out); egress is
+/// OFF by default. Config applies live (no listener, no restart).
+///
+/// Server-side DTOs only — these never cross the SignalR/StateDto wire, only the
+/// /api/hamclock/push-config + /api/hamclock/dx REST endpoints and the frontend
+/// store consume them as JSON (keeps a Zeus.Contracts wire change off the table).
+/// </summary>
+public sealed class HamClockPushManagementService
+{
+    private readonly ILogger<HamClockPushManagementService> _log;
+    private readonly HamClockPushConfigStore _store;
+    private readonly object _sync = new();
+    private HamClockPushConfig _config;
+
+    public HamClockPushManagementService(ILogger<HamClockPushManagementService> log, HamClockPushConfigStore store)
+    {
+        _log = log;
+        _store = store;
+        _config = _store.Get() ?? new HamClockPushConfig();
+    }
+
+    public HamClockPushConfig GetConfig()
+    {
+        lock (_sync) return _config;
+    }
+
+    public HamClockPushConfig SetConfig(HamClockPushConfig config)
+    {
+        var trigger = config.Trigger?.Trim().ToLowerInvariant() switch
+        {
+            "on-active-qso" => "on-active-QSO",
+            _ => "on-click",
+        };
+        var target = string.Equals(config.Target?.Trim(), "bundled", StringComparison.OrdinalIgnoreCase)
+            ? "bundled"
+            : "external";
+
+        var normalized = new HamClockPushConfig(
+            Enabled: config.Enabled,
+            Trigger: trigger,
+            Target: target,
+            ExternalHost: (config.ExternalHost ?? "").Trim(),
+            ExternalPort: config.ExternalPort is > 0 and < 65536 ? config.ExternalPort : 8080);
+
+        lock (_sync) _config = normalized;
+        try { _store.Set(normalized); }
+        catch (Exception ex) { _log.LogWarning(ex, "hamclock.push.config.persist failed"); }
+
+        _log.LogInformation(
+            "hamclock.push.config.updated enabled={En} trigger={Tr} target={Tg} host={Host} port={Port}",
+            normalized.Enabled, normalized.Trigger, normalized.Target, normalized.ExternalHost, normalized.ExternalPort);
+        return normalized;
+    }
+}
+
+// POST body for /api/hamclock/dx. Grid is the worked station's Maidenhead
+// locator (required for a push — classic HamClock sets DX by grid, not call).
+// Call is accepted for logging context only.
+public sealed record HamClockDxRequest(string? Grid = null, string? Call = null);
+
+public sealed record HamClockPushConfig(
+    bool Enabled = false,
+    string Trigger = "on-click",        // "on-click" | "on-active-QSO"
+    string Target = "external",         // "external" | "bundled" (bundled unsupported today)
+    string ExternalHost = "",
+    int ExternalPort = 8080);           // classic HamClock REST default port
+
+// Single-row LiteDB collection (Connection=shared + Directory guard, GH #682).
+public sealed class HamClockPushConfigStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<HamClockPushConfigEntry> _entries;
+    private readonly object _sync = new();
+
+    public HamClockPushConfigStore(ILogger<HamClockPushConfigStore> log, string? dbPathOverride = null)
+    {
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _entries = _db.GetCollection<HamClockPushConfigEntry>("hamclock_push_config");
+        log.LogInformation("HamClockPushConfigStore initialized at {Path}", dbPath);
+    }
+
+    public HamClockPushConfig? Get()
+    {
+        lock (_sync)
+        {
+            var e = _entries.FindAll().FirstOrDefault();
+            if (e is null) return null;
+            return new HamClockPushConfig(
+                Enabled: e.Enabled,
+                Trigger: string.IsNullOrWhiteSpace(e.Trigger) ? "on-click" : e.Trigger,
+                Target: string.IsNullOrWhiteSpace(e.Target) ? "external" : e.Target,
+                ExternalHost: e.ExternalHost ?? "",
+                ExternalPort: e.ExternalPort is > 0 and < 65536 ? e.ExternalPort : 8080);
+        }
+    }
+
+    public void Set(HamClockPushConfig config)
+    {
+        lock (_sync)
+        {
+            var existing = _entries.FindAll().FirstOrDefault() ?? new HamClockPushConfigEntry();
+            existing.Enabled = config.Enabled;
+            existing.Trigger = config.Trigger;
+            existing.Target = config.Target;
+            existing.ExternalHost = config.ExternalHost;
+            existing.ExternalPort = config.ExternalPort;
+            existing.UpdatedUtc = DateTime.UtcNow;
+            if (existing.Id == 0) _entries.Insert(existing);
+            else _entries.Update(existing);
+        }
+    }
+
+    public void Dispose() => _db.Dispose();
+}
+
+public sealed class HamClockPushConfigEntry
+{
+    public int Id { get; set; }
+    public bool Enabled { get; set; }
+    public string Trigger { get; set; } = "on-click";
+    public string Target { get; set; } = "external";
+    public string? ExternalHost { get; set; }
+    public int ExternalPort { get; set; } = 8080;
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/HamClockService.cs
+++ b/Zeus.Server.Hosting/HamClockService.cs
@@ -200,6 +200,104 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
         }
     }
 
+    // -- DX push (outbound "set the worked station on the map") ----------
+
+    // Short-timeout client for the DX-push GET — distinct from the 10-minute
+    // download client. A push must never stall the FT8 UI, so we cap it tight and
+    // swallow every failure.
+    private static readonly HttpClient PushHttp = new() { Timeout = TimeSpan.FromSeconds(4) };
+
+    /// <summary>
+    /// Push a worked station's grid to HamClock's map as the new DX location.
+    /// SEND-ONLY: issues a single HTTP GET to the classic-HamClock REST surface
+    /// (<c>set_newdx?grid=...</c>) and never reads anything back; it cannot key TX.
+    /// Never throws — returns false on any skip/failure.
+    /// </summary>
+    /// <param name="grid">4- or 6-char Maidenhead locator. Required: classic
+    /// HamClock's set_newdx sets the DX by grid (or lat/long); there is no
+    /// set-DX-by-callsign, so a null/invalid grid is a no-op.</param>
+    /// <param name="target">"external" (a classic HamClock at host:port) or
+    /// "bundled" (the OpenHamClock sidecar — NOT supported today; no-op).</param>
+    public async Task<bool> PushDxAsync(
+        string? grid, string target, string externalHost, int externalPort, CancellationToken ct = default)
+    {
+        if (!TryNormalizeGrid(grid, out var locator))
+        {
+            _log.LogDebug("hamclock.dx skipped: no valid grid ({Grid})", grid);
+            return false;
+        }
+
+        // The bundled accius/openhamclock sidecar has no set-DX endpoint yet, so a
+        // real push only works against an external classic HamClock. Gate the
+        // bundled path as a logged no-op until an upstream OpenHamClock PR lands.
+        if (string.Equals(target, "bundled", StringComparison.OrdinalIgnoreCase))
+        {
+            _log.LogInformation(
+                "hamclock.dx: bundled OpenHamClock has no set-DX endpoint; push not supported " +
+                "(use an external classic HamClock, or await an upstream OpenHamClock PR). grid={Grid}",
+                locator);
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(externalHost))
+        {
+            _log.LogDebug("hamclock.dx skipped: external host not configured");
+            return false;
+        }
+
+        var url = BuildSetDxUrl(externalHost, externalPort, locator);
+        try
+        {
+            using var resp = await PushHttp.GetAsync(url, ct).ConfigureAwait(false);
+            if (resp.IsSuccessStatusCode)
+            {
+                _log.LogInformation("hamclock.dx pushed grid={Grid} -> {Url}", locator, url);
+                return true;
+            }
+            _log.LogWarning("hamclock.dx push HTTP {Code} -> {Url}", (int)resp.StatusCode, url);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "hamclock.dx push failed -> {Url}", url);
+            return false;
+        }
+    }
+
+    /// <summary>Build the classic-HamClock set-DX REST URL. The grid is passed as
+    /// a named <c>grid=</c> query parameter per the HamClock API
+    /// (tardate/ESPHamClock doc/api.md, verified June 2026) — NOT a bare arg.</summary>
+    internal static string BuildSetDxUrl(string host, int port, string grid)
+        => $"http://{host.Trim()}:{port}/set_newdx?grid={Uri.EscapeDataString(grid)}";
+
+    /// <summary>Validate + normalize a Maidenhead locator to 4 or 6 chars
+    /// (field pair A-R, square 0-9, optional subsquare a-x). Returns false for
+    /// null/empty/malformed grids.</summary>
+    internal static bool TryNormalizeGrid(string? grid, out string normalized)
+    {
+        normalized = "";
+        if (string.IsNullOrWhiteSpace(grid)) return false;
+        var g = grid.Trim();
+        if (g.Length != 4 && g.Length != 6) return false;
+
+        // Canonical Maidenhead casing: field upper, subsquare lower.
+        char f1 = char.ToUpperInvariant(g[0]), f2 = char.ToUpperInvariant(g[1]);
+        char s1 = g[2], s2 = g[3];
+        if (f1 is < 'A' or > 'R' || f2 is < 'A' or > 'R') return false;   // field A-R
+        if (s1 is < '0' or > '9' || s2 is < '0' or > '9') return false;   // square 0-9
+
+        if (g.Length == 4)
+        {
+            normalized = $"{f1}{f2}{s1}{s2}";
+            return true;
+        }
+
+        char u1 = char.ToLowerInvariant(g[4]), u2 = char.ToLowerInvariant(g[5]);
+        if (u1 is < 'a' or > 'x' || u2 is < 'a' or > 'x') return false;   // subsquare a-x
+        normalized = $"{f1}{f2}{s1}{s2}{u1}{u2}";
+        return true;
+    }
+
     public HamClockStatus Snapshot()
     {
         // Probe Node outside _gate (it may spawn `node --version`) and cache it.

--- a/Zeus.Server.Hosting/Wsjtx/N1mmBroadcaster.cs
+++ b/Zeus.Server.Hosting/Wsjtx/N1mmBroadcaster.cs
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using System.Net.Sockets;
+using LiteDB;
+using Zeus.Contracts;
+
+namespace Zeus.Server.Wsjtx;
+
+/// <summary>
+/// Sends the N1MM Logger+ "contactinfo" datagram (see
+/// <see cref="N1mmContactInfoEncoder"/>) to a logger that listens for the N1MM
+/// external-broadcast format — HRD Logbook "QSO Forwarding" or DXKeeper via the
+/// N1MM→DXKeeper Gateway. SEPARATE from the WSJT-X type-12 broadcaster: a
+/// different wire format on its own configurable port (default 2333).
+///
+/// SEND-ONLY, no listener; no-op when disabled (the default). Pure
+/// <see cref="UdpClient"/>, cross-platform, no native deps. Mirrors
+/// <see cref="WsjtxUdpBroadcaster"/>: one cached send socket, sends serialised
+/// through a gate, never throws to the caller (a send failure must not break the
+/// log POST).
+/// </summary>
+public sealed class N1mmBroadcaster : IDisposable
+{
+    private readonly ILogger<N1mmBroadcaster> _log;
+    private readonly N1mmConfigStore _store;
+    private readonly SpottingManagementService? _operator;
+    private readonly SemaphoreSlim _sendGate = new(1, 1);
+    private readonly object _sync = new();
+    private N1mmConfig _config;
+    private UdpClient? _udp;
+    private bool _disposed;
+
+    public N1mmBroadcaster(
+        ILogger<N1mmBroadcaster> log,
+        N1mmConfigStore store,
+        SpottingManagementService? operatorIdentity = null)
+    {
+        _log = log;
+        _store = store;
+        _operator = operatorIdentity;
+        _config = _store.Get() ?? new N1mmConfig();
+    }
+
+    public N1mmConfig GetConfig()
+    {
+        lock (_sync) return _config;
+    }
+
+    public N1mmConfig SetConfig(N1mmConfig config)
+    {
+        var normalized = new N1mmConfig(
+            Enabled: config.Enabled,
+            Host: string.IsNullOrWhiteSpace(config.Host) ? "127.0.0.1" : config.Host.Trim(),
+            Port: config.Port is > 0 and < 65536 ? config.Port : 2333);
+
+        lock (_sync) _config = normalized;
+        try { _store.Set(normalized); }
+        catch (Exception ex) { _log.LogWarning(ex, "n1mm.config.persist failed"); }
+
+        _log.LogInformation(
+            "n1mm.config.updated enabled={Enabled} host={Host} port={Port}",
+            normalized.Enabled, normalized.Host, normalized.Port);
+        return normalized;
+    }
+
+    /// <summary>Broadcast one logged QSO as an N1MM contactinfo datagram. No-op
+    /// when disabled; never throws.</summary>
+    public async Task BroadcastLoggedQsoAsync(LogEntry entry, CancellationToken ct = default)
+    {
+        var cfg = GetConfig();
+        if (!cfg.Enabled) return;
+
+        try
+        {
+            var (myCall, _) = _operator?.ResolveOperator() ?? ("", "");
+            var datagram = N1mmContactInfoEncoder.Encode(entry, myCall);
+            await SendAsync(cfg, datagram, ct).ConfigureAwait(false);
+            _log.LogInformation(
+                "n1mm.broadcast call={Call} -> {Host}:{Port} bytes={Bytes}",
+                entry.Callsign, cfg.Host, cfg.Port, datagram.Length);
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "n1mm.broadcast failed call={Call}", entry.Callsign);
+        }
+    }
+
+    private async Task SendAsync(N1mmConfig cfg, byte[] datagram, CancellationToken ct)
+    {
+        await _sendGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var udp = _udp ??= new UdpClient();
+            await udp.SendAsync(datagram, datagram.Length, cfg.Host, cfg.Port)
+                .WaitAsync(TimeSpan.FromSeconds(5), ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _sendGate.Release();
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _udp?.Dispose();
+        _sendGate.Dispose();
+    }
+}
+
+// Server-side config (NOT Zeus.Contracts — never crosses the hub wire).
+public sealed record N1mmConfig(
+    bool Enabled = false,
+    string Host = "127.0.0.1",
+    int Port = 2333);
+
+// Single-row LiteDB collection. Same Connection=shared pattern + Directory guard
+// as WsjtxConfigStore (GH #682 caveat).
+public sealed class N1mmConfigStore : IDisposable
+{
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<N1mmConfigEntry> _entries;
+    private readonly object _sync = new();
+
+    public N1mmConfigStore(ILogger<N1mmConfigStore> log, string? dbPathOverride = null)
+    {
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _db = new LiteDatabase($"Filename={dbPath};Connection=shared");
+        _entries = _db.GetCollection<N1mmConfigEntry>("n1mm_config");
+        log.LogInformation("N1mmConfigStore initialized at {Path}", dbPath);
+    }
+
+    public N1mmConfig? Get()
+    {
+        lock (_sync)
+        {
+            var e = _entries.FindAll().FirstOrDefault();
+            if (e is null) return null;
+            return new N1mmConfig(
+                Enabled: e.Enabled,
+                Host: string.IsNullOrWhiteSpace(e.Host) ? "127.0.0.1" : e.Host,
+                Port: e.Port is > 0 and < 65536 ? e.Port : 2333);
+        }
+    }
+
+    public void Set(N1mmConfig config)
+    {
+        lock (_sync)
+        {
+            var existing = _entries.FindAll().FirstOrDefault() ?? new N1mmConfigEntry();
+            existing.Enabled = config.Enabled;
+            existing.Host = config.Host;
+            existing.Port = config.Port;
+            existing.UpdatedUtc = DateTime.UtcNow;
+            if (existing.Id == 0) _entries.Insert(existing);
+            else _entries.Update(existing);
+        }
+    }
+
+    public void Dispose() => _db.Dispose();
+}
+
+public sealed class N1mmConfigEntry
+{
+    public int Id { get; set; }
+    public bool Enabled { get; set; }
+    public string Host { get; set; } = "127.0.0.1";
+    public int Port { get; set; } = 2333;
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/Wsjtx/N1mmContactInfoEncoder.cs
+++ b/Zeus.Server.Hosting/Wsjtx/N1mmContactInfoEncoder.cs
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using System.Globalization;
+using System.Security;
+using System.Text;
+using Zeus.Contracts;
+
+namespace Zeus.Server.Wsjtx;
+
+/// <summary>
+/// Builds the N1MM Logger+ "contactinfo" UDP datagram (XML) so loggers that
+/// listen for the N1MM external-broadcast format — HRD Logbook "QSO Forwarding",
+/// DXKeeper via the N1MM→DXKeeper Gateway — pick up Zeus's logged QSOs. This is
+/// a DIFFERENT wire format from the WSJT-X type-12 LoggedADIF datagram (those
+/// consumers do not parse the WSJT-X binary format).
+///
+/// Field order and the <c>rxfreq</c>/<c>txfreq</c> units (tens of Hz — i.e.
+/// frequency in Hz divided by 10) follow the N1MM External UDP Broadcasts spec
+/// (n1mmwp.hamdocs.com/appendices/external-udp-broadcasts, verified June 2026).
+/// The full element set is emitted in order; fields Zeus does not have are left
+/// empty so position/tag-indexed parsers still line up.
+///
+/// SEND-ONLY: this only produces a byte[]; it never opens a socket and never
+/// triggers TX.
+/// </summary>
+public static class N1mmContactInfoEncoder
+{
+    /// <summary>Encode one logged QSO. <paramref name="myCall"/> is the operator
+    /// station call (may be empty if unresolved).</summary>
+    public static byte[] Encode(LogEntry entry, string myCall)
+        => Encoding.UTF8.GetBytes(EncodeXml(entry, myCall));
+
+    internal static string EncodeXml(LogEntry entry, string myCall)
+    {
+        // rxfreq / txfreq in tens of Hz. We log a single QSO frequency, so RX==TX.
+        long freqTensHz = 0;
+        if (entry.FrequencyMhz is { } mhz && mhz > 0)
+            freqTensHz = (long)Math.Round(mhz * 100_000.0); // MHz -> tens of Hz (×1e6/10)
+
+        var sb = new StringBuilder(1024);
+        sb.Append("<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n");
+        sb.Append("<contactinfo>");
+        Tag(sb, "app", "Zeus");
+        Tag(sb, "contestname", "");
+        Tag(sb, "contestnr", "1");
+        Tag(sb, "timestamp", entry.QsoDateTimeUtc.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture));
+        Tag(sb, "mycall", myCall);
+        Tag(sb, "band", NormalizeBand(entry.Band, entry.FrequencyMhz));
+        Tag(sb, "rxfreq", freqTensHz.ToString(CultureInfo.InvariantCulture));
+        Tag(sb, "txfreq", freqTensHz.ToString(CultureInfo.InvariantCulture));
+        Tag(sb, "operator", myCall);
+        Tag(sb, "mode", entry.Mode ?? "");
+        Tag(sb, "call", entry.Callsign ?? "");
+        Tag(sb, "countryprefix", "");
+        Tag(sb, "wpxprefix", "");
+        Tag(sb, "stationprefix", myCall);
+        Tag(sb, "continent", "");
+        Tag(sb, "snt", entry.RstSent ?? "");
+        Tag(sb, "sntnr", "0");
+        Tag(sb, "rcv", entry.RstRcvd ?? "");
+        Tag(sb, "rcvnr", "0");
+        Tag(sb, "gridsquare", entry.Grid ?? "");
+        Tag(sb, "exchange1", "");
+        Tag(sb, "section", "");
+        Tag(sb, "comment", entry.Comment ?? "");
+        Tag(sb, "qth", "");
+        Tag(sb, "name", entry.Name ?? "");
+        Tag(sb, "power", "");
+        Tag(sb, "misctext", "");
+        Tag(sb, "zone", entry.CqZone?.ToString(CultureInfo.InvariantCulture) ?? "0");
+        Tag(sb, "prec", "");
+        Tag(sb, "ck", "0");
+        Tag(sb, "ismultiplier1", "0");
+        Tag(sb, "ismultiplier2", "0");
+        Tag(sb, "ismultiplier3", "0");
+        Tag(sb, "points", "1");
+        Tag(sb, "radionr", "1");
+        Tag(sb, "run1run2", "1");
+        Tag(sb, "RoverLocation", "");
+        Tag(sb, "RadioInterfaced", "0");
+        Tag(sb, "NetworkedCompNr", "0");
+        Tag(sb, "IsOriginal", "True");
+        Tag(sb, "NetBiosName", "");
+        Tag(sb, "IsRunQSO", "0");
+        Tag(sb, "StationName", "Zeus");
+        Tag(sb, "ID", Guid.NewGuid().ToString("N"));
+        Tag(sb, "IsClaimedQso", "1");
+        Tag(sb, "oldtimestamp", "");
+        Tag(sb, "oldcall", "");
+        Tag(sb, "SentExchange", "");
+        sb.Append("</contactinfo>");
+        sb.Append("\r\n");
+        return sb.ToString();
+    }
+
+    private static void Tag(StringBuilder sb, string name, string value)
+        => sb.Append('<').Append(name).Append('>')
+             .Append(SecurityElement.Escape(value) ?? "")
+             .Append("</").Append(name).Append('>');
+
+    // N1MM <band> is the MHz band designator (e.g. "3.5" for 80m, "14" for 20m),
+    // NOT the band in meters. The N1MM External UDP Broadcasts spec example
+    // datagram shows <band>3.5</band> for 80m and states the value is "2 or 3
+    // characters that may include localized delimiters"
+    // (n1mmwp.hamdocs.com/appendices/external-udp-broadcasts). Consumers that key
+    // on <band> (HRD QSO-Forwarding / DXKeeper via the N1MM Gateway) expect MHz.
+    //
+    // Map the meters label to its MHz designator; if the label is unrecognised,
+    // fall back to deriving the band from the QSO frequency, and finally to the
+    // raw (meters-stripped) value so nothing crashes on an exotic band.
+    internal static string NormalizeBand(string? band, double? frequencyMhz = null)
+    {
+        if (MetersLabelToMhz(band) is { } fromLabel) return fromLabel;
+
+        if (frequencyMhz is { } mhz && mhz > 0)
+        {
+            var meters = BandUtils.FreqToBand((long)Math.Round(mhz * 1_000_000.0));
+            if (MetersLabelToMhz(meters) is { } fromFreq) return fromFreq;
+        }
+
+        // Unknown band: best-effort — strip a trailing 'm' and pass it through.
+        if (string.IsNullOrWhiteSpace(band)) return "";
+        var b = band.Trim();
+        if (b.EndsWith("m", StringComparison.OrdinalIgnoreCase))
+            b = b[..^1];
+        return b.Trim();
+    }
+
+    // Meters label (with/without trailing 'm') -> N1MM MHz band designator.
+    // Decimal designators only where the band starts on a fractional MHz
+    // (160/80/60), integers elsewhere — matching N1MM's "2 or 3 character" rule.
+    private static string? MetersLabelToMhz(string? band)
+    {
+        if (string.IsNullOrWhiteSpace(band)) return null;
+        var b = band.Trim();
+        if (b.EndsWith("m", StringComparison.OrdinalIgnoreCase))
+            b = b[..^1];
+        return b.Trim() switch
+        {
+            "160" => "1.8",
+            "80" => "3.5",
+            "60" => "5.3",
+            "40" => "7",
+            "30" => "10",
+            "20" => "14",
+            "17" => "18",
+            "15" => "21",
+            "12" => "24",
+            "10" => "28",
+            "6" => "50",
+            "4" => "70",
+            "2" => "144",
+            _ => null,
+        };
+    }
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -3275,19 +3275,27 @@ public static class ZeusEndpoints
             return Results.Ok(response);
         });
 
-        app.MapPost("/api/log/entry", async (CreateLogEntryRequest req, LogService logService, WsjtxUdpBroadcaster wsjtx, HttpContext ctx) =>
+        app.MapPost("/api/log/entry", async (
+            CreateLogEntryRequest req,
+            LogService logService,
+            WsjtxUdpBroadcaster wsjtx,
+            Wsjtx.N1mmBroadcaster n1mm,
+            CloudLog.CloudLogService cloudLog,
+            HttpContext ctx) =>
         {
             if (string.IsNullOrWhiteSpace(req.Callsign))
                 return Results.BadRequest(new { error = "callsign required" });
             var entry = await logService.CreateLogEntryAsync(req, ctx.RequestAborted);
-            // Push the just-logged QSO to a third-party logger if the operator has
-            // opted in (WSJT-X type-12 LoggedADIF). No-op when disabled; this is the
-            // only logging path that broadcasts (ADIF bulk import never does).
-            // Fire-and-forget so a slow/blocked send (e.g. a free-text Host whose
-            // DNS is dead) can never delay the operator's log confirmation. The
-            // broadcaster swallows all send failures internally; use a detached
-            // token so the post-response request abort doesn't cancel it.
-            _ = wsjtx.BroadcastLoggedQsoAsync(entry, CancellationToken.None);
+            // Push the just-logged QSO to every opted-in external logger. Each
+            // target is OFF by default and no-ops when disabled; this is the only
+            // logging path that egresses (ADIF bulk import never does).
+            // Fire-and-forget so a slow/blocked target (e.g. a free-text Host whose
+            // DNS is dead) can never delay the operator's log confirmation. Each
+            // client swallows its own failures internally; use a detached token so
+            // the post-response request abort doesn't cancel them.
+            _ = wsjtx.BroadcastLoggedQsoAsync(entry, CancellationToken.None);   // Class A: WSJT-X type-12 UDP
+            _ = n1mm.BroadcastLoggedQsoAsync(entry, CancellationToken.None);    // Class B: N1MM contactinfo UDP
+            _ = cloudLog.PublishAsync(entry, CancellationToken.None);           // Class C: Wavelog/Cloudlog + Club Log HTTP
             return Results.Ok(entry);
         });
 
@@ -3350,6 +3358,60 @@ public static class ZeusEndpoints
                 SuccessCount: successCount,
                 FailedCount: failedCount,
                 Results: results));
+        });
+
+        // -- Logging v2: HTTP cloud-log uploaders (Wavelog/Cloudlog + Club Log) --
+        // Per-QSO realtime ADIF push. Egress OFF by default; fired automatically
+        // from /api/log/entry. These endpoints manage config/secrets and a manual
+        // batch re-publish. Secrets are write-only — status reports presence only.
+        app.MapGet("/api/log/cloud/config", async (CloudLog.CloudLogService cloud, HttpContext ctx) =>
+            Results.Ok(await cloud.GetStatusAsync(ctx.RequestAborted)));
+
+        app.MapPost("/api/log/cloud/config", (CloudLog.CloudLogConfig req, CloudLog.CloudLogService cloud) =>
+        {
+            log.LogInformation(
+                "api.log.cloud.config wavelog={Wl} clublog={Cl}",
+                req.Wavelog.Enabled, req.ClubLog.Enabled);
+            return Results.Ok(cloud.SetConfig(req));
+        });
+
+        app.MapPost("/api/log/cloud/credentials", async (
+            CloudLog.CloudLogCredentialsRequest req, CloudLog.CloudLogService cloud, HttpContext ctx) =>
+        {
+            // Each non-null field is applied; an empty string clears that secret.
+            if (req.WavelogApiKey is not null)
+                await cloud.SetWavelogApiKeyAsync(req.WavelogApiKey, ctx.RequestAborted);
+            if (req.ClubLogPassword is not null || req.ClubLogApiKey is not null)
+                await cloud.SetClubLogCredentialsAsync(req.ClubLogPassword, req.ClubLogApiKey, ctx.RequestAborted);
+            return Results.Ok(await cloud.GetStatusAsync(ctx.RequestAborted));
+        });
+
+        app.MapPost("/api/log/publish/cloud", async (
+            QrzPublishRequest req, CloudLog.CloudLogService cloud, LogService logService, HttpContext ctx) =>
+        {
+            if (req.LogEntryIds == null || !req.LogEntryIds.Any())
+                return Results.BadRequest(new { error = "no log entry IDs provided" });
+            var entries = await logService.GetLogEntriesByIdsAsync(req.LogEntryIds, ctx.RequestAborted);
+            var results = new List<CloudLog.CloudLogResult>();
+            foreach (var entry in entries)
+                results.AddRange(await cloud.PublishOnceAsync(entry, ctx.RequestAborted));
+            return Results.Ok(new
+            {
+                total = results.Count,
+                successCount = results.Count(r => r.Success),
+                failedCount = results.Count(r => !r.Success),
+                results,
+            });
+        });
+
+        // -- Logging v2: N1MM-format UDP broadcaster (HRD / DXKeeper gateway) -----
+        app.MapGet("/api/n1mm/config", (Wsjtx.N1mmBroadcaster n1mm) => Results.Ok(n1mm.GetConfig()));
+
+        app.MapPost("/api/n1mm/config", (Wsjtx.N1mmConfig req, Wsjtx.N1mmBroadcaster n1mm) =>
+        {
+            log.LogInformation(
+                "api.n1mm.config enabled={En} host={Host} port={Port}", req.Enabled, req.Host, req.Port);
+            return Results.Ok(n1mm.SetConfig(req));
         });
 
         app.MapGet("/api/rotator/status", (RotctldService rot) => rot.GetStatus());
@@ -3592,6 +3654,32 @@ public static class ZeusEndpoints
         {
             hc.Stop();
             return Results.Ok(hc.Snapshot());
+        });
+
+        // HamClock DX-push config + push (Logging v2). Outbound "set the worked
+        // station on the map". Egress OFF by default; server-side forward avoids
+        // browser CORS / HTTPS-mixed-content blocking the classic-HamClock host.
+        app.MapGet("/api/hamclock/push-config", (HamClockPushManagementService push) =>
+            Results.Ok(push.GetConfig()));
+
+        app.MapPost("/api/hamclock/push-config", (HamClockPushConfig req, HamClockPushManagementService push) =>
+        {
+            log.LogInformation(
+                "api.hamclock.push-config enabled={En} trigger={Tr} target={Tg} host={Host} port={Port}",
+                req.Enabled, req.Trigger, req.Target, req.ExternalHost, req.ExternalPort);
+            return Results.Ok(push.SetConfig(req));
+        });
+
+        app.MapPost("/api/hamclock/dx", async (
+            HamClockDxRequest req, HamClockPushManagementService push, HamClockService hc) =>
+        {
+            var cfg = push.GetConfig();
+            if (!cfg.Enabled)
+                return Results.Ok(new { pushed = false, skipped = "disabled" });
+            // Fire the GET inline but tightly time-bounded inside PushDxAsync; it
+            // never throws and returns false on any skip/failure.
+            bool pushed = await hc.PushDxAsync(req.Grid, cfg.Target, cfg.ExternalHost, cfg.ExternalPort);
+            return Results.Ok(new { pushed });
         });
 
         return app;

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -560,6 +560,11 @@ public static class ZeusHost
         // QRZ.com XML client. HttpClient default timeout is 100 s — cap at 10 s so a
         // hung login surfaces quickly in the UI.
         builder.Services.AddHttpClient("Qrz", c => c.Timeout = TimeSpan.FromSeconds(10));
+        // Per-QSO HTTP cloud-log uploaders (Wavelog/Cloudlog + Club Log realtime).
+        // SEND-ONLY, default OFF. Tight timeouts so a slow/blocked endpoint never
+        // delays the operator's log confirmation.
+        builder.Services.AddHttpClient("Wavelog", c => c.Timeout = TimeSpan.FromSeconds(10));
+        builder.Services.AddHttpClient("ClubLog", c => c.Timeout = TimeSpan.FromSeconds(10));
         // Localhost proxy to the HamClock sidecar's propagation engine. The first
         // P.533-14 prediction for a cold path can take ~20 s upstream; allow for it.
         builder.Services.AddHttpClient("Propagation", c => c.Timeout = TimeSpan.FromSeconds(25));
@@ -820,6 +825,11 @@ public static class ZeusHost
         // only so its sidecar Node process is killed on Zeus shutdown.
         builder.Services.AddSingleton<HamClockService>();
         builder.Services.AddHostedService(sp => sp.GetRequiredService<HamClockService>());
+        // HamClock DX-push config (Logging v2). Outbound "set the worked station
+        // on the map" — SEND-ONLY HTTP GET, DISABLED by default. The push itself
+        // lives on HamClockService.PushDxAsync; this owns the live config.
+        builder.Services.AddSingleton<HamClockPushConfigStore>();
+        builder.Services.AddSingleton<HamClockPushManagementService>();
         // Point-to-point propagation (proxies the HamClock sidecar's P.533-14 API).
         builder.Services.AddSingleton<PropagationService>();
         // Comprehensive solar / space-weather (proxies the sidecar's N0NBH feed).
@@ -919,6 +929,23 @@ public static class ZeusHost
         // so the default path emits nothing. SEND-ONLY via the broadcaster.
         builder.Services.AddSingleton<Wsjtx.WsjtxLiveEmitter>();
         builder.Services.AddHostedService(sp => sp.GetRequiredService<Wsjtx.WsjtxLiveEmitter>());
+
+        // Logging v2 — N1MM-format UDP broadcaster (Class B). Sends the N1MM
+        // "contactinfo" datagram (a DIFFERENT wire format from the WSJT-X type-12
+        // path above) on a configurable port (default 2333) for HRD Logbook "QSO
+        // Forwarding" and DXKeeper via the N1MM→DXKeeper Gateway. SEND-ONLY, no
+        // listener, DISABLED by default; fired from the /api/log/entry fan-out.
+        builder.Services.AddSingleton<Wsjtx.N1mmConfigStore>();
+        builder.Services.AddSingleton<Wsjtx.N1mmBroadcaster>();
+
+        // Logging v2 — HTTP cloud-log uploaders (Class C): per-QSO realtime ADIF
+        // POST to Wavelog/Cloudlog and Club Log. NEW network egress, both DISABLED
+        // by default and additionally no-op until credentials are stored. SEND-ONLY
+        // (HttpClient POST out only). Fired from the /api/log/entry fan-out.
+        builder.Services.AddSingleton<CloudLog.CloudLogConfigStore>();
+        builder.Services.AddSingleton<CloudLog.WavelogClient>();
+        builder.Services.AddSingleton<CloudLog.ClubLogClient>();
+        builder.Services.AddSingleton<CloudLog.CloudLogService>();
 
         // Digital-mode spotting uploaders — FT8/FT4 decodes to PSK Reporter and
         // WSPR spots to WSPRnet. NEW network egress; both DISABLED by default and

--- a/tests/Zeus.Server.Tests/CloudLog/CloudLogTests.cs
+++ b/tests/Zeus.Server.Tests/CloudLog/CloudLogTests.cs
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Net;
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server;
+using Zeus.Server.CloudLog;
+
+namespace Zeus.Server.Tests.CloudLog;
+
+public sealed class CloudLogTests
+{
+    private const string Adif = "<CALL:5>K1ABC <MODE:3>FT8 <EOR>";
+
+    // ---- Wavelog ---------------------------------------------------------
+
+    [Fact]
+    public async Task Wavelog_PostsJsonToApiQso_WithKeyAndProfile()
+    {
+        var handler = new StubHandler((_, _) => Reply(HttpStatusCode.OK, "{\"id\":42}"));
+        var client = new WavelogClient(new SingleClientFactory(handler), NullLogger<WavelogClient>.Instance);
+        var cfg = new WavelogConfig(Enabled: true, BaseUrl: "https://log.example.com", StationProfileId: "3");
+
+        var result = await client.PublishAsync(cfg, "KEY123", Adif);
+
+        Assert.True(result.Success);
+        Assert.Equal("42", result.RemoteId);
+        Assert.Single(handler.Requests);
+        var req = handler.Requests[0];
+        Assert.Equal("https://log.example.com/api/qso", req.Url);
+        Assert.Equal("application/json", req.ContentType);
+        Assert.Contains("\"key\":\"KEY123\"", req.Body);
+        Assert.Contains("\"station_profile_id\":\"3\"", req.Body);
+        Assert.Contains("\"type\":\"adif\"", req.Body);
+        Assert.Contains("EOR", req.Body);
+    }
+
+    [Fact]
+    public async Task Wavelog_RetriesIndexPhpOn404()
+    {
+        int call = 0;
+        var handler = new StubHandler((_, _) =>
+            ++call == 1 ? Reply(HttpStatusCode.NotFound, "") : Reply(HttpStatusCode.OK, "{}"));
+        var client = new WavelogClient(new SingleClientFactory(handler), NullLogger<WavelogClient>.Instance);
+        var cfg = new WavelogConfig(Enabled: true, BaseUrl: "https://log.example.com/", StationProfileId: "1");
+
+        var result = await client.PublishAsync(cfg, "KEY", Adif);
+
+        Assert.True(result.Success);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal("https://log.example.com/api/qso", handler.Requests[0].Url);
+        Assert.Equal("https://log.example.com/index.php/api/qso", handler.Requests[1].Url);
+    }
+
+    [Fact]
+    public async Task Wavelog_MissingCredentials_SkipsWithoutSending()
+    {
+        var handler = new StubHandler((_, _) => Reply(HttpStatusCode.OK, "{}"));
+        var client = new WavelogClient(new SingleClientFactory(handler), NullLogger<WavelogClient>.Instance);
+
+        var result = await client.PublishAsync(
+            new WavelogConfig(Enabled: true, BaseUrl: "https://x", StationProfileId: "1"), apiKey: "", Adif);
+
+        Assert.False(result.Success);
+        Assert.Empty(handler.Requests);
+    }
+
+    [Theory]
+    [InlineData("https://x", false, "https://x/api/qso")]
+    [InlineData("https://x/", false, "https://x/api/qso")]
+    [InlineData("https://x", true, "https://x/index.php/api/qso")]
+    public void Wavelog_BuildQsoUrl(string baseUrl, bool indexPhp, string expected)
+        => Assert.Equal(expected, WavelogClient.BuildQsoUrl(baseUrl, indexPhp));
+
+    // ---- Club Log --------------------------------------------------------
+
+    [Fact]
+    public async Task ClubLog_PostsFormUrlEncodedToRealtime()
+    {
+        var handler = new StubHandler((_, _) => Reply(HttpStatusCode.OK, "QSO OK"));
+        var client = new ClubLogClient(new SingleClientFactory(handler), NullLogger<ClubLogClient>.Instance);
+        var cfg = new ClubLogConfig(Enabled: true, Email: "me@example.com", Callsign: "k1abc");
+
+        var result = await client.PublishAsync(cfg, "pw", "api", Adif);
+
+        Assert.True(result.Success);
+        var req = handler.Requests[0];
+        Assert.Equal("https://clublog.org/realtime.php", req.Url);
+        Assert.Equal("application/x-www-form-urlencoded", req.ContentType);
+        Assert.Contains("email=me%40example.com", req.Body);
+        Assert.Contains("callsign=K1ABC", req.Body); // upper-cased
+        Assert.Contains("api=api", req.Body);
+        Assert.Contains("password=pw", req.Body);
+    }
+
+    [Fact]
+    public void ClubLog_403_IsHardStop()
+    {
+        var client = new ClubLogClient(new SingleClientFactory(new StubHandler((_, _) => Reply(HttpStatusCode.OK, ""))),
+            NullLogger<ClubLogClient>.Instance);
+        var r = client.MapResponse(HttpStatusCode.Forbidden, "auth failed");
+        Assert.False(r.Success);
+        Assert.True(r.HardStop);
+    }
+
+    [Theory]
+    [InlineData(200, true, false)]
+    [InlineData(400, false, false)]
+    [InlineData(500, false, false)]
+    public void ClubLog_StatusMapping(int code, bool success, bool hardStop)
+    {
+        var client = new ClubLogClient(new SingleClientFactory(new StubHandler((_, _) => Reply(HttpStatusCode.OK, ""))),
+            NullLogger<ClubLogClient>.Instance);
+        var r = client.MapResponse((HttpStatusCode)code, "body");
+        Assert.Equal(success, r.Success);
+        Assert.Equal(hardStop, r.HardStop);
+    }
+
+    // ---- CloudLogService: per-secret credential update -------------------
+
+    [Fact]
+    public async Task SetClubLogCredentials_PasswordOnlyUpdate_KeepsApiKey()
+    {
+        using var tmp = new TempDb();
+        using var b = BuildService(tmp);
+        b.Service.SetConfig(new CloudLogConfig(
+            new WavelogConfig(), new ClubLogConfig(Enabled: true, Email: "a@b.com", Callsign: "K1ABC")));
+
+        // Save both secrets.
+        await b.Service.SetClubLogCredentialsAsync("pw1", "api1");
+        var s1 = await b.Service.GetStatusAsync();
+        Assert.True(s1.ClubLog.HasPassword);
+        Assert.True(s1.ClubLog.HasApiKey);
+
+        // Rotate ONLY the password (apiKey omitted -> null -> unchanged).
+        await b.Service.SetClubLogCredentialsAsync("pw2", apiKey: null);
+        var s2 = await b.Service.GetStatusAsync();
+        Assert.True(s2.ClubLog.HasPassword);
+        Assert.True(s2.ClubLog.HasApiKey); // survived the password-only rotation
+
+        // Rotate ONLY the API key (password omitted -> null -> unchanged).
+        await b.Service.SetClubLogCredentialsAsync(password: null, "api2");
+        var s3 = await b.Service.GetStatusAsync();
+        Assert.True(s3.ClubLog.HasPassword); // survived
+        Assert.True(s3.ClubLog.HasApiKey);
+    }
+
+    [Fact]
+    public async Task SetClubLogCredentials_EmptyStringClearsThatSecretOnly()
+    {
+        using var tmp = new TempDb();
+        using var b = BuildService(tmp);
+        b.Service.SetConfig(new CloudLogConfig(
+            new WavelogConfig(), new ClubLogConfig(Enabled: true, Email: "a@b.com", Callsign: "K1ABC")));
+
+        await b.Service.SetClubLogCredentialsAsync("pw1", "api1");
+        await b.Service.SetClubLogCredentialsAsync("", apiKey: null); // empty clears pw, null leaves api key
+
+        var s = await b.Service.GetStatusAsync();
+        Assert.False(s.ClubLog.HasPassword); // cleared
+        Assert.True(s.ClubLog.HasApiKey);    // untouched
+    }
+
+    [Fact]
+    public async Task Publish_ClubLog403_DisablesClubLogInPersistedConfig()
+    {
+        using var tmp = new TempDb();
+        var clubHandler = new StubHandler((_, _) => Reply(HttpStatusCode.Forbidden, "auth failed"));
+        using var b = BuildService(tmp, clubHandler);
+        b.Service.SetConfig(new CloudLogConfig(
+            new WavelogConfig(), new ClubLogConfig(Enabled: true, Email: "a@b.com", Callsign: "K1ABC")));
+        await b.Service.SetClubLogCredentialsAsync("pw", "api");
+
+        await b.Service.PublishAsync(SampleLogEntry());
+
+        Assert.True(clubHandler.Requests.Count >= 1);       // it really tried
+        Assert.False(b.Service.GetConfig().ClubLog.Enabled); // hard-stop disabled it
+        Assert.False(b.Store.Get()!.ClubLog.Enabled);        // and persisted the disable
+    }
+
+    private static LogEntry SampleLogEntry() => new(
+        Id: "x", QsoDateTimeUtc: new DateTime(2026, 6, 27, 14, 30, 0, DateTimeKind.Utc),
+        Callsign: "K1ABC", Name: null, FrequencyMhz: 14.074, Band: "20m", Mode: "FT8",
+        RstSent: "-12", RstRcvd: "-08", Grid: "FN31", Country: null, Dxcc: null, CqZone: null,
+        ItuZone: null, State: null, Comment: null, CreatedUtc: DateTime.UtcNow);
+
+    private static ServiceBundle BuildService(TempDb tmp, HttpMessageHandler? clubHandler = null)
+    {
+        var store = new CloudLogConfigStore(NullLogger<CloudLogConfigStore>.Instance, tmp.Path);
+        var creds = new CredentialStore(NullLogger<CredentialStore>.Instance, tmp.Path);
+        var noop = new StubHandler((_, _) => Reply(HttpStatusCode.OK, "{}"));
+        var wavelog = new WavelogClient(new SingleClientFactory(noop), NullLogger<WavelogClient>.Instance);
+        var clubLog = new ClubLogClient(
+            new SingleClientFactory(clubHandler ?? noop), NullLogger<ClubLogClient>.Instance);
+        var svc = new CloudLogService(
+            NullLogger<CloudLogService>.Instance, store, creds, wavelog, clubLog);
+        return new ServiceBundle(svc, store, creds);
+    }
+
+    private sealed class ServiceBundle : IDisposable
+    {
+        public CloudLogService Service { get; }
+        public CloudLogConfigStore Store { get; }
+        private readonly CredentialStore _creds;
+        public ServiceBundle(CloudLogService svc, CloudLogConfigStore store, CredentialStore creds)
+        {
+            Service = svc; Store = store; _creds = creds;
+        }
+        public void Dispose() { Store.Dispose(); _creds.Dispose(); }
+    }
+
+    // ---- Config store ----------------------------------------------------
+
+    [Fact]
+    public void ConfigStore_DefaultsToOff()
+    {
+        using var tmp = new TempDb();
+        using var store = new CloudLogConfigStore(NullLogger<CloudLogConfigStore>.Instance, tmp.Path);
+        Assert.Null(store.Get()); // nothing persisted -> caller uses default (OFF)
+    }
+
+    [Fact]
+    public void ConfigStore_RoundTrips()
+    {
+        using var tmp = new TempDb();
+        using (var store = new CloudLogConfigStore(NullLogger<CloudLogConfigStore>.Instance, tmp.Path))
+        {
+            store.Set(new CloudLogConfig(
+                new WavelogConfig(true, "https://log", "7"),
+                new ClubLogConfig(true, "a@b.com", "K1ABC")));
+        }
+        using (var store = new CloudLogConfigStore(NullLogger<CloudLogConfigStore>.Instance, tmp.Path))
+        {
+            var c = store.Get();
+            Assert.NotNull(c);
+            Assert.True(c!.Wavelog.Enabled);
+            Assert.Equal("https://log", c.Wavelog.BaseUrl);
+            Assert.Equal("7", c.Wavelog.StationProfileId);
+            Assert.True(c.ClubLog.Enabled);
+            Assert.Equal("a@b.com", c.ClubLog.Email);
+            Assert.Equal("K1ABC", c.ClubLog.Callsign);
+        }
+    }
+
+    // ---- helpers ---------------------------------------------------------
+
+    private static HttpResponseMessage Reply(HttpStatusCode code, string body) =>
+        new(code) { Content = new StringContent(body) };
+
+    private sealed record CapturedRequest(string Url, string? ContentType, string Body);
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> _fn;
+        public List<CapturedRequest> Requests { get; } = new();
+
+        public StubHandler(Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> fn) => _fn = fn;
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var body = request.Content is null ? "" : await request.Content.ReadAsStringAsync(cancellationToken);
+            Requests.Add(new CapturedRequest(
+                request.RequestUri!.ToString(),
+                request.Content?.Headers.ContentType?.MediaType,
+                body));
+            return _fn(request, cancellationToken);
+        }
+    }
+
+    private sealed class SingleClientFactory : IHttpClientFactory
+    {
+        private readonly HttpMessageHandler _handler;
+        public SingleClientFactory(HttpMessageHandler handler) => _handler = handler;
+        public HttpClient CreateClient(string name) => new(_handler, disposeHandler: false);
+    }
+
+    private sealed class TempDb : IDisposable
+    {
+        public string Path { get; }
+        private readonly string _dir;
+        public TempDb()
+        {
+            _dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"zeus-test-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(_dir);
+            Path = System.IO.Path.Combine(_dir, "zeus-prefs.db");
+        }
+        public void Dispose()
+        {
+            try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+}

--- a/tests/Zeus.Server.Tests/HamClockPushTests.cs
+++ b/tests/Zeus.Server.Tests/HamClockPushTests.cs
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Zeus.Server.Tests;
+
+public sealed class HamClockPushTests
+{
+    // ---- URL builder -----------------------------------------------------
+
+    [Fact]
+    public void BuildSetDxUrl_UsesNamedGridParamAndClassicPort()
+    {
+        // Classic HamClock REST: set_newdx?grid=<grid> (named param, NOT a bare
+        // arg) on the REST port (default 8080) — verified June 2026.
+        Assert.Equal(
+            "http://192.168.1.50:8080/set_newdx?grid=FN31",
+            HamClockService.BuildSetDxUrl("192.168.1.50", 8080, "FN31"));
+    }
+
+    [Fact]
+    public void BuildSetDxUrl_EscapesGrid()
+    {
+        var url = HamClockService.BuildSetDxUrl("host", 8080, "FN31aa");
+        Assert.Equal("http://host:8080/set_newdx?grid=FN31aa", url);
+    }
+
+    // ---- Grid validation -------------------------------------------------
+
+    [Theory]
+    [InlineData("FN31", "FN31")]
+    [InlineData("fn31", "FN31")]            // field upper-cased
+    [InlineData("FN31aa", "FN31aa")]
+    [InlineData("FN31AA", "FN31aa")]        // subsquare lower-cased
+    [InlineData(" FN31 ", "FN31")]          // trimmed
+    public void TryNormalizeGrid_AcceptsValid(string input, string expected)
+    {
+        Assert.True(HamClockService.TryNormalizeGrid(input, out var g));
+        Assert.Equal(expected, g);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("F")]
+    [InlineData("FN3")]                     // 3 chars
+    [InlineData("FN311")]                   // 5 chars
+    [InlineData("ZN31")]                    // field out of A-R
+    [InlineData("FNAB")]                    // square not digits
+    [InlineData("FN31zz")]                  // subsquare out of a-x
+    public void TryNormalizeGrid_RejectsInvalid(string? input)
+    {
+        Assert.False(HamClockService.TryNormalizeGrid(input, out var g));
+        Assert.Equal("", g);
+    }
+
+    // ---- PushDxAsync gating (no network) ---------------------------------
+
+    [Fact]
+    public async Task PushDxAsync_InvalidGrid_NoOp()
+    {
+        var hc = new HamClockService(NullLogger<HamClockService>.Instance);
+        Assert.False(await hc.PushDxAsync("nope", "external", "127.0.0.1", 8080));
+    }
+
+    [Fact]
+    public async Task PushDxAsync_BundledTarget_NoOp()
+    {
+        // The bundled OpenHamClock sidecar has no set-DX endpoint; bundled must be
+        // a logged no-op (returns false) even with a valid grid.
+        var hc = new HamClockService(NullLogger<HamClockService>.Instance);
+        Assert.False(await hc.PushDxAsync("FN31", "bundled", "127.0.0.1", 8080));
+    }
+
+    [Fact]
+    public async Task PushDxAsync_ExternalWithoutHost_NoOp()
+    {
+        var hc = new HamClockService(NullLogger<HamClockService>.Instance);
+        Assert.False(await hc.PushDxAsync("FN31", "external", "", 8080));
+    }
+
+    // ---- Push config store ----------------------------------------------
+
+    [Fact]
+    public void PushConfigStore_DefaultsToOff()
+    {
+        using var tmp = new TempDb();
+        using var store = new HamClockPushConfigStore(NullLogger<HamClockPushConfigStore>.Instance, tmp.Path);
+        Assert.Null(store.Get());
+    }
+
+    [Fact]
+    public void PushConfigStore_RoundTrips()
+    {
+        using var tmp = new TempDb();
+        using (var store = new HamClockPushConfigStore(NullLogger<HamClockPushConfigStore>.Instance, tmp.Path))
+            store.Set(new HamClockPushConfig(true, "on-active-QSO", "external", "10.0.0.5", 8080));
+        using (var store = new HamClockPushConfigStore(NullLogger<HamClockPushConfigStore>.Instance, tmp.Path))
+        {
+            var c = store.Get();
+            Assert.NotNull(c);
+            Assert.True(c!.Enabled);
+            Assert.Equal("on-active-QSO", c.Trigger);
+            Assert.Equal("10.0.0.5", c.ExternalHost);
+            Assert.Equal(8080, c.ExternalPort);
+        }
+    }
+
+    [Fact]
+    public void Management_NormalizesTriggerTargetAndPort()
+    {
+        using var tmp = new TempDb();
+        using var store = new HamClockPushConfigStore(NullLogger<HamClockPushConfigStore>.Instance, tmp.Path);
+        var mgmt = new HamClockPushManagementService(NullLogger<HamClockPushManagementService>.Instance, store);
+
+        var c = mgmt.SetConfig(new HamClockPushConfig(true, "garbage", "weird", "  host  ", 0));
+        Assert.Equal("on-click", c.Trigger);   // unknown trigger -> default
+        Assert.Equal("external", c.Target);    // unknown target -> external
+        Assert.Equal("host", c.ExternalHost);  // trimmed
+        Assert.Equal(8080, c.ExternalPort);    // invalid port -> default
+    }
+
+    private sealed class TempDb : IDisposable
+    {
+        public string Path { get; }
+        private readonly string _dir;
+        public TempDb()
+        {
+            _dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"zeus-test-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(_dir);
+            Path = System.IO.Path.Combine(_dir, "zeus-prefs.db");
+        }
+        public void Dispose()
+        {
+            try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+}

--- a/tests/Zeus.Server.Tests/Wsjtx/N1mmBroadcasterTests.cs
+++ b/tests/Zeus.Server.Tests/Wsjtx/N1mmBroadcasterTests.cs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Server.Wsjtx;
+
+namespace Zeus.Server.Tests.Wsjtx;
+
+public sealed class N1mmBroadcasterTests
+{
+    [Fact]
+    public void ConfigStore_DefaultsToOff()
+    {
+        using var tmp = new TempDb();
+        using var store = new N1mmConfigStore(NullLogger<N1mmConfigStore>.Instance, tmp.Path);
+        Assert.Null(store.Get()); // nothing persisted -> caller uses default (OFF, port 2333)
+    }
+
+    [Fact]
+    public void ConfigStore_RoundTrips()
+    {
+        using var tmp = new TempDb();
+        using (var store = new N1mmConfigStore(NullLogger<N1mmConfigStore>.Instance, tmp.Path))
+            store.Set(new N1mmConfig(Enabled: true, Host: "10.0.0.9", Port: 12060));
+        using (var store = new N1mmConfigStore(NullLogger<N1mmConfigStore>.Instance, tmp.Path))
+        {
+            var c = store.Get();
+            Assert.NotNull(c);
+            Assert.True(c!.Enabled);
+            Assert.Equal("10.0.0.9", c.Host);
+            Assert.Equal(12060, c.Port);
+        }
+    }
+
+    [Fact]
+    public void Broadcaster_DefaultConfigIsOffPort2333()
+    {
+        using var tmp = new TempDb();
+        using var store = new N1mmConfigStore(NullLogger<N1mmConfigStore>.Instance, tmp.Path);
+        using var b = new N1mmBroadcaster(NullLogger<N1mmBroadcaster>.Instance, store);
+        var c = b.GetConfig();
+        Assert.False(c.Enabled);
+        Assert.Equal(2333, c.Port);
+        Assert.Equal("127.0.0.1", c.Host);
+    }
+
+    [Fact]
+    public void Broadcaster_SetConfig_NormalizesAndPersists()
+    {
+        using var tmp = new TempDb();
+        using var store = new N1mmConfigStore(NullLogger<N1mmConfigStore>.Instance, tmp.Path);
+        using var b = new N1mmBroadcaster(NullLogger<N1mmBroadcaster>.Instance, store);
+
+        var c = b.SetConfig(new N1mmConfig(Enabled: true, Host: "  ", Port: 0));
+        Assert.Equal("127.0.0.1", c.Host); // blank -> loopback
+        Assert.Equal(2333, c.Port);        // invalid -> default
+        Assert.Equal(2333, store.Get()!.Port); // persisted
+    }
+
+    private sealed class TempDb : IDisposable
+    {
+        public string Path { get; }
+        private readonly string _dir;
+        public TempDb()
+        {
+            _dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"zeus-test-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(_dir);
+            Path = System.IO.Path.Combine(_dir, "zeus-prefs.db");
+        }
+        public void Dispose()
+        {
+            try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+}

--- a/tests/Zeus.Server.Tests/Wsjtx/N1mmContactInfoEncoderTests.cs
+++ b/tests/Zeus.Server.Tests/Wsjtx/N1mmContactInfoEncoderTests.cs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Text;
+using System.Xml.Linq;
+using Zeus.Contracts;
+using Zeus.Server.Wsjtx;
+
+namespace Zeus.Server.Tests.Wsjtx;
+
+public sealed class N1mmContactInfoEncoderTests
+{
+    private static LogEntry SampleEntry() => new(
+        Id: "abc",
+        QsoDateTimeUtc: new DateTime(2026, 6, 27, 14, 30, 15, DateTimeKind.Utc),
+        Callsign: "K1ABC",
+        Name: "Joe",
+        FrequencyMhz: 14.074,
+        Band: "20m",
+        Mode: "FT8",
+        RstSent: "-12",
+        RstRcvd: "-08",
+        Grid: "FN31",
+        Country: "United States",
+        Dxcc: 291,
+        CqZone: 5,
+        ItuZone: 8,
+        State: "CT",
+        Comment: "tnx",
+        CreatedUtc: DateTime.UtcNow);
+
+    [Fact]
+    public void Encode_ProducesWellFormedContactInfoXml()
+    {
+        var xml = N1mmContactInfoEncoder.EncodeXml(SampleEntry(), "W1XYZ");
+        var doc = XDocument.Parse(xml); // throws if not well-formed
+        Assert.Equal("contactinfo", doc.Root!.Name.LocalName);
+    }
+
+    [Fact]
+    public void Encode_MapsLoadBearingFields()
+    {
+        var xml = N1mmContactInfoEncoder.EncodeXml(SampleEntry(), "W1XYZ");
+        var root = XDocument.Parse(xml).Root!;
+
+        string Get(string n) => root.Element(n)?.Value ?? "";
+
+        Assert.Equal("K1ABC", Get("call"));
+        Assert.Equal("W1XYZ", Get("mycall"));
+        Assert.Equal("W1XYZ", Get("operator"));
+        Assert.Equal("FT8", Get("mode"));
+        Assert.Equal("FN31", Get("gridsquare"));
+        Assert.Equal("-12", Get("snt"));
+        Assert.Equal("-08", Get("rcv"));
+        Assert.Equal("14", Get("band")); // N1MM MHz designator for 20m
+        Assert.Equal("Joe", Get("name"));
+        Assert.Equal("2026-06-27 14:30:15", Get("timestamp"));
+    }
+
+    [Fact]
+    public void Encode_FrequencyIsTensOfHz()
+    {
+        // 14.074 MHz -> 14_074_000 Hz -> 1_407_400 tens-of-Hz (N1MM unit).
+        var xml = N1mmContactInfoEncoder.EncodeXml(SampleEntry(), "W1XYZ");
+        var root = XDocument.Parse(xml).Root!;
+        Assert.Equal("1407400", root.Element("rxfreq")!.Value);
+        Assert.Equal("1407400", root.Element("txfreq")!.Value);
+    }
+
+    [Fact]
+    public void Encode_EscapesXmlSpecialCharacters()
+    {
+        var entry = SampleEntry() with { Comment = "a & b <test>" };
+        var xml = N1mmContactInfoEncoder.EncodeXml(entry, "W1XYZ");
+        // Must still parse and round-trip the literal value.
+        var root = XDocument.Parse(xml).Root!;
+        Assert.Equal("a & b <test>", root.Element("comment")!.Value);
+    }
+
+    [Fact]
+    public void Encode_NoFrequency_EmitsZeroFreq()
+    {
+        var entry = SampleEntry() with { FrequencyMhz = null };
+        var root = XDocument.Parse(N1mmContactInfoEncoder.EncodeXml(entry, "W1XYZ")).Root!;
+        Assert.Equal("0", root.Element("txfreq")!.Value);
+    }
+
+    [Theory]
+    [InlineData("20m", "14")]
+    [InlineData("20M", "14")]
+    [InlineData("20", "14")]
+    [InlineData("160m", "1.8")]
+    [InlineData("80m", "3.5")]
+    [InlineData("40m", "7")]
+    [InlineData("30m", "10")]
+    [InlineData("10m", "28")]
+    [InlineData("6m", "50")]
+    [InlineData("", "")]
+    [InlineData(null, "")]
+    public void NormalizeBand_MapsMetersToMhzDesignator(string? input, string expected)
+        => Assert.Equal(expected, N1mmContactInfoEncoder.NormalizeBand(input));
+
+    [Fact]
+    public void NormalizeBand_UnknownLabel_DerivesFromFrequency()
+        // Label we don't have in the table -> fall back to the QSO frequency.
+        => Assert.Equal("14", N1mmContactInfoEncoder.NormalizeBand("twenty", 14.074));
+
+    [Fact]
+    public void NormalizeBand_UnknownLabelNoFreq_PassesThroughStripped()
+        => Assert.Equal("999", N1mmContactInfoEncoder.NormalizeBand("999m"));
+
+    [Fact]
+    public void Encode_OutputIsUtf8()
+    {
+        var bytes = N1mmContactInfoEncoder.Encode(SampleEntry(), "W1XYZ");
+        var s = Encoding.UTF8.GetString(bytes);
+        Assert.Contains("<contactinfo>", s);
+    }
+}

--- a/zeus-web/src/api/cloud-log.ts
+++ b/zeus-web/src/api/cloud-log.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+// REST client for the per-QSO HTTP cloud-log uploaders (Wavelog/Cloudlog +
+// Club Log realtime). Each logged QSO is pushed as a single ADIF record. Egress
+// is OFF by default and SEND-ONLY. SECRETS ARE WRITE-ONLY: the config/status
+// shape only ever reports secret PRESENCE booleans (hasApiKey / hasPassword);
+// the keys themselves go up through POST /api/log/cloud/credentials and never
+// come back down. These records live server-side only (not in Zeus.Contracts).
+
+import { ApiError } from './client';
+
+export type WavelogStatus = {
+  enabled: boolean;
+  baseUrl: string;
+  stationProfileId: string;
+  hasApiKey: boolean;
+};
+
+export type ClubLogStatus = {
+  enabled: boolean;
+  email: string;
+  callsign: string;
+  hasPassword: boolean;
+  hasApiKey: boolean;
+};
+
+export type CloudLogStatus = {
+  wavelog: WavelogStatus;
+  clubLog: ClubLogStatus;
+};
+
+// Non-secret config written back to the server. Mirrors CloudLogConfig server-side.
+export type CloudLogConfig = {
+  wavelog: { enabled: boolean; baseUrl: string; stationProfileId: string };
+  clubLog: { enabled: boolean; email: string; callsign: string };
+};
+
+// Write-only secret setter. Only include the fields being changed; an empty
+// string clears that secret, a field left out is unchanged on the server.
+export type CloudLogCredentials = {
+  wavelogApiKey?: string;
+  clubLogPassword?: string;
+  clubLogApiKey?: string;
+};
+
+function normalizeStatus(raw: unknown): CloudLogStatus {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  const wl = (r.wavelog ?? {}) as Record<string, unknown>;
+  const cl = (r.clubLog ?? {}) as Record<string, unknown>;
+  return {
+    wavelog: {
+      enabled: Boolean(wl.enabled),
+      baseUrl: typeof wl.baseUrl === 'string' ? wl.baseUrl : '',
+      stationProfileId: typeof wl.stationProfileId === 'string' ? wl.stationProfileId : '',
+      hasApiKey: Boolean(wl.hasApiKey),
+    },
+    clubLog: {
+      enabled: Boolean(cl.enabled),
+      email: typeof cl.email === 'string' ? cl.email : '',
+      callsign: typeof cl.callsign === 'string' ? cl.callsign : '',
+      hasPassword: Boolean(cl.hasPassword),
+      hasApiKey: Boolean(cl.hasApiKey),
+    },
+  };
+}
+
+async function jsonFetch<T>(
+  input: RequestInfo,
+  init: RequestInit | undefined,
+  parse: (raw: unknown) => T,
+): Promise<T> {
+  const res = await fetch(input, init);
+  if (!res.ok) throw new ApiError(res.status, `${res.status} ${res.statusText}`);
+  return parse((await res.json()) as unknown);
+}
+
+export function getCloudLogStatus(signal?: AbortSignal): Promise<CloudLogStatus> {
+  return jsonFetch('/api/log/cloud/config', { signal }, normalizeStatus);
+}
+
+export function postCloudLogConfig(cfg: CloudLogConfig, signal?: AbortSignal): Promise<CloudLogStatus> {
+  return jsonFetch(
+    '/api/log/cloud/config',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(cfg),
+      signal,
+    },
+    normalizeStatus,
+  );
+}
+
+export function postCloudLogCredentials(
+  creds: CloudLogCredentials,
+  signal?: AbortSignal,
+): Promise<CloudLogStatus> {
+  return jsonFetch(
+    '/api/log/cloud/credentials',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(creds),
+      signal,
+    },
+    normalizeStatus,
+  );
+}

--- a/zeus-web/src/api/n1mm.ts
+++ b/zeus-web/src/api/n1mm.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+// REST client for the N1MM-format ("N1MM Logger+ Broadcasts") UDP broadcaster.
+// This is the contactinfo datagram HRD Logbook QSO-Forwarding and the
+// DXKeeper-via-Gateway path expect — a DIFFERENT wire format from the WSJT-X
+// type-12 ADIF datagram, on its own configurable port (default 2333). SEND-ONLY,
+// egress OFF by default, applies live (no listener, no restart). These records
+// live server-side only (not in Zeus.Contracts) — no wire-format change.
+
+import { ApiError } from './client';
+
+export type N1mmConfig = {
+  enabled: boolean;
+  host: string;
+  port: number;
+};
+
+export const N1MM_DEFAULT_PORT = 2333;
+
+function normalizeConfig(raw: unknown): N1mmConfig {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  return {
+    enabled: Boolean(r.enabled),
+    host: typeof r.host === 'string' ? r.host : '127.0.0.1',
+    port: typeof r.port === 'number' ? r.port : N1MM_DEFAULT_PORT,
+  };
+}
+
+async function jsonFetch<T>(
+  input: RequestInfo,
+  init: RequestInit | undefined,
+  parse: (raw: unknown) => T,
+): Promise<T> {
+  const res = await fetch(input, init);
+  if (!res.ok) throw new ApiError(res.status, `${res.status} ${res.statusText}`);
+  return parse((await res.json()) as unknown);
+}
+
+export function getN1mmConfig(signal?: AbortSignal): Promise<N1mmConfig> {
+  return jsonFetch('/api/n1mm/config', { signal }, normalizeConfig);
+}
+
+export function postN1mmConfig(cfg: N1mmConfig, signal?: AbortSignal): Promise<N1mmConfig> {
+  return jsonFetch(
+    '/api/n1mm/config',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(cfg),
+      signal,
+    },
+    normalizeConfig,
+  );
+}

--- a/zeus-web/src/components/HamClockSettingsPanel.test.tsx
+++ b/zeus-web/src/components/HamClockSettingsPanel.test.tsx
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// HamClockSettingsPanel — "Push DX to HamClock" section test. Verifies the
+// outbound DX-push form: default OFF, opting in reveals trigger/target/host/port,
+// the bundled target is disabled (unsupported), and SAVE persists the config.
+// Harness import first installs the localStorage polyfill + act flag before any
+// store loads; store methods are stubbed so no real fetch fires.
+
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { createElement } from 'react';
+import { act, render } from './meters/__tests__/harness';
+import { HamClockSettingsPanel } from './HamClockSettingsPanel';
+import { useHamClockStore, type HamClockPushConfig } from '../state/hamclock-store';
+
+const OFF_PUSH: HamClockPushConfig = {
+  enabled: false,
+  trigger: 'on-click',
+  target: 'external',
+  externalHost: '',
+  externalPort: 8080,
+};
+
+function setSelectValue(select: HTMLSelectElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLSelectElement.prototype,
+    'value',
+  )!.set!;
+  act(() => {
+    setter.call(select, value);
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+}
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    'value',
+  )!.set!;
+  act(() => {
+    setter.call(input, value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+}
+
+function clickByText(container: HTMLElement, text: string) {
+  const btn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === text);
+  expect(btn, `button "${text}"`).toBeTruthy();
+  act(() => (btn as HTMLButtonElement).click());
+}
+
+describe('HamClockSettingsPanel — Push DX', () => {
+  beforeEach(() => {
+    act(() => {
+      // Stub every fetch-backed store method so the panel mounts cleanly.
+      useHamClockStore.setState({
+        pushConfig: { ...OFF_PUSH },
+        loadStatus: async () => {},
+        loadPushConfig: async () => {},
+        savePushConfig: async () => {},
+      } as never);
+    });
+  });
+
+  it('renders the push section OFF by default with the controls hidden', () => {
+    const { container, unmount } = render(createElement(HamClockSettingsPanel));
+    expect(container.textContent).toContain('Push DX to HamClock');
+    const toggle = container.querySelector(
+      'button[aria-label="Push DX to HamClock"]',
+    ) as HTMLButtonElement;
+    expect(toggle.getAttribute('aria-checked')).toBe('false');
+    // Trigger/target/host controls only appear once enabled.
+    expect(container.querySelector('select[aria-label="Push trigger"]')).toBeNull();
+    unmount();
+  });
+
+  it('opting in reveals trigger/target/host/port and marks the bundled target unsupported', () => {
+    const { container, unmount } = render(createElement(HamClockSettingsPanel));
+    const toggle = container.querySelector(
+      'button[aria-label="Push DX to HamClock"]',
+    ) as HTMLButtonElement;
+    act(() => toggle.click());
+    expect(container.querySelector('select[aria-label="Push trigger"]')).toBeTruthy();
+    expect(container.querySelector('input[aria-label="HamClock host"]')).toBeTruthy();
+    // Bundled target option is present but disabled (no set-DX endpoint yet).
+    const targetSel = container.querySelector('select[aria-label="Push target"]') as HTMLSelectElement;
+    const bundled = Array.from(targetSel.options).find((o) => o.value === 'bundled');
+    expect(bundled?.disabled).toBe(true);
+    unmount();
+  });
+
+  it('SAVE persists the full external push config to the backend', () => {
+    const savePushConfig = vi.fn(async () => {});
+    act(() => {
+      useHamClockStore.setState({ savePushConfig } as never);
+    });
+    const { container, unmount } = render(createElement(HamClockSettingsPanel));
+    const toggle = container.querySelector(
+      'button[aria-label="Push DX to HamClock"]',
+    ) as HTMLButtonElement;
+    act(() => toggle.click());
+
+    setSelectValue(
+      container.querySelector('select[aria-label="Push trigger"]') as HTMLSelectElement,
+      'on-active-QSO',
+    );
+    setInputValue(container.querySelector('input[aria-label="HamClock host"]') as HTMLInputElement, '10.0.0.5');
+    setInputValue(container.querySelector('input[aria-label="HamClock port"]') as HTMLInputElement, '8080');
+
+    clickByText(container, 'SAVE');
+    expect(savePushConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: true,
+        trigger: 'on-active-QSO',
+        target: 'external',
+        externalHost: '10.0.0.5',
+        externalPort: 8080,
+      }),
+    );
+    unmount();
+  });
+});

--- a/zeus-web/src/components/HamClockSettingsPanel.tsx
+++ b/zeus-web/src/components/HamClockSettingsPanel.tsx
@@ -9,8 +9,13 @@
 // not the Zeus installer). Node 18+ must be present; the panel surfaces a
 // clear prereq warning when it isn't.
 
-import { useEffect, useRef } from 'react';
-import { HAMCLOCK_LAYOUT_NAME, useHamClockStore } from '../state/hamclock-store';
+import { useEffect, useRef, useState, type CSSProperties } from 'react';
+import {
+  HAMCLOCK_LAYOUT_NAME,
+  HAMCLOCK_PUSH_DEFAULT_PORT,
+  useHamClockStore,
+  type HamClockPushConfig,
+} from '../state/hamclock-store';
 import { useLayoutStore } from '../state/layout-store';
 
 export function HamClockSettingsPanel() {
@@ -194,6 +199,9 @@ export function HamClockSettingsPanel() {
             : 'Enable the workspace to add a HamClock tab to the left layout bar.'}
       </div>
 
+      {/* Push DX to HamClock — outbound, SEND-ONLY, OFF by default. */}
+      <PushDxSection />
+
       {/* Install / run log */}
       {status.log.length > 0 && (
         <div>
@@ -223,6 +231,148 @@ export function HamClockSettingsPanel() {
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+// Outbound "push the worked station onto the HamClock map" config. SEND-ONLY:
+// the backend issues a single HTTP GET to the HamClock REST API (set_newdx?grid=)
+// when a QSO partner is clicked or goes active in the FT8 pop-out. Egress is OFF
+// by default; the server-side forward avoids browser CORS / HTTPS mixed-content.
+// The bundled OpenHamClock sidecar has no set-DX endpoint yet, so that target is
+// surfaced as unsupported (an upstream PR is needed).
+function PushDxSection() {
+  const pushConfig = useHamClockStore((s) => s.pushConfig);
+  const loadPushConfig = useHamClockStore((s) => s.loadPushConfig);
+  const savePushConfig = useHamClockStore((s) => s.savePushConfig);
+
+  const [form, setForm] = useState<HamClockPushConfig>(pushConfig);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    void loadPushConfig();
+  }, [loadPushConfig]);
+  useEffect(() => {
+    setForm(pushConfig);
+  }, [pushConfig]);
+
+  const patch = (p: Partial<HamClockPushConfig>) => setForm((f) => ({ ...f, ...p }));
+
+  async function onSave() {
+    setSaving(true);
+    try {
+      const port =
+        Number.isFinite(form.externalPort) && form.externalPort > 0 && form.externalPort < 65536
+          ? form.externalPort
+          : HAMCLOCK_PUSH_DEFAULT_PORT;
+      await savePushConfig({ ...form, externalPort: port, externalHost: form.externalHost.trim() });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const labelStyle: CSSProperties = { color: 'var(--fg-2)', fontSize: 12, minWidth: 92 };
+  const inputStyle: CSSProperties = {
+    flex: 1,
+    background: 'var(--bg-1, #0e1014)',
+    border: '1px solid var(--line-1, var(--line))',
+    borderRadius: 'var(--r-sm, 4px)',
+    color: 'var(--fg-0)',
+    fontSize: 12,
+    padding: '5px 8px',
+  };
+  const rowStyle: CSSProperties = { display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 };
+
+  return (
+    <div style={{ marginTop: 4, marginBottom: 20, paddingTop: 16, borderTop: '1px solid var(--line-1, var(--line))' }}>
+      <div style={{
+        fontSize: 11, letterSpacing: 0.8, textTransform: 'uppercase',
+        color: 'var(--fg-2)', marginBottom: 10, fontWeight: 700,
+      }}>
+        Push DX to HamClock
+      </div>
+      <p style={{ margin: '0 0 12px 0', lineHeight: 1.6, color: 'var(--fg-3)', fontSize: 12 }}>
+        When you work or click a station in the digital pop-out, place it on the HamClock map by its
+        grid. Send-only — nothing controls your radio. Off by default.
+      </p>
+
+      <label style={{ ...rowStyle, cursor: 'pointer' }}>
+        <span style={labelStyle}>Enable</span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={form.enabled}
+          aria-label="Push DX to HamClock"
+          className={`btn sm${form.enabled ? ' active' : ''}`}
+          onClick={() => patch({ enabled: !form.enabled })}
+        >
+          {form.enabled ? 'ON' : 'OFF'}
+        </button>
+      </label>
+
+      {form.enabled && (
+        <>
+          <div style={rowStyle}>
+            <span style={labelStyle}>Trigger</span>
+            <select
+              aria-label="Push trigger"
+              style={inputStyle}
+              value={form.trigger}
+              onChange={(e) => patch({ trigger: e.target.value as HamClockPushConfig['trigger'] })}
+            >
+              <option value="on-click">On click (when I click a station)</option>
+              <option value="on-active-QSO">On active QSO (the station I'm working)</option>
+            </select>
+          </div>
+
+          <div style={rowStyle}>
+            <span style={labelStyle}>Target</span>
+            <select
+              aria-label="Push target"
+              style={inputStyle}
+              value={form.target}
+              onChange={(e) => patch({ target: e.target.value as HamClockPushConfig['target'] })}
+            >
+              <option value="external">External HamClock (host : port)</option>
+              <option value="bundled" disabled>
+                Bundled OpenHamClock (set-DX not supported yet)
+              </option>
+            </select>
+          </div>
+
+          {form.target === 'external' && (
+            <>
+              <div style={rowStyle}>
+                <span style={labelStyle}>Host</span>
+                <input
+                  aria-label="HamClock host"
+                  style={inputStyle}
+                  value={form.externalHost}
+                  placeholder="192.168.1.50"
+                  spellCheck={false}
+                  onChange={(e) => patch({ externalHost: e.target.value })}
+                />
+              </div>
+              <div style={rowStyle}>
+                <span style={labelStyle}>Port</span>
+                <input
+                  aria-label="HamClock port"
+                  type="number"
+                  min={1}
+                  max={65535}
+                  style={inputStyle}
+                  value={form.externalPort}
+                  onChange={(e) => patch({ externalPort: Number(e.target.value) })}
+                />
+              </div>
+            </>
+          )}
+        </>
+      )}
+
+      <button type="button" className="btn sm" disabled={saving} onClick={() => void onSave()}>
+        {saving ? 'SAVING…' : 'SAVE'}
+      </button>
     </div>
   );
 }

--- a/zeus-web/src/components/ZeusDigitalSettingsPanel.test.tsx
+++ b/zeus-web/src/components/ZeusDigitalSettingsPanel.test.tsx
@@ -105,15 +105,37 @@ vi.mock('../api/wsjtx', () => ({
   postWsjtxConfig: vi.fn(async (c: Record<string, unknown>) => ({ ...c })),
 }));
 
+vi.mock('../api/n1mm', () => ({
+  N1MM_DEFAULT_PORT: 2333,
+  getN1mmConfig: vi.fn(async () => ({ enabled: false, host: '127.0.0.1', port: 2333 })),
+  postN1mmConfig: vi.fn(async (c: Record<string, unknown>) => ({ ...c })),
+}));
+
+vi.mock('../api/cloud-log', () => {
+  const EMPTY = {
+    wavelog: { enabled: false, baseUrl: '', stationProfileId: '', hasApiKey: false },
+    clubLog: { enabled: false, email: '', callsign: '', hasPassword: false, hasApiKey: false },
+  };
+  return {
+    getCloudLogStatus: vi.fn(async () => EMPTY),
+    postCloudLogConfig: vi.fn(async () => EMPTY),
+    postCloudLogCredentials: vi.fn(async () => EMPTY),
+  };
+});
+
 import { ZeusDigitalSettingsPanel } from './ZeusDigitalSettingsPanel';
 import { useFt8Store } from '../state/ft8-store';
 import { useFt8SettingsStore } from '../state/ft8-settings-store';
 import { useLayoutStore } from '../state/layout-store';
 import { useWsjtxStore } from '../state/wsjtx-store';
+import { useN1mmStore } from '../state/n1mm-store';
+import { useCloudLogStore } from '../state/cloud-log-store';
 import type { WsjtxConfig } from '../api/wsjtx';
 import * as operatorApi from '../api/operator';
 import * as ft8SettingsApi from '../api/ft8-settings';
 import * as wsjtxApi from '../api/wsjtx';
+import * as n1mmApi from '../api/n1mm';
+import * as cloudLogApi from '../api/cloud-log';
 
 const WSJTX_BASE_CONFIG: WsjtxConfig = {
   enabled: false,
@@ -177,6 +199,14 @@ describe('ZeusDigitalSettingsPanel', () => {
     // Reset the (singleton) WSJT-X store to a known disabled baseline so the
     // external-logging form starts clean in every test.
     useWsjtxStore.setState({ config: { ...WSJTX_BASE_CONFIG }, status: { ...WSJTX_BASE_CONFIG } });
+    // Reset the singleton N1MM + cloud-log stores to a clean disabled baseline.
+    useN1mmStore.setState({ config: { enabled: false, host: '127.0.0.1', port: 2333 } });
+    useCloudLogStore.setState({
+      status: {
+        wavelog: { enabled: false, baseUrl: '', stationProfileId: '', hasApiKey: false },
+        clubLog: { enabled: false, email: '', callsign: '', hasPassword: false, hasApiKey: false },
+      },
+    });
   });
 
   it('renders the GLOBAL Station identity fields and the mode selector', () => {
@@ -336,6 +366,65 @@ describe('ZeusDigitalSettingsPanel', () => {
         multicastGroup: '224.0.0.73',
         sendLiveDecodes: true,
       }),
+    );
+    unmount();
+  });
+
+  it('N1MM-format logging is additive + default off; opting in reveals host/port and SAVE persists', async () => {
+    const { container, unmount } = render(createElement(ZeusDigitalSettingsPanel));
+    expect(container.textContent).toContain('Also send to an HRD / N1MM-format logger');
+    // Default off — host/port hidden until opted in.
+    expect(
+      container.querySelector('button[aria-label="Also send to an HRD / N1MM-format logger"]')
+        ?.getAttribute('aria-checked'),
+    ).toBe('false');
+    clickSwitch(container, 'Also send to an HRD / N1MM-format logger');
+    // The N1MM SAVE persists the enabled config (default port 2333) to the backend.
+    const group = container.querySelector(
+      'div[aria-label="N1MM-format logging (HRD / DXKeeper)"]',
+    ) as HTMLElement;
+    expect(group).toBeTruthy();
+    clickByText(group, 'SAVE');
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(n1mmApi.postN1mmConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: true, port: 2333 }),
+    );
+    unmount();
+  });
+
+  it('Wavelog cloud logging is additive + default off; opting in + SAVE persists config and the write-only API key', async () => {
+    const { container, unmount } = render(createElement(ZeusDigitalSettingsPanel));
+    expect(container.textContent).toContain('Also push to Wavelog / Cloudlog');
+    expect(container.textContent).toContain('Also push to Club Log');
+    // Wavelog fields hidden until opted in.
+    expect(container.textContent).not.toContain('Base URL');
+    clickSwitch(container, 'Also push to Wavelog / Cloudlog');
+    expect(container.textContent).toContain('Base URL');
+
+    const group = container.querySelector(
+      'div[aria-label="Cloud logging (Wavelog / Club Log)"]',
+    ) as HTMLElement;
+    const baseUrl = group.querySelector(
+      'input.ft8-set-input:not([type="password"]):not([type="number"])',
+    ) as HTMLInputElement;
+    setInputValue(baseUrl, 'https://log.example.com');
+    const apiKey = group.querySelector('input[type="password"]') as HTMLInputElement;
+    setInputValue(apiKey, 'SECRETKEY');
+
+    clickByText(group, 'SAVE');
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(cloudLogApi.postCloudLogConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        wavelog: expect.objectContaining({ enabled: true, baseUrl: 'https://log.example.com' }),
+      }),
+    );
+    // The secret goes up the write-only credentials endpoint, not the config one.
+    expect(cloudLogApi.postCloudLogCredentials).toHaveBeenCalledWith(
+      expect.objectContaining({ wavelogApiKey: 'SECRETKEY' }),
     );
     unmount();
   });

--- a/zeus-web/src/components/ZeusDigitalSettingsPanel.tsx
+++ b/zeus-web/src/components/ZeusDigitalSettingsPanel.tsx
@@ -36,7 +36,10 @@ import { useSpottingStore } from '../state/spotting-store';
 import { useWsjtxStore } from '../state/wsjtx-store';
 import { useQrzStore } from '../state/qrz-store';
 import { useLayoutStore } from '../state/layout-store';
+import { useN1mmStore } from '../state/n1mm-store';
+import { useCloudLogStore } from '../state/cloud-log-store';
 import type { WsjtxConfig } from '../api/wsjtx';
+import type { N1mmConfig } from '../api/n1mm';
 import {
   DIGITAL_MODES,
   WF_PALETTES,
@@ -451,6 +454,16 @@ export function ZeusDigitalSettingsPanel({
 
           <div className="ft8-set-divider" />
 
+          {/* Additive N1MM-format UDP logger (HRD Logbook / DXKeeper gateway). */}
+          <N1mmLoggingGroup />
+
+          <div className="ft8-set-divider" />
+
+          {/* Additive per-QSO HTTP cloud loggers (Wavelog/Cloudlog + Club Log). */}
+          <CloudLoggingGroup />
+
+          <div className="ft8-set-divider" />
+
           {/* QRZ cloud logbook — credential lives on the QRZ tab. */}
           <div className="ft8-set-chips">
             <Chip label="QRZ Logbook (cloud)" on={qrzHasApiKey} />
@@ -652,6 +665,311 @@ export function ExternalLoggingGroup() {
               ? status?.transport === 'multicast'
                 ? `Sending to multicast ${status?.multicastGroup}:${status?.port}`
                 : `Sending to ${status?.host}:${status?.port}`
+              : 'Disabled — no QSO data leaves this machine.'}
+          </span>
+        </span>
+        <button type="button" className="ft8-set-link" disabled={saving} onClick={() => void onSave()}>
+          {saving ? 'SAVING…' : 'SAVE'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// N1MM-format UDP logging — the "N1MM Logger+ Broadcasts" contactinfo datagram
+// (a DIFFERENT wire format from the WSJT-X type-12 ADIF datagram above). HRD
+// Logbook's QSO-Forwarding and DXKeeper-via-Gateway listen for THIS, on its own
+// configurable port (default 2333). Server-backed (useN1mmStore), SEND-ONLY,
+// egress OFF until the operator opts in and SAVES.
+// ---------------------------------------------------------------------------
+
+function N1mmLoggingGroup() {
+  const config = useN1mmStore((s) => s.config);
+  const saveConfig = useN1mmStore((s) => s.saveConfig);
+  const refreshConfig = useN1mmStore((s) => s.refreshConfig);
+
+  const [form, setForm] = useState<N1mmConfig>(config);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    void refreshConfig();
+  }, [refreshConfig]);
+  useEffect(() => {
+    setForm(config);
+  }, [config]);
+
+  const patch = (p: Partial<N1mmConfig>) => setForm((f) => ({ ...f, ...p }));
+
+  async function onSave() {
+    setSaving(true);
+    try {
+      const port = Number.isFinite(form.port) && form.port > 0 && form.port < 65536 ? form.port : 2333;
+      await saveConfig({ ...form, port, host: form.host.trim() || '127.0.0.1' });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div aria-label="N1MM-format logging (HRD / DXKeeper)">
+      <ToggleRow
+        label="Also send to an HRD / N1MM-format logger"
+        hint="Mirror each logged QSO out as the N1MM contactinfo UDP datagram. HRD Logbook & DXKeeper-via-Gateway speak this. Additive — Zeus keeps the internal copy."
+        checked={form.enabled}
+        onChange={(v) => patch({ enabled: v })}
+      />
+
+      {form.enabled && (
+        <>
+          <TextRow
+            label="Host"
+            hint="127.0.0.1 for a logger on this machine; otherwise the logger's LAN IP."
+            value={form.host}
+            placeholder="127.0.0.1"
+            onChange={(v) => patch({ host: v })}
+          />
+          <NumberRow
+            label="Port"
+            hint="N1MM-broadcast default is 2333 — match your logger's UDP input."
+            value={form.port}
+            min={1}
+            max={65535}
+            onChange={(v) => patch({ port: v })}
+          />
+        </>
+      )}
+
+      <div className="ft8-set-row ft8-set-row--readonly">
+        <span className="ft8-set-row__text">
+          <span className="ft8-set-row__label">
+            <span
+              className="ft8-set-chip__dot"
+              style={{ background: config.enabled ? 'var(--hud-cq)' : 'var(--hud-text-dim)' }}
+            />{' '}
+            N1MM-format logger
+          </span>
+          <span className="ft8-set-row__hint">
+            {config.enabled
+              ? `Sending to ${config.host}:${config.port}`
+              : 'Disabled — no QSO data leaves this machine.'}
+          </span>
+        </span>
+        <button type="button" className="ft8-set-link" disabled={saving} onClick={() => void onSave()}>
+          {saving ? 'SAVING…' : 'SAVE'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// HTTP cloud loggers — per-QSO realtime ADIF push to Wavelog/Cloudlog and Club
+// Log. Server-backed (useCloudLogStore), SEND-ONLY, egress OFF by default.
+// SECRETS ARE WRITE-ONLY: the API key / application password are typed into a
+// password field and POSTed to a separate credentials endpoint; they never come
+// back down, so the form only shows a "key saved" indicator from the status.
+// ---------------------------------------------------------------------------
+
+// Minimal masked input for write-only secrets (the shared TextRow does not mask).
+function SecretRow(props: {
+  label: string;
+  hint?: string;
+  value: string;
+  placeholder?: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div className="ft8-set-row">
+      <span className="ft8-set-row__text">
+        <span className="ft8-set-row__label">{props.label}</span>
+        {props.hint && <span className="ft8-set-row__hint">{props.hint}</span>}
+      </span>
+      <input
+        className="ft8-set-input"
+        type="password"
+        autoComplete="off"
+        value={props.value}
+        placeholder={props.placeholder}
+        spellCheck={false}
+        aria-label={props.label}
+        onChange={(e) => props.onChange(e.target.value)}
+      />
+    </div>
+  );
+}
+
+function CloudLoggingGroup() {
+  const status = useCloudLogStore((s) => s.status);
+  const refreshStatus = useCloudLogStore((s) => s.refreshStatus);
+  const saveConfig = useCloudLogStore((s) => s.saveConfig);
+  const saveCredentials = useCloudLogStore((s) => s.saveCredentials);
+
+  // Non-secret form state, seeded from the server status. Secrets stay in their
+  // own local state and are cleared after a save (never echoed back).
+  const [wlEnabled, setWlEnabled] = useState(false);
+  const [wlBaseUrl, setWlBaseUrl] = useState('');
+  const [wlProfile, setWlProfile] = useState('');
+  const [wlKey, setWlKey] = useState('');
+
+  const [clEnabled, setClEnabled] = useState(false);
+  const [clEmail, setClEmail] = useState('');
+  const [clCall, setClCall] = useState('');
+  const [clPassword, setClPassword] = useState('');
+  const [clApiKey, setClApiKey] = useState('');
+
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    void refreshStatus();
+  }, [refreshStatus]);
+  useEffect(() => {
+    setWlEnabled(status.wavelog.enabled);
+    setWlBaseUrl(status.wavelog.baseUrl);
+    setWlProfile(status.wavelog.stationProfileId);
+    setClEnabled(status.clubLog.enabled);
+    setClEmail(status.clubLog.email);
+    setClCall(status.clubLog.callsign);
+  }, [status]);
+
+  async function onSave() {
+    setSaving(true);
+    try {
+      await saveConfig({
+        wavelog: {
+          enabled: wlEnabled,
+          baseUrl: wlBaseUrl.trim(),
+          stationProfileId: wlProfile.trim(),
+        },
+        clubLog: {
+          enabled: clEnabled,
+          email: clEmail.trim(),
+          callsign: clCall.trim().toUpperCase(),
+        },
+      });
+      // Only push secrets the operator actually typed this session.
+      const creds: { wavelogApiKey?: string; clubLogPassword?: string; clubLogApiKey?: string } = {};
+      if (wlKey) creds.wavelogApiKey = wlKey;
+      if (clPassword) creds.clubLogPassword = clPassword;
+      if (clApiKey) creds.clubLogApiKey = clApiKey;
+      if (Object.keys(creds).length > 0) await saveCredentials(creds);
+      setWlKey('');
+      setClPassword('');
+      setClApiKey('');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div aria-label="Cloud logging (Wavelog / Club Log)">
+      {/* Wavelog / Cloudlog */}
+      <ToggleRow
+        label="Also push to Wavelog / Cloudlog"
+        hint="Upload each logged QSO to a Wavelog or Cloudlog instance over HTTPS. Additive — Zeus keeps the internal copy."
+        checked={wlEnabled}
+        onChange={setWlEnabled}
+      />
+      {wlEnabled && (
+        <>
+          <TextRow
+            label="Base URL"
+            hint="Your instance root, e.g. https://log.example.com (Zeus adds /api/qso)."
+            value={wlBaseUrl}
+            placeholder="https://log.example.com"
+            onChange={setWlBaseUrl}
+          />
+          <TextRow
+            label="Station profile id"
+            hint="The Wavelog station-location / profile id this log feeds."
+            value={wlProfile}
+            placeholder="1"
+            onChange={setWlProfile}
+          />
+          <SecretRow
+            label="API key"
+            hint={
+              status.wavelog.hasApiKey
+                ? 'A key is saved — type a new one to replace it.'
+                : 'Wavelog account → API keys. Stored on the server, never shown again.'
+            }
+            value={wlKey}
+            placeholder={status.wavelog.hasApiKey ? '•••••• (saved)' : 'paste API key'}
+            onChange={setWlKey}
+          />
+        </>
+      )}
+
+      <div className="ft8-set-divider" />
+
+      {/* Club Log */}
+      <ToggleRow
+        label="Also push to Club Log"
+        hint="Upload each logged QSO to Club Log's realtime API over HTTPS. Additive — Zeus keeps the internal copy."
+        checked={clEnabled}
+        onChange={setClEnabled}
+      />
+      {clEnabled && (
+        <>
+          <TextRow
+            label="Email"
+            hint="The email of your Club Log account."
+            value={clEmail}
+            placeholder="you@example.com"
+            onChange={setClEmail}
+          />
+          <TextRow
+            label="Callsign"
+            hint="The logging callsign for this Club Log account."
+            value={clCall}
+            placeholder="MYCALL"
+            upper
+            onChange={setClCall}
+          />
+          <SecretRow
+            label="Password"
+            hint={
+              status.clubLog.hasPassword
+                ? 'A password is saved — type a new one to replace it.'
+                : 'Your Club Log account password. Stored on the server, never shown again.'
+            }
+            value={clPassword}
+            placeholder={status.clubLog.hasPassword ? '•••••• (saved)' : 'account password'}
+            onChange={setClPassword}
+          />
+          <SecretRow
+            label="API key"
+            hint={
+              status.clubLog.hasApiKey
+                ? 'A key is saved — type a new one to replace it.'
+                : 'Club Log application API key (clublog.org/api.php).'
+            }
+            value={clApiKey}
+            placeholder={status.clubLog.hasApiKey ? '•••••• (saved)' : 'application API key'}
+            onChange={setClApiKey}
+          />
+        </>
+      )}
+
+      <div className="ft8-set-row ft8-set-row--readonly">
+        <span className="ft8-set-row__text">
+          <span className="ft8-set-row__label">
+            <span
+              className="ft8-set-chip__dot"
+              style={{
+                background:
+                  status.wavelog.enabled || status.clubLog.enabled
+                    ? 'var(--hud-cq)'
+                    : 'var(--hud-text-dim)',
+              }}
+            />{' '}
+            Cloud loggers
+          </span>
+          <span className="ft8-set-row__hint">
+            {status.wavelog.enabled || status.clubLog.enabled
+              ? `Active: ${[status.wavelog.enabled ? 'Wavelog' : null, status.clubLog.enabled ? 'Club Log' : null]
+                  .filter(Boolean)
+                  .join(' + ')}`
               : 'Disabled — no QSO data leaves this machine.'}
           </span>
         </span>

--- a/zeus-web/src/layout/ft8/Ft8PopBody.test.tsx
+++ b/zeus-web/src/layout/ft8/Ft8PopBody.test.tsx
@@ -13,6 +13,7 @@ import { Ft8PopBody } from './Ft8PopBody';
 import { useFt8Store, type Ft8Row } from '../../state/ft8-store';
 import { useOperatorStore } from '../../state/operator-store';
 import { useLayoutStore } from '../../state/layout-store';
+import { useHamClockStore } from '../../state/hamclock-store';
 
 function row(text: string): Ft8Row {
   return {
@@ -41,6 +42,12 @@ describe('Ft8PopBody → existing QRZ panel wiring', () => {
       useFt8Store.setState({ open: true, protocol: 'FT8', band: '20m', rows: [row('CQ K1ABC FN42')] });
       // Operator call must be set or click-to-call bails to the settings view.
       useOperatorStore.setState({ resolvedCall: 'MYCALL', resolvedGrid: 'FN31' } as never);
+      // Default the HamClock DX push OFF; loadPushConfig stubbed so no fetch fires.
+      useHamClockStore.setState({
+        pushConfig: { enabled: false, trigger: 'on-click', target: 'external', externalHost: '', externalPort: 8080 },
+        loadPushConfig: async () => {},
+        pushDx: async () => {},
+      } as never);
     });
   });
 
@@ -58,6 +65,51 @@ describe('Ft8PopBody → existing QRZ panel wiring', () => {
     });
 
     expect(runQrzLookup).toHaveBeenCalledWith('K1ABC');
+    unmount();
+  });
+
+  it('clicking a station pushes its grid to HamClock when on-click push is enabled', () => {
+    const pushDx = vi.fn(async () => {});
+    act(() => {
+      useHamClockStore.setState({
+        pushConfig: { enabled: true, trigger: 'on-click', target: 'external', externalHost: '10.0.0.5', externalPort: 8080 },
+        loadPushConfig: async () => {},
+        pushDx,
+      } as never);
+    });
+    const { container, unmount } = renderWithQrz(vi.fn());
+
+    const targetRow = Array.from(container.querySelectorAll('tbody tr')).find((tr) =>
+      tr.textContent?.includes('K1ABC'),
+    );
+    expect(targetRow).toBeTruthy();
+    act(() => {
+      targetRow!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    // Grid (FN42) is parsed from the decode and forwarded; call is context only.
+    expect(pushDx).toHaveBeenCalledWith('FN42', 'K1ABC');
+    unmount();
+  });
+
+  it('does NOT push to HamClock on click when the push feature is disabled', () => {
+    const pushDx = vi.fn(async () => {});
+    act(() => {
+      useHamClockStore.setState({
+        pushConfig: { enabled: false, trigger: 'on-click', target: 'external', externalHost: '', externalPort: 8080 },
+        loadPushConfig: async () => {},
+        pushDx,
+      } as never);
+    });
+    const { container, unmount } = renderWithQrz(vi.fn());
+
+    const targetRow = Array.from(container.querySelectorAll('tbody tr')).find((tr) =>
+      tr.textContent?.includes('K1ABC'),
+    );
+    act(() => {
+      targetRow!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(pushDx).not.toHaveBeenCalled();
     unmount();
   });
 

--- a/zeus-web/src/layout/ft8/Ft8PopBody.tsx
+++ b/zeus-web/src/layout/ft8/Ft8PopBody.tsx
@@ -25,6 +25,7 @@ import { qsoStateToLogEntry } from '../../dsp/ft8-qso-log';
 import { parseFt8Message } from '../../dsp/ft8-message';
 import { useLoggerStore } from '../../state/logger-store';
 import { useLayoutStore } from '../../state/layout-store';
+import { useHamClockStore } from '../../state/hamclock-store';
 import { useWorkspace } from '../WorkspaceContext';
 import { Ft8DecodeTable } from './Ft8DecodeTable';
 import { Ft8TxControl } from './Ft8TxControl';
@@ -83,6 +84,14 @@ export function Ft8PopBody() {
 
   // Click a station / live QSO partner → the operator's EXISTING QRZ panel.
   const { runQrzLookup } = useWorkspace();
+
+  // HamClock DX push — place the worked station on the HamClock map by grid.
+  // Server-backed config (egress OFF by default); the frontend gates on the
+  // configured trigger (on-click vs on-active-QSO) and the server gates again on
+  // `enabled`. A grid is mandatory — classic HamClock sets DX by grid, not call.
+  const pushConfig = useHamClockStore((s) => s.pushConfig);
+  const loadPushConfig = useHamClockStore((s) => s.loadPushConfig);
+  const pushDx = useHamClockStore((s) => s.pushDx);
 
   // Worked-before / new-grid sets for decode-table highlighting, memoized from
   // the logbook. NOTE: useLoggerStore.loadEntries caps at 100 entries (#1015).
@@ -153,11 +162,13 @@ export function Ft8PopBody() {
     }
   };
 
-  // Hydrate the logbook + operator identity once when the pop-out opens.
+  // Hydrate the logbook + operator identity + HamClock push config once when the
+  // pop-out opens.
   useEffect(() => {
     void useLoggerStore.getState().loadEntries();
     void hydrateOperator();
-  }, [hydrateOperator]);
+    void loadPushConfig();
+  }, [hydrateOperator, loadPushConfig]);
 
   // REUSE WIRING: when the live QSO partner changes (we answered a station, or a
   // station answered our CQ), populate the operator's existing QRZ panel.
@@ -170,6 +181,27 @@ export function Ft8PopBody() {
     }
     if (!dxCall) lastQrzCall.current = null;
   }, [dxCall, runQrzLookup]);
+
+  // HamClock "on-active-QSO" trigger: push the partner's grid to the map once it
+  // is known. Keyed on dxGrid4 (NOT dxCall) because the grid lags the call — we
+  // learn the call when we answer/are answered, the grid arrives a sequence step
+  // later. Fires once per distinct grid; the on-click path is handled separately.
+  const dxGrid4 = tx.qso.dxGrid4;
+  const lastPushGrid = useRef<string | null>(null);
+  useEffect(() => {
+    if (
+      pushConfig.enabled &&
+      pushConfig.trigger === 'on-active-QSO' &&
+      dxGrid4 &&
+      dxGrid4 !== lastPushGrid.current
+    ) {
+      lastPushGrid.current = dxGrid4;
+      void pushDx(dxGrid4, tx.qso.dxCall);
+    }
+    if (!dxGrid4) lastPushGrid.current = null;
+    // tx.qso.dxCall is read at fire-time only; excluded from deps on purpose.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dxGrid4, pushConfig.enabled, pushConfig.trigger, pushDx]);
 
   // Band-follow while engaged: if the operator changes the MAIN band (BandButtons
   // retune the VFO out of this digital sub-band), re-QSY to the new band's
@@ -193,8 +225,13 @@ export function Ft8PopBody() {
     const secs = new Date(row.slotStartUnixMs).getUTCSeconds();
     const senderSlot = slotOf(secs, protocol);
     tx.callStation(row.text, senderSlot);
-    const sender = parseFt8Message(row.text).deCall;
-    if (sender) runQrzLookup(sender);
+    const parsed = parseFt8Message(row.text);
+    if (parsed.deCall) runQrzLookup(parsed.deCall);
+    // HamClock "on-click" trigger: push the clicked station's grid to the map.
+    // No grid in this decode (e.g. a bare CQ) → nothing to place; skip silently.
+    if (pushConfig.enabled && pushConfig.trigger === 'on-click' && parsed.grid) {
+      void pushDx(parsed.grid, parsed.deCall);
+    }
   };
 
   const bandsForProtocol = useMemo(

--- a/zeus-web/src/state/cloud-log-store.ts
+++ b/zeus-web/src/state/cloud-log-store.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// HTTP cloud-log uploader store (Wavelog/Cloudlog + Club Log realtime). The
+// backend (CloudLogConfigStore + CredentialStore) is the source of truth: the
+// form initialises from GET /api/log/cloud/config once it arrives. Secrets are
+// WRITE-ONLY — the status only ever reports presence booleans, never the keys —
+// so credentials POST through a separate endpoint. Egress is OFF by default.
+
+import { create } from 'zustand';
+import {
+  getCloudLogStatus,
+  postCloudLogConfig,
+  postCloudLogCredentials,
+  type CloudLogConfig,
+  type CloudLogCredentials,
+  type CloudLogStatus,
+} from '../api/cloud-log';
+
+const DEFAULT_STATUS: CloudLogStatus = {
+  wavelog: { enabled: false, baseUrl: '', stationProfileId: '', hasApiKey: false },
+  clubLog: { enabled: false, email: '', callsign: '', hasPassword: false, hasApiKey: false },
+};
+
+export type CloudLogStoreState = {
+  status: CloudLogStatus;
+  refreshStatus: () => Promise<void>;
+  saveConfig: (cfg: CloudLogConfig) => Promise<CloudLogStatus>;
+  saveCredentials: (creds: CloudLogCredentials) => Promise<CloudLogStatus>;
+};
+
+export const useCloudLogStore = create<CloudLogStoreState>((set) => ({
+  status: DEFAULT_STATUS,
+
+  refreshStatus: async () => {
+    try {
+      set({ status: await getCloudLogStatus() });
+    } catch {
+      /* transient — next refresh recovers */
+    }
+  },
+
+  saveConfig: async (cfg) => {
+    const status = await postCloudLogConfig(cfg);
+    set({ status });
+    return status;
+  },
+
+  saveCredentials: async (creds) => {
+    const status = await postCloudLogCredentials(creds);
+    set({ status });
+    return status;
+  },
+}));
+
+// Initial status probe (one-shot — config applies live so no polling needed).
+if (typeof window !== 'undefined') {
+  void useCloudLogStore.getState().refreshStatus();
+}

--- a/zeus-web/src/state/hamclock-store.ts
+++ b/zeus-web/src/state/hamclock-store.ts
@@ -70,12 +70,63 @@ const EMPTY_STATUS: HamClockStatus = {
   log: [],
 };
 
+/**
+ * Config for the outbound "push worked station to HamClock" feature. SEND-ONLY
+ * (the backend issues a single HTTP GET to the HamClock REST API), egress OFF by
+ * default. Mirrors the server-side HamClockPushConfig — these never cross the
+ * SignalR/StateDto wire, only the /api/hamclock/push-config + /api/hamclock/dx
+ * REST endpoints. `bundled` (the embedded OpenHamClock sidecar) has no set-DX
+ * endpoint today, so that target is surfaced as unsupported in the UI.
+ */
+export interface HamClockPushConfig {
+  enabled: boolean;
+  trigger: 'on-click' | 'on-active-QSO';
+  target: 'bundled' | 'external';
+  externalHost: string;
+  externalPort: number;
+}
+
+export const HAMCLOCK_PUSH_DEFAULT_PORT = 8080;
+
+const DEFAULT_PUSH_CONFIG: HamClockPushConfig = {
+  enabled: false,
+  trigger: 'on-click',
+  target: 'external',
+  externalHost: '',
+  externalPort: HAMCLOCK_PUSH_DEFAULT_PORT,
+};
+
+function normalizePushConfig(raw: unknown): HamClockPushConfig {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  return {
+    enabled: Boolean(r.enabled),
+    trigger: r.trigger === 'on-active-QSO' ? 'on-active-QSO' : 'on-click',
+    target: r.target === 'bundled' ? 'bundled' : 'external',
+    externalHost: typeof r.externalHost === 'string' ? r.externalHost : '',
+    externalPort:
+      typeof r.externalPort === 'number' && r.externalPort > 0 && r.externalPort < 65536
+        ? r.externalPort
+        : HAMCLOCK_PUSH_DEFAULT_PORT,
+  };
+}
+
 interface HamClockState {
   status: HamClockStatus;
   loadStatus(): Promise<void>;
   install(): Promise<void>;
   start(): Promise<void>;
   stop(): Promise<void>;
+
+  /** Outbound DX-push config (server-backed, egress OFF by default). */
+  pushConfig: HamClockPushConfig;
+  /** GET /api/hamclock/push-config → seed the push form. */
+  loadPushConfig(): Promise<void>;
+  /** POST /api/hamclock/push-config → persist + apply live. */
+  savePushConfig(cfg: HamClockPushConfig): Promise<void>;
+  /** POST /api/hamclock/dx → forward a worked station's grid to HamClock.
+   *  Server-side forward (avoids browser CORS / HTTPS mixed-content). The server
+   *  also gates on `enabled`; this no-ops silently on any failure. */
+  pushDx(grid: string, call?: string | null): Promise<void>;
   /** Enable the HamClock workspace: ensure the layout exists and switch to it.
    *  Creates it (single full-bleed hamclock tile) on first use. Idempotent. */
   openWorkspace(): void;
@@ -165,5 +216,42 @@ export const useHamClockStore = create<HamClockState>()((set) => ({
     const ls = useLayoutStore.getState();
     const existing = ls.layouts.find((l) => l.name === HAMCLOCK_LAYOUT_NAME);
     if (existing) ls.removeLayout(existing.id);
+  },
+
+  pushConfig: DEFAULT_PUSH_CONFIG,
+
+  loadPushConfig: async () => {
+    try {
+      const res = await fetch('/api/hamclock/push-config');
+      if (!res.ok) return;
+      set({ pushConfig: normalizePushConfig(await res.json()) });
+    } catch (err) {
+      console.warn('hamclock push-config GET threw', err);
+    }
+  },
+
+  savePushConfig: async (cfg) => {
+    try {
+      const res = await fetch('/api/hamclock/push-config', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(cfg),
+      });
+      if (res.ok) set({ pushConfig: normalizePushConfig(await res.json()) });
+    } catch (err) {
+      console.warn('hamclock push-config POST threw', err);
+    }
+  },
+
+  pushDx: async (grid, call) => {
+    try {
+      await fetch('/api/hamclock/dx', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ grid, call: call ?? null }),
+      });
+    } catch (err) {
+      console.warn('hamclock dx POST threw', err);
+    }
   },
 }));

--- a/zeus-web/src/state/n1mm-store.ts
+++ b/zeus-web/src/state/n1mm-store.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// N1MM-format UDP broadcaster store. The backend (N1mmBroadcaster on disk) is
+// the source of truth: the form initialises from GET /api/n1mm/config once it
+// arrives. Like the WSJT-X store, do NOT seed from localStorage and do NOT
+// auto-POST on load. Egress is OFF by default.
+
+import { create } from 'zustand';
+import {
+  getN1mmConfig,
+  postN1mmConfig,
+  N1MM_DEFAULT_PORT,
+  type N1mmConfig,
+} from '../api/n1mm';
+
+const DEFAULT_CONFIG: N1mmConfig = {
+  enabled: false,
+  host: '127.0.0.1',
+  port: N1MM_DEFAULT_PORT,
+};
+
+export type N1mmStoreState = {
+  config: N1mmConfig;
+  refreshConfig: () => Promise<void>;
+  saveConfig: (cfg: N1mmConfig) => Promise<N1mmConfig>;
+};
+
+export const useN1mmStore = create<N1mmStoreState>((set) => ({
+  config: DEFAULT_CONFIG,
+
+  refreshConfig: async () => {
+    try {
+      set({ config: await getN1mmConfig() });
+    } catch {
+      /* transient — next refresh recovers */
+    }
+  },
+
+  saveConfig: async (cfg) => {
+    const saved = await postN1mmConfig(cfg);
+    set({ config: saved });
+    return saved;
+  },
+}));
+
+// Initial config probe (one-shot — config applies live so no polling needed).
+if (typeof window !== 'undefined') {
+  void useN1mmStore.getState().refreshConfig();
+}


### PR DESCRIPTION
## ⛔ DO NOT MERGE — bench + Contracts sign-off required

**Stack: on top of `ft8/logging-v1` (#1084). Top of the FT8 stack.** Finishes external logging + the HamClock map integration. All additive over the internal logbook, all **default OFF**, **send-only**.

### What's in it
- **Cloud (Class C):** Wavelog/Cloudlog (`POST {base}/api/qso`, `/index.php` fallback) + Club Log (`clublog.org/realtime.php`) — per-QSO realtime, failure-tolerant, secrets in the existing plaintext `CredentialStore`. Fired on the same QSO-log fan-out as QRZ.
- **N1MM-format UDP (Class B, port 2333):** `<contactinfo>` XML encoder + broadcaster for HRD QSO-Forwarding / DXKeeper-gateway.
- **HamClock DX-push:** server-side flavor-agnostic forward (`/api/hamclock/dx` → `set_newdx?grid=`), so clicking/working a station pushes its grid to your HamClock map (reuses the existing embed/sidecar; bundled OpenHamClock gated pending an upstream set-DX endpoint). Push toggle/trigger/target in HamClock settings.
- Zeus Digital "Logging" UI extended with the new targets.

### Audit caught & fixed
- Club Log host (`secure.`→`clublog.org`), per-secret credential guard (no clobber), N1MM `<band>` as **MHz** not meters.
- The "critical" `set_newdxgrid` finding was a **verified false positive** (it cited a HamClock fork; canonical HamClock uses `set_newdx?grid=`).

### Safety / red-light
- Send-only; no inbound TX-trigger. Egress off by default; Club Log 403 → auto-disable.
- **Contracts:** any new DTOs need **Christian (N9WAR)** sign-off.
- Bench: verify a real Wavelog/Club Log/HRD/HamClock accepts the output.

### Status
Build 0/0; **2019 server + FE** suites green. PureSignal untouched.
**Known minor:** a raw-hex `var()` fallback in the HamClock PushDxSection to tidy.
