### PR TITLE
fix(desktop): hide console window when launching dev build from shortcut

### DIFF
--- a/scripts/launch-zeus-desktop-hidden.vbs
+++ b/scripts/launch-zeus-desktop-hidden.vbs
@@ -1,0 +1,18 @@
+' Launch the Zeus desktop build with NO visible console window.
+'
+' launch-zeus-desktop.cmd does the real work (pick the develop build, kill any
+' running instance, wait for it to release port 6061, then launch the GUI exe).
+' Run from a shortcut, that .cmd opens a cmd.exe console -- and on Windows 11 the
+' default console host is Windows Terminal, so it shows up as a transparent
+' (acrylic) terminal window flashing behind the Zeus frame.
+'
+' WScript.Shell.Run with intWindowStyle = 0 runs the same .cmd with a hidden
+' window: no console flash, no taskbar button. The Zeus exe is a GUI-subsystem
+' binary (WinExe), so its own window still appears normally -- only the cmd
+' console is suppressed. Point the "Zeus" desktop shortcut at:
+'   wscript.exe "<repo>\scripts\launch-zeus-desktop-hidden.vbs"
+Dim sh, scriptDir
+Set sh = CreateObject("WScript.Shell")
+scriptDir = Left(WScript.ScriptFullName, InStrRev(WScript.ScriptFullName, "\"))
+' 0 = hidden window, False = don't wait for the .cmd to finish.
+sh.Run "cmd /c """ & scriptDir & "launch-zeus-desktop.cmd""", 0, False


### PR DESCRIPTION
## Problem

Launching the Zeus desktop dev build from the **Zeus** shortcut pops a transparent terminal window behind the app frame. The shortcut runs `cmd.exe /c launch-zeus-desktop.cmd`, and on Windows 11 the default console host is **Windows Terminal**, which renders that console with acrylic transparency. Marking the shortcut "Minimized" doesn't suppress it — it still flashes and gets a taskbar button.

The installed-app shortcuts (`OpenHPSDR-Zeus.lnk`) were never affected because they launch the GUI-subsystem (`WinExe`) binary directly, which Windows never gives a console.

## Fix

Add a windowless VBScript wrapper, `scripts/launch-zeus-desktop-hidden.vbs`, that runs the existing `launch-zeus-desktop.cmd` via `WScript.Shell.Run(..., 0, False)`. The cmd console is created **hidden** (no flash, no taskbar button); the Photino window still appears normally.

Point the dev launcher shortcut at:

```
wscript.exe "<repo>\scripts\launch-zeus-desktop-hidden.vbs"
```

## Notes

- All of the `.cmd`'s behavior is unchanged — develop-build selection, `taskkill` of the running instance, and the port-6061 pin all still run.
- `Rebuild Zeus.lnk` is intentionally left visible (it should show build progress / error pauses).
- This is Windows-only (`.vbs` + `wscript`); no effect on macOS/Linux launch paths.
- The shortcut re-point itself is local machine state; this PR ships the reusable wrapper script.