### PR TITLE
feat(diag,cloud): broker relay + host signaling for support sessions (remote-diag P3b)

### DIFF
--- a/Zeus.Server.Hosting/Remote/RemoteBrokerClient.cs
+++ b/Zeus.Server.Hosting/Remote/RemoteBrokerClient.cs
@@ -1,8 +1,10 @@
 using System.Net.WebSockets;
 using System.Text;
 using System.Text.Json;
+using System.Threading.Channels;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Zeus.Server.Hosting.Support;
 
 namespace Zeus.Server.Hosting.Remote;
 
@@ -13,13 +15,20 @@ namespace Zeus.Server.Hosting.Remote;
 /// turns each relayed WebRTC <c>offer</c> into an <c>answer</c> via
 /// <see cref="RemoteWebRtcService"/> (gated by the SPAKE2+ password, ADR-0008).
 ///
+/// It ALSO carries the maintainer-support control plane (remote-diag P3): an
+/// inbound <c>support-request</c> is parked on <see cref="SupportRequestCoordinator"/>
+/// (which prompts the operator); when the operator approves, the resulting grant is
+/// pushed back to the broker as <c>support-grant</c> so the waiting admin sends its
+/// offer; a support <c>offer</c> is answered via <see cref="SupportWebRtcService"/>
+/// (read-only, grant-gated) instead of the operator tunnel.
+///
 /// Inert until the operator opts in (no password → no connection). The broker
-/// only relays signaling; media is peer-to-peer and the password is proven
+/// only relays signaling; media is peer-to-peer and the password/grant are proven
 /// end-to-end at the radio, so the broker is never trusted.
 ///
-/// NOTE: vanilla-ICE — candidates are embedded in the offer/answer SDP, so the
-/// only relayed messages are offer→answer. Live verification needs the deployed
-/// broker; <see cref="HandleSignalAsync"/> (the offer→answer bridge) is unit-tested.
+/// NOTE: vanilla-ICE — candidates are embedded in the offer/answer SDP. Live
+/// verification needs the deployed broker; the offer→answer + support dispatch
+/// (<see cref="HandleSignalAsync"/>) is unit-tested headlessly.
 /// </summary>
 public sealed class RemoteBrokerClient : BackgroundService
 {
@@ -28,16 +37,21 @@ public sealed class RemoteBrokerClient : BackgroundService
 
     private readonly RemotePasswordStore _passwords;
     private readonly RemoteWebRtcService _rtc;
+    private readonly SupportWebRtcService _support;
+    private readonly SupportRequestCoordinator _coord;
     private readonly QrzService _qrz;
     private readonly ILogger<RemoteBrokerClient> _log;
     private readonly string _brokerUrl;
 
     public RemoteBrokerClient(
-        RemotePasswordStore passwords, RemoteWebRtcService rtc, QrzService qrz,
-        ILogger<RemoteBrokerClient> log)
+        RemotePasswordStore passwords, RemoteWebRtcService rtc,
+        SupportWebRtcService support, SupportRequestCoordinator coord,
+        QrzService qrz, ILogger<RemoteBrokerClient> log)
     {
         _passwords = passwords;
         _rtc = rtc;
+        _support = support;
+        _coord = coord;
         _qrz = qrz;
         _log = log;
         _brokerUrl = Environment.GetEnvironmentVariable("ZEUS_REMOTE_BROKER_URL")
@@ -102,29 +116,106 @@ public sealed class RemoteBrokerClient : BackgroundService
         await socket.ConnectAsync(new Uri(_brokerUrl), ct);
         _log.LogInformation("remote broker: host online for {Callsign}", callsign);
 
-        var buffer = new byte[64 * 1024];
-        while (socket.State == WebSocketState.Open && !ct.IsCancellationRequested)
-        {
-            var json = await ReceiveTextAsync(socket, buffer, ct);
-            if (json is null) break; // close frame
+        // All outbound frames go through one queue + one send loop so the receive
+        // loop's answers and the async support-grant pushes never call SendAsync
+        // concurrently (ClientWebSocket forbids overlapping sends).
+        var outbound = Channel.CreateUnbounded<string>(
+            new UnboundedChannelOptions { SingleReader = true });
 
-            var reply = await HandleSignalAsync(json, ct);
-            if (reply is not null)
-            {
-                var bytes = Encoding.UTF8.GetBytes(reply);
-                await socket.SendAsync(bytes, WebSocketMessageType.Text, true, ct);
-            }
+        // Operator approved a support request → push the grant to the waiting admin
+        // so it sends its WebRTC offer. Subscribed only while this connection is up.
+        void OnApproved(SupportGrant g)
+            => outbound.Writer.TryWrite(
+                JsonSerializer.Serialize(new { t = "support-grant", requestId = g.RequestId }));
+        _coord.Approved += OnApproved;
+
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        try
+        {
+            var recv = ReceiveLoopAsync(socket, outbound.Writer, linked.Token);
+            var send = SendLoopAsync(socket, outbound.Reader, linked.Token);
+            await Task.WhenAny(recv, send).ConfigureAwait(false);
+            linked.Cancel(); // whichever ended, stop the other
+            await Task.WhenAll(
+                recv.ContinueWith(_ => { }, CancellationToken.None),
+                send.ContinueWith(_ => { }, CancellationToken.None)).ConfigureAwait(false);
+        }
+        finally
+        {
+            _coord.Approved -= OnApproved;
+            outbound.Writer.TryComplete();
         }
     }
 
+    private async Task ReceiveLoopAsync(ClientWebSocket socket, ChannelWriter<string> outbound, CancellationToken ct)
+    {
+        try
+        {
+            var buffer = new byte[64 * 1024];
+            while (socket.State == WebSocketState.Open && !ct.IsCancellationRequested)
+            {
+                var json = await ReceiveTextAsync(socket, buffer, ct);
+                if (json is null) break; // close frame
+
+                var reply = await HandleSignalAsync(json, ct);
+                if (reply is not null) outbound.TryWrite(reply);
+            }
+        }
+        finally
+        {
+            outbound.TryComplete();
+        }
+    }
+
+    private static async Task SendLoopAsync(ClientWebSocket socket, ChannelReader<string> outbound, CancellationToken ct)
+    {
+        try
+        {
+            await foreach (var msg in outbound.ReadAllAsync(ct).ConfigureAwait(false))
+            {
+                var bytes = Encoding.UTF8.GetBytes(msg);
+                await socket.SendAsync(bytes, WebSocketMessageType.Text, true, ct).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) { /* shutting down */ }
+    }
+
     /// <summary>
-    /// Bridge one signaling message: an <c>offer</c> becomes an <c>answer</c>
-    /// (tagged with the broker's <c>clientId</c>); everything else is ignored.
-    /// Returns the JSON to send back, or null. Never throws — a bad offer just
-    /// yields no answer (fails closed).
+    /// Dispatch one inbound signaling message. Maintainer-support traffic
+    /// (<c>support-request</c> and a support <c>offer</c>) routes to the read-only,
+    /// grant-gated support path; everything else is the operator tunnel's
+    /// password-gated offer→answer bridge. Returns the JSON to send back, or null.
+    /// Never throws — malformed or unauthorised input simply yields no reply
+    /// (fails closed).
     /// </summary>
     internal Task<string?> HandleSignalAsync(string json, CancellationToken ct)
-        => BridgeSignalAsync(_rtc, json, _log, ct);
+    {
+        bool isSupport;
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            isSupport = IsSupportMessage(doc.RootElement);
+        }
+        catch
+        {
+            return Task.FromResult<string?>(null); // unparseable — ignore
+        }
+
+        return isSupport
+            ? HandleSupportSignalAsync(_support, _coord, json, _log, ct)
+            : BridgeSignalAsync(_rtc, json, _log, ct);
+    }
+
+    /// <summary>True for the maintainer-support message types (a <c>support-request</c>,
+    /// or an <c>offer</c> explicitly tagged <c>support:true</c>).</summary>
+    internal static bool IsSupportMessage(JsonElement root)
+    {
+        var t = root.TryGetProperty("t", out var tEl) ? tEl.GetString() : null;
+        if (t == "support-request") return true;
+        return t == "offer"
+            && root.TryGetProperty("support", out var sEl)
+            && sEl.ValueKind == JsonValueKind.True;
+    }
 
     internal static async Task<string?> BridgeSignalAsync(
         RemoteWebRtcService rtc, string json, ILogger log, CancellationToken ct)
@@ -153,6 +244,56 @@ public sealed class RemoteBrokerClient : BackgroundService
         catch (Exception ex)
         {
             log.LogWarning(ex, "remote broker: failed to answer offer");
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Handle a maintainer-support signaling message:
+    ///   • <c>support-request</c> → park it on the coordinator (prompts the operator);
+    ///     no reply (the grant, if approved, is pushed later as <c>support-grant</c>).
+    ///   • support <c>offer</c> → answer via the grant-gated, read-only support
+    ///     service, echoing <c>clientId</c> and tagging the answer <c>support:true</c>.
+    /// Never throws; an unauthorised offer (no operator grant) yields no answer.
+    /// </summary>
+    internal static async Task<string?> HandleSupportSignalAsync(
+        SupportWebRtcService support, SupportRequestCoordinator coord,
+        string json, ILogger log, CancellationToken ct)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            var t = root.TryGetProperty("t", out var tEl) ? tEl.GetString() : null;
+
+            if (t == "support-request")
+            {
+                var requestId = root.TryGetProperty("requestId", out var r) ? r.GetString() : null;
+                var admin = root.TryGetProperty("admin", out var a) ? a.GetString() : null;
+                if (!string.IsNullOrEmpty(requestId))
+                    coord.RegisterRequest(requestId!, admin ?? "");
+                return null; // operator must Allow before anything flows
+            }
+
+            if (t == "offer")
+            {
+                var requestId = root.TryGetProperty("requestId", out var r) ? r.GetString() : null;
+                var clientId = root.TryGetProperty("clientId", out var c) ? c.GetString() : null;
+                var sdp = root.TryGetProperty("sdp", out var s) ? s.GetString() : null;
+                if (string.IsNullOrEmpty(requestId) || string.IsNullOrEmpty(sdp))
+                    return null;
+
+                var answer = await support.ConnectSupportAsync(requestId!, sdp!, ct);
+                return JsonSerializer.Serialize(new { t = "answer", sdp = answer, clientId, support = true });
+            }
+        }
+        catch (SupportNotAuthorizedException)
+        {
+            log.LogWarning("remote broker: support offer without an operator grant — ignoring");
+        }
+        catch (Exception ex)
+        {
+            log.LogWarning(ex, "remote broker: failed to answer support offer");
         }
         return null;
     }

--- a/cloud/zeus-remote-broker/src/admin-api.ts
+++ b/cloud/zeus-remote-broker/src/admin-api.ts
@@ -114,12 +114,10 @@ export async function handleAdmin(
       return json(body, 200, cors);
     }
 
-    // diagnostics-session request (STUB in P2; wired in P3)
+    // diagnostics-session request (remote-diag P3): notify the target operator and
+    // hand the dashboard a single-use ticket to open the support WebSocket with.
     if (path === '/admin/request' && request.method === 'POST') {
-      const target = norm(((await safeJson(request)).callsign as string) ?? '');
-      if (!target) return json({ error: 'callsign required' }, 400, cors);
-      await insertAudit(env.ADMIN_DB, { actor: auth.callsign, action: 'request', target });
-      return json({ ok: true, status: 'stub', note: 'diagnostics session wired in P3' }, 202, cors);
+      return await handleSupportRequest(request, env, auth, cors);
     }
 
     return json({ error: 'not found' }, 404, cors);
@@ -300,6 +298,43 @@ async function handleDisableAdmin(
     detail: admin ? 'existed' : 'absent',
   });
   return json({ ok: true }, 200, cors);
+}
+
+// --- support request --------------------------------------------------------
+
+/**
+ * Ask the target operator's SignalRoom to mint a maintainer-support request and
+ * notify the radio (host). On success the dashboard gets a single-use `ticket` it
+ * opens `role=support&callsign=<target>&ticket=<ticket>` with; the operator must
+ * still approve at the radio before anything flows (remote-diag P3). 503 when the
+ * operator is offline (no host socket).
+ */
+async function handleSupportRequest(
+  request: Request,
+  env: Env,
+  auth: AuthCtx,
+  cors: Record<string, string>,
+): Promise<Response> {
+  const target = norm(((await safeJson(request)).callsign as string) ?? '');
+  if (!target) return json({ error: 'callsign required' }, 400, cors);
+
+  const room = env.SIGNAL_ROOM.get(env.SIGNAL_ROOM.idFromName(target));
+  const res = await room.fetch('https://signal.internal/support-request', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ admin: auth.callsign }),
+  });
+
+  if (res.status === 503) {
+    await insertAudit(env.ADMIN_DB, { actor: auth.callsign, action: 'request', target, detail: 'offline' });
+    return json({ error: 'operator offline' }, 503, cors);
+  }
+  if (!res.ok) return json({ error: 'error' }, 502, cors);
+
+  const { requestId, ticket } = await res.json<{ requestId: string; ticket: string }>();
+  await insertAudit(env.ADMIN_DB, { actor: auth.callsign, action: 'request', target, detail: requestId });
+  // The ticket is a short-lived secret — never let an intermediary cache it.
+  return json({ ok: true, requestId, ticket, callsign: target }, 200, cors, { 'Cache-Control': 'no-store' });
 }
 
 // --- auth -------------------------------------------------------------------

--- a/cloud/zeus-remote-broker/src/index.ts
+++ b/cloud/zeus-remote-broker/src/index.ts
@@ -67,7 +67,8 @@ export default {
         return new Response('expected websocket upgrade', { status: 426 });
       }
 
-      const role = url.searchParams.get('role') === 'host' ? 'host' : 'client';
+      const roleParam = url.searchParams.get('role');
+      const role = roleParam === 'host' ? 'host' : roleParam === 'support' ? 'support' : 'client';
       let callsign = (url.searchParams.get('callsign') ?? '').trim().toUpperCase();
       const headers = new Headers(request.headers);
 
@@ -84,6 +85,11 @@ export default {
         callsign = verified || callsign;
         headers.set('X-Operator-Callsign', callsign);
       }
+      // role=support is NOT QRZ-gated here: the admin already proved authorisation
+      // to /admin/request, which issued the single-use ticket carried on this WS.
+      // The SignalRoom DO redeems + validates that ticket before joining the room,
+      // so an unauthorised peer can never become a support connection. `callsign`
+      // is the TARGET operator's room (supplied by the dashboard).
 
       if (!callsign) return new Response('callsign required', { status: 400 });
 

--- a/cloud/zeus-remote-broker/src/signal-room.ts
+++ b/cloud/zeus-remote-broker/src/signal-room.ts
@@ -4,24 +4,54 @@ import type { Env } from './types';
 /**
  * Per-connection state, persisted on the socket so it survives DO hibernation.
  * One `host` (the radio) and any number of `client`s (remote browsers) share a
- * room keyed by callsign.
+ * room keyed by callsign. A `support` connection is a maintainer's read-only
+ * diagnostics session (remote-diag P3): it behaves like a client but is bound to
+ * an operator-approvable `requestId` and identified by the admin callsign.
  */
 interface Att {
-  role: 'host' | 'client';
+  role: 'host' | 'client' | 'support';
   callsign: string;
-  /** Stable id for a client connection, so the host can address its answer. */
+  /** Stable id for a client/support connection, so the host can address its answer. */
   clientId?: string;
+  /** (support only) the maintainer request this connection serves. */
+  requestId?: string;
+  /** (support only) the admin callsign, for the operator's prompt + audit. */
+  admin?: string;
 }
+
+/** A redeemable support ticket (stored in DO storage so it survives hibernation). */
+interface SupportTicket {
+  requestId: string;
+  admin: string;
+  /** unix ms; redemption past this fails. */
+  expiresAt: number;
+}
+
+/** How long an issued support ticket stays redeemable (the dashboard connects promptly). */
+const SUPPORT_TICKET_TTL_MS = 120_000;
 
 /**
  * WebRTC signaling relay for one callsign (idFromName(callsign)). The browser
  * cannot reach the radio directly over the internet, so the radio keeps a
  * persistent `host` socket here and the broker relays SDP/ICE between it and
- * each `client`. The broker never sees media — only signaling — and never the
- * session password (that is proven end-to-end at the radio, ADR-0008).
+ * each `client`/`support` connection. The broker never sees media — only
+ * signaling — and never the session password or support grant (both are proven
+ * end-to-end at the radio, ADR-0008).
+ *
+ * Maintainer-support flow (remote-diag P3):
+ *   1. admin-api POSTs `/support-request` here (after verifying the admin); we
+ *      mint a requestId + a single-use ticket, push `support-request` to the host,
+ *      and return {requestId, ticket}.
+ *   2. the dashboard opens a `role=support` WS with that ticket; we redeem it and
+ *      bind the socket to the requestId/admin.
+ *   3. the operator approves at the radio; the host sends `support-grant{requestId}`,
+ *      which we route to the matching support socket.
+ *   4. the support socket sends an `offer`; we stamp `support:true`+`requestId`
+ *      (from the trusted attachment, never client-supplied) and relay to the host,
+ *      whose `answer` routes back by clientId.
  *
  * Uses the WebSocket Hibernation API so a long-lived-but-idle session costs no
- * GB-s between the bursty offer/answer/candidate exchanges.
+ * GB-s between the bursty exchanges.
  */
 export class SignalRoom extends DurableObject<Env> {
   constructor(ctx: DurableObjectState, env: Env) {
@@ -37,10 +67,27 @@ export class SignalRoom extends DurableObject<Env> {
 
   override async fetch(request: Request): Promise<Response> {
     const url = new URL(request.url);
-    const role = url.searchParams.get('role') === 'host' ? 'host' : 'client';
+
+    // Internal control path (called by admin-api after verifying the admin): mint
+    // a request + ticket and notify the host. NOT a WebSocket upgrade.
+    if (url.pathname === '/support-request' && request.method === 'POST') {
+      return this.createSupportRequest(request);
+    }
+
+    const roleParam = url.searchParams.get('role');
+    const role: Att['role'] = roleParam === 'host' ? 'host' : roleParam === 'support' ? 'support' : 'client';
     const callsign = (request.headers.get('X-Operator-Callsign') ?? url.searchParams.get('callsign') ?? '')
       .trim()
       .toUpperCase();
+
+    // A support connection must redeem a valid, unexpired, single-use ticket
+    // (the admin proved authorisation to admin-api to obtain it). Validate BEFORE
+    // accepting the socket so an unauthorised peer never joins the room.
+    let ticket: SupportTicket | null = null;
+    if (role === 'support') {
+      ticket = await this.redeemTicket(url.searchParams.get('ticket') ?? '');
+      if (!ticket) return new Response('invalid or expired support ticket', { status: 401 });
+    }
 
     const pair = new WebSocketPair();
     const client = pair[0];
@@ -56,6 +103,14 @@ export class SignalRoom extends DurableObject<Env> {
         }
       }
       server.serializeAttachment({ role: 'host', callsign } satisfies Att);
+    } else if (role === 'support') {
+      server.serializeAttachment({
+        role: 'support',
+        callsign,
+        clientId: crypto.randomUUID(),
+        requestId: ticket!.requestId,
+        admin: ticket!.admin,
+      } satisfies Att);
     } else {
       server.serializeAttachment({ role: 'client', callsign, clientId: crypto.randomUUID() } satisfies Att);
     }
@@ -74,19 +129,32 @@ export class SignalRoom extends DurableObject<Env> {
       return;
     }
 
-    if (att.role === 'client') {
-      // client → host: offer / candidate / bye. Tag with this client's id.
+    if (att.role === 'client' || att.role === 'support') {
+      // client/support → host: offer / candidate / bye, tagged with this
+      // connection's id. For support we additionally stamp support:true and the
+      // requestId FROM THE TRUSTED ATTACHMENT (never from client-supplied fields),
+      // so a support peer cannot masquerade as a normal client or forge a grant.
       const host = this.host();
       if (!host) {
         this.send(ws, { t: 'offline' });
         return;
       }
       if (msg.t === 'offer' || msg.t === 'candidate' || msg.t === 'bye') {
-        this.send(host, { ...msg, clientId: att.clientId });
+        const tagged =
+          att.role === 'support'
+            ? { ...msg, clientId: att.clientId, support: true, requestId: att.requestId }
+            : { ...msg, clientId: att.clientId };
+        this.send(host, tagged);
       }
     } else {
-      // host → a specific client by clientId: answer / candidate / bye.
-      const target = msg.clientId ? this.clientById(msg.clientId) : undefined;
+      // host → answer / candidate / bye to a specific connection by clientId, or
+      // support-grant to the support connection bound to a requestId.
+      if (msg.t === 'support-grant') {
+        const target = typeof msg.requestId === 'string' ? this.supportByRequestId(msg.requestId) : undefined;
+        if (target) this.send(target, { t: 'support-grant', requestId: msg.requestId });
+        return;
+      }
+      const target = msg.clientId ? this.connectionById(msg.clientId) : undefined;
       if (!target) return;
       if (msg.t === 'answer' || msg.t === 'candidate' || msg.t === 'bye') {
         const { clientId: _omit, ...rest } = msg;
@@ -100,8 +168,8 @@ export class SignalRoom extends DurableObject<Env> {
     try { ws.close(code, reason); } catch { /* already closing */ }
 
     if (att?.role === 'host') {
-      // Radio went away — every in-flight client should know.
-      for (const c of this.clients()) this.send(c, { t: 'offline' });
+      // Radio went away — every in-flight client/support connection should know.
+      for (const c of this.nonHostConnections()) this.send(c, { t: 'offline' });
     } else if (att?.clientId) {
       const host = this.host();
       if (host) this.send(host, { t: 'bye', clientId: att.clientId });
@@ -112,6 +180,48 @@ export class SignalRoom extends DurableObject<Env> {
     /* nothing to reconcile — close handles teardown */
   }
 
+  // -- maintainer-support control --------------------------------------------
+
+  /**
+   * Mint a requestId + single-use ticket for a maintainer support request and
+   * push `support-request` to the host. Called by admin-api (which has already
+   * verified the admin). Returns 503 if the operator (host) is offline.
+   */
+  private async createSupportRequest(request: Request): Promise<Response> {
+    let admin = '';
+    try {
+      const body = (await request.json()) as { admin?: string };
+      admin = (body.admin ?? '').trim().toUpperCase();
+    } catch {
+      /* empty body → anonymous admin label */
+    }
+
+    const host = this.host();
+    if (!host) return Response.json({ error: 'operator offline' }, { status: 503 });
+
+    const requestId = crypto.randomUUID();
+    const ticket = randomToken();
+    await this.ctx.storage.put(
+      `ticket:${ticket}`,
+      { requestId, admin, expiresAt: Date.now() + SUPPORT_TICKET_TTL_MS } satisfies SupportTicket,
+    );
+    this.send(host, { t: 'support-request', requestId, admin });
+    return Response.json({ requestId, ticket });
+  }
+
+  /** Redeem (consume) a support ticket; returns it iff present and unexpired. */
+  private async redeemTicket(ticket: string): Promise<SupportTicket | null> {
+    if (!ticket) return null;
+    const key = `ticket:${ticket}`;
+    const stored = await this.ctx.storage.get<SupportTicket>(key);
+    if (!stored) return null;
+    await this.ctx.storage.delete(key); // single-use, redeemed exactly once
+    if (stored.expiresAt <= Date.now()) return null;
+    return stored;
+  }
+
+  // -- connection lookups -----------------------------------------------------
+
   private host(): WebSocket | undefined {
     for (const ws of this.ctx.getWebSockets()) {
       if ((ws.deserializeAttachment() as Att | null)?.role === 'host') return ws;
@@ -119,16 +229,26 @@ export class SignalRoom extends DurableObject<Env> {
     return undefined;
   }
 
-  private clients(): WebSocket[] {
+  private nonHostConnections(): WebSocket[] {
     return this.ctx
       .getWebSockets()
-      .filter((ws) => (ws.deserializeAttachment() as Att | null)?.role === 'client');
+      .filter((ws) => (ws.deserializeAttachment() as Att | null)?.role !== 'host');
   }
 
-  private clientById(id: string): WebSocket | undefined {
+  /** Any non-host connection (client or support) addressed by its clientId. */
+  private connectionById(id: string): WebSocket | undefined {
     for (const ws of this.ctx.getWebSockets()) {
       const a = ws.deserializeAttachment() as Att | null;
-      if (a?.role === 'client' && a.clientId === id) return ws;
+      if (a && a.role !== 'host' && a.clientId === id) return ws;
+    }
+    return undefined;
+  }
+
+  /** The support connection bound to a requestId (for routing support-grant). */
+  private supportByRequestId(requestId: string): WebSocket | undefined {
+    for (const ws of this.ctx.getWebSockets()) {
+      const a = ws.deserializeAttachment() as Att | null;
+      if (a?.role === 'support' && a.requestId === requestId) return ws;
     }
     return undefined;
   }
@@ -136,4 +256,12 @@ export class SignalRoom extends DurableObject<Env> {
   private send(ws: WebSocket, msg: unknown): void {
     try { ws.send(JSON.stringify(msg)); } catch { /* socket gone */ }
   }
+}
+
+/** A URL-safe random token (24 bytes → base64url) for one-time support tickets. */
+function randomToken(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(24));
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }

--- a/tests/Zeus.Server.Tests/RemoteBrokerClientTests.cs
+++ b/tests/Zeus.Server.Tests/RemoteBrokerClientTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Microsoft.Extensions.Logging.Abstractions;
 using SIPSorcery.Net;
 using Zeus.Server.Hosting.Remote;
+using Zeus.Server.Hosting.Support;
 
 namespace Zeus.Server.Tests;
 
@@ -59,6 +60,81 @@ public sealed class RemoteBrokerClientTests
         {
             try { File.Delete(path); } catch { /* best effort */ }
         }
+    }
+
+    // -- maintainer-support signaling (remote-diag P3b) ----------------------
+
+    [Theory]
+    [InlineData("{\"t\":\"support-request\",\"requestId\":\"r1\"}", true)]
+    [InlineData("{\"t\":\"offer\",\"support\":true,\"sdp\":\"x\"}", true)]
+    [InlineData("{\"t\":\"offer\",\"sdp\":\"x\"}", false)]           // operator offer (no support flag)
+    [InlineData("{\"t\":\"offer\",\"support\":false,\"sdp\":\"x\"}", false)]
+    [InlineData("{\"t\":\"candidate\"}", false)]
+    public void IsSupportMessage_ClassifiesCorrectly(string json, bool expected)
+    {
+        using var doc = JsonDocument.Parse(json);
+        Assert.Equal(expected, RemoteBrokerClient.IsSupportMessage(doc.RootElement));
+    }
+
+    [Fact]
+    public async Task HandleSupportSignal_SupportRequest_RegistersAndYieldsNoReply()
+    {
+        var grants = new SupportGrantStore();
+        var coord = new SupportRequestCoordinator(grants, NullLogger<SupportRequestCoordinator>.Instance);
+        var support = new SupportWebRtcService(grants, NullLogger<SupportWebRtcService>.Instance);
+
+        var json = JsonSerializer.Serialize(new { t = "support-request", requestId = "r1", admin = "KB2UKA" });
+        var reply = await RemoteBrokerClient.HandleSupportSignalAsync(support, coord, json, NullLogger.Instance, default);
+
+        Assert.Null(reply); // nothing flows until the operator approves
+        var pending = coord.Pending();
+        Assert.Single(pending);
+        Assert.Equal("r1", pending[0].RequestId);
+        Assert.Equal("KB2UKA", pending[0].AdminCallsign);
+    }
+
+    [Fact]
+    public async Task HandleSupportSignal_OfferWithoutGrant_YieldsNoAnswer()
+    {
+        var grants = new SupportGrantStore();
+        var coord = new SupportRequestCoordinator(grants, NullLogger<SupportRequestCoordinator>.Instance);
+        var support = new SupportWebRtcService(grants, NullLogger<SupportWebRtcService>.Instance);
+
+        var offerSdp = await MakeOfferAsync();
+        // No operator approval → no grant for "r1" → support service refuses.
+        var json = JsonSerializer.Serialize(
+            new { t = "offer", support = true, requestId = "r1", sdp = offerSdp, clientId = "c1" });
+        var reply = await RemoteBrokerClient.HandleSupportSignalAsync(support, coord, json, NullLogger.Instance, default);
+
+        Assert.Null(reply);
+    }
+
+    [Fact]
+    public async Task HandleSupportSignal_OfferWithGrant_BecomesSupportAnswer()
+    {
+        var grants = new SupportGrantStore();
+        var coord = new SupportRequestCoordinator(grants, NullLogger<SupportRequestCoordinator>.Instance);
+        var support = new SupportWebRtcService(grants, NullLogger<SupportWebRtcService>.Instance);
+
+        // Operator approves the request → a single-use grant exists for "r1".
+        coord.RegisterRequest("r1", "KB2UKA");
+        Assert.True(coord.Approve("r1"));
+
+        var offerSdp = await MakeOfferAsync();
+        var json = JsonSerializer.Serialize(
+            new { t = "offer", support = true, requestId = "r1", sdp = offerSdp, clientId = "c1" });
+        var reply = await RemoteBrokerClient.HandleSupportSignalAsync(support, coord, json, NullLogger.Instance, default);
+
+        Assert.NotNull(reply);
+        using var doc = JsonDocument.Parse(reply!);
+        Assert.Equal("answer", doc.RootElement.GetProperty("t").GetString());
+        Assert.Equal("c1", doc.RootElement.GetProperty("clientId").GetString());
+        Assert.True(doc.RootElement.GetProperty("support").GetBoolean());
+        Assert.False(string.IsNullOrWhiteSpace(doc.RootElement.GetProperty("sdp").GetString()));
+
+        // Grant is single-use: a replayed offer for the same id is now refused.
+        var replay = await RemoteBrokerClient.HandleSupportSignalAsync(support, coord, json, NullLogger.Instance, default);
+        Assert.Null(replay);
     }
 
     private static async Task<string> MakeOfferAsync()


### PR DESCRIPTION
Part of the remote-diagnostics epic (beads `zeus-87ca`, issue `zeus-15x2`). **P3b** wires the read-only maintainer support session **end-to-end** across the broker and the radio's broker client, on top of the **P3a** backend core (#1093, now merged to develop).

### Flow (both gates preserved — ADR-0008, broker never trusted)
1. **Admin** → `POST /admin/request {callsign}` (Bearer-authed). Broker verifies the admin, asks the operator's `SignalRoom` to mint a `requestId` + single-use **ticket**, pushes `support-request` to the host, returns `{requestId, ticket}` (`Cache-Control: no-store`). `503` if the operator is offline.
2. **Dashboard** opens `role=support&callsign=<op>&ticket=<ticket>` — the ticket (issued only to a verified admin; browsers can't set WS auth headers) is redeemed in the DO before joining. The operator's local **Allow** is still the real gate.
3. **Operator** approves at the radio → `SupportRequestCoordinator.Approved` → host pushes `support-grant{requestId}` → broker routes it to the bound support socket.
4. **Dashboard** sends its `offer`; the room stamps `support:true`+`requestId` **from the trusted attachment** (never client-supplied) and relays to the host, which answers via the grant-gated, read-only `SupportWebRtcService`; the answer routes back by `clientId`.

### Broker (`zeus-remote-broker`)
- `SignalRoom`: new `support` role + request/grant relay; internal `POST /support-request` (mint requestId+ticket, notify host). **Tickets live in DO storage** so they survive hibernation between the HTTP request and the WS connect. A support peer can't masquerade as a normal client or forge a grant.
- `index.ts`: routes `role=support` to the DO (the ticket is the gate, not QRZ).
- `admin-api.ts`: `/admin/request` is now real (was a stub).

### Radio (`RemoteBrokerClient`)
- Dispatches support traffic separately from the operator tunnel; `support-request` → coordinator, support `offer` → `SupportWebRtcService` (read-only, grant-gated). Non-support offers keep the password-gated path unchanged.
- **All outbound frames now go through one queue + one send loop**, so the receive loop's answers and the async `support-grant` pushes never call `SendAsync` concurrently (`ClientWebSocket` forbids overlapping sends).

### Tests
8 new backend cases: support-message classification, `support-request` registers + yields no reply, offer-without-grant refused, offer-with-grant → support answer (clientId echoed, `support:true`) + single-use replay refused. **Broker typecheck + admin-auth suite green; backend subset 101 passed** (rebased onto develop with P3a merged). The broker DO signaling needs the deployed object for live verification (matches the existing convention).

### Not in this PR (P3c)
Sidecar (`Zeus.SupportAgent`) presence heartbeat to the broker `PresenceRoom` (operator L1 switch) + crash auto-share upload. Independent of the live-session path.

### Maintainer deploy note
The broker DO gained a new internal route + storage-backed tickets — redeploy `zeus-remote-broker` (`npm run deploy`) for the live path. No new bindings/secrets beyond P2's.