### PR TITLE
fix(web,lan): remote LAN Browser inline page + bookmark bar

### DIFF
--- a/Zeus.Server.Hosting/LanProxyService.cs
+++ b/Zeus.Server.Hosting/LanProxyService.cs
@@ -324,6 +324,18 @@ public sealed partial class LanProxyService
     private const int InlineBudgetBytes = 6 * 1024 * 1024;
     private const int InlinePerResourceBytes = 2 * 1024 * 1024;
 
+    // Overall wall-clock budget for inlining one page (fetch every sub-resource +
+    // base64-encode it). Kept comfortably UNDER the remote tunnel's LAN-proxy
+    // client deadline (api-tunnel.ts LAN_PROXY_TIMEOUT_MS, 60 s) so the reply
+    // always beats the client's timeout — the prior unbounded serial fetch could
+    // run past the flat 15 s tunnel deadline and surface as a spurious "Remote
+    // API request timed out." Sub-resources not fetched within the budget are
+    // simply omitted (the page still renders), never an error.
+    internal static readonly TimeSpan InlineMaxDuration = TimeSpan.FromSeconds(30);
+    // Per-sub-resource ceiling so one slow/hung asset can't consume the whole
+    // page budget on its own.
+    private static readonly TimeSpan InlineSubResourceTimeout = TimeSpan.FromSeconds(5);
+
     // Injected into the inlined page so anchor clicks / form submits ask the Zeus
     // panel (the iframe's parent) to navigate, instead of the sandboxed srcdoc
     // iframe trying to load a URL it can't reach over the remote tunnel.
@@ -352,27 +364,67 @@ public sealed partial class LanProxyService
             baseUri = declared;
         }
 
+        // Bound the whole inline operation. A device with many (or slow) sub-
+        // resources must not push the tunnelled reply past the client's deadline;
+        // when this elapses, in-flight/remaining sub-resource fetches fast-fail
+        // and the asset is omitted. The outer `ct` (real client cancel) is still
+        // honoured and propagated by FetchSubResourceAsync.
+        using var inlineCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        inlineCts.CancelAfter(InlineMaxDuration);
+        var ict = inlineCts.Token;
+
         int budget = InlineBudgetBytes;
 
-        // 1. Stylesheets: <link rel="stylesheet" href="…"> → <style>…</style>.
+        // Inline the url(...) assets (web fonts, background images) a CSS string
+        // references as data: URIs, resolving each against its own stylesheet
+        // base. Un-fetchable assets (over budget, unreachable, timed out) are
+        // left as-is. This is what stops the operator's HTTPS, off-LAN browser
+        // from trying to pull web fonts straight off the radio's LAN (the
+        // "Failed to decode font / OTS parsing error" symptom).
+        async Task<string> InlineCssAsync(string css, Uri cssBase) =>
+            await ReplaceAsync(CssUrlRegex(), css, async m =>
+            {
+                var raw = m.Groups["url"].Value.Trim().Trim('\'', '"', ' ');
+                if (raw.Length == 0
+                    || raw[0] == '#'
+                    || raw.StartsWith("data:", StringComparison.OrdinalIgnoreCase)) return m.Value;
+                if (!Uri.TryCreate(cssBase, raw, out var abs)) return m.Value;
+                if (abs.Scheme != Uri.UriSchemeHttp && abs.Scheme != Uri.UriSchemeHttps) return m.Value;
+                var res = await FetchSubResourceAsync(abs, ict, ct).ConfigureAwait(false);
+                if (res is null || budget - res.Value.bytes.Length < 0) return m.Value;
+                budget -= res.Value.bytes.Length;
+                var mime = res.Value.contentType ?? "application/octet-stream";
+                return $"url(\"data:{mime};base64,{Convert.ToBase64String(res.Value.bytes)}\")";
+            }).ConfigureAwait(false);
+
+        // 1. Inline <style> blocks: inline their url(...) assets (page-relative).
+        //    Done before stylesheet links so it only sees the page's own blocks.
+        html = await ReplaceAsync(StyleBlockRegex(), html, async m =>
+        {
+            var css = await InlineCssAsync(m.Groups["css"].Value, baseUri).ConfigureAwait(false);
+            return $"<style{m.Groups["attrs"].Value}>{css}</style>";
+        }).ConfigureAwait(false);
+
+        // 2. Stylesheets: <link rel="stylesheet" href="…"> → <style>…</style>,
+        //    with the stylesheet's own url(...) assets inlined against its base.
         html = await ReplaceAsync(StylesheetLinkRegex(), html, async m =>
         {
             var href = m.Groups["url"].Value;
             if (!Uri.TryCreate(baseUri, href, out var abs)) return m.Value;
-            var res = await FetchSubResourceAsync(abs, ct).ConfigureAwait(false);
+            var res = await FetchSubResourceAsync(abs, ict, ct).ConfigureAwait(false);
             if (res is null || budget - res.Value.bytes.Length < 0) return m.Value;
             budget -= res.Value.bytes.Length;
-            var css = Encoding.UTF8.GetString(res.Value.bytes);
+            var css = await InlineCssAsync(Encoding.UTF8.GetString(res.Value.bytes), abs).ConfigureAwait(false);
             return $"<style>{css}</style>";
         }).ConfigureAwait(false);
 
-        // 2. Images: <img … src="…"> → data: URI.
+        // 3. Images: <img … src="…"> → data: URI.
         html = await ReplaceAsync(ImgTagRegex(), html, async m =>
         {
             var src = m.Groups["url"].Value;
             if (src.StartsWith("data:", StringComparison.OrdinalIgnoreCase)) return m.Value;
             if (!Uri.TryCreate(baseUri, src, out var abs)) return m.Value;
-            var res = await FetchSubResourceAsync(abs, ct).ConfigureAwait(false);
+            var res = await FetchSubResourceAsync(abs, ict, ct).ConfigureAwait(false);
             if (res is null || budget - res.Value.bytes.Length < 0) return m.Value;
             budget -= res.Value.bytes.Length;
             var mime = res.Value.contentType ?? "image/*";
@@ -380,7 +432,7 @@ public sealed partial class LanProxyService
             return m.Value.Replace(src, dataUri, StringComparison.Ordinal);
         }).ConfigureAwait(false);
 
-        // 3. Anchors: route clicks to the parent panel instead of the dead iframe.
+        // 4. Anchors: route clicks to the parent panel instead of the dead iframe.
         html = AnchorHrefRegex().Replace(html, m =>
         {
             var href = m.Groups["url"].Value;
@@ -392,7 +444,7 @@ public sealed partial class LanProxyService
             return $"<a href=\"#\" data-zeus-lan=\"{EscapeAttr(abs.ToString())}\"";
         });
 
-        // 4. Forms: relay the action target too (GET forms; best-effort).
+        // 5. Forms: relay the action target too (GET forms; best-effort).
         html = FormActionRegex().Replace(html, m =>
         {
             var action = m.Groups["url"].Value;
@@ -401,33 +453,87 @@ public sealed partial class LanProxyService
             return $"<form data-zeus-lan-form=\"{EscapeAttr(abs.ToString())}\"";
         });
 
-        // 5. Inject the nav interceptor just before </body> (or append).
+        // 6. Neutralise every reference that would otherwise make the operator's
+        //    (HTTPS, off-LAN) browser fetch from the radio's LAN itself, which it
+        //    cannot: framesets/iframes, external scripts, and any leftover
+        //    src/href. Without this the srcdoc is NOT self-contained — those loads
+        //    fail as mixed-content (http:// in an https page), DNS errors (LAN
+        //    hostnames), or font-decode errors, spraying the console and breaking
+        //    layout. This was the source of the "insecure frame" /
+        //    ERR_NAME_NOT_RESOLVED symptoms. After this pass the page renders from
+        //    inlined assets only.
+        html = NeutralizeEscapingRefs(html);
+
+        // 7. Inject the nav interceptor just before </body> (or append).
         int bodyEnd = html.LastIndexOf("</body>", StringComparison.OrdinalIgnoreCase);
         html = bodyEnd >= 0 ? html.Insert(bodyEnd, NavInterceptorScript) : html + NavInterceptorScript;
 
         return html;
     }
 
-    /// <summary>Fetch one sub-resource for inlining: validate it's private, GET it,
-    /// cap its size. Returns null on any failure (the caller keeps the original).</summary>
-    private async Task<(string? contentType, byte[] bytes)?> FetchSubResourceAsync(Uri abs, CancellationToken ct)
+    /// <summary>Fetch one sub-resource for inlining: validate it's private, GET it
+    /// (under its own short timeout, also bounded by the page-wide
+    /// <paramref name="inlineCt"/>), cap its size. Returns null on any failure or
+    /// timeout — the caller then leaves the original reference (which the final
+    /// neutralise pass blanks). A genuine client cancel (<paramref name="outerCt"/>)
+    /// still propagates.</summary>
+    private async Task<(string? contentType, byte[] bytes)?> FetchSubResourceAsync(
+        Uri abs, CancellationToken inlineCt, CancellationToken outerCt)
     {
         if (!TryValidateTarget(abs.ToString(), out _, out _)) return null;
         try
         {
+            using var perResource = CancellationTokenSource.CreateLinkedTokenSource(inlineCt);
+            perResource.CancelAfter(InlineSubResourceTimeout);
             var client = _httpFactory.CreateClient(HttpClientName);
             using var req = new HttpRequestMessage(HttpMethod.Get, abs);
             req.Headers.TryAddWithoutValidation("User-Agent", "Mozilla/5.0 (Zeus LAN Browser)");
-            using var resp = await client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct)
+            using var resp = await client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, perResource.Token)
                 .ConfigureAwait(false);
             if (!resp.IsSuccessStatusCode) return null;
             if (resp.Content.Headers.ContentLength is > InlinePerResourceBytes) return null;
-            var bytes = await resp.Content.ReadAsByteArrayAsync(ct).ConfigureAwait(false);
+            var bytes = await resp.Content.ReadAsByteArrayAsync(perResource.Token).ConfigureAwait(false);
             if (bytes.Length > InlinePerResourceBytes) return null;
             return (resp.Content.Headers.ContentType?.ToString(), bytes);
         }
-        catch (OperationCanceledException) { throw; }
+        // Real client cancel propagates; a per-resource/page-budget timeout just
+        // skips this asset.
+        catch (OperationCanceledException) when (outerCt.IsCancellationRequested) { throw; }
         catch { return null; }
+    }
+
+    /// <summary>
+    /// Blank every remaining network reference in an inlined page so the result is
+    /// truly self-contained for an iframe <c>srcdoc</c>: iframes/framesets point at
+    /// <c>about:blank</c>, and any leftover <c>src</c>/<c>href</c> to a fetchable
+    /// target (external script, icon/preload link, media, an un-inlined asset) is
+    /// emptied. In-page (<c>#</c>), <c>data:</c>, <c>about:</c>, and the
+    /// non-navigating schemes are left untouched, as are the intercept anchors
+    /// (which carry their target on <c>data-zeus-lan</c>, not <c>href</c>).
+    /// </summary>
+    internal static string NeutralizeEscapingRefs(string html)
+    {
+        // Iframes/framesets first — blank the src so the remote browser never
+        // tries to load a LAN frame (the mixed-content / unreachable-frame source).
+        html = FrameSrcRegex().Replace(html, m =>
+            $"{m.Groups["pre"].Value} src=\"about:blank\"{m.Groups["post"].Value}");
+
+        // Any residual src=/href= that still points somewhere fetchable → empty it.
+        html = ResidualRefRegex().Replace(html, m =>
+        {
+            var url = m.Groups["url"].Value.Trim();
+            if (url.Length == 0
+                || url[0] == '#'
+                || url.StartsWith("data:", StringComparison.OrdinalIgnoreCase)
+                || url.StartsWith("about:", StringComparison.OrdinalIgnoreCase)
+                || url.StartsWith("javascript:", StringComparison.OrdinalIgnoreCase)
+                || url.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase)
+                || url.StartsWith("tel:", StringComparison.OrdinalIgnoreCase))
+                return m.Value;
+            return $"{m.Groups["attr"].Value}=\"\"";
+        });
+
+        return html;
     }
 
     private static string EscapeAttr(string s) =>
@@ -522,4 +628,17 @@ public sealed partial class LanProxyService
     // Opening <form … action="…"
     [GeneratedRegex(@"<form\b[^>]*?\baction\s*=\s*[""'](?<url>[^""']*)[""']", RegexOptions.IgnoreCase)]
     private static partial Regex FormActionRegex();
+
+    // A <style …>…</style> block: its attributes and inner CSS captured separately.
+    [GeneratedRegex(@"<style(?<attrs>[^>]*)>(?<css>.*?)</style>", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    private static partial Regex StyleBlockRegex();
+
+    // <iframe|frame … src="…" …> split around src so the value can be blanked,
+    // preserving the attributes on either side.
+    [GeneratedRegex(@"(?<pre><(?:iframe|frame)\b[^>]*?)\bsrc\s*=\s*(?<q>[""'])[^""']*\k<q>(?<post>[^>]*>)", RegexOptions.IgnoreCase)]
+    private static partial Regex FrameSrcRegex();
+
+    // Any src= / href= with a quoted value (residual-reference neutraliser).
+    [GeneratedRegex(@"(?<attr>\b(?:src|href))\s*=\s*(?<q>[""'])(?<url>[^""']*)\k<q>", RegexOptions.IgnoreCase)]
+    private static partial Regex ResidualRefRegex();
 }

--- a/tests/Zeus.Server.Tests/LanProxyServiceTests.cs
+++ b/tests/Zeus.Server.Tests/LanProxyServiceTests.cs
@@ -160,6 +160,51 @@ public class LanProxyServiceTests
         Assert.Contains("</body>", result);
     }
 
+    [Fact]
+    public void NeutralizeEscapingRefs_BlanksFramesAndExternalRefs()
+    {
+        var html =
+            "<iframe src=\"http://192.168.1.50:53433/console\"></iframe>" +
+            "<frame src='http://nas.local/ui'>" +
+            "<script src=\"http://192.168.1.50/app.js\"></script>" +
+            "<link rel=\"icon\" href=\"http://192.168.1.50/favicon.ico\">" +
+            "<img src=\"data:image/png;base64,AAAA\">" +
+            "<a href=\"#\" data-zeus-lan=\"http://192.168.1.50/next\">next</a>" +
+            "<a href=\"#top\">top</a>";
+
+        var result = LanProxyService.NeutralizeEscapingRefs(html);
+
+        // Frames point at about:blank — never the LAN (the mixed-content source).
+        Assert.Contains("src=\"about:blank\"", result);
+        Assert.DoesNotContain(":53433", result);
+        Assert.DoesNotContain("nas.local", result);
+        // External script + icon link are emptied.
+        Assert.DoesNotContain("app.js", result);
+        Assert.DoesNotContain("favicon.ico", result);
+        // Self-contained + in-page references survive untouched.
+        Assert.Contains("src=\"data:image/png;base64,AAAA\"", result);
+        Assert.Contains("data-zeus-lan=\"http://192.168.1.50/next\"", result);
+        Assert.Contains("href=\"#top\"", result);
+    }
+
+    [Fact]
+    public async Task InlineHtml_IsSelfContained_NoLanRefsEscape()
+    {
+        // No <link>/<img>/<style> → the throwing factory is never hit; this proves
+        // a device page with a frame + external script comes back self-contained.
+        var svc = NewService();
+        var baseUri = new Uri("http://192.168.1.50/index.html");
+        var html =
+            "<html><body><iframe src=\"http://192.168.1.50:53433/\"></iframe>" +
+            "<script src=\"http://192.168.1.50/x.js\"></script></body></html>";
+
+        var result = await svc.InlineHtmlAsync(html, baseUri, default);
+
+        Assert.DoesNotContain(":53433", result);
+        Assert.DoesNotContain("x.js", result);
+        Assert.Contains("about:blank", result);
+    }
+
     // -- minimal fakes --------------------------------------------------------
 
     private sealed class ThrowingHttpClientFactory : IHttpClientFactory

--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -76,6 +76,10 @@ import {
   parseUrlEmbedConfig,
   type UrlEmbedConfig,
 } from './panels/urlEmbedConfig';
+import {
+  parseLanBrowserConfig,
+  type LanBrowserConfig,
+} from './panels/lanBrowserConfig';
 
 const WORKSPACE_GRID_MARGIN_PX = 3;
 
@@ -1185,12 +1189,12 @@ function LanBrowserTileBody({
   const updateTileInstanceConfig = useLayoutStore(
     (s) => s.updateTileInstanceConfigInLayout,
   );
-  const config: UrlEmbedConfig = useMemo(
-    () => parseUrlEmbedConfig(tile.instanceConfig),
+  const config: LanBrowserConfig = useMemo(
+    () => parseLanBrowserConfig(tile.instanceConfig),
     [tile.instanceConfig],
   );
   const setConfig = useCallback(
-    (next: UrlEmbedConfig) => {
+    (next: LanBrowserConfig) => {
       updateTileInstanceConfig(layoutId, tile.uid, next);
     },
     [layoutId, tile.uid, updateTileInstanceConfig],

--- a/zeus-web/src/layout/panels/LanBrowserPanel.tsx
+++ b/zeus-web/src/layout/panels/LanBrowserPanel.tsx
@@ -31,19 +31,28 @@ import {
   useState,
   type FormEvent,
 } from 'react';
-import { GripVertical, ArrowRight, RefreshCw, X, Network } from 'lucide-react';
+import {
+  GripVertical,
+  ArrowRight,
+  RefreshCw,
+  X,
+  Network,
+  Star,
+} from 'lucide-react';
 import { TileLockButton } from '../TileChrome';
 import { isRemoteMode } from '../../remote/remote-client';
+import { urlEmbedTitle } from './urlEmbedConfig';
 import {
-  EMPTY_URL_EMBED_CONFIG,
-  urlEmbedTitle,
-  type UrlEmbedConfig,
-} from './urlEmbedConfig';
+  EMPTY_LAN_BROWSER_CONFIG,
+  lanBookmarkLabel,
+  normalizeLanUrl,
+  type LanBrowserConfig,
+} from './lanBrowserConfig';
 
 interface LanBrowserPanelProps {
-  /** Per-instance config blob (shares the URL-embed shape: url + title). */
-  config?: UrlEmbedConfig;
-  setConfig?: (next: UrlEmbedConfig) => void;
+  /** Per-instance config blob (URL-embed shape: url + title, plus bookmarks). */
+  config?: LanBrowserConfig;
+  setConfig?: (next: LanBrowserConfig) => void;
   onRemove?: () => void;
   tileLocked?: boolean;
   workspaceLocked?: boolean;
@@ -55,26 +64,6 @@ interface LanBrowserPanelProps {
 // runs in an opaque origin and cannot reach window.parent, Zeus cookies, or
 // the operator's session. Scripts/forms still work for ordinary device UIs.
 const SANDBOX = 'allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox';
-
-/** Normalise operator input into a private-LAN http(s) URL, defaulting a bare
- *  host to http:// (device admin pages are overwhelmingly plain HTTP). Returns
- *  null for anything that isn't an http/https URL. The SERVER is the real
- *  guard (rejects non-private targets); this is just input hygiene. */
-function normalizeLanUrl(raw: string): string | null {
-  const trimmed = raw.trim();
-  if (!trimmed) return null;
-  const candidate = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(trimmed)
-    ? trimmed
-    : `http://${trimmed}`;
-  try {
-    const parsed = new URL(candidate);
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
-    if (!parsed.hostname) return null;
-    return parsed.toString();
-  } catch {
-    return null;
-  }
-}
 
 /** Wrap an absolute LAN URL as the same-origin proxy path the iframe loads. */
 function proxySrc(url: string): string {
@@ -88,7 +77,7 @@ function proxyInlineSrc(url: string): string {
 }
 
 export function LanBrowserPanel({
-  config = EMPTY_URL_EMBED_CONFIG,
+  config = EMPTY_LAN_BROWSER_CONFIG,
   setConfig,
   onRemove,
   tileLocked = false,
@@ -175,6 +164,38 @@ export function LanBrowserPanel({
     [draft, config, setConfig],
   );
 
+  const bookmarks = config.bookmarks;
+  const isBookmarked = useMemo(
+    () => !!committedUrl && bookmarks.some((b) => b.url === committedUrl),
+    [bookmarks, committedUrl],
+  );
+
+  // Navigate to a pinned page (used by the bookmark chips).
+  const openBookmark = useCallback(
+    (url: string) => {
+      setDraft(url);
+      setError(false);
+      setConfig?.({ ...config, url });
+    },
+    [config, setConfig],
+  );
+
+  // Star button: pin the current page if it isn't pinned, else un-pin it.
+  const toggleBookmark = useCallback(() => {
+    if (!committedUrl) return;
+    const next = isBookmarked
+      ? bookmarks.filter((b) => b.url !== committedUrl)
+      : [...bookmarks, { url: committedUrl, label: '' }];
+    setConfig?.({ ...config, bookmarks: next });
+  }, [committedUrl, isBookmarked, bookmarks, config, setConfig]);
+
+  const removeBookmark = useCallback(
+    (url: string) => {
+      setConfig?.({ ...config, bookmarks: bookmarks.filter((b) => b.url !== url) });
+    },
+    [bookmarks, config, setConfig],
+  );
+
   const handleRemove = onRemove ?? (() => {});
   const stop = (e: { stopPropagation: () => void }) => e.stopPropagation();
   const title = urlEmbedTitle(config);
@@ -227,6 +248,23 @@ export function LanBrowserPanel({
         {committedUrl ? (
           <button
             type="button"
+            className={`url-embed-btn${isBookmarked ? ' url-embed-btn--active' : ''}`}
+            title={isBookmarked ? 'Remove bookmark' : 'Bookmark this page'}
+            aria-label={isBookmarked ? 'Remove bookmark' : 'Bookmark this page'}
+            aria-pressed={isBookmarked}
+            onClick={(e) => {
+              stop(e);
+              toggleBookmark();
+            }}
+            onMouseDown={stop}
+            onPointerDown={stop}
+          >
+            <Star size={13} fill={isBookmarked ? 'currentColor' : 'none'} />
+          </button>
+        ) : null}
+        {committedUrl ? (
+          <button
+            type="button"
             className="url-embed-btn url-embed-ext"
             title="Reload page"
             aria-label="Reload page"
@@ -262,6 +300,44 @@ export function LanBrowserPanel({
           <X size={12} />
         </button>
       </div>
+      {bookmarks.length ? (
+        <div className="lan-bookmark-bar" onPointerDown={stop} onMouseDown={stop}>
+          {bookmarks.map((bm) => {
+            const label = lanBookmarkLabel(bm);
+            const active = bm.url === committedUrl;
+            return (
+              <span
+                key={bm.url}
+                className={`lan-bookmark${active ? ' lan-bookmark--active' : ''}`}
+              >
+                <button
+                  type="button"
+                  className="lan-bookmark-go"
+                  title={bm.url}
+                  onClick={(e) => {
+                    stop(e);
+                    openBookmark(bm.url);
+                  }}
+                >
+                  {label}
+                </button>
+                <button
+                  type="button"
+                  className="lan-bookmark-del"
+                  aria-label={`Remove bookmark ${label}`}
+                  title="Remove bookmark"
+                  onClick={(e) => {
+                    stop(e);
+                    removeBookmark(bm.url);
+                  }}
+                >
+                  <X size={9} />
+                </button>
+              </span>
+            );
+          })}
+        </div>
+      ) : null}
       <div className="workspace-tile-body url-embed-body">
         {committedUrl && remote ? (
           // Remote: render the tunnelled, self-contained page via srcDoc.

--- a/zeus-web/src/layout/panels/lanBrowserConfig.test.ts
+++ b/zeus-web/src/layout/panels/lanBrowserConfig.test.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF), Christian Suarez (N9WAR), and contributors.
+
+import { describe, it, expect } from 'vitest';
+import {
+  lanBookmarkLabel,
+  normalizeLanUrl,
+  parseLanBrowserConfig,
+} from './lanBrowserConfig';
+
+describe('normalizeLanUrl', () => {
+  it('defaults a bare host to http (device pages are plain HTTP)', () => {
+    expect(normalizeLanUrl('192.168.1.1')).toBe('http://192.168.1.1/');
+  });
+
+  it('keeps an explicit https scheme', () => {
+    expect(normalizeLanUrl('https://192.168.1.50:8443/admin')).toBe(
+      'https://192.168.1.50:8443/admin',
+    );
+  });
+
+  it('rejects non-http(s) schemes', () => {
+    expect(normalizeLanUrl('javascript:alert(1)')).toBeNull();
+    expect(normalizeLanUrl('data:text/html,x')).toBeNull();
+    expect(normalizeLanUrl('')).toBeNull();
+  });
+});
+
+describe('parseLanBrowserConfig', () => {
+  it('defaults bookmarks to an empty array for a legacy blob', () => {
+    const c = parseLanBrowserConfig({ url: 'http://192.168.1.1/', title: '' });
+    expect(c.url).toBe('http://192.168.1.1/');
+    expect(c.bookmarks).toEqual([]);
+  });
+
+  it('sanitises, normalises and keeps valid bookmarks', () => {
+    const c = parseLanBrowserConfig({
+      bookmarks: [
+        { url: '192.168.1.1', label: 'Router' },
+        { url: 'https://10.0.0.5/status', label: '' },
+      ],
+    });
+    expect(c.bookmarks).toEqual([
+      { url: 'http://192.168.1.1/', label: 'Router' },
+      { url: 'https://10.0.0.5/status', label: '' },
+    ]);
+  });
+
+  it('drops malformed / unsafe bookmarks and de-dupes by URL', () => {
+    const c = parseLanBrowserConfig({
+      bookmarks: [
+        { url: 'javascript:alert(1)', label: 'evil' },
+        { url: '192.168.1.1' },
+        { url: 'http://192.168.1.1/' }, // dup of the normalised entry above
+        'not-an-object',
+        { label: 'no url' },
+      ],
+    });
+    expect(c.bookmarks).toEqual([{ url: 'http://192.168.1.1/', label: '' }]);
+  });
+
+  it('tolerates a non-array bookmarks field', () => {
+    expect(parseLanBrowserConfig({ bookmarks: 'nope' }).bookmarks).toEqual([]);
+    expect(parseLanBrowserConfig(null).bookmarks).toEqual([]);
+  });
+});
+
+describe('lanBookmarkLabel', () => {
+  it('prefers an explicit label', () => {
+    expect(lanBookmarkLabel({ url: 'http://192.168.1.1/', label: 'Router' })).toBe(
+      'Router',
+    );
+  });
+
+  it('falls back to the host', () => {
+    expect(lanBookmarkLabel({ url: 'http://192.168.1.50:8080/x', label: '' })).toBe(
+      '192.168.1.50:8080',
+    );
+  });
+});

--- a/zeus-web/src/layout/panels/lanBrowserConfig.ts
+++ b/zeus-web/src/layout/panels/lanBrowserConfig.ts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF), Christian Suarez (N9WAR), and contributors.
+//
+// Per-tile config shape for the LAN Browser panel. It builds on the URL-Embed
+// shape (assigned url + title) and adds a persisted bookmark bar so an operator
+// can pin the device pages they reach often (router, rotator, amp, another
+// SDR's console) and jump between them with one click — handy when operating
+// remotely, where each page is fetched through the radio host.
+//
+// Bookmarks persist in this tile's instance config, so they survive a reload /
+// reconnect. Each bookmark is sanitised through normalizeLanUrl on the way in
+// (both when the operator adds one and when a stored blob is parsed) so a
+// tampered blob can never smuggle a non-http(s) scheme into the address bar.
+
+import {
+  EMPTY_URL_EMBED_CONFIG,
+  parseUrlEmbedConfig,
+  type UrlEmbedConfig,
+} from './urlEmbedConfig';
+
+/** A single pinned LAN page: the (sanitised) URL plus an optional label. */
+export interface LanBookmark {
+  url: string;
+  /** Operator label override. Empty = derive from the URL host. */
+  label: string;
+}
+
+export interface LanBrowserConfig extends UrlEmbedConfig {
+  /** Pinned LAN pages, in operator order. */
+  bookmarks: LanBookmark[];
+}
+
+export const EMPTY_LAN_BROWSER_CONFIG: LanBrowserConfig = {
+  ...EMPTY_URL_EMBED_CONFIG,
+  bookmarks: [],
+};
+
+// A device address can sit on any private host; the LAN Browser only ever
+// reaches RFC1918 / IPv6-ULA targets (the SERVER is the real guard). Cap the
+// stored list so a tampered blob can't bloat the layout store unboundedly.
+const MAX_BOOKMARKS = 64;
+
+/** Normalise operator input into a private-LAN http(s) URL, defaulting a bare
+ *  host to http:// (device admin pages are overwhelmingly plain HTTP). Returns
+ *  null for anything that isn't an http/https URL. The SERVER is the real guard
+ *  (rejects non-private targets); this is just input hygiene. Shared by the
+ *  panel's address bar and the bookmark parser so both sanitise identically. */
+export function normalizeLanUrl(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const candidate = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(trimmed)
+    ? trimmed
+    : `http://${trimmed}`;
+  try {
+    const parsed = new URL(candidate);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+    if (!parsed.hostname) return null;
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+/** Best-effort parse of an unknown JSON blob from the workspace store. Reuses
+ *  the URL-Embed parser for url/title, then layers on a sanitised, de-duped
+ *  bookmark list. Tolerates a missing/legacy blob (no bookmarks field). */
+export function parseLanBrowserConfig(raw: unknown): LanBrowserConfig {
+  const base = parseUrlEmbedConfig(raw);
+  const bookmarks: LanBookmark[] = [];
+  const seen = new Set<string>();
+
+  if (raw && typeof raw === 'object') {
+    const list = (raw as Record<string, unknown>).bookmarks;
+    if (Array.isArray(list)) {
+      for (const entry of list) {
+        if (bookmarks.length >= MAX_BOOKMARKS) break;
+        if (!entry || typeof entry !== 'object') continue;
+        const e = entry as Record<string, unknown>;
+        const url = typeof e.url === 'string' ? normalizeLanUrl(e.url) : null;
+        if (!url || seen.has(url)) continue;
+        seen.add(url);
+        const label = typeof e.label === 'string' ? e.label.trim() : '';
+        bookmarks.push({ url, label });
+      }
+    }
+  }
+
+  return { ...base, bookmarks };
+}
+
+/** Display label for a bookmark chip: operator label if set, else the host. */
+export function lanBookmarkLabel(bookmark: LanBookmark): string {
+  if (bookmark.label) return bookmark.label;
+  try {
+    return new URL(bookmark.url).host || bookmark.url;
+  } catch {
+    return bookmark.url;
+  }
+}

--- a/zeus-web/src/remote/api-tunnel.ts
+++ b/zeus-web/src/remote/api-tunnel.ts
@@ -28,6 +28,15 @@
 const API_PREFIX = '/api/';
 const REQUEST_TIMEOUT_MS = 15_000;
 
+// The LAN Browser proxy (/api/lan/proxy?...&inline=1) is the one tunnelled
+// endpoint whose reply is legitimately slow: the radio host fetches a whole
+// device page AND inlines its stylesheets/images/fonts before replying. The
+// 15 s default — sized for the small chrome JSON — fires before that work can
+// finish, so this path gets a longer deadline (kept above the server's own
+// inline budget; see LanProxyService.InlineMaxDuration).
+const LAN_PROXY_PREFIX = '/api/lan/proxy';
+const LAN_PROXY_TIMEOUT_MS = 60_000;
+
 interface TunnelResponse {
   id: number;
   status: number;
@@ -107,6 +116,11 @@ function tunnel(
   contentType?: string,
 ): Promise<TunnelResponse> {
   const id = nextId++;
+  // The LAN Browser proxy reply is legitimately slow (whole-page inline on the
+  // radio host); everything else is small chrome JSON on the default deadline.
+  const timeoutMs = path.startsWith(LAN_PROXY_PREFIX)
+    ? LAN_PROXY_TIMEOUT_MS
+    : REQUEST_TIMEOUT_MS;
   return new Promise<TunnelResponse>((resolve, reject) => {
     const timer = setTimeout(() => {
       pending.delete(id);
@@ -114,7 +128,7 @@ function tunnel(
       const qi = queue.findIndex((q) => q.id === id);
       if (qi >= 0) queue.splice(qi, 1);
       reject(new Error('Remote API request timed out.'));
-    }, REQUEST_TIMEOUT_MS);
+    }, timeoutMs);
 
     pending.set(id, { resolve, reject, timer });
     const req: QueuedRequest = { id, path, method, body, contentType };

--- a/zeus-web/src/styles/all-panels.css
+++ b/zeus-web/src/styles/all-panels.css
@@ -634,6 +634,81 @@
   color: var(--tx);
 }
 
+/* Star button shows its pinned state by adopting the accent colour. */
+.url-embed-btn.url-embed-btn--active {
+  color: var(--accent);
+}
+
+/* LAN Browser bookmark bar — a thin strip of pinned device pages between the
+ * address-bar header and the iframe body. Horizontally scrollable so a long
+ * list never pushes the body out. */
+.lan-bookmark-bar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 6px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+  background: var(--panel-bot, rgba(0, 0, 0, 0.2));
+  border-top: 1px solid var(--line);
+}
+.lan-bookmark {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  max-width: 160px;
+  height: 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-xs, 2px);
+  background: var(--bg-1, rgba(255, 255, 255, 0.04));
+  color: var(--fg-2);
+  transition: border-color var(--dur-fast), color var(--dur-fast);
+}
+.lan-bookmark:hover {
+  color: var(--fg-0);
+  border-color: var(--accent);
+}
+.lan-bookmark--active {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.lan-bookmark-go {
+  max-width: 138px;
+  padding: 0 4px 0 6px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 14px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+}
+.lan-bookmark-del {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  border: 0;
+  background: transparent;
+  color: var(--fg-3);
+  cursor: pointer;
+}
+.lan-bookmark-del:hover {
+  color: var(--tx);
+}
+.lan-bookmark-go:focus-visible,
+.lan-bookmark-del:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 1px;
+}
+
 .workspace-tile--unavailable {
   border-style: dashed;
 }


### PR DESCRIPTION
## Summary

Fixes the **LAN Browser** failing in remote (WebRTC) mode and adds a **bookmark bar**.

### 1. Fix — remote LAN Browser inline page (`fix`)
Reported symptom: `Error: Remote API request timed out.` plus console noise:
`Mixed Content … insecure frame 'http://app.openhpsdrzeus.com:53433/'`,
`ERR_NAME_NOT_RESOLVED`, and `Failed to decode font / OTS parsing error`.

Two root causes in the inline-page path:

- **Timeout mismatch.** `api-tunnel.ts` applied a flat **15 s** deadline to every tunnelled `/api/*` request, but `/api/lan/proxy?...&inline=1` fetches the device page *and* serially fetches each stylesheet/image on the radio host — routinely >15 s. Now `/api/lan/proxy` gets a **60 s** client deadline, and the server bounds its inline work (**30 s** overall budget + **5 s** per sub-resource) so the reply always beats the client timeout. Assets that miss the budget are omitted, never an error.
- **Incomplete inlining.** The inliner only handled `<link rel=stylesheet>` and `<img>`, so `<iframe>`/`<frame>`, `<script src>`, and web-font `url()` references leaked into the `srcdoc` as live LAN URLs — which the operator's off-LAN HTTPS browser then tried to fetch itself (the mixed-content / DNS / font errors). Now CSS `url()` assets inline as `data:` URIs, and a final `NeutralizeEscapingRefs` pass blanks frames (`about:blank`) and empties any remaining external `src`/`href`. The page is truly self-contained.

### 2. Feature — LAN Browser bookmark bar (`feat`)
- Star button in the address bar pins / un-pins the current page.
- A thin, horizontally-scrollable chip bar between the address bar and the iframe; click to navigate, ✕ to remove.
- Bookmarks persist per-tile via a dedicated `LanBrowserConfig` (extends the URL-embed shape with a sanitised, de-duped list). Shared `normalizeLanUrl` so the address bar and bookmark parser sanitise identically — no non-http(s) scheme can be stored. Styling uses existing tokens only (no palette changes).

## Tests
- New `LanProxyServiceTests`: `NeutralizeEscapingRefs` blanks frames + external refs; `InlineHtml` is self-contained. Full suite **35 passed**.
- New `lanBrowserConfig.test.ts`: normalizer + parser sanitisation / de-dup / legacy tolerance. Web suite green; `tsc` typecheck clean against `develop`.

## Verification notes
- `dotnet test` (LanProxy), web `typecheck`, web `vitest`, and the production `vite build` all pass (build verified in the primary checkout; the fresh worktree can't build only because the unrelated `external/deepcw-engine` submodule asset isn't checked out).
- **Not** reproducible in this environment: a true end-to-end remote WebRTC session against a real radio host + LAN device. The fix is split across the tunnel (SPA on Cloudflare Pages) and the radio host (backend) — **both halves must ship** for the remote path to be fixed live.
