### PR TITLE
feat(web): unified premium chat composer field

### DIFF
--- a/zeus-web/src/layout/panels/ChatPanel.tsx
+++ b/zeus-web/src/layout/panels/ChatPanel.tsx
@@ -1763,6 +1763,9 @@ export function ChatPanel() {
   const setShowRosterOverlay = useDisplaySettingsStore((s) => s.setShowChatRosterOverlay);
 
   const [draft, setDraft] = useState('');
+  // Whether the composer field has keyboard focus — drives the accent focus
+  // ring/glow on the unified input field (inline styles can't use :focus-within).
+  const [composerFocused, setComposerFocused] = useState(false);
   // Pending inline photo: compressed and ready to send, shown as a preview chip
   // above the composer until the operator sends or removes it.
   const [pendingAttachment, setPendingAttachment] = useState<ChatAttachment | null>(null);
@@ -2044,6 +2047,20 @@ export function ChatPanel() {
       : activeTone === 'dm'
       ? '1px solid rgba(255,177,60,0.28)'
       : '1px solid var(--line-strong)';
+  // Tone-matched accent used for the composer field's focus ring/glow and the
+  // border colour it brightens to while focused.
+  const composerAccent =
+    activeTone === 'group'
+      ? '176,124,255'
+      : activeTone === 'dm'
+      ? '255,177,60'
+      : '78,166,255';
+  const composerFieldBorder = composerFocused
+    ? `1px solid rgba(${composerAccent},0.65)`
+    : composerBorder;
+  const composerFieldShadow = composerFocused
+    ? `0 0 0 3px rgba(${composerAccent},0.14), inset 0 1px 0 rgba(255,255,255,0.03)`
+    : 'inset 0 1px 0 rgba(255,255,255,0.03)';
 
   return (
     <div
@@ -2742,13 +2759,30 @@ export function ChatPanel() {
                 </button>
               </div>
             ) : (
-              <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
-                {/* Left action stack: mic on top, paperclip below. */}
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 4, flexShrink: 0 }}>
+              /* Unified composer field — mic + paperclip live inline on the
+                 left, the borderless textarea fills the middle, and the Send
+                 pill caps the right. The whole row is one rounded surface that
+                 lifts on focus (tone-matched accent ring), the way a modern
+                 chat composer reads. */
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'flex-end',
+                  gap: 4,
+                  padding: '4px 4px 4px 5px',
+                  borderRadius: 'var(--r-lg)',
+                  border: composerFieldBorder,
+                  background: connected ? '#0c0c10' : 'var(--bg-1)',
+                  boxShadow: composerFieldShadow,
+                  transition: `border-color var(--dur-fast) var(--ease-out), box-shadow var(--dur-fast) var(--ease-out)`,
+                }}
+              >
+                {/* Left action cluster: mic + paperclip as ghost icon buttons. */}
+                <div style={{ display: 'flex', alignItems: 'center', gap: 1, flexShrink: 0 }}>
                   {voice.supported && (
                     <button
                       type="button"
-                      className="btn sm"
+                      className="chat-composer-icon"
                       disabled={!connected || lockedActive || attaching || voice.preparing || pendingAttachment !== null}
                       onClick={() => {
                         setAttachError(null);
@@ -2765,7 +2799,7 @@ export function ChatPanel() {
                           : 'Record a voice message (max 60s)'
                       }
                       aria-label="Record a voice message"
-                      style={{ flexShrink: 0, padding: '5px 8px', color: 'var(--tx)' }}
+                      style={{ color: 'var(--tx)' }}
                     >
                       {voice.preparing ? '…' : <MicIcon />}
                     </button>
@@ -2773,12 +2807,11 @@ export function ChatPanel() {
                   {/* Paperclip — attach a photo. */}
                   <button
                     type="button"
-                    className="btn sm"
+                    className="chat-composer-icon"
                     disabled={!connected || attaching || lockedActive}
                     onClick={() => fileInputRef.current?.click()}
                     title={connected ? (lockedActive ? 'Not a member of this group' : 'Attach a photo') : 'Not connected'}
                     aria-label="Attach a photo"
-                    style={{ flexShrink: 0, padding: '5px 8px' }}
                   >
                     {attaching ? '…' : <PaperclipIcon />}
                   </button>
@@ -2788,6 +2821,8 @@ export function ChatPanel() {
                   className="mono"
                   value={draft}
                   onChange={(e) => setDraft(e.target.value)}
+                  onFocus={() => setComposerFocused(true)}
+                  onBlur={() => setComposerFocused(false)}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter' && !e.shiftKey) {
                       e.preventDefault();
@@ -2813,27 +2848,25 @@ export function ChatPanel() {
                     resize: 'none',
                     overflowY: 'auto',
                     maxHeight: 90,
-                    minHeight: 28,
-                    padding: '5px 8px',
+                    minHeight: 30,
+                    padding: '6px 4px',
                     boxSizing: 'border-box',
-                    borderRadius: 'var(--r-sm)',
-                    border: composerBorder,
-                    background: connected ? '#0c0c10' : 'var(--bg-1)',
-                    color: '#d8d8dc',
+                    border: 'none',
+                    background: 'transparent',
+                    color: '#e4e4e8',
                     fontSize: 12,
-                    lineHeight: 1.4,
+                    lineHeight: 1.45,
                     outline: 'none',
-                    transition: `border-color var(--dur-fast) var(--ease-out)`,
                   }}
                 />
-                {/* Send — vertically centered on the right edge. */}
+                {/* Send — pill capping the right edge, sits on the field floor. */}
                 <button
                   type="button"
                   className={`btn sm${canSend ? ' active' : ''}`}
                   disabled={!canSend}
                   onClick={() => void doSend()}
                   title={connected ? 'Send (Enter)' : 'Not connected'}
-                  style={{ flexShrink: 0, alignSelf: 'center' }}
+                  style={{ flexShrink: 0, alignSelf: 'stretch', padding: '0 12px', borderRadius: 'var(--r-md)' }}
                 >
                   Send
                 </button>

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -1142,6 +1142,35 @@
   filter: brightness(1.1);
 }
 
+/* Chat composer ghost-icon buttons (mic, paperclip). Borderless square hit
+   targets that live INSIDE the unified composer field, so they carry no chrome
+   at rest and only wash in on hover — keeps the field reading as one surface. */
+.chat-composer-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--r-md);
+  background: transparent;
+  color: var(--fg-2);
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out), color var(--dur-fast) var(--ease-out);
+}
+.chat-composer-icon:hover:not(:disabled) {
+  background: rgba(255,255,255,0.07);
+  color: var(--fg-0);
+}
+.chat-composer-icon:active:not(:disabled) {
+  background: rgba(255,255,255,0.04);
+}
+.chat-composer-icon:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
 /* 4K-and-above bump. 34" ultrawide (3440 CSS px) stays under this threshold
    on purpose — buttons are already sized right there. Native-scaled 4K
    (3840 CSS px) and 5K trigger this and get larger, ergonomic buttons. */
@@ -3127,6 +3156,37 @@
 .swx--fair  { color: var(--power); border-color: var(--power); }
 .swx--poor  { color: var(--tx); border-color: var(--tx); }
 .swx--muted { color: var(--fg-2); }
+
+/* ── Active Sessions panel ─────────────────────────────────────────────── */
+.sess-panel { display: flex; flex-direction: column; height: 100%; overflow: hidden; }
+.sess-head {
+  display: flex; align-items: center; gap: 6px;
+  padding: 4px 8px; border-bottom: 1px solid var(--panel-border, var(--line-strong));
+  flex: 0 0 auto;
+}
+.sess-title { font-size: 11px; font-weight: 700; color: var(--accent); letter-spacing: 0.04em; }
+.sess-count {
+  font-size: 10px; font-weight: 700; color: var(--fg-1);
+  background: var(--bg-2); border: 1px solid var(--line-strong);
+  border-radius: var(--r-xs); padding: 0 6px; min-width: 18px; text-align: center;
+}
+.sess-empty { padding: 16px; color: var(--fg-2); }
+.sess-list { flex: 1; min-height: 0; overflow: auto; padding: 4px 0; }
+.sess-row {
+  display: grid;
+  grid-template-columns: 64px minmax(0, 1.2fr) minmax(0, 1.4fr) 56px 64px;
+  align-items: center; gap: 8px;
+  padding: 5px 8px;
+  border-bottom: 1px dotted rgba(255,255,255,0.06);
+  font-size: 11px;
+}
+.sess-kind { display: flex; align-items: center; gap: 5px; font-weight: 700; white-space: nowrap; }
+.sess-dot { width: 7px; height: 7px; border-radius: 50%; flex: 0 0 auto; }
+.sess-addr { color: var(--fg-1); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.sess-agent { color: var(--fg-2); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.sess-dur { color: var(--fg-1); text-align: right; }
+.sess-stream { color: var(--fg-2); text-align: right; white-space: nowrap; }
+.sess-stream.is-on { color: var(--ok); font-weight: 700; }
 
 .cs-input {
   width: 90px;


### PR DESCRIPTION
## What

Reworks the chat panel's message input from three visibly disjoint pieces into a single, modern composer field.

**Before:** a stacked mic/paperclip column, a separately-bordered textarea, and a Send button — three boxes with gaps between them.

**After:** one rounded field (`--r-lg`) holding everything:
- The textarea is borderless/transparent so it melts into the field surface.
- Mic + paperclip are inline **ghost icon buttons** (new `.chat-composer-icon`) — no chrome at rest, wash in on hover.
- Send is a pill that caps the right edge and stretches to the field's full height.
- A **tone-matched focus ring** brightens the border + adds a soft glow when the field has focus: blue for Public, gold for DMs, violet for groups (reuses the existing per-room accent system). Wired via a `composerFocused` state since inline styles can't use `:focus-within`.

## Files
- `zeus-web/src/layout/panels/ChatPanel.tsx` — composer restructure + focus state
- `zeus-web/src/styles/layout.css` — `.chat-composer-icon` ghost-button class

## Verification
- `tsc --noEmit` passes.
- Loaded in the Vite dev server: confirmed the composer renders as one rounded surface — borderless transparent textarea seated inside the field, inline ghost icons, inset top-highlight, Send pill — via computed-style inspection. (Full-page screenshots hang on the WebGL panadapter under headless preview, so styles were verified directly through the DOM.)

Uses only existing design tokens; no palette changes. Mic keeps its TX-red tint.