### PR TITLE
feat(diag): read-only maintainer support-session core (remote-diag P3a)

### DIFF
--- a/Zeus.Server.Hosting/Diagnostics/DiagnosticLogBuffer.cs
+++ b/Zeus.Server.Hosting/Diagnostics/DiagnosticLogBuffer.cs
@@ -25,6 +25,15 @@ public sealed class DiagnosticLogBuffer
     private int _next;   // index of next write
     private int _count;  // number of valid entries (<= Capacity)
 
+    /// <summary>
+    /// Raised once per appended line, AFTER it lands in the ring, OUTSIDE the
+    /// buffer lock. Lets a live consumer (a maintainer support session's "log"
+    /// data channel) tail new lines as they arrive without polling. Subscribers
+    /// MUST be cheap and non-blocking — they run on whatever thread logged the
+    /// line; any exception they throw is swallowed so logging never fails.
+    /// </summary>
+    public event Action<string>? LineAdded;
+
     /// <summary>Append one formatted log line. Cheap; safe from any thread.</summary>
     public void Add(string line)
     {
@@ -34,6 +43,15 @@ public sealed class DiagnosticLogBuffer
             _ring[_next] = line;
             _next = (_next + 1) % Capacity;
             if (_count < Capacity) _count++;
+        }
+
+        // Fan out to live tailers outside the lock so a slow/misbehaving
+        // subscriber can never stall a logging thread or deadlock the ring.
+        var handler = LineAdded;
+        if (handler is not null)
+        {
+            try { handler(line); }
+            catch { /* a live tailer must never break logging */ }
         }
     }
 

--- a/Zeus.Server.Hosting/Remote/RemoteWebRtcSession.cs
+++ b/Zeus.Server.Hosting/Remote/RemoteWebRtcSession.cs
@@ -126,6 +126,11 @@ public sealed class RemoteWebRtcSession
         "/api/remote/password",
         "/api/prefs/databases/export",
         "/api/log/export",
+        // /api/support — the maintainer-support Allow/Deny surface. It is the
+        // OPERATOR's local decision point; a remote peer (even the authenticated
+        // station owner) must never approve a read-only support session for itself
+        // or another admin through the tunnel (remote-diag P3).
+        "/api/support",
     };
 
     /// <summary>

--- a/Zeus.Server.Hosting/Support/SupportApiProxy.cs
+++ b/Zeus.Server.Hosting/Support/SupportApiProxy.cs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Net.Http;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace Zeus.Server.Hosting.Support;
+
+/// <summary>One tunnelled read request from a support session ({id, method, path}).</summary>
+public readonly record struct SupportApiRequest(int Id, string Method, string Path);
+
+/// <summary>The radio's reply for a <see cref="SupportApiRequest"/>.</summary>
+public readonly record struct SupportApiReply(int Id, int Status, string? ContentType, string? Body);
+
+/// <summary>
+/// The read-only loopback proxy at the heart of a support session's "api" data
+/// channel — factored out of the WebRTC plumbing so the safety-critical gating is
+/// unit-testable without a live PeerConnection (mirrors how the operator tunnel's
+/// guards are validated).
+///
+/// Every request runs the gauntlet, fail-closed at each step:
+///   1. method not GET/HEAD          → 405 (no mutation EVER reaches loopback)
+///   2. malformed / non-absolute path → 502
+///   3. path traversal ("../", %2e)  → 403 (can't collapse onto a non-allowlisted path)
+///   4. target not loopback           → 502 (SSRF guard — stay on 127.0.0.1)
+///   5. path off the read allowlist   → 403 (<see cref="SupportSessionPolicy"/>)
+///   6. otherwise                     → proxy to the radio's own Kestrel; 502 on
+///                                       oversized reply or transport error.
+/// Never throws out of <see cref="HandleAsync"/>; a failure becomes a 502 reply.
+/// </summary>
+public sealed class SupportApiProxy
+{
+    /// <summary>Named loopback HttpClient (shares the operator tunnel's registration).</summary>
+    public const string LoopbackHttpClientName =
+        Zeus.Server.Hosting.Remote.RemoteWebRtcSession.LoopbackHttpClientName;
+
+    // Diagnostic dumps (a full diagnostics-v2 snapshot) can be larger than the
+    // operator tunnel's 1 MiB chrome cap, but must still be bounded so the read
+    // channel can't be turned into an unbounded exfiltration pipe.
+    private const int MaxResponseBytes = 4 * 1024 * 1024;
+
+    private readonly IHttpClientFactory _httpFactory;
+    private readonly string _loopbackBaseUrl;
+    private readonly ILogger _log;
+
+    public SupportApiProxy(IHttpClientFactory httpFactory, string loopbackBaseUrl, ILogger log)
+    {
+        _httpFactory = httpFactory;
+        _loopbackBaseUrl = (loopbackBaseUrl ?? "").TrimEnd('/');
+        _log = log;
+    }
+
+    public async Task<SupportApiReply> HandleAsync(SupportApiRequest req, CancellationToken ct = default)
+    {
+        int id = req.Id;
+        try
+        {
+            var method = req.Method ?? "GET";
+            var path = req.Path ?? "";
+
+            // 1. Read-only methods only — a support session can never mutate the radio.
+            if (!SupportSessionPolicy.IsReadOnlyMethod(method))
+                return new SupportApiReply(id, 405, null, null);
+
+            if (string.IsNullOrEmpty(_loopbackBaseUrl) || !path.StartsWith('/'))
+                return new SupportApiReply(id, 502, null, null);
+
+            // 3. Reject path traversal before canonicalisation can collapse "../"
+            //    onto a non-allowlisted endpoint.
+            if (path.Contains("..", StringComparison.Ordinal)
+                || path.Contains("%2e", StringComparison.OrdinalIgnoreCase))
+            {
+                _log.LogWarning("support.api DENY (traversal) {Path}", path);
+                return new SupportApiReply(id, 403, null, null);
+            }
+
+            // 4. Build the loopback target and confirm it stays on 127.0.0.1 (SSRF guard).
+            if (!Uri.TryCreate(_loopbackBaseUrl + path, UriKind.Absolute, out var target)
+                || !target.IsLoopback)
+            {
+                return new SupportApiReply(id, 502, null, null);
+            }
+
+            // 5. Allowlist the CANONICAL path that will actually be requested.
+            if (!SupportSessionPolicy.IsAllowedPath(target.AbsolutePath))
+            {
+                _log.LogWarning("support.api DENY (not allowlisted) {Method} {Path}", method, target.AbsolutePath);
+                return new SupportApiReply(id, 403, null, null);
+            }
+
+            // HEAD proxies as GET with the body discarded.
+            var isHead = string.Equals(method, "HEAD", StringComparison.OrdinalIgnoreCase);
+            var client = _httpFactory.CreateClient(LoopbackHttpClientName);
+            using var msg = new HttpRequestMessage(HttpMethod.Get, target);
+            using var resp = await client.SendAsync(msg, HttpCompletionOption.ResponseHeadersRead, ct)
+                .ConfigureAwait(false);
+
+            if (resp.Content.Headers.ContentLength is long len && len > MaxResponseBytes)
+                return new SupportApiReply(id, 502, null, null);
+            var bytes = await resp.Content.ReadAsByteArrayAsync(ct).ConfigureAwait(false);
+            if (bytes.Length > MaxResponseBytes)
+                return new SupportApiReply(id, 502, null, null);
+
+            var respContentType = resp.Content.Headers.ContentType?.ToString();
+            var body = isHead ? "" : Encoding.UTF8.GetString(bytes);
+            return new SupportApiReply(id, (int)resp.StatusCode, respContentType, body);
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "support.api request failed — replying 502");
+            return new SupportApiReply(id, 502, null, null);
+        }
+    }
+}

--- a/Zeus.Server.Hosting/Support/SupportGrant.cs
+++ b/Zeus.Server.Hosting/Support/SupportGrant.cs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.Server.Hosting.Support;
+
+/// <summary>
+/// A single, operator-approved authorisation to open ONE read-only support
+/// session for a specific maintainer request. Minted locally by the radio the
+/// instant the operator clicks "Allow" (<see cref="SupportRequestCoordinator"/>)
+/// and consumed once by <see cref="SupportWebRtcService"/> when the matching
+/// WebRTC offer arrives.
+///
+/// This is the ADR-0008 end-to-end authority for a support session: the grant is
+/// produced by the operator's own Zeus on a local human decision, never by the
+/// broker. A support session can therefore exist only because (1) the maintainer
+/// proved an admin credential to the broker AND (2) the operator personally
+/// approved THIS request id — two independent gates, the second enforced here at
+/// the radio.
+/// </summary>
+/// <param name="RequestId">The maintainer request this grant authorises (opaque, broker-relayed).</param>
+/// <param name="AdminCallsign">The admin callsign the operator approved (display/audit only).</param>
+/// <param name="IssuedAt">When the operator approved (monotonic via the store's TimeProvider).</param>
+/// <param name="ExpiresAt">Hard deadline; the maintainer must connect before this or re-request.</param>
+public sealed record SupportGrant(
+    string RequestId,
+    string AdminCallsign,
+    DateTimeOffset IssuedAt,
+    DateTimeOffset ExpiresAt);

--- a/Zeus.Server.Hosting/Support/SupportGrantStore.cs
+++ b/Zeus.Server.Hosting/Support/SupportGrantStore.cs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Collections.Concurrent;
+
+namespace Zeus.Server.Hosting.Support;
+
+/// <summary>
+/// The radio's local authority for read-only support sessions. Holds the
+/// short-lived, single-use <see cref="SupportGrant"/>s the operator has approved
+/// but not yet redeemed. Deny-by-default: with no matching grant,
+/// <see cref="SupportWebRtcService"/> refuses to answer a support offer, so a
+/// maintainer session can never open without an explicit operator "Allow".
+///
+/// Grants are single-use (one approval = one session) and short-TTL (the
+/// maintainer must connect promptly after Allow, else re-request), which bounds
+/// the window in which an intercepted request id could be replayed. Thread-safe;
+/// registered as a singleton.
+/// </summary>
+public sealed class SupportGrantStore
+{
+    /// <summary>How long an approved-but-unredeemed grant stays valid.</summary>
+    public static readonly TimeSpan DefaultTtl = TimeSpan.FromMinutes(2);
+
+    private readonly TimeProvider _time;
+    private readonly TimeSpan _ttl;
+    private readonly ConcurrentDictionary<string, SupportGrant> _grants = new(StringComparer.Ordinal);
+
+    public SupportGrantStore(TimeProvider? timeProvider = null, TimeSpan? ttl = null)
+    {
+        _time = timeProvider ?? TimeProvider.System;
+        _ttl = ttl ?? DefaultTtl;
+    }
+
+    /// <summary>
+    /// Record an operator approval for <paramref name="requestId"/>, replacing any
+    /// prior unredeemed grant for the same id (a re-approval refreshes the TTL).
+    /// Returns the minted grant.
+    /// </summary>
+    public SupportGrant Approve(string requestId, string adminCallsign)
+    {
+        if (string.IsNullOrWhiteSpace(requestId))
+            throw new ArgumentException("requestId required", nameof(requestId));
+
+        var now = _time.GetUtcNow();
+        var grant = new SupportGrant(requestId, adminCallsign ?? "", now, now + _ttl);
+        _grants[requestId] = grant;
+        return grant;
+    }
+
+    /// <summary>
+    /// Atomically redeem the grant for <paramref name="requestId"/>: removes it and
+    /// returns it iff present AND not expired. Single-use — a second call for the
+    /// same id returns false. Expired grants are dropped (and reported as absent).
+    /// </summary>
+    public bool TryConsume(string requestId, out SupportGrant grant)
+    {
+        grant = null!;
+        if (string.IsNullOrEmpty(requestId)) return false;
+        if (!_grants.TryRemove(requestId, out var found)) return false;
+        if (found.ExpiresAt <= _time.GetUtcNow()) return false; // expired → treat as absent
+        grant = found;
+        return true;
+    }
+
+    /// <summary>Explicitly drop a grant (e.g. the operator revoked or the request was withdrawn).</summary>
+    public void Revoke(string requestId)
+    {
+        if (!string.IsNullOrEmpty(requestId)) _grants.TryRemove(requestId, out _);
+    }
+
+    /// <summary>Remove every expired grant. Cheap; safe to call opportunistically.</summary>
+    public void PruneExpired()
+    {
+        var now = _time.GetUtcNow();
+        foreach (var kv in _grants)
+            if (kv.Value.ExpiresAt <= now)
+                _grants.TryRemove(kv.Key, out _);
+    }
+
+    /// <summary>Count of live (unexpired) grants — for diagnostics/tests only.</summary>
+    public int LiveCount
+    {
+        get
+        {
+            PruneExpired();
+            return _grants.Count;
+        }
+    }
+}

--- a/Zeus.Server.Hosting/Support/SupportRequestCoordinator.cs
+++ b/Zeus.Server.Hosting/Support/SupportRequestCoordinator.cs
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace Zeus.Server.Hosting.Support;
+
+/// <summary>A maintainer support request awaiting the operator's Allow/Deny.</summary>
+/// <param name="RequestId">Opaque id minted by the broker, correlates the whole flow.</param>
+/// <param name="AdminCallsign">The maintainer asking (verified admin at the broker).</param>
+/// <param name="CreatedAt">When the request arrived.</param>
+/// <param name="ExpiresAt">When the prompt goes stale (auto-dismiss; the maintainer must re-ask).</param>
+public sealed record PendingSupportRequest(
+    string RequestId,
+    string AdminCallsign,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset ExpiresAt);
+
+/// <summary>
+/// Orchestrates the request → Allow/Deny flow for read-only maintainer support
+/// sessions. The broker relays an admin's request in (<see cref="RegisterRequest"/>);
+/// this raises <see cref="Requested"/> so the operator UI (P5) can prompt. The
+/// operator's decision arrives via the local <c>/api/support/*</c> endpoints:
+///   • <see cref="Approve"/> mints a single-use <see cref="SupportGrant"/> in the
+///     <see cref="SupportGrantStore"/> and raises <see cref="Approved"/> (the broker
+///     client signals the waiting admin to send its WebRTC offer).
+///   • <see cref="Deny"/> drops the request and raises <see cref="Denied"/>.
+///
+/// Nothing is ever auto-approved: with no operator Approve, no grant is minted and
+/// <see cref="SupportWebRtcService"/> refuses the offer. Pending requests auto-expire
+/// so an unanswered prompt cannot linger. Thread-safe; registered as a singleton.
+/// </summary>
+public sealed class SupportRequestCoordinator
+{
+    /// <summary>How long an unanswered request stays actionable before it auto-expires.</summary>
+    public static readonly TimeSpan DefaultPendingTtl = TimeSpan.FromSeconds(90);
+
+    private readonly SupportGrantStore _grants;
+    private readonly TimeProvider _time;
+    private readonly TimeSpan _pendingTtl;
+    private readonly ILogger<SupportRequestCoordinator> _log;
+    private readonly ConcurrentDictionary<string, PendingSupportRequest> _pending = new(StringComparer.Ordinal);
+
+    public SupportRequestCoordinator(
+        SupportGrantStore grants,
+        ILogger<SupportRequestCoordinator> log,
+        TimeProvider? timeProvider = null,
+        TimeSpan? pendingTtl = null)
+    {
+        _grants = grants;
+        _log = log;
+        _time = timeProvider ?? TimeProvider.System;
+        _pendingTtl = pendingTtl ?? DefaultPendingTtl;
+    }
+
+    /// <summary>Raised when a new request arrives (the operator UI shows an Allow/Deny prompt).</summary>
+    public event Action<PendingSupportRequest>? Requested;
+
+    /// <summary>Raised when the operator approves — carries the minted grant (the broker client signals the admin).</summary>
+    public event Action<SupportGrant>? Approved;
+
+    /// <summary>Raised when the operator denies (or a request is withdrawn) — carries the request id.</summary>
+    public event Action<string>? Denied;
+
+    /// <summary>
+    /// Record an inbound maintainer request and prompt the operator. Returns false
+    /// (and re-raises nothing) for a duplicate id already pending, or for missing
+    /// input. The decision is the operator's — this only surfaces the ask.
+    /// </summary>
+    public bool RegisterRequest(string requestId, string adminCallsign)
+    {
+        if (string.IsNullOrWhiteSpace(requestId)) return false;
+        PruneExpired();
+
+        var now = _time.GetUtcNow();
+        var req = new PendingSupportRequest(requestId, adminCallsign ?? "", now, now + _pendingTtl);
+        if (!_pending.TryAdd(requestId, req)) return false; // already pending — don't double-prompt
+
+        _log.LogInformation("support.request from {Admin} (id {RequestId}) — awaiting operator decision",
+            req.AdminCallsign, requestId);
+        Raise(Requested, req);
+        return true;
+    }
+
+    /// <summary>
+    /// Operator approves <paramref name="requestId"/>: mint a single-use grant and
+    /// signal it. Returns false if no such request is pending (or it expired).
+    /// </summary>
+    public bool Approve(string requestId)
+    {
+        if (string.IsNullOrEmpty(requestId)) return false;
+        if (!_pending.TryRemove(requestId, out var req)) return false;
+        if (req.ExpiresAt <= _time.GetUtcNow())
+        {
+            _log.LogInformation("support.request {RequestId} expired before approval", requestId);
+            return false;
+        }
+
+        var grant = _grants.Approve(requestId, req.AdminCallsign);
+        _log.LogInformation("support.request {RequestId} APPROVED for {Admin}", requestId, req.AdminCallsign);
+        Raise(Approved, grant);
+        return true;
+    }
+
+    /// <summary>Operator denies (or withdraws) <paramref name="requestId"/>. Returns whether it was pending.</summary>
+    public bool Deny(string requestId)
+    {
+        if (string.IsNullOrEmpty(requestId)) return false;
+        bool was = _pending.TryRemove(requestId, out _);
+        _grants.Revoke(requestId); // belt-and-braces: drop any grant if one slipped in
+        if (was)
+        {
+            _log.LogInformation("support.request {RequestId} DENIED", requestId);
+            Raise(Denied, requestId);
+        }
+        return was;
+    }
+
+    /// <summary>Live (unexpired) pending requests, newest first — for the operator UI / local endpoint.</summary>
+    public IReadOnlyList<PendingSupportRequest> Pending()
+    {
+        PruneExpired();
+        var list = new List<PendingSupportRequest>(_pending.Values);
+        list.Sort((a, b) => b.CreatedAt.CompareTo(a.CreatedAt));
+        return list;
+    }
+
+    /// <summary>Drop expired pending requests (and raise <see cref="Denied"/> for each, so UIs can dismiss).</summary>
+    public void PruneExpired()
+    {
+        var now = _time.GetUtcNow();
+        foreach (var kv in _pending)
+        {
+            if (kv.Value.ExpiresAt <= now && _pending.TryRemove(kv.Key, out _))
+                Raise(Denied, kv.Key);
+        }
+    }
+
+    private void Raise<T>(Action<T>? handler, T arg)
+    {
+        if (handler is null) return;
+        try { handler(arg); }
+        catch (Exception ex) { _log.LogWarning(ex, "support.coordinator subscriber threw"); }
+    }
+}

--- a/Zeus.Server.Hosting/Support/SupportSessionPolicy.cs
+++ b/Zeus.Server.Hosting/Support/SupportSessionPolicy.cs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.Server.Hosting.Support;
+
+/// <summary>
+/// The read-only access policy for a maintainer support session — deliberately an
+/// <b>ALLOWLIST</b>, the inverse of the operator's own remote tunnel (which is a
+/// permissive read-write session restrained by a denylist). A support session
+/// exists only to debug a crash/bug: it may READ a narrow set of diagnostic
+/// surfaces and NOTHING else.
+///
+/// Hard rules enforced here:
+///   1. Only safe, side-effect-free methods (GET / HEAD). Every mutating method
+///      (POST/PUT/DELETE/PATCH) is refused — no control, no settings writes, no
+///      TX, no PureSignal, ever.
+///   2. The path must prefix-match the small <see cref="AllowedReadPrefixes"/>
+///      allowlist. Anything not explicitly listed is denied.
+///
+/// What is intentionally NOT on the allowlist, and why:
+///   /api/log            — the ham LOGBOOK (QSO history, ADIF/PII). The diagnostic
+///                         application log reaches the maintainer over the session's
+///                         dedicated live-"log" data channel, never as logbook PII.
+///   /api/qrz, /api/chat — operator identity / messaging.
+///   /api/prefs*         — preferences DB (carries the QRZ password + remote verifier).
+///   /api/remote*        — the remote-access password store.
+///   /api/support*       — the approve/deny surface itself (a session must never be
+///                         able to widen its own authorisation).
+/// When unsure, deny.
+/// </summary>
+public static class SupportSessionPolicy
+{
+    /// <summary>
+    /// Read-only diagnostic surfaces a support session may GET. Prefix-matched
+    /// (case-insensitive) on the canonical URL path. Kept narrow and reviewable:
+    ///   /api/diagnostics  — the diagnostics v2 framework (providers, self-checks,
+    ///                       symptoms). The maintainer's primary signal.
+    ///   /api/version      — running build/version (is the operator on an old build?).
+    ///   /api/capabilities — per-board capability fingerprint (what radio is this?).
+    ///   /api/system/update— updater status (available/applied version).
+    ///   /api/state        — the live radio state snapshot (mode/VFO/meters context;
+    ///                       read-only, no secrets). Invaluable for "their radio shows X".
+    /// </summary>
+    public static readonly string[] AllowedReadPrefixes =
+    {
+        "/api/diagnostics",
+        "/api/version",
+        "/api/capabilities",
+        "/api/system/update",
+        "/api/state",
+    };
+
+    /// <summary>True for safe, side-effect-free methods (GET / HEAD); false for every mutating one.</summary>
+    public static bool IsReadOnlyMethod(string? method)
+        => !string.IsNullOrEmpty(method) && method.ToUpperInvariant() is "GET" or "HEAD";
+
+    /// <summary>
+    /// Whether <paramref name="path"/> is on the read allowlist. Prefix-matched on
+    /// the path only — any query string is stripped first so it can't smuggle a
+    /// non-allowlisted suffix past the check.
+    /// </summary>
+    public static bool IsAllowedPath(string? path)
+    {
+        if (string.IsNullOrEmpty(path)) return false;
+        int q = path.IndexOf('?');
+        var p = q >= 0 ? path[..q] : path;
+        foreach (var prefix in AllowedReadPrefixes)
+            if (p.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                return true;
+        return false;
+    }
+
+    /// <summary>
+    /// Whether a support session may proxy <paramref name="method"/> on
+    /// <paramref name="path"/> to the radio's loopback. Fail-closed: any non-GET/HEAD
+    /// method, any path off the allowlist, and any malformed input returns false.
+    /// </summary>
+    /// <param name="method">HTTP method (case-insensitive).</param>
+    /// <param name="path">Canonical request path; a query string (if any) is ignored.</param>
+    public static bool IsAllowed(string? method, string? path)
+        => IsReadOnlyMethod(method) && IsAllowedPath(path);
+}

--- a/Zeus.Server.Hosting/Support/SupportWebRtcService.cs
+++ b/Zeus.Server.Hosting/Support/SupportWebRtcService.cs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Collections.Concurrent;
+using System.Net.Http;
+using Microsoft.Extensions.Logging;
+using SIPSorcery.Net;
+using Zeus.Server.Diagnostics;
+
+namespace Zeus.Server.Hosting.Support;
+
+/// <summary>
+/// Signaling entry point for read-only maintainer support sessions. A support
+/// offer is answered ONLY if it carries a request id the operator has approved
+/// (a single-use <see cref="SupportGrant"/> in the <see cref="SupportGrantStore"/>);
+/// otherwise it is refused. Deny-by-default end-to-end at the radio (ADR-0008):
+/// the broker can relay an offer, but without the operator's local "Allow" there
+/// is no grant and no session.
+/// </summary>
+public sealed class SupportWebRtcService
+{
+    private readonly SupportGrantStore _grants;
+    private readonly ILogger<SupportWebRtcService> _log;
+    private readonly IHttpClientFactory? _httpFactory;
+    private readonly string? _loopbackBaseUrl;
+    private readonly DiagnosticLogBuffer? _logBuffer;
+    private readonly ConcurrentDictionary<Guid, SupportWebRtcSession> _sessions = new();
+
+    public SupportWebRtcService(
+        SupportGrantStore grants,
+        ILogger<SupportWebRtcService> log,
+        DiagnosticLogBuffer? logBuffer = null,
+        IHttpClientFactory? httpFactory = null,
+        string? loopbackBaseUrl = null)
+    {
+        _grants = grants;
+        _log = log;
+        _logBuffer = logBuffer;
+        _httpFactory = httpFactory;
+        _loopbackBaseUrl = loopbackBaseUrl;
+    }
+
+    public int ActiveSessions => _sessions.Count;
+
+    /// <summary>
+    /// Answer a maintainer support offer for <paramref name="requestId"/>. Throws
+    /// <see cref="SupportNotAuthorizedException"/> if there is no live operator-approved
+    /// grant for that id (consumed single-use here, so a replayed offer is refused).
+    /// </summary>
+    public async Task<string> ConnectSupportAsync(string requestId, string offerSdp, CancellationToken ct = default)
+    {
+        if (!_grants.TryConsume(requestId, out var grant))
+            throw new SupportNotAuthorizedException();
+
+        SupportApiProxy? proxy = null;
+        if (_httpFactory is not null && !string.IsNullOrEmpty(_loopbackBaseUrl))
+            proxy = new SupportApiProxy(_httpFactory, _loopbackBaseUrl, _log);
+
+        var id = Guid.NewGuid();
+        var session = new SupportWebRtcSession(grant, _log, IceServers(), proxy, _logBuffer);
+        _sessions[id] = session;
+        session.Closed += () =>
+        {
+            if (_sessions.TryRemove(id, out _))
+                _log.LogInformation("support.rtc session {Id} closed ({Count} active)", id, _sessions.Count);
+        };
+
+        _log.LogInformation(
+            "support.rtc answering offer for {Admin} (request {RequestId}), session {Id}",
+            grant.AdminCallsign, requestId, id);
+        return await session.CreateAnswerAsync(offerSdp, ct);
+    }
+
+    public void CloseAll()
+    {
+        foreach (var kv in _sessions)
+            if (_sessions.TryRemove(kv.Key, out var s))
+                s.Close();
+    }
+
+    // STUN only here; the production path swaps in Cloudflare TURN credentials
+    // minted by the broker for NAT/CGNAT traversal (same as the operator tunnel).
+    private static List<RTCIceServer> IceServers() =>
+    [
+        new RTCIceServer { urls = "stun:stun.cloudflare.com:3478" },
+    ];
+}
+
+/// <summary>Thrown when a support offer arrives without a live operator-approved grant.</summary>
+public sealed class SupportNotAuthorizedException()
+    : Exception("Support session refused: no operator-approved grant for this request.");

--- a/Zeus.Server.Hosting/Support/SupportWebRtcSession.cs
+++ b/Zeus.Server.Hosting/Support/SupportWebRtcSession.cs
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using SIPSorcery.Net;
+using Zeus.Server.Diagnostics;
+
+namespace Zeus.Server.Hosting.Support;
+
+/// <summary>
+/// One read-only maintainer support session over WebRTC. Unlike the operator's
+/// own remote tunnel (<see cref="Zeus.Server.Hosting.Remote.RemoteWebRtcSession"/>,
+/// a permissive read-write session gated by the SPAKE2+ password), a support
+/// session:
+///   • is authorised by an operator-approved <see cref="SupportGrant"/> — already
+///     consumed by <see cref="SupportWebRtcService"/> before this session is built,
+///     so there is no password handshake; the operator's local "Allow" IS the gate.
+///   • is strictly READ-ONLY and diagnostics-scoped: the "api" channel proxies only
+///     GET/HEAD on the <see cref="SupportSessionPolicy"/> allowlist; there is NO
+///     radio-frame bridge, NO audio, NO control verbs, NO TX — nothing can mutate
+///     the radio.
+///   • streams the live application log on a dedicated "log" data channel.
+///
+/// Channels are client-initiated (the maintainer sends {t:"hello"} on each channel
+/// it wants), mirroring the operator tunnel's pattern — the answerer-side onopen is
+/// not relied upon.
+/// </summary>
+public sealed class SupportWebRtcSession
+{
+    private readonly ILogger _log;
+    private readonly SupportApiProxy? _proxy;
+    private readonly DiagnosticLogBuffer? _logBuffer;
+    private readonly SupportGrant _grant;
+    private readonly RTCPeerConnection _pc;
+
+    private RTCDataChannel? _control;
+    private RTCDataChannel? _api;
+    private RTCDataChannel? _logChan;
+
+    private int _closed;
+    private int _logSubscribed;
+    private Action<string>? _logHandler;
+
+    /// <summary>How many recent log lines to replay when the maintainer attaches the log channel.</summary>
+    private const int LogBacklogLines = 300;
+
+    public SupportWebRtcSession(
+        SupportGrant grant,
+        ILogger log,
+        IReadOnlyList<RTCIceServer>? iceServers = null,
+        SupportApiProxy? proxy = null,
+        DiagnosticLogBuffer? logBuffer = null)
+    {
+        _grant = grant;
+        _log = log;
+        _proxy = proxy;
+        _logBuffer = logBuffer;
+
+        _pc = new RTCPeerConnection(new RTCConfiguration
+        {
+            iceServers = iceServers?.ToList() ?? new List<RTCIceServer>(),
+        });
+        _pc.ondatachannel += OnDataChannel;
+        _pc.onconnectionstatechange += state =>
+        {
+            if (state is RTCPeerConnectionState.closed
+                or RTCPeerConnectionState.failed
+                or RTCPeerConnectionState.disconnected)
+                Close();
+        };
+    }
+
+    /// <summary>The request this session serves (for owner bookkeeping / logging).</summary>
+    public string RequestId => _grant.RequestId;
+
+    /// <summary>The maintainer callsign the operator approved.</summary>
+    public string AdminCallsign => _grant.AdminCallsign;
+
+    /// <summary>Raised once, when the session is torn down (for owner cleanup).</summary>
+    public event Action? Closed;
+
+    /// <summary>Answer the maintainer's offer with a self-contained (vanilla-ICE) SDP.</summary>
+    public async Task<string> CreateAnswerAsync(string offerSdp, CancellationToken ct = default)
+    {
+        var setResult = _pc.setRemoteDescription(
+            new RTCSessionDescriptionInit { type = RTCSdpType.offer, sdp = offerSdp });
+        if (setResult != SetDescriptionResultEnum.OK)
+            throw new InvalidOperationException($"setRemoteDescription failed: {setResult}");
+
+        var answer = _pc.createAnswer(null);
+        await _pc.setLocalDescription(answer);
+        await WaitForIceGatheringAsync(_pc, TimeSpan.FromMilliseconds(750), ct);
+        return _pc.localDescription.sdp.ToString();
+    }
+
+    public void Close()
+    {
+        if (Interlocked.Exchange(ref _closed, 1) != 0) return;
+
+        // Detach the live-log tail so a closed session stops touching the buffer.
+        if (_logBuffer is not null && _logHandler is not null)
+        {
+            _logBuffer.LineAdded -= _logHandler;
+            _logHandler = null;
+        }
+
+        try { _pc.close(); } catch { /* already torn down */ }
+        Closed?.Invoke();
+    }
+
+    private void OnDataChannel(RTCDataChannel dc)
+    {
+        switch (dc.label)
+        {
+            case "control":
+                _control = dc;
+                dc.onmessage += (_, _, data) => OnControlMessage(data);
+                break;
+            case "api":
+                _api = dc;
+                dc.onmessage += (_, _, data) => OnApiMessage(data);
+                break;
+            case "log":
+                _logChan = dc;
+                dc.onmessage += (_, _, data) => OnLogMessage(data);
+                break;
+            default:
+                _log.LogWarning("support.rtc unexpected data channel '{Label}'", dc.label);
+                break;
+        }
+    }
+
+    // -- control: client hello → readiness ack -------------------------------
+
+    private void OnControlMessage(byte[] data)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(data);
+            if (doc.RootElement.TryGetProperty("t", out var tEl) && tEl.GetString() == "hello")
+            {
+                _control?.send(JsonSerializer.Serialize(new
+                {
+                    t = "support-ready",
+                    requestId = _grant.RequestId,
+                    admin = _grant.AdminCallsign,
+                }));
+            }
+        }
+        catch { /* malformed control message — ignore (read-only session, nothing to abuse) */ }
+    }
+
+    // -- api: read-only allowlist loopback proxy -----------------------------
+
+    private void OnApiMessage(byte[] data)
+    {
+        if (Volatile.Read(ref _closed) != 0 || _proxy is null) return;
+        _ = HandleApiAsync(data);
+    }
+
+    private async Task HandleApiAsync(byte[] data)
+    {
+        int id = 0;
+        try
+        {
+            string method, path;
+            using (var doc = JsonDocument.Parse(data))
+            {
+                var root = doc.RootElement;
+                id = root.TryGetProperty("id", out var idEl) ? idEl.GetInt32() : 0;
+                method = (root.TryGetProperty("method", out var mEl) ? mEl.GetString() : null) ?? "GET";
+                path = (root.TryGetProperty("path", out var pEl) ? pEl.GetString() : null) ?? "";
+            }
+
+            var reply = await _proxy!.HandleAsync(new SupportApiRequest(id, method, path)).ConfigureAwait(false);
+            SendApiReply(reply);
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "support.rtc api dispatch failed — replying 502");
+            try { SendApiReply(new SupportApiReply(id, 502, null, null)); } catch { /* channel gone */ }
+        }
+    }
+
+    private void SendApiReply(SupportApiReply reply)
+    {
+        if (_api is null) return;
+        var payload = new Dictionary<string, object?>
+        {
+            ["id"] = reply.Id,
+            ["status"] = reply.Status,
+        };
+        if (reply.ContentType is not null) payload["contentType"] = reply.ContentType;
+        if (reply.Body is not null) payload["body"] = reply.Body;
+        try { _api.send(JsonSerializer.Serialize(payload)); } catch { /* channel closed */ }
+    }
+
+    // -- log: backlog replay + live tail -------------------------------------
+
+    private void OnLogMessage(byte[] data)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(data);
+            if (!(doc.RootElement.TryGetProperty("t", out var tEl) && tEl.GetString() == "hello"))
+                return;
+        }
+        catch { return; }
+
+        // Subscribe exactly once, even if the client sends multiple hellos.
+        if (_logBuffer is null || Interlocked.Exchange(ref _logSubscribed, 1) != 0) return;
+
+        // Replay the recent backlog first so the maintainer sees context, then
+        // stream new lines as they arrive.
+        try
+        {
+            var backlog = _logBuffer.Snapshot(LogBacklogLines);
+            _logChan?.send(JsonSerializer.Serialize(new { t = "backlog", lines = backlog }));
+        }
+        catch (Exception ex) { _log.LogWarning(ex, "support.rtc log backlog send failed"); }
+
+        _logHandler = OnLogLine;
+        _logBuffer.LineAdded += _logHandler;
+    }
+
+    private void OnLogLine(string line)
+    {
+        if (Volatile.Read(ref _closed) != 0) return;
+        try { _logChan?.send(JsonSerializer.Serialize(new { t = "line", line })); }
+        catch { /* channel gone — the connection-state handler will Close() us */ }
+    }
+
+    private static async Task WaitForIceGatheringAsync(RTCPeerConnection pc, TimeSpan timeout, CancellationToken ct)
+    {
+        if (pc.iceGatheringState == RTCIceGatheringState.complete)
+            return;
+
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        void OnChange(RTCIceGatheringState s)
+        {
+            if (s == RTCIceGatheringState.complete) tcs.TrySetResult();
+        }
+
+        pc.onicegatheringstatechange += OnChange;
+        try
+        {
+            if (pc.iceGatheringState == RTCIceGatheringState.complete) return;
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(timeout);
+            await using (cts.Token.Register(() => tcs.TrySetResult()))
+                await tcs.Task.ConfigureAwait(false);
+        }
+        finally
+        {
+            pc.onicegatheringstatechange -= OnChange;
+        }
+    }
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -71,6 +71,34 @@ public static class ZeusEndpoints
                 return Results.Ok(diag.Build(req));
             });
 
+        // Maintainer remote-support: the OPERATOR's local decision surface for an
+        // inbound read-only diagnostics request (remote-diag P3). The request
+        // arrives over the broker and is parked by SupportRequestCoordinator; these
+        // endpoints let the in-app Allow/Deny UI (P5) list and answer it. They are
+        // intentionally LOCAL only — the support tunnel's allowlist excludes
+        // /api/support and the operator tunnel denies it, so a remote peer can
+        // never approve a session for itself.
+        app.MapGet("/api/support/pending",
+            (Zeus.Server.Hosting.Support.SupportRequestCoordinator coord) => Results.Ok(coord.Pending()));
+
+        app.MapPost("/api/support/approve",
+            (SupportDecisionRequest req, Zeus.Server.Hosting.Support.SupportRequestCoordinator coord) =>
+            {
+                var id = req.RequestId ?? "";
+                var ok = coord.Approve(id);
+                log.LogInformation("api.support.approve id={RequestId} ok={Ok}", id, ok);
+                return ok ? Results.Ok(new { ok = true }) : Results.NotFound(new { ok = false });
+            });
+
+        app.MapPost("/api/support/deny",
+            (SupportDecisionRequest req, Zeus.Server.Hosting.Support.SupportRequestCoordinator coord) =>
+            {
+                var id = req.RequestId ?? "";
+                var ok = coord.Deny(id);
+                log.LogInformation("api.support.deny id={RequestId} ok={Ok}", id, ok);
+                return ok ? Results.Ok(new { ok = true }) : Results.NotFound(new { ok = false });
+            });
+
         // Capabilities snapshot — host-mode + platform metadata. Frontend
         // fetches once on app mount; future feature gates will reattach as
         // the new plugin system fills the FeatureMatrix. The HttpContext-
@@ -5067,6 +5095,8 @@ public static class ZeusEndpoints
 }
 
 internal sealed record NativeMuteRequest(bool Muted);
+/// <summary>Operator Allow/Deny body for a maintainer remote-support request (remote-diag P3).</summary>
+internal sealed record SupportDecisionRequest(string? RequestId);
 internal sealed record NativeAudioDevicesSetRequest(string? InputDeviceId, string? OutputDeviceId);
 internal sealed record NativeAudioDeviceDto(string Id, string Name, bool IsDefault);
 internal sealed record NativeAudioDevicesResponse(

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -405,6 +405,26 @@ public static class ZeusHost
         // Radio-side broker glue (Phase 3). Inert until a remote-access password
         // is set; then it keeps a "host" socket on the broker and answers offers.
         builder.Services.AddHostedService<Zeus.Server.Hosting.Remote.RemoteBrokerClient>();
+
+        // Maintainer remote-support (remote-diag P3): a SECOND, strictly read-only
+        // session type over the same tunnel for diagnosing a consented user's
+        // crashes/bugs. Three collaborators:
+        //   • SupportGrantStore — the radio's local authority; holds the single-use,
+        //     short-TTL grant the operator's "Allow" mints (ADR-0008 end-to-end gate).
+        //   • SupportRequestCoordinator — request→Allow/Deny orchestration the in-app
+        //     prompt (P5) and the broker client (P3b) hang off.
+        //   • SupportWebRtcService — answers a support offer ONLY against a live
+        //     grant, with a diagnostics-only allowlist + a live-log channel.
+        // Inert until the operator both opts in and approves a specific request.
+        builder.Services.AddSingleton<Zeus.Server.Hosting.Support.SupportGrantStore>();
+        builder.Services.AddSingleton<Zeus.Server.Hosting.Support.SupportRequestCoordinator>();
+        builder.Services.AddSingleton<Zeus.Server.Hosting.Support.SupportWebRtcService>(sp =>
+            new Zeus.Server.Hosting.Support.SupportWebRtcService(
+                sp.GetRequiredService<Zeus.Server.Hosting.Support.SupportGrantStore>(),
+                sp.GetRequiredService<ILogger<Zeus.Server.Hosting.Support.SupportWebRtcService>>(),
+                sp.GetService<DiagnosticLogBuffer>(),
+                sp.GetService<IHttpClientFactory>(),
+                options.HttpPort != 0 ? $"http://127.0.0.1:{options.HttpPort}" : null));
         // LAN Browser proxy: fetches private-LAN device web UIs on behalf of the
         // panel (esp. for remote operators whose browser can't reach the radio's
         // LAN). No auto-redirect — LanProxyService follows + re-validates each hop

--- a/tests/Zeus.Server.Tests/DiagnosticLogBufferLineAddedTests.cs
+++ b/tests/Zeus.Server.Tests/DiagnosticLogBufferLineAddedTests.cs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Zeus.Server.Diagnostics;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// The live-tail hook a maintainer support session's "log" channel rides on:
+/// every appended line is fanned to subscribers, and a misbehaving subscriber can
+/// never break logging.
+/// </summary>
+public sealed class DiagnosticLogBufferLineAddedTests
+{
+    [Fact]
+    public void LineAdded_FiresWithAppendedLine()
+    {
+        var buffer = new DiagnosticLogBuffer();
+        var seen = new List<string>();
+        buffer.LineAdded += seen.Add;
+
+        buffer.Add("12:00:00.000 INFO RadioService hello");
+        buffer.Add("12:00:01.000 WARN Foo bar");
+
+        Assert.Equal(
+            new[] { "12:00:00.000 INFO RadioService hello", "12:00:01.000 WARN Foo bar" },
+            seen);
+    }
+
+    [Fact]
+    public void EmptyLine_DoesNotFire()
+    {
+        var buffer = new DiagnosticLogBuffer();
+        int count = 0;
+        buffer.LineAdded += _ => count++;
+
+        buffer.Add("");
+        buffer.Add(null!);
+
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public void ThrowingSubscriber_DoesNotBreakLogging()
+    {
+        var buffer = new DiagnosticLogBuffer();
+        buffer.LineAdded += _ => throw new InvalidOperationException("subscriber boom");
+
+        // Add must not propagate the subscriber's exception…
+        var ex = Record.Exception(() => buffer.Add("still logged"));
+        Assert.Null(ex);
+
+        // …and the line still lands in the ring.
+        Assert.Contains("still logged", buffer.Snapshot(10));
+    }
+
+    [Fact]
+    public void Unsubscribe_StopsDelivery()
+    {
+        var buffer = new DiagnosticLogBuffer();
+        var seen = new List<string>();
+        void Handler(string l) => seen.Add(l);
+
+        buffer.LineAdded += Handler;
+        buffer.Add("one");
+        buffer.LineAdded -= Handler;
+        buffer.Add("two");
+
+        Assert.Equal(new[] { "one" }, seen);
+    }
+}

--- a/tests/Zeus.Server.Tests/SupportApiProxyTests.cs
+++ b/tests/Zeus.Server.Tests/SupportApiProxyTests.cs
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Server.Hosting.Support;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// The support "api" channel proxy must be bulletproof: read-only, allowlisted,
+/// loopback-only, traversal-proof, and size-bounded. These exercise each gate
+/// without a live PeerConnection (the proxy is factored out precisely so it can be).
+/// </summary>
+public sealed class SupportApiProxyTests
+{
+    private const string LoopbackBase = "http://127.0.0.1:6060";
+
+    [Fact]
+    public async Task Get_Allowlisted_ProxiesToLoopback()
+    {
+        var factory = new StubHttpClientFactory(req =>
+        {
+            Assert.Equal(HttpMethod.Get, req.Method);
+            Assert.Equal($"{LoopbackBase}/api/diagnostics/v2", req.RequestUri!.ToString());
+            return Json("{\"ok\":true}");
+        });
+        var proxy = new SupportApiProxy(factory, LoopbackBase, NullLogger.Instance);
+
+        var reply = await proxy.HandleAsync(new SupportApiRequest(7, "GET", "/api/diagnostics/v2"));
+
+        Assert.Equal(7, reply.Id);
+        Assert.Equal(200, reply.Status);
+        Assert.Equal("{\"ok\":true}", reply.Body);
+        Assert.Equal("application/json; charset=utf-8", reply.ContentType);
+        Assert.Equal(1, factory.CallCount);
+    }
+
+    [Theory]
+    [InlineData("POST")]
+    [InlineData("PUT")]
+    [InlineData("DELETE")]
+    [InlineData("PATCH")]
+    public async Task MutatingMethod_Is405_NeverHitsLoopback(string method)
+    {
+        var factory = new StubHttpClientFactory(_ => Json("nope"));
+        var proxy = new SupportApiProxy(factory, LoopbackBase, NullLogger.Instance);
+
+        var reply = await proxy.HandleAsync(new SupportApiRequest(1, method, "/api/state"));
+
+        Assert.Equal(405, reply.Status);
+        Assert.Equal(0, factory.CallCount); // refused before any loopback call
+    }
+
+    [Fact]
+    public async Task NonAllowlistedPath_Is403()
+    {
+        var factory = new StubHttpClientFactory(_ => Json("secret"));
+        var proxy = new SupportApiProxy(factory, LoopbackBase, NullLogger.Instance);
+
+        var reply = await proxy.HandleAsync(new SupportApiRequest(2, "GET", "/api/prefs/databases"));
+
+        Assert.Equal(403, reply.Status);
+        Assert.Equal(0, factory.CallCount);
+    }
+
+    [Theory]
+    [InlineData("/api/state/../prefs/databases")]
+    [InlineData("/api/diagnostics/%2e%2e/prefs")]
+    public async Task Traversal_Is403_NeverHitsLoopback(string path)
+    {
+        var factory = new StubHttpClientFactory(_ => Json("secret"));
+        var proxy = new SupportApiProxy(factory, LoopbackBase, NullLogger.Instance);
+
+        var reply = await proxy.HandleAsync(new SupportApiRequest(3, "GET", path));
+
+        Assert.Equal(403, reply.Status);
+        Assert.Equal(0, factory.CallCount);
+    }
+
+    [Fact]
+    public async Task NonLoopbackBase_Is502_SsrfGuard()
+    {
+        // Even with an allowlisted path, a non-loopback base must never be reached.
+        var factory = new StubHttpClientFactory(_ => Json("offbox"));
+        var proxy = new SupportApiProxy(factory, "http://198.51.100.7", NullLogger.Instance);
+
+        var reply = await proxy.HandleAsync(new SupportApiRequest(4, "GET", "/api/state"));
+
+        Assert.Equal(502, reply.Status);
+        Assert.Equal(0, factory.CallCount);
+    }
+
+    [Fact]
+    public async Task NonAbsolutePath_Is502()
+    {
+        var factory = new StubHttpClientFactory(_ => Json("x"));
+        var proxy = new SupportApiProxy(factory, LoopbackBase, NullLogger.Instance);
+
+        var reply = await proxy.HandleAsync(new SupportApiRequest(5, "GET", "api/state"));
+
+        Assert.Equal(502, reply.Status);
+        Assert.Equal(0, factory.CallCount);
+    }
+
+    [Fact]
+    public async Task Head_ProxiesAsGet_AndDiscardsBody()
+    {
+        HttpMethod? seen = null;
+        var factory = new StubHttpClientFactory(req => { seen = req.Method; return Json("{\"v\":1}"); });
+        var proxy = new SupportApiProxy(factory, LoopbackBase, NullLogger.Instance);
+
+        var reply = await proxy.HandleAsync(new SupportApiRequest(6, "HEAD", "/api/version"));
+
+        Assert.Equal(HttpMethod.Get, seen);  // HEAD is proxied as GET
+        Assert.Equal(200, reply.Status);
+        Assert.Equal("", reply.Body);        // body discarded for HEAD
+    }
+
+    [Fact]
+    public async Task OversizedResponse_Is502()
+    {
+        var factory = new StubHttpClientFactory(_ =>
+        {
+            var resp = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(Encoding.UTF8.GetBytes("small")),
+            };
+            resp.Content.Headers.ContentLength = 5L * 1024 * 1024; // > 4 MiB cap
+            return resp;
+        });
+        var proxy = new SupportApiProxy(factory, LoopbackBase, NullLogger.Instance);
+
+        var reply = await proxy.HandleAsync(new SupportApiRequest(8, "GET", "/api/diagnostics/v2"));
+
+        Assert.Equal(502, reply.Status);
+    }
+
+    private static HttpResponseMessage Json(string body) =>
+        new(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+    private sealed class StubHttpClientFactory : IHttpClientFactory
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _respond;
+        public int CallCount { get; private set; }
+
+        public StubHttpClientFactory(Func<HttpRequestMessage, HttpResponseMessage> respond)
+            => _respond = respond;
+
+        public HttpClient CreateClient(string name) => new(new StubHandler(this));
+
+        private sealed class StubHandler(StubHttpClientFactory owner) : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                owner.CallCount++;
+                return Task.FromResult(owner._respond(request));
+            }
+        }
+    }
+}

--- a/tests/Zeus.Server.Tests/SupportGrantStoreTests.cs
+++ b/tests/Zeus.Server.Tests/SupportGrantStoreTests.cs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Zeus.Server.Hosting.Support;
+
+namespace Zeus.Server.Tests;
+
+public sealed class SupportGrantStoreTests
+{
+    private static readonly DateTimeOffset T0 = new(2026, 6, 27, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Approve_ThenConsume_ReturnsGrant_AndIsSingleUse()
+    {
+        var store = new SupportGrantStore();
+        var minted = store.Approve("req-1", "KB2UKA");
+        Assert.Equal("req-1", minted.RequestId);
+        Assert.Equal("KB2UKA", minted.AdminCallsign);
+
+        Assert.True(store.TryConsume("req-1", out var got));
+        Assert.Equal("req-1", got.RequestId);
+
+        // Single-use: a replayed offer for the same id is refused.
+        Assert.False(store.TryConsume("req-1", out _));
+    }
+
+    [Fact]
+    public void Consume_UnknownId_ReturnsFalse()
+    {
+        var store = new SupportGrantStore();
+        Assert.False(store.TryConsume("nope", out _));
+    }
+
+    [Fact]
+    public void Grant_ExpiresAfterTtl()
+    {
+        var clock = new TestClock(T0);
+        var store = new SupportGrantStore(clock, TimeSpan.FromMinutes(2));
+        store.Approve("req-1", "KB2UKA");
+
+        clock.Advance(TimeSpan.FromMinutes(3)); // past TTL
+        Assert.False(store.TryConsume("req-1", out _));
+        Assert.Equal(0, store.LiveCount);
+    }
+
+    [Fact]
+    public void Grant_JustBeforeExpiry_StillConsumable()
+    {
+        var clock = new TestClock(T0);
+        var store = new SupportGrantStore(clock, TimeSpan.FromMinutes(2));
+        store.Approve("req-1", "KB2UKA");
+
+        clock.Advance(TimeSpan.FromMinutes(1)); // still inside TTL
+        Assert.True(store.TryConsume("req-1", out _));
+    }
+
+    [Fact]
+    public void Revoke_RemovesGrant()
+    {
+        var store = new SupportGrantStore();
+        store.Approve("req-1", "KB2UKA");
+        store.Revoke("req-1");
+        Assert.False(store.TryConsume("req-1", out _));
+    }
+
+    [Fact]
+    public void Reapprove_RefreshesTtl()
+    {
+        var clock = new TestClock(T0);
+        var store = new SupportGrantStore(clock, TimeSpan.FromMinutes(2));
+        store.Approve("req-1", "KB2UKA");
+        clock.Advance(TimeSpan.FromMinutes(1.5));
+        store.Approve("req-1", "KB2UKA"); // refresh
+        clock.Advance(TimeSpan.FromMinutes(1)); // 1 min after refresh, < TTL
+        Assert.True(store.TryConsume("req-1", out _));
+    }
+
+    [Fact]
+    public void Approve_EmptyId_Throws()
+    {
+        var store = new SupportGrantStore();
+        Assert.Throws<ArgumentException>(() => store.Approve("", "KB2UKA"));
+    }
+
+    /// <summary>A manually-advanced <see cref="TimeProvider"/> for deterministic TTL tests.</summary>
+    private sealed class TestClock(DateTimeOffset start) : TimeProvider
+    {
+        private DateTimeOffset _now = start;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan d) => _now += d;
+    }
+}

--- a/tests/Zeus.Server.Tests/SupportRequestCoordinatorTests.cs
+++ b/tests/Zeus.Server.Tests/SupportRequestCoordinatorTests.cs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Server.Hosting.Support;
+
+namespace Zeus.Server.Tests;
+
+public sealed class SupportRequestCoordinatorTests
+{
+    private static readonly DateTimeOffset T0 = new(2026, 6, 27, 12, 0, 0, TimeSpan.Zero);
+
+    private static (SupportRequestCoordinator coord, SupportGrantStore grants, TestClock clock) New(
+        TimeSpan? pendingTtl = null)
+    {
+        var clock = new TestClock(T0);
+        var grants = new SupportGrantStore(clock, TimeSpan.FromMinutes(2));
+        var coord = new SupportRequestCoordinator(
+            grants, NullLogger<SupportRequestCoordinator>.Instance, clock, pendingTtl);
+        return (coord, grants, clock);
+    }
+
+    [Fact]
+    public void Register_RaisesRequested_AndIsListed()
+    {
+        var (coord, _, _) = New();
+        PendingSupportRequest? seen = null;
+        coord.Requested += r => seen = r;
+
+        Assert.True(coord.RegisterRequest("req-1", "KB2UKA"));
+        Assert.NotNull(seen);
+        Assert.Equal("req-1", seen!.RequestId);
+        Assert.Equal("KB2UKA", seen.AdminCallsign);
+
+        var pending = coord.Pending();
+        Assert.Single(pending);
+        Assert.Equal("req-1", pending[0].RequestId);
+    }
+
+    [Fact]
+    public void Register_DuplicateId_IsRejected()
+    {
+        var (coord, _, _) = New();
+        Assert.True(coord.RegisterRequest("req-1", "KB2UKA"));
+        Assert.False(coord.RegisterRequest("req-1", "KB2UKA")); // already pending
+    }
+
+    [Fact]
+    public void Approve_MintsGrant_RaisesApproved_AndClearsPending()
+    {
+        var (coord, grants, _) = New();
+        coord.RegisterRequest("req-1", "KB2UKA");
+
+        SupportGrant? approved = null;
+        coord.Approved += g => approved = g;
+
+        Assert.True(coord.Approve("req-1"));
+        Assert.NotNull(approved);
+        Assert.Equal("req-1", approved!.RequestId);
+
+        // The grant is now consumable exactly once (the offer redeems it).
+        Assert.True(grants.TryConsume("req-1", out _));
+        // No longer pending.
+        Assert.Empty(coord.Pending());
+    }
+
+    [Fact]
+    public void Approve_UnknownId_ReturnsFalse_AndMintsNothing()
+    {
+        var (coord, grants, _) = New();
+        Assert.False(coord.Approve("ghost"));
+        Assert.False(grants.TryConsume("ghost", out _));
+    }
+
+    [Fact]
+    public void Deny_RemovesPending_RaisesDenied_AndBlocksLaterApprove()
+    {
+        var (coord, grants, _) = New();
+        coord.RegisterRequest("req-1", "KB2UKA");
+
+        string? denied = null;
+        coord.Denied += id => denied = id;
+
+        Assert.True(coord.Deny("req-1"));
+        Assert.Equal("req-1", denied);
+        Assert.Empty(coord.Pending());
+
+        // A denied request cannot subsequently be approved into a grant.
+        Assert.False(coord.Approve("req-1"));
+        Assert.False(grants.TryConsume("req-1", out _));
+    }
+
+    [Fact]
+    public void Pending_ExpiresAfterTtl_AndApproveThenFails()
+    {
+        var (coord, _, clock) = New(TimeSpan.FromSeconds(90));
+        coord.RegisterRequest("req-1", "KB2UKA");
+
+        string? denied = null;
+        coord.Denied += id => denied = id;
+
+        clock.Advance(TimeSpan.FromSeconds(120)); // past pending TTL
+        Assert.Empty(coord.Pending());            // prune drops it…
+        Assert.Equal("req-1", denied);            // …and signals a dismiss
+        Assert.False(coord.Approve("req-1"));     // too late to approve
+    }
+
+    private sealed class TestClock(DateTimeOffset start) : TimeProvider
+    {
+        private DateTimeOffset _now = start;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan d) => _now += d;
+    }
+}

--- a/tests/Zeus.Server.Tests/SupportSessionPolicyTests.cs
+++ b/tests/Zeus.Server.Tests/SupportSessionPolicyTests.cs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Zeus.Server.Hosting.Support;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// The read-only allowlist is the safety core of a maintainer support session, so
+/// it gets exhaustive coverage: every mutating method refused, only the named
+/// diagnostic surfaces readable, and nothing smuggleable past via query strings.
+/// </summary>
+public sealed class SupportSessionPolicyTests
+{
+    [Theory]
+    [InlineData("/api/diagnostics")]
+    [InlineData("/api/diagnostics/v2")]
+    [InlineData("/api/version")]
+    [InlineData("/api/capabilities")]
+    [InlineData("/api/system/update")]
+    [InlineData("/api/state")]
+    public void Get_OnAllowlistedPath_IsAllowed(string path)
+    {
+        Assert.True(SupportSessionPolicy.IsAllowed("GET", path));
+        Assert.True(SupportSessionPolicy.IsAllowed("HEAD", path));
+    }
+
+    [Theory]
+    [InlineData("POST")]
+    [InlineData("PUT")]
+    [InlineData("DELETE")]
+    [InlineData("PATCH")]
+    public void MutatingMethod_OnAllowlistedPath_IsDenied(string method)
+    {
+        // Even on an otherwise-readable path, no mutating method is ever allowed.
+        Assert.False(SupportSessionPolicy.IsAllowed(method, "/api/state"));
+        Assert.False(SupportSessionPolicy.IsReadOnlyMethod(method));
+    }
+
+    [Theory]
+    [InlineData("/api/prefs/databases")]
+    [InlineData("/api/log/export")]
+    [InlineData("/api/log")]
+    [InlineData("/api/qrz")]
+    [InlineData("/api/chat")]
+    [InlineData("/api/tx/ps")]
+    [InlineData("/api/remote/password")]
+    [InlineData("/api/support/approve")]
+    [InlineData("/api/audio/native")]
+    [InlineData("/")]
+    [InlineData("/api")]
+    public void Get_OnNonAllowlistedPath_IsDenied(string path)
+    {
+        Assert.False(SupportSessionPolicy.IsAllowed("GET", path));
+        Assert.False(SupportSessionPolicy.IsAllowedPath(path));
+    }
+
+    [Fact]
+    public void QueryString_IsStrippedBeforeMatching()
+    {
+        // A query on an allowlisted path doesn't change the verdict…
+        Assert.True(SupportSessionPolicy.IsAllowed("GET", "/api/state?x=1"));
+        // …and an allowlisted-looking query on a NON-allowlisted path cannot smuggle it through.
+        Assert.False(SupportSessionPolicy.IsAllowed("GET", "/api/prefs?x=/api/state"));
+    }
+
+    [Fact]
+    public void Matching_IsCaseInsensitive()
+    {
+        Assert.True(SupportSessionPolicy.IsAllowed("get", "/API/STATE"));
+        Assert.True(SupportSessionPolicy.IsReadOnlyMethod("Head"));
+    }
+
+    [Theory]
+    [InlineData(null, "/api/state")]
+    [InlineData("GET", null)]
+    [InlineData("", "/api/state")]
+    [InlineData("GET", "")]
+    public void NullOrEmptyInput_IsDenied(string? method, string? path)
+    {
+        Assert.False(SupportSessionPolicy.IsAllowed(method, path));
+    }
+}


### PR DESCRIPTION
Part of the remote-diagnostics epic (beads `zeus-87ca`, issue `zeus-15x2`). **P3a** — the backend mechanism for a privileged, **read-only** maintainer support session over the existing remote tunnel. First of two stacked PRs; **P3b** adds the broker-side signaling relay (admin-token-gated `/signal?support=1` client, `support-request`/`support-grant` relay, real `/admin/request`) and the sidecar presence heartbeat + crash auto-share.

### Authority model (ADR-0008 preserved — broker never trusted)
A support session can open only because **(1)** the maintainer proved an admin credential to the broker **and (2)** the operator personally approved **this** request. The second gate is enforced locally at the radio by a **single-use, short-TTL grant** the operator's own *Allow* mints. There is no password handshake — the operator's decision *is* the gate.

### Read-only by construction (inverse of the operator's own tunnel)
- **`SupportSessionPolicy`** is an **allowlist**, not a denylist: `GET`/`HEAD` only, and only on `/api/diagnostics`, `/api/version`, `/api/capabilities`, `/api/system/update`, `/api/state`. Every mutating method is refused — no control, no settings, no TX, no PureSignal, ever. The ham logbook (`/api/log`), QRZ, chat, and prefs are **not** allowlisted; the diagnostic application log reaches the maintainer over a dedicated live `log` data channel, never as logbook PII.
- **`SupportApiProxy`** carries the same traversal / loopback-SSRF / size guards as the operator tunnel, factored out so the gating is unit-testable without a live `PeerConnection`.
- `/api/support` (the Allow/Deny surface itself) is now **also denied on the operator's own remote tunnel**, so a remote peer can't approve a support session for itself.

### Pieces
| Component | Role |
|---|---|
| `SupportGrant` / `SupportGrantStore` | the radio's local grant authority (single-use, expiring) |
| `SupportSessionPolicy` / `SupportApiProxy` | read-only allowlist + guarded loopback proxy |
| `SupportWebRtcSession` / `SupportWebRtcService` | answer a support offer **only** against a live grant; diagnostics-only `api` channel + live `log` channel |
| `SupportRequestCoordinator` | request → Allow/Deny orchestration; events the in-app prompt (P5) and broker client (P3b) attach to; nothing auto-approves; unanswered prompts auto-expire |
| `DiagnosticLogBuffer.LineAdded` | cheap, non-throwing live-tail hook (fans the same redacted lines, outside the buffer lock) |
| `/api/support/pending\|approve\|deny` | local operator decision surface |

### Tests
36 new cases: policy allowlist exhaustively (every mutating method + off-allowlist path refused, query-string strip, case-insensitivity), grant single-use + expiry, proxy 405/403/502 + traversal/SSRF/HEAD/size, coordinator request/approve/deny/expiry, live-log fan-out incl. throwing-subscriber isolation. **Filtered Support+Diagnostics suite: 104 passed, 0 failed.** Full project graph compiles.

### Not in this PR (P3b)
Broker `SignalRoom` relay of `support-request`/`support-grant` + admin-token verification on the support client; `RemoteBrokerClient` support signaling (outbound queue + offer routing to `SupportWebRtcService`); sidecar presence/crash-share. Until then `SupportWebRtcService.ConnectSupportAsync` is reachable only once that signaling is wired (matches how the operator tunnel's `BridgeSignalAsync` is unit-tested ahead of the live broker).