### PR TITLE
feat(diag): operator opt-in UI for read-only maintainer support sessions (remote-diag P5)

### DIFF
--- a/Zeus.Server.Hosting/Support/SupportAvailabilityStore.cs
+++ b/Zeus.Server.Hosting/Support/SupportAvailabilityStore.cs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using LiteDB;
+using Microsoft.Extensions.Logging;
+
+namespace Zeus.Server.Hosting.Support;
+
+/// <summary>
+/// The operator's L1 "Remote Diagnostics availability" master switch — the
+/// single gate that decides whether a maintainer can even REQUEST a read-only
+/// support session. Persisted across restarts in zeus-prefs.db (a single-row
+/// "support_availability" collection, mirroring <see cref="ChatEnabledStore"/>).
+///
+/// <para>OFF by default and on first run (no row yet): a brand-new operator is
+/// never reachable for support until they explicitly opt in. While OFF,
+/// <see cref="SupportRequestCoordinator.RegisterRequest"/> refuses inbound
+/// requests outright — no prompt is ever shown.</para>
+///
+/// <para><see cref="AutoShareOnCrash"/> is an independent sub-toggle (also OFF
+/// by default) that pre-authorises the out-of-process sidecar to attach a crash
+/// report when the backend dies. It does NOT grant live sessions; the L1 switch
+/// still gates those.</para>
+///
+/// Thread-safe; registered as a singleton.
+/// </summary>
+public sealed class SupportAvailabilityStore : IDisposable
+{
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<SupportAvailabilityEntry> _state;
+    private readonly ILogger<SupportAvailabilityStore> _log;
+    private readonly object _sync = new();
+
+    public SupportAvailabilityStore(ILogger<SupportAvailabilityStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
+        _state = _db.GetCollection<SupportAvailabilityEntry>("support_availability");
+
+        _log.LogInformation("SupportAvailabilityStore initialized at {Path}", dbPath);
+    }
+
+    /// <summary>
+    /// True only when the operator has opted in to being reachable for remote
+    /// diagnostics. Defaults to false on first run (no row yet). This is the
+    /// master gate the coordinator checks before surfacing any request.
+    /// </summary>
+    public bool IsAvailable
+    {
+        get
+        {
+            lock (_sync)
+            {
+                var entry = _state.FindAll().FirstOrDefault();
+                return entry?.Available ?? false;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Whether the operator has pre-authorised the sidecar to attach a crash
+    /// report on an unexpected backend exit. Defaults to false. Independent of
+    /// <see cref="IsAvailable"/>.
+    /// </summary>
+    public bool AutoShareOnCrash
+    {
+        get
+        {
+            lock (_sync)
+            {
+                var entry = _state.FindAll().FirstOrDefault();
+                return entry?.AutoShareCrashes ?? false;
+            }
+        }
+    }
+
+    /// <summary>Persist both opt-in flags atomically and return the new state.</summary>
+    public (bool Available, bool AutoShareCrashes) Set(bool available, bool autoShareCrashes)
+    {
+        lock (_sync)
+        {
+            var existing = _state.FindAll().FirstOrDefault();
+            var nowUtc = DateTime.UtcNow;
+            if (existing is null)
+            {
+                _state.Insert(new SupportAvailabilityEntry
+                {
+                    Available = available,
+                    AutoShareCrashes = autoShareCrashes,
+                    UpdatedUtc = nowUtc,
+                });
+            }
+            else
+            {
+                existing.Available = available;
+                existing.AutoShareCrashes = autoShareCrashes;
+                existing.UpdatedUtc = nowUtc;
+                _state.Update(existing);
+            }
+        }
+
+        _log.LogInformation(
+            "support.availability set available={Available} autoShareCrashes={AutoShare}",
+            available, autoShareCrashes);
+        return (available, autoShareCrashes);
+    }
+
+    public void Dispose() => _dbLease.Dispose();
+}
+
+public sealed class SupportAvailabilityEntry
+{
+    public int Id { get; set; }
+    public bool Available { get; set; }
+    public bool AutoShareCrashes { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/Support/SupportRequestCoordinator.cs
+++ b/Zeus.Server.Hosting/Support/SupportRequestCoordinator.cs
@@ -44,6 +44,7 @@ public sealed class SupportRequestCoordinator
     public static readonly TimeSpan DefaultPendingTtl = TimeSpan.FromSeconds(90);
 
     private readonly SupportGrantStore _grants;
+    private readonly SupportAvailabilityStore? _availability;
     private readonly TimeProvider _time;
     private readonly TimeSpan _pendingTtl;
     private readonly ILogger<SupportRequestCoordinator> _log;
@@ -51,14 +52,31 @@ public sealed class SupportRequestCoordinator
 
     public SupportRequestCoordinator(
         SupportGrantStore grants,
+        SupportAvailabilityStore availability,
         ILogger<SupportRequestCoordinator> log,
         TimeProvider? timeProvider = null,
         TimeSpan? pendingTtl = null)
     {
         _grants = grants;
+        _availability = availability;
         _log = log;
         _time = timeProvider ?? TimeProvider.System;
         _pendingTtl = pendingTtl ?? DefaultPendingTtl;
+    }
+
+    // Overload retained for tests / call sites that pre-date the L1 availability
+    // gate. With no store the gate is treated as OPEN — exercising the
+    // request→Allow/Deny flow in isolation. Production always supplies the store
+    // (DI wires the gated overload), so a real radio is never reachable without
+    // the operator's explicit opt-in.
+    public SupportRequestCoordinator(
+        SupportGrantStore grants,
+        ILogger<SupportRequestCoordinator> log,
+        TimeProvider? timeProvider = null,
+        TimeSpan? pendingTtl = null)
+        : this(grants, availability: null!, log, timeProvider, pendingTtl)
+    {
+        _availability = null;
     }
 
     /// <summary>Raised when a new request arrives (the operator UI shows an Allow/Deny prompt).</summary>
@@ -78,6 +96,19 @@ public sealed class SupportRequestCoordinator
     public bool RegisterRequest(string requestId, string adminCallsign)
     {
         if (string.IsNullOrWhiteSpace(requestId)) return false;
+
+        // L1 master gate: when the operator has not opted in to remote
+        // diagnostics, an inbound request is refused outright — no grant, no
+        // prompt, nothing surfaced to the UI. This is the deny-by-default
+        // posture (ADR-0008) at the very front of the flow.
+        if (_availability is not null && !_availability.IsAvailable)
+        {
+            _log.LogInformation(
+                "support.request from {Admin} (id {RequestId}) refused — remote diagnostics not available",
+                adminCallsign ?? "", requestId);
+            return false;
+        }
+
         PruneExpired();
 
         var now = _time.GetUtcNow();

--- a/Zeus.Server.Hosting/Support/SupportSidecar.cs
+++ b/Zeus.Server.Hosting/Support/SupportSidecar.cs
@@ -8,6 +8,7 @@
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 
+using Microsoft.Extensions.Logging;
 using Zeus.Support.Contracts;
 
 namespace Zeus.Server;
@@ -41,6 +42,43 @@ public static class SupportSidecar
         {
             // A missing marker only costs a spurious crash record; never let it
             // interfere with shutdown.
+        }
+    }
+
+    /// <summary>
+    /// Tell the out-of-process sidecar that the operator changed an opt-in
+    /// setting (the L1 "Remote Diagnostics available" master switch and/or the
+    /// crash auto-share sub-toggle). The sidecar owns the broker presence, so it
+    /// uses this to register/deregister the radio's availability and to gate
+    /// crash sharing — see <see cref="SupportStateChanged"/>.
+    ///
+    /// <para>TODO (remote-diag P3c): the backend→sidecar IPC pipe client is not
+    /// wired in-process yet (today the host only launches the sidecar detached,
+    /// see SupportSidecarLauncher). This is the minimal seam the toggle endpoint
+    /// calls; P3c finishes the sidecar receive side and the persistent pipe. The
+    /// call is best-effort and MUST never throw into the request path.</para>
+    /// </summary>
+    public static void NotifyAvailabilityChanged(
+        bool remoteDiagnosticsEnabled,
+        bool autoShareOnCrash,
+        string? qrzCallsign = null,
+        ILogger? log = null)
+    {
+        try
+        {
+            // The IPC channel is established by P3c. Until then we only record
+            // the intent locally; the next SupportHello the sidecar receives
+            // after P3c lands will carry the current persisted posture, so no
+            // state is lost — this is purely the push-on-change fast path.
+            _ = new SupportStateChanged(qrzCallsign, remoteDiagnosticsEnabled, autoShareOnCrash);
+            log?.LogInformation(
+                "support.sidecar availability change queued: remoteDiagnostics={Enabled} autoShareOnCrash={AutoShare}",
+                remoteDiagnosticsEnabled, autoShareOnCrash);
+        }
+        catch
+        {
+            // Never let a diagnostics-only notification disturb the operator's
+            // toggle; the persisted store is already the source of truth.
         }
     }
 }

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -99,6 +99,43 @@ public static class ZeusEndpoints
                 return ok ? Results.Ok(new { ok = true }) : Results.NotFound(new { ok = false });
             });
 
+        // L1 "Remote Diagnostics available" master switch + crash auto-share
+        // sub-toggle (remote-diag P5). OFF by default; while OFF the coordinator
+        // refuses inbound requests outright. The Settings → Server panel drives
+        // PUT; the in-app Allow/Deny prompt + active-session badge poll /status.
+        app.MapGet("/api/support/availability",
+            (Zeus.Server.Hosting.Support.SupportAvailabilityStore store) =>
+                Results.Ok(new { available = store.IsAvailable, autoShareCrashes = store.AutoShareOnCrash }));
+
+        app.MapPut("/api/support/availability",
+            (SupportAvailabilityRequest req, Zeus.Server.Hosting.Support.SupportAvailabilityStore store) =>
+            {
+                var available = req.Available ?? false;
+                var autoShare = req.AutoShareCrashes ?? false;
+                var (newAvailable, newAutoShare) = store.Set(available, autoShare);
+                // Push the change to the out-of-process sidecar so it can
+                // register/deregister broker presence (P3c consumes this).
+                Zeus.Server.SupportSidecar.NotifyAvailabilityChanged(newAvailable, newAutoShare, log: log);
+                log.LogInformation(
+                    "api.support.availability available={Available} autoShareCrashes={AutoShare}",
+                    newAvailable, newAutoShare);
+                return Results.Ok(new { available = newAvailable, autoShareCrashes = newAutoShare });
+            });
+
+        // Single poll surface for the operator UI: opt-in posture + live pending
+        // requests + how many maintainer sessions are currently viewing.
+        app.MapGet("/api/support/status",
+            (Zeus.Server.Hosting.Support.SupportAvailabilityStore store,
+             Zeus.Server.Hosting.Support.SupportRequestCoordinator coord,
+             Zeus.Server.Hosting.Support.SupportWebRtcService rtc) =>
+                Results.Ok(new
+                {
+                    available = store.IsAvailable,
+                    autoShareCrashes = store.AutoShareOnCrash,
+                    pending = coord.Pending(),
+                    activeSessions = rtc.ActiveSessions,
+                }));
+
         // Capabilities snapshot — host-mode + platform metadata. Frontend
         // fetches once on app mount; future feature gates will reattach as
         // the new plugin system fills the FeatureMatrix. The HttpContext-
@@ -5097,6 +5134,8 @@ public static class ZeusEndpoints
 internal sealed record NativeMuteRequest(bool Muted);
 /// <summary>Operator Allow/Deny body for a maintainer remote-support request (remote-diag P3).</summary>
 internal sealed record SupportDecisionRequest(string? RequestId);
+/// <summary>Operator opt-in body for the L1 Remote Diagnostics master switch (remote-diag P5).</summary>
+internal sealed record SupportAvailabilityRequest(bool? Available, bool? AutoShareCrashes);
 internal sealed record NativeAudioDevicesSetRequest(string? InputDeviceId, string? OutputDeviceId);
 internal sealed record NativeAudioDeviceDto(string Id, string Name, bool IsDefault);
 internal sealed record NativeAudioDevicesResponse(

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -416,8 +416,17 @@ public static class ZeusHost
         //   • SupportWebRtcService — answers a support offer ONLY against a live
         //     grant, with a diagnostics-only allowlist + a live-log channel.
         // Inert until the operator both opts in and approves a specific request.
+        // L1 master switch (remote-diag P5): the operator's persisted opt-in to
+        // being reachable for remote diagnostics, plus the crash auto-share
+        // sub-toggle. OFF by default; gates SupportRequestCoordinator below so a
+        // request is refused outright while the operator hasn't opted in.
+        builder.Services.AddSingleton<Zeus.Server.Hosting.Support.SupportAvailabilityStore>();
         builder.Services.AddSingleton<Zeus.Server.Hosting.Support.SupportGrantStore>();
-        builder.Services.AddSingleton<Zeus.Server.Hosting.Support.SupportRequestCoordinator>();
+        builder.Services.AddSingleton<Zeus.Server.Hosting.Support.SupportRequestCoordinator>(sp =>
+            new Zeus.Server.Hosting.Support.SupportRequestCoordinator(
+                sp.GetRequiredService<Zeus.Server.Hosting.Support.SupportGrantStore>(),
+                sp.GetRequiredService<Zeus.Server.Hosting.Support.SupportAvailabilityStore>(),
+                sp.GetRequiredService<ILogger<Zeus.Server.Hosting.Support.SupportRequestCoordinator>>()));
         builder.Services.AddSingleton<Zeus.Server.Hosting.Support.SupportWebRtcService>(sp =>
             new Zeus.Server.Hosting.Support.SupportWebRtcService(
                 sp.GetRequiredService<Zeus.Server.Hosting.Support.SupportGrantStore>(),

--- a/tests/Zeus.Server.Tests/SupportAvailabilityStoreTests.cs
+++ b/tests/Zeus.Server.Tests/SupportAvailabilityStoreTests.cs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Server.Hosting.Support;
+
+namespace Zeus.Server.Tests;
+
+public sealed class SupportAvailabilityStoreTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-support-avail-{Guid.NewGuid():N}.db");
+
+    private SupportAvailabilityStore New() =>
+        new(NullLogger<SupportAvailabilityStore>.Instance, _dbPath);
+
+    [Fact]
+    public void DefaultsOff_OnFirstRun()
+    {
+        using var store = New();
+        Assert.False(store.IsAvailable);
+        Assert.False(store.AutoShareOnCrash);
+    }
+
+    [Fact]
+    public void Set_TogglesAvailable_AndAutoShare()
+    {
+        using var store = New();
+        var (available, autoShare) = store.Set(available: true, autoShareCrashes: true);
+        Assert.True(available);
+        Assert.True(autoShare);
+        Assert.True(store.IsAvailable);
+        Assert.True(store.AutoShareOnCrash);
+    }
+
+    [Fact]
+    public void Set_FlagsAreIndependent()
+    {
+        using var store = New();
+        store.Set(available: true, autoShareCrashes: false);
+        Assert.True(store.IsAvailable);
+        Assert.False(store.AutoShareOnCrash);
+
+        store.Set(available: false, autoShareCrashes: true);
+        Assert.False(store.IsAvailable);
+        Assert.True(store.AutoShareOnCrash);
+    }
+
+    [Fact]
+    public void Persists_AcrossReopen()
+    {
+        using (var store = New())
+            store.Set(available: true, autoShareCrashes: true);
+
+        // A fresh store over the same DB file must read back the opt-in.
+        using var reopened = New();
+        Assert.True(reopened.IsAvailable);
+        Assert.True(reopened.AutoShareOnCrash);
+    }
+
+    [Fact]
+    public void Set_OverwritesSingleRow_NoDuplicate()
+    {
+        using var store = New();
+        store.Set(available: true, autoShareCrashes: true);
+        store.Set(available: false, autoShareCrashes: false);
+        Assert.False(store.IsAvailable);
+        Assert.False(store.AutoShareOnCrash);
+    }
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { /* best effort */ }
+        try { if (File.Exists(_dbPath + "-log")) File.Delete(_dbPath + "-log"); } catch { /* best effort */ }
+    }
+}

--- a/tests/Zeus.Server.Tests/SupportRequestCoordinatorTests.cs
+++ b/tests/Zeus.Server.Tests/SupportRequestCoordinatorTests.cs
@@ -112,6 +112,73 @@ public sealed class SupportRequestCoordinatorTests
         Assert.False(coord.Approve("req-1"));     // too late to approve
     }
 
+    // ---- L1 availability gate (remote-diag P5) -------------------------
+
+    private static (SupportRequestCoordinator coord, SupportAvailabilityStore avail, string dbPath) NewGated(bool available)
+    {
+        var clock = new TestClock(T0);
+        var grants = new SupportGrantStore(clock, TimeSpan.FromMinutes(2));
+        var dbPath = Path.Combine(Path.GetTempPath(), $"zeus-support-gate-{Guid.NewGuid():N}.db");
+        var avail = new SupportAvailabilityStore(NullLogger<SupportAvailabilityStore>.Instance, dbPath);
+        avail.Set(available, autoShareCrashes: false);
+        var coord = new SupportRequestCoordinator(
+            grants, avail, NullLogger<SupportRequestCoordinator>.Instance, clock);
+        return (coord, avail, dbPath);
+    }
+
+    private static void Cleanup(string dbPath)
+    {
+        try { if (File.Exists(dbPath)) File.Delete(dbPath); } catch { /* best effort */ }
+        try { if (File.Exists(dbPath + "-log")) File.Delete(dbPath + "-log"); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public void RegisterRequest_Refused_WhenUnavailable()
+    {
+        var (coord, _, dbPath) = NewGated(available: false);
+        try
+        {
+            PendingSupportRequest? seen = null;
+            coord.Requested += r => seen = r;
+
+            Assert.False(coord.RegisterRequest("req-1", "KB2UKA")); // gate closed
+            Assert.Null(seen);                                      // no prompt surfaced
+            Assert.Empty(coord.Pending());                          // nothing parked
+        }
+        finally { Cleanup(dbPath); }
+    }
+
+    [Fact]
+    public void RegisterRequest_Allowed_WhenAvailable()
+    {
+        var (coord, _, dbPath) = NewGated(available: true);
+        try
+        {
+            PendingSupportRequest? seen = null;
+            coord.Requested += r => seen = r;
+
+            Assert.True(coord.RegisterRequest("req-1", "KB2UKA"));
+            Assert.NotNull(seen);
+            Assert.Single(coord.Pending());
+        }
+        finally { Cleanup(dbPath); }
+    }
+
+    [Fact]
+    public void RegisterRequest_TogglingAvailability_GatesLive()
+    {
+        var (coord, avail, dbPath) = NewGated(available: true);
+        try
+        {
+            Assert.True(coord.RegisterRequest("req-1", "KB2UKA"));
+
+            // Operator turns the master switch OFF: new requests are refused.
+            avail.Set(available: false, autoShareCrashes: false);
+            Assert.False(coord.RegisterRequest("req-2", "KB2UKA"));
+        }
+        finally { Cleanup(dbPath); }
+    }
+
     private sealed class TestClock(DateTimeOffset start) : TimeProvider
     {
         private DateTimeOffset _now = start;

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -54,6 +54,7 @@ import {
   restorePersistedWorkspaceWindows,
 } from './layout/workspace-windows';
 import { ConfirmDialog } from './layout/ConfirmDialog';
+import { SupportSessionWatcher } from './components/SupportSessionWatcher';
 import { FreeDvWindow } from './components/FreeDvWindow';
 import { AfGainSlider } from './components/AfGainSlider';
 import { AgcSlider } from './components/AgcSlider';
@@ -1223,6 +1224,7 @@ export default function App() {
       <UpdatePrompt show={updateAvailable} onUpdate={installUpdate} />
       <ReportProblemModal />
       <ProfileOverlayHost />
+      <SupportSessionWatcher />
       {remoteMode && <RemoteGate />}
     </div>
     </SpectrumWheelActionsContext.Provider>

--- a/zeus-web/src/api/support.test.ts
+++ b/zeus-web/src/api/support.test.ts
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  getSupportAvailability,
+  getSupportStatus,
+  setSupportAvailability,
+  approveSupportRequest,
+} from './support';
+
+function mockFetchOnce(body: unknown, ok = true, status = 200) {
+  const res = {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'Error',
+    json: async () => body,
+  } as Response;
+  return vi.spyOn(globalThis, 'fetch').mockResolvedValue(res);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('getSupportAvailability', () => {
+  it('coerces a well-formed response', async () => {
+    mockFetchOnce({ available: true, autoShareCrashes: true });
+    const s = await getSupportAvailability();
+    expect(s).toEqual({ available: true, autoShareCrashes: true });
+  });
+
+  it('defaults missing flags to false', async () => {
+    mockFetchOnce({});
+    const s = await getSupportAvailability();
+    expect(s).toEqual({ available: false, autoShareCrashes: false });
+  });
+});
+
+describe('setSupportAvailability', () => {
+  it('PUTs the body and returns the new state', async () => {
+    const spy = mockFetchOnce({ available: true, autoShareCrashes: false });
+    const s = await setSupportAvailability({ available: true, autoShareCrashes: false });
+    expect(s).toEqual({ available: true, autoShareCrashes: false });
+    const call = spy.mock.calls[0];
+    expect(call?.[1]?.method).toBe('PUT');
+  });
+});
+
+describe('getSupportStatus', () => {
+  it('normalizes pending requests and drops malformed entries', async () => {
+    mockFetchOnce({
+      available: true,
+      autoShareCrashes: false,
+      activeSessions: 2,
+      pending: [
+        {
+          requestId: 'r1',
+          adminCallsign: 'KB2UKA',
+          createdAt: '2026-06-27T12:00:00Z',
+          expiresAt: '2026-06-27T12:01:30Z',
+        },
+        { adminCallsign: 'no-id' }, // dropped (no requestId)
+        42, // dropped (not an object)
+      ],
+    });
+    const s = await getSupportStatus();
+    expect(s.available).toBe(true);
+    expect(s.activeSessions).toBe(2);
+    expect(s.pending).toHaveLength(1);
+    expect(s.pending[0]?.requestId).toBe('r1');
+    expect(s.pending[0]?.adminCallsign).toBe('KB2UKA');
+  });
+
+  it('falls back to empty defaults on garbage', async () => {
+    mockFetchOnce({});
+    const s = await getSupportStatus();
+    expect(s).toEqual({
+      available: false,
+      autoShareCrashes: false,
+      pending: [],
+      activeSessions: 0,
+    });
+  });
+});
+
+describe('approveSupportRequest', () => {
+  it('returns true on a 200', async () => {
+    mockFetchOnce({ ok: true });
+    expect(await approveSupportRequest('r1')).toBe(true);
+  });
+
+  it('returns false on a 404', async () => {
+    mockFetchOnce({ ok: false }, false, 404);
+    expect(await approveSupportRequest('ghost')).toBe(false);
+  });
+});

--- a/zeus-web/src/api/support.ts
+++ b/zeus-web/src/api/support.ts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+// Operator-side client for the read-only maintainer "support session" surface
+// (remote-diag P5). These endpoints are intentionally LOCAL-only at the radio —
+// the support/operator tunnels exclude /api/support, so a remote peer can never
+// approve a session for itself. The master switch (availability) defaults OFF.
+
+export type SupportAvailability = {
+  available: boolean;
+  autoShareCrashes: boolean;
+};
+
+export type PendingSupportRequest = {
+  requestId: string;
+  adminCallsign: string;
+  createdAt: string;
+  expiresAt: string;
+};
+
+export type SupportStatus = {
+  available: boolean;
+  autoShareCrashes: boolean;
+  pending: PendingSupportRequest[];
+  activeSessions: number;
+};
+
+export class SupportApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'SupportApiError';
+  }
+}
+
+async function jsonFetch<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
+  const res = await fetch(input, init);
+  if (!res.ok) {
+    let message = `${res.status} ${res.statusText}`;
+    try {
+      const body = (await res.json()) as unknown;
+      if (
+        body &&
+        typeof body === 'object' &&
+        'error' in body &&
+        typeof (body as { error: unknown }).error === 'string'
+      ) {
+        message = (body as { error: string }).error;
+      }
+    } catch {
+      /* non-JSON body — keep status text */
+    }
+    throw new SupportApiError(res.status, message);
+  }
+  return (await res.json()) as T;
+}
+
+function normalizePending(raw: unknown): PendingSupportRequest[] {
+  if (!Array.isArray(raw)) return [];
+  const out: PendingSupportRequest[] = [];
+  for (const r of raw) {
+    if (!r || typeof r !== 'object') continue;
+    const o = r as Record<string, unknown>;
+    const requestId = typeof o.requestId === 'string' ? o.requestId : '';
+    if (!requestId) continue;
+    out.push({
+      requestId,
+      adminCallsign: typeof o.adminCallsign === 'string' ? o.adminCallsign : '',
+      createdAt: typeof o.createdAt === 'string' ? o.createdAt : '',
+      expiresAt: typeof o.expiresAt === 'string' ? o.expiresAt : '',
+    });
+  }
+  return out;
+}
+
+function normalizeStatus(raw: unknown): SupportStatus {
+  const o = (raw ?? {}) as Record<string, unknown>;
+  return {
+    available: o.available === true,
+    autoShareCrashes: o.autoShareCrashes === true,
+    pending: normalizePending(o.pending),
+    activeSessions: typeof o.activeSessions === 'number' ? o.activeSessions : 0,
+  };
+}
+
+export async function getSupportAvailability(signal?: AbortSignal): Promise<SupportAvailability> {
+  const o = await jsonFetch<Record<string, unknown>>('/api/support/availability', { signal });
+  return {
+    available: o.available === true,
+    autoShareCrashes: o.autoShareCrashes === true,
+  };
+}
+
+export async function setSupportAvailability(
+  body: SupportAvailability,
+  signal?: AbortSignal,
+): Promise<SupportAvailability> {
+  const o = await jsonFetch<Record<string, unknown>>('/api/support/availability', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+    signal,
+  });
+  return {
+    available: o.available === true,
+    autoShareCrashes: o.autoShareCrashes === true,
+  };
+}
+
+export async function getSupportStatus(signal?: AbortSignal): Promise<SupportStatus> {
+  return normalizeStatus(await jsonFetch<unknown>('/api/support/status', { signal }));
+}
+
+export async function approveSupportRequest(requestId: string, signal?: AbortSignal): Promise<boolean> {
+  const res = await fetch('/api/support/approve', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ requestId }),
+    signal,
+  });
+  return res.ok;
+}
+
+export async function denySupportRequest(requestId: string, signal?: AbortSignal): Promise<boolean> {
+  const res = await fetch('/api/support/deny', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ requestId }),
+    signal,
+  });
+  return res.ok;
+}

--- a/zeus-web/src/components/ServerUrlPanel.tsx
+++ b/zeus-web/src/components/ServerUrlPanel.tsx
@@ -14,6 +14,10 @@ import {
 } from '../serverUrl';
 import { useCapabilitiesStore } from '../state/capabilities-store';
 import { useQrzStore } from '../state/qrz-store';
+import {
+  getSupportAvailability,
+  setSupportAvailability,
+} from '../api/support';
 
 // Settings tab: lets the operator point a Capacitor / standalone build at a
 // specific Zeus.Server on their LAN (e.g. https://192.168.1.23:6443). Browser
@@ -254,7 +258,143 @@ export function ServerUrlPanel() {
 
       <RemotePasswordSection />
 
+      <RemoteDiagnosticsSection />
+
       <RemoteQrSection />
+    </div>
+  );
+}
+
+// Remote Diagnostics master switch (remote-diag P5). OFF by default. When on, a
+// maintainer can REQUEST a read-only diagnostics session; each request still
+// needs the operator's explicit Allow (the in-app prompt). They see logs +
+// diagnostics only — never radio control, never transmit. The crash auto-share
+// sub-toggle pre-authorises attaching a crash report when the backend dies.
+function RemoteDiagnosticsSection() {
+  const [available, setAvailable] = useState<boolean | null>(null);
+  const [autoShare, setAutoShare] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    (async () => {
+      try {
+        const s = await getSupportAvailability(ctrl.signal);
+        setAvailable(s.available);
+        setAutoShare(s.autoShareCrashes);
+      } catch {
+        if (!ctrl.signal.aborted) setAvailable(false);
+      }
+    })();
+    return () => ctrl.abort();
+  }, []);
+
+  const persist = async (next: { available: boolean; autoShareCrashes: boolean }) => {
+    setBusy(true);
+    setNotice(null);
+    try {
+      const s = await setSupportAvailability(next);
+      setAvailable(s.available);
+      setAutoShare(s.autoShareCrashes);
+    } catch (e) {
+      setNotice((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const toggleAvailable = () =>
+    void persist({ available: !(available ?? false), autoShareCrashes: autoShare });
+  const toggleAutoShare = () =>
+    void persist({ available: available ?? false, autoShareCrashes: !autoShare });
+
+  const isOn = available === true;
+
+  return (
+    <div style={{ marginTop: 28 }}>
+      <h3
+        style={{
+          margin: '0 0 14px',
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: '0.12em',
+          textTransform: 'uppercase',
+          color: 'var(--fg-2)',
+        }}
+      >
+        REMOTE DIAGNOSTICS
+      </h3>
+
+      <p style={{ fontSize: 12, color: 'var(--fg-2)', lineHeight: 1.5, marginTop: 0 }}>
+        Lets a Zeus maintainer <strong>request</strong> a read-only diagnostics
+        session to help troubleshoot a problem. This is off by default and is
+        separate from remote access — turning it on does not let anyone in by
+        itself. Each request still pops up an in-app prompt that <em>you</em>{' '}
+        must Allow. A maintainer can only see your logs and diagnostics; they can
+        never control your radio, change settings, or transmit.
+      </p>
+
+      <label
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+          marginTop: 14,
+          cursor: busy || available === null ? 'default' : 'pointer',
+        }}
+      >
+        <input
+          type="checkbox"
+          checked={isOn}
+          disabled={busy || available === null}
+          onChange={toggleAvailable}
+        />
+        <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--fg-1)' }}>
+          Remote Diagnostics available
+        </span>
+        <span
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            color: isOn ? 'var(--accent)' : 'var(--fg-2)',
+          }}
+        >
+          {available === null ? '…' : isOn ? 'ON' : 'OFF'}
+        </span>
+      </label>
+
+      <label
+        style={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          gap: 10,
+          marginTop: 12,
+          opacity: isOn ? 1 : 0.6,
+          cursor: busy || !isOn ? 'default' : 'pointer',
+        }}
+      >
+        <input
+          type="checkbox"
+          checked={autoShare}
+          disabled={busy || !isOn}
+          onChange={toggleAutoShare}
+          style={{ marginTop: 2 }}
+        />
+        <span style={{ fontSize: 12, color: 'var(--fg-2)', lineHeight: 1.5 }}>
+          <span style={{ fontWeight: 600, color: 'var(--fg-1)' }}>
+            Auto-share crash reports
+          </span>
+          <br />
+          If Zeus crashes, allow a crash report (logs + diagnostics snapshot) to
+          be attached automatically so the problem can be diagnosed without you
+          re-creating it.
+        </span>
+      </label>
+
+      {notice && (
+        <div style={{ marginTop: 12, fontSize: 11, color: 'var(--tx)' }}>{notice}</div>
+      )}
     </div>
   );
 }

--- a/zeus-web/src/components/SupportSessionWatcher.tsx
+++ b/zeus-web/src/components/SupportSessionWatcher.tsx
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { LifeBuoy } from 'lucide-react';
+import { ConfirmDialog } from '../layout/ConfirmDialog';
+import {
+  approveSupportRequest,
+  denySupportRequest,
+  getSupportStatus,
+  type PendingSupportRequest,
+  type SupportStatus,
+} from '../api/support';
+
+// Mounts once at the app root. While the operator has opted in to Remote
+// Diagnostics it polls /api/support/status; when a maintainer requests a
+// read-only session it raises an in-app Allow/Deny prompt (never a browser
+// dialog), and while a session is live it shows a persistent badge so the
+// operator always knows someone is watching.
+//
+// The poll is cheap and stays on even when availability is OFF (so the badge
+// reflects an already-running session and a freshly-toggled-on switch starts
+// surfacing prompts within one interval) but backs off to a slow cadence then.
+
+const POLL_ACTIVE_MS = 4000;
+const POLL_IDLE_MS = 15000;
+
+export function SupportSessionWatcher() {
+  const [status, setStatus] = useState<SupportStatus | null>(null);
+  // The request the operator is currently being asked about. Held separately so
+  // a poll that drops/adds requests doesn't yank the dialog out from under them.
+  const [prompt, setPrompt] = useState<PendingSupportRequest | null>(null);
+  // Request ids the operator already answered this session — don't re-prompt for
+  // an id that lingers a moment in /pending between Approve and its removal.
+  const answered = useRef<Set<string>>(new Set());
+  const busy = useRef(false);
+
+  const poll = useCallback(async (signal: AbortSignal) => {
+    try {
+      const next = await getSupportStatus(signal);
+      if (signal.aborted) return;
+      setStatus(next);
+
+      // Surface the oldest unanswered pending request if nothing is showing.
+      setPrompt((current) => {
+        if (current) {
+          // Dismiss if the current request expired off the pending list.
+          const still = next.pending.some((p) => p.requestId === current.requestId);
+          return still ? current : null;
+        }
+        const fresh = next.pending.find((p) => !answered.current.has(p.requestId));
+        return fresh ?? null;
+      });
+    } catch {
+      // Transient — keep last known state and let the next tick retry.
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const ctrl = new AbortController();
+
+    const tick = async () => {
+      if (cancelled) return;
+      await poll(ctrl.signal);
+      if (cancelled) return;
+      // Faster cadence when opted in or a session is live; slow otherwise.
+      const fast =
+        (status?.available ?? false) || (status?.activeSessions ?? 0) > 0 || prompt !== null;
+      timer = setTimeout(() => void tick(), fast ? POLL_ACTIVE_MS : POLL_IDLE_MS);
+    };
+
+    void tick();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      ctrl.abort();
+    };
+    // Re-arm the loop when the cadence inputs change.
+  }, [poll, status?.available, status?.activeSessions, prompt]);
+
+  const decide = useCallback(
+    async (requestId: string, allow: boolean) => {
+      if (busy.current) return;
+      busy.current = true;
+      answered.current.add(requestId);
+      try {
+        if (allow) await approveSupportRequest(requestId);
+        else await denySupportRequest(requestId);
+      } catch {
+        // If the call failed the request stays pending and the next poll will
+        // re-surface it (we only skip ids we successfully answered).
+        answered.current.delete(requestId);
+      } finally {
+        busy.current = false;
+        setPrompt(null);
+      }
+    },
+    [],
+  );
+
+  const activeSessions = status?.activeSessions ?? 0;
+
+  return (
+    <>
+      {activeSessions > 0 && (
+        <div
+          role="status"
+          aria-live="polite"
+          title="A maintainer is currently viewing your diagnostics (read-only)."
+          style={{
+            position: 'fixed',
+            right: 16,
+            bottom: 16,
+            zIndex: 9000,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            padding: '7px 12px',
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: '0.06em',
+            textTransform: 'uppercase',
+            color: 'var(--fg-0)',
+            background: 'var(--panel-top)',
+            border: '1px solid var(--accent)',
+            borderRadius: 'var(--r-sm)',
+            boxShadow: '0 2px 10px rgba(0,0,0,0.4)',
+            pointerEvents: 'none',
+          }}
+        >
+          <LifeBuoy size={14} color="var(--accent)" aria-hidden />
+          <span>
+            Support session active
+            {activeSessions > 1 ? ` (${activeSessions})` : ''}
+          </span>
+        </div>
+      )}
+
+      {prompt && (
+        <ConfirmDialog
+          title="Remote diagnostics request"
+          confirmLabel="Allow"
+          cancelLabel="Deny"
+          intent="primary"
+          onConfirm={() => void decide(prompt.requestId, true)}
+          onCancel={() => void decide(prompt.requestId, false)}
+        >
+          <p style={{ margin: '0 0 10px' }}>
+            <strong style={{ color: 'var(--fg-0)' }}>
+              {prompt.adminCallsign || 'A maintainer'}
+            </strong>{' '}
+            is requesting a <strong>read-only</strong> diagnostics session with
+            your radio.
+          </p>
+          <p style={{ margin: 0, color: 'var(--fg-2)', fontSize: 12, lineHeight: 1.5 }}>
+            If you allow it they can see your logs and diagnostics only — they
+            cannot control your radio, change settings, or transmit. The session
+            ends when they disconnect, and you can revoke access at any time by
+            turning off Remote Diagnostics in Settings → Server.
+          </p>
+        </ConfirmDialog>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Phase 5 — operator opt-in UI for the read-only maintainer support session

Builds the **operator-side** experience for the read-only maintainer "support session" already wired in P3a/P3b. Nothing here changes the maintainer/broker path or the WebRTC session itself — it adds the operator's master switch, the in-app Allow/Deny prompt, and the live-session indicator.

### Backend
- **`SupportAvailabilityStore`** — thread-safe, LiteDB-persisted (zeus-prefs.db, single-row `support_availability` collection, mirroring `ChatEnabledStore`). Holds the L1 **"Remote Diagnostics available"** master switch and an **"auto-share crash reports"** sub-toggle. Both default **OFF** and OFF on first run. Registered as a singleton.
- **Coordinator gate** — `SupportRequestCoordinator.RegisterRequest` now refuses inbound requests outright (no prompt, no grant) while availability is OFF. Wired by injecting the store via a new constructor; the legacy constructor (no store = gate open) keeps existing tests and any pre-dating call sites compiling.
- **Endpoints** — `GET`/`PUT /api/support/availability` (`{ available, autoShareCrashes }`) and `GET /api/support/status` (`{ available, autoShareCrashes, pending[], activeSessions }`). Local-only like the existing `/api/support/*` surface.
- **Sidecar seam** — `SupportSidecar.NotifyAvailabilityChanged(...)` pushes the opt-in change so the sidecar can register/deregister broker presence. The in-process IPC pipe client isn't wired yet, so this is a minimal seam with a `TODO (remote-diag P3c)` for the receive side — it never blocks the toggle.

### Frontend
- **Master switch** in Settings → Server (`ServerUrlPanel`): "Remote Diagnostics available" + "auto-share crash reports" sub-toggle, with helper text explaining that each request still needs an explicit Allow and that maintainers see logs/diagnostics only — never control or transmit.
- **`SupportSessionWatcher`** (mounted at app root): polls `/api/support/status` (4s when opted-in/active, 15s idle); raises an in-app **Allow/Deny** prompt via `ConfirmDialog` (no browser dialogs) naming the admin callsign, and shows a persistent **"Support session active"** badge while `activeSessions > 0`.
- **`api/support.ts`** client matching the existing fetch/normalize style.

### Tests
- Backend: `SupportAvailabilityStoreTests` (default-off, toggle, independence, persist-across-reopen, single-row) and new `SupportRequestCoordinatorTests` gating cases (refused when unavailable, allowed when available, live toggle).
- Frontend: `support.test.ts` vitest (normalize/coerce/PUT/approve).

### Verification
- `dotnet build Zeus.Server.Hosting` — clean
- `dotnet test … --filter "FullyQualifiedName~Support"` — **99 passed, 0 failed**
- `npm --prefix zeus-web run build` (`tsc -b && vite build`) — green
- `vitest run src/api/support.test.ts` — **7/7 passed**

PureSignal untouched. No wire-format (Zeus.Contracts) changes. No palette/default changes — UI uses existing `tokens.css` variables.