### PR TITLE
fix(web): auto-close FreeDV popout when leaving FreeDV mode

### DIFF
--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -401,12 +401,16 @@ export default function App() {
   // rather than a docked workspace tile, so engaging FreeDV never rearranges the
   // operator's console. Fires only on the false→true edge into FreeDV on either
   // VFO (tracked via a ref) so closing the window while still in FreeDV doesn't
-  // immediately reopen it.
+  // immediately reopen it. The true→false edge (leaving FreeDV on both VFOs)
+  // closes the popup automatically — the modem controls have nothing to act on
+  // once the mode is gone, so leaving the window up reads as stale.
   const wasInFreeDv = useRef(false);
   useEffect(() => {
     const inFreeDv = mode === 'FREEDV' || modeB === 'FREEDV';
     if (inFreeDv && !wasInFreeDv.current) {
       useFreeDvWindowStore.getState().open();
+    } else if (!inFreeDv && wasInFreeDv.current) {
+      useFreeDvWindowStore.getState().close();
     }
     wasInFreeDv.current = inFreeDv;
   }, [mode, modeB]);


### PR DESCRIPTION
## Problem

When the operator switches **out** of FreeDV mode, the floating FreeDV popout stays open showing stale modem controls (submode / SYNC / SNR / TX-text) that have nothing left to act on.

## Root cause

The mode→window effect in `zeus-web/src/App.tsx` opened the popup on the false→true edge *into* FreeDV but had no matching close on the edge *out*. So leaving FreeDV (on both VFOs) never dismissed the window.

## Fix

Add the symmetric `else if` branch: when neither VFO is in FreeDV anymore (true→false edge), call `useFreeDvWindowStore.getState().close()`. It fires only on the transition, so it won't fight a manual reopen, and mirrors the existing open logic exactly.

## Verification

- `npx tsc --noEmit` passes clean.
- Logic is edge-triggered via the existing `wasInFreeDv` ref — no change to the open path or to manual open/close behavior while staying in FreeDV.