### PR TITLE
feat(tools): agent-accessible admin support CLI (remote-diag P4b)

### DIFF
--- a/cloud/ADMIN_AUTH_DESIGN.md
+++ b/cloud/ADMIN_AUTH_DESIGN.md
@@ -133,3 +133,13 @@ npm run deploy
 #   curl -sX POST .../admin/tokens -H 'Authorization: Bearer <session>' \
 #     -d '{"label":"agent"}'                                   # -> agent token (shown once)
 ```
+
+## Agent-facing consumer: `tools/zeus-support-cli` (Phase 4b)
+
+The non-interactive CLI in [`tools/zeus-support-cli`](../tools/zeus-support-cli)
+is the reference *consumer* of this admin surface. It wraps the curl flow above
+(`login` → `token mint`), lists consented online operators (`presence`), requests
+a read-only diagnostics session (`request`), and runs the full
+request → support-WS → WebRTC → `api`/`log` data-channel `pull`. It reads its
+Bearer token from `ZEUS_ADMIN_TOKEN` and writes no secret to disk. It changes no
+broker code — see that tool's README for usage and the agent-token flow.

--- a/tools/zeus-support-cli/.gitignore
+++ b/tools/zeus-support-cli/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.log

--- a/tools/zeus-support-cli/README.md
+++ b/tools/zeus-support-cli/README.md
@@ -1,0 +1,158 @@
+# zeus-support-cli
+
+Non-interactive admin CLI for the **Zeus remote-diagnostics** broker
+(`cloud/zeus-remote-broker`, see [`cloud/ADMIN_AUTH_DESIGN.md`](../../cloud/ADMIN_AUTH_DESIGN.md)).
+It lets an automated agent — or a maintainer at a terminal — authenticate with an
+admin token, see which **consented** operators are online, request a **read-only**
+diagnostics session, and pull a consenting operator's logs + diagnostics over
+WebRTC.
+
+This is **Phase 4b** of the remote-diagnostics epic. It is a pure *consumer* of
+the broker's already-deployed HTTP + WebSocket + data-channel APIs; it changes no
+backend or broker code.
+
+> **Consent is enforced at the radio, not here.** `pull` cannot read anything
+> until the operator presses **Allow** on their own radio (the broker only hands
+> back a single-use ticket; the data session needs the operator's grant). The
+> session is GET-only over an allowlist — no control, no transmit, never any
+> PureSignal surface.
+
+## Install
+
+```bash
+cd tools/zeus-support-cli
+npm install
+npm run typecheck   # green
+npm test            # unit tests for the report/config shaping
+```
+
+Runs on Node 18+ via [`tsx`](https://github.com/privatenumber/tsx). WebRTC is
+provided by the pure-TypeScript [`werift`](https://github.com/shinyoshiaki/werift-webrtc)
+stack, so there are no native build steps.
+
+## Configuration
+
+| Env var | Meaning | Default |
+| --- | --- | --- |
+| `ZEUS_ADMIN_TOKEN` | Bearer token (`zsa_…`) for protected commands | — |
+| `ZEUS_REMOTE_BROKER_URL` | broker base url | `https://remote.openhpsdrzeus.com` |
+| `ZEUS_QRZ_CALLSIGN` / `ZEUS_QRZ_SESSION` / `ZEUS_ADMIN_PASSWORD` | `login` credentials | — |
+
+Every command also accepts `--broker <url>` and `--token <tok>` flags, and a
+`--json` flag for machine-readable output. **No secret is ever written to disk.**
+
+## Commands
+
+```
+zeus-support login      authenticate (QRZ + password); print a session token
+zeus-support token mint exchange a session token for a long-lived agent token
+zeus-support presence   list online, support-available operators (alias: list, whoami)
+zeus-support request <callsign>   ask an operator to Allow a diagnostics session
+zeus-support pull <callsign>      request + connect + collect a diagnostics report
+```
+
+Run any command with `--help` for its full options.
+
+### Agent-token flow (recommended for automation)
+
+A session token expires in ~12h; an **agent token** never expires (it is
+revocable instead). Mint one once and store it in your agent's secret store:
+
+```bash
+# 1. interactive login (proves callsign ownership via QRZ + admin password),
+#    minting a long-lived agent token in the same step:
+zeus-support login \
+  --callsign KB2UKA \
+  --qrz-session "$QRZ_SESSION_KEY" \
+  --password "$ADMIN_PASSWORD" \
+  --mint
+
+# → prints the agent token ONCE. Store it:
+export ZEUS_ADMIN_TOKEN=zsa_xxxxxxxxxxxxxxxxxxxx
+```
+
+You can also mint later from an existing session token:
+
+```bash
+ZEUS_ADMIN_TOKEN=<session-token> zeus-support token mint --label agent
+```
+
+### See who is online
+
+```bash
+ZEUS_ADMIN_TOKEN=zsa_… zeus-support presence
+# Online operators (1):
+#   N9WAR      since 2026-06-27 18:00Z  last-seen 2026-06-27 18:04Z
+
+ZEUS_ADMIN_TOKEN=zsa_… zeus-support presence --json
+```
+
+### Request a session (operator must Allow)
+
+```bash
+ZEUS_ADMIN_TOKEN=zsa_… zeus-support request N9WAR
+# requestId : 8f3c…
+# ticket    : tkt_…
+# N9WAR must press Allow on their radio. Then run:
+#   zeus-support pull N9WAR
+```
+
+`request` exits non-zero with a clear message if the operator is offline (broker
+returns `503 operator offline`).
+
+### Pull a diagnostics report (the full flow)
+
+```bash
+ZEUS_ADMIN_TOKEN=zsa_… zeus-support pull N9WAR \
+  --format json \
+  --log-seconds 5 \
+  --out n9war-report.json
+```
+
+`pull` does everything end-to-end:
+
+1. `POST /admin/request` → single-use `ticket` (`503` ⇒ *operator offline*).
+2. Opens `wss://<broker>/signal?role=support&callsign=<OP>&ticket=<ticket>`.
+3. Waits up to `--grant-timeout` seconds (default 90) for the operator's
+   `{t:"support-grant"}` (i.e. they pressed **Allow**). No grant ⇒ clean
+   *denied/timeout* exit.
+4. WebRTC: creates the `control` / `api` / `log` data channels, sends
+   `{t:"offer", sdp}` (the broker stamps `support`+`requestId`), applies the
+   `{t:"answer"}`.
+5. `control` `hello` → `support-ready`; fetches `/api/version`, `/api/state`,
+   `/api/diagnostics/v2` (override with `--paths a,b,c`) over the GET-only `api`
+   channel; captures the `log` backlog + `--log-seconds` of live log.
+6. Writes a tidy JSON or text report to `--out` (or stdout).
+
+#### Offline shaping / dry run
+
+The live `pull` path needs the deployed broker **and** a consenting online
+operator. To exercise the report shaping without any network:
+
+```bash
+zeus-support pull N9WAR --mock              # synthetic JSON report
+zeus-support pull N9WAR --mock --format text
+```
+
+## Exit codes
+
+| code | meaning |
+| --- | --- |
+| 0 | success |
+| 1 | generic failure (e.g. unauthorized) |
+| 2 | usage / configuration error (missing token, bad flag) |
+| 4 | login rate-limited |
+| 5 | operator offline |
+| 6 | network / WebSocket error or timeout |
+| 7 | WebRTC negotiation / data-channel failure |
+| 8 | operator denied or did not Allow in time |
+
+## What needs the live broker to verify
+
+`login`, `token mint`, `presence`, `request`, and the live `pull` path all
+require the deployed broker (and, for `pull`, an online operator who presses
+Allow), so they can't be fully exercised in CI — matching the project's
+"live needs the deployed broker" convention. What *is* verified here:
+`npm run typecheck` is green, the unit tests cover the report/config shaping, and
+`pull --mock` exercises the full formatting path offline. The WS / WebRTC /
+data-channel protocol is implemented exactly per the Phase-4b spec.

--- a/tools/zeus-support-cli/package-lock.json
+++ b/tools/zeus-support-cli/package-lock.json
@@ -1,0 +1,1311 @@
+{
+  "name": "zeus-support-cli",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "zeus-support-cli",
+      "version": "0.1.0",
+      "dependencies": {
+        "werift": "^0.20.0",
+        "ws": "^8.18.0"
+      },
+      "bin": {
+        "zeus-support": "src/cli.ts"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.0",
+        "@types/ws": "^8.5.13",
+        "tsx": "^4.19.0",
+        "typescript": "^5.7.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@fidm/asn1": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@fidm/asn1/-/asn1-1.0.4.tgz",
+      "integrity": "sha512-esd1jyNvRb2HVaQGq2Gg8Z0kbQPXzV9Tq5Z14KNIov6KfFD6PTaRIO8UpcsYiTNzOqJpmyzWgVTrUwFV3UF4TQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@fidm/x509": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@fidm/x509/-/x509-1.2.1.tgz",
+      "integrity": "sha512-nwc2iesjyc9hkuzcrMCBXQRn653XuAUKorfWM8PZyJawiy1QzLj4vahwzaI25+pfpwOLvMzbJ0uKpWLDNmo16w==",
+      "license": "MIT",
+      "dependencies": {
+        "@fidm/asn1": "^1.0.4",
+        "tweetnacl": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+      "license": "MIT"
+    },
+    "node_modules/@minhducsun2002/leb128": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@minhducsun2002/leb128/-/leb128-1.0.0.tgz",
+      "integrity": "sha512-eFrYUPDVHeuwWHluTG1kwNQUEUcFjVKYwPkU8z9DR1JH3AW7JtJsG9cRVGmwz809kKtGfwGJj58juCZxEvnI/g==",
+      "license": "MIT"
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz",
+      "integrity": "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-x509-attr": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.8.0.tgz",
+      "integrity": "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz",
+      "integrity": "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.8.0.tgz",
+      "integrity": "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.8.0",
+        "@peculiar/asn1-pkcs8": "^2.8.0",
+        "@peculiar/asn1-rsa": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.8.0.tgz",
+      "integrity": "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.8.0.tgz",
+      "integrity": "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.8.0",
+        "@peculiar/asn1-pfx": "^2.8.0",
+        "@peculiar/asn1-pkcs8": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-x509-attr": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz",
+      "integrity": "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+      "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
+      "integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.8.0.tgz",
+      "integrity": "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+      "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@shinyoshiaki/binary-data": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@shinyoshiaki/binary-data/-/binary-data-0.6.1.tgz",
+      "integrity": "sha512-7HDb/fQAop2bCmvDIzU5+69i+UJaFgIVp99h1VzK1mpg1JwSODOkjbqD7ilTYnqlnadF8C4XjpwpepxDsGY6+w==",
+      "license": "MIT",
+      "dependencies": {
+        "generate-function": "^2.3.1",
+        "is-plain-object": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@shinyoshiaki/ebml-builder": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@shinyoshiaki/ebml-builder/-/ebml-builder-0.0.1.tgz",
+      "integrity": "sha512-rz1LklnlZ0yvVIt924yRGu+R87Fhfa06BdRIZR6GF6SXVSBTD9wCQmN6opXQLuSkoKXleWJwF3PW1ls8DGZjtw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.memoize": "^4.1.2"
+      }
+    },
+    "node_modules/@shinyoshiaki/jspack": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@shinyoshiaki/jspack/-/jspack-0.0.6.tgz",
+      "integrity": "sha512-SdsNhLjQh4onBlyPrn4ia1Pdx5bXT88G/LIEpOYAjx2u4xeY/m/HB5yHqlkJB1uQR3Zw4R3hBWLj46STRAN0rg=="
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/aes-js": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
+      "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==",
+      "license": "MIT"
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/dns-packet": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/int64-buffer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-1.1.0.tgz",
+      "integrity": "sha512-94smTCQOvigN4d/2R/YDjz8YVG0Sufvv2aAh8P5m42gwhCsDAJqnbNOrxJsrADuAFAA69Q/ptGzxvNcNuIJcvw==",
+      "license": "MIT"
+    },
+    "node_modules/ip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "license": "MIT"
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "license": "MIT"
+    },
+    "node_modules/mp4box": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/mp4box/-/mp4box-0.5.4.tgz",
+      "integrity": "sha512-GcCH0fySxBurJtvr0dfhz0IxHZjc1RP+F+I8xw+LIwkU1a+7HJx8NCDiww1I5u4Hz6g4eR1JlGADEGJ9r4lSfA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/multicast-dns": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
+      "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
+      "license": "MIT",
+      "dependencies": {
+        "dns-packet": "^5.2.2",
+        "thunky": "^1.0.2"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      }
+    },
+    "node_modules/nano-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
+      "license": "ISC",
+      "dependencies": {
+        "big-integer": "^1.6.16"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/rx.mini": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/rx.mini/-/rx.mini-1.4.0.tgz",
+      "integrity": "sha512-8w5cSc1mwNja7fl465DXOkVvIOkpvh2GW4jo31nAIvX4WTXCsRnKJGUfiDBzWtYRInEcHAUYIZfzusjIrea8gA=="
+    },
+    "node_modules/thunky": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/turbo-crc32": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/turbo-crc32/-/turbo-crc32-1.0.1.tgz",
+      "integrity": "sha512-8yyRd1ZdNp+AQLGqi3lTaA2k81JjlIZOyFQEsi7GQWBgirnQOxjqVtDEbYHM2Z4yFdJ5AQw0fxBLLnDCl6RXoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/werift": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/werift/-/werift-0.20.1.tgz",
+      "integrity": "sha512-wZRIfTyvyC2c9daZ2udqkFkaH2cvIAoELeH5w2raBtODC7StILNjUFxgKs9msgn1g4IC3dkSKZo2ZyDDIJsrWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fidm/x509": "^1.2.1",
+        "@minhducsun2002/leb128": "^1.0.0",
+        "@noble/curves": "^1.3.0",
+        "@peculiar/x509": "^1.9.2",
+        "@shinyoshiaki/binary-data": "^0.6.1",
+        "@shinyoshiaki/ebml-builder": "^0.0.1",
+        "@shinyoshiaki/jspack": "^0.0.6",
+        "aes-js": "^3.1.2",
+        "buffer-crc32": "^1.0.0",
+        "date-fns": "^2.29.3",
+        "debug": "^4.3.4",
+        "int64-buffer": "^1.0.1",
+        "ip": "^2.0.1",
+        "lodash": "^4.17.21",
+        "mp4box": "^0.5.2",
+        "nano-time": "^1.0.0",
+        "p-cancelable": "^2.1.1",
+        "rx.mini": "^1.2.2",
+        "turbo-crc32": "^1.0.1",
+        "tweetnacl": "^1.0.3",
+        "uuid": "^9.0.0",
+        "werift-common": "*",
+        "werift-dtls": "*",
+        "werift-ice": "*",
+        "werift-rtp": "*",
+        "werift-sctp": "*"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/werift-common": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/werift-common/-/werift-common-0.0.3.tgz",
+      "integrity": "sha512-ma3E4BqKTyZVLhrdfTVs2T1tg9seeUtKMRn5e64LwgrogWa62+3LAUoLBUSl1yPWhgSkXId7GmcHuWDen9IJeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shinyoshiaki/jspack": "^0.0.6",
+        "debug": "^4.4.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/werift-dtls": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/werift-dtls/-/werift-dtls-0.5.7.tgz",
+      "integrity": "sha512-z2fjbP7fFUFmu/Ky4bCKXzdgPTtmSY1DYi0TUf3GG2zJT4jMQ3TQmGY8y7BSSNGetvL4h3pRZ5un0EcSOWpPog==",
+      "license": "MIT",
+      "dependencies": {
+        "@fidm/x509": "^1.2.1",
+        "@noble/curves": "^1.3.0",
+        "@peculiar/x509": "^1.9.2",
+        "@shinyoshiaki/binary-data": "^0.6.1",
+        "date-fns": "^2.29.3",
+        "lodash": "^4.17.21",
+        "rx.mini": "^1.2.2",
+        "tweetnacl": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/werift-ice": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/werift-ice/-/werift-ice-0.2.2.tgz",
+      "integrity": "sha512-td52pHp+JmFnUn5jfDr/SSNO0dMCbknhuPdN1tFp9cfRj5jaktN63qnAdUuZC20QCC3ETWdsOthcm+RalHpFCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shinyoshiaki/jspack": "^0.0.6",
+        "buffer-crc32": "^1.0.0",
+        "debug": "^4.3.4",
+        "int64-buffer": "^1.0.1",
+        "ip": "^2.0.1",
+        "lodash": "^4.17.21",
+        "multicast-dns": "^7.2.5",
+        "p-cancelable": "^2.1.1",
+        "rx.mini": "^1.2.2"
+      }
+    },
+    "node_modules/werift-rtp": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/werift-rtp/-/werift-rtp-0.8.8.tgz",
+      "integrity": "sha512-GiYMSdvCyScQaw5bnEsraSoHUVZpjfokJAiLV4R1FsiB06t6XiebPYPpkqB9nYNNKiA8Z/cYWsym7wISq1sYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@minhducsun2002/leb128": "^1.0.0",
+        "@shinyoshiaki/jspack": "^0.0.6",
+        "aes-js": "^3.1.2",
+        "buffer": "^6.0.3",
+        "mp4box": "^0.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/werift-sctp": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/werift-sctp/-/werift-sctp-0.0.11.tgz",
+      "integrity": "sha512-7109yuI5U7NTEHjqjn0A8VeynytkgVaxM6lRr1Ziv0D8bPcaB8A7U/P88M7WaCpWDoELHoXiRUjQycMWStIgjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shinyoshiaki/jspack": "^0.0.6"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/tools/zeus-support-cli/package.json
+++ b/tools/zeus-support-cli/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "zeus-support-cli",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Non-interactive admin CLI for the Zeus remote-diagnostics broker: authenticate with an admin token, list consented online operators, request a read-only diagnostics session, and pull a consenting operator's logs + diagnostics over WebRTC.",
+  "bin": {
+    "zeus-support": "src/cli.ts"
+  },
+  "scripts": {
+    "start": "tsx src/cli.ts",
+    "typecheck": "tsc --noEmit",
+    "build": "tsc -p tsconfig.build.json",
+    "test": "node --import tsx --test test/*.test.ts"
+  },
+  "dependencies": {
+    "werift": "^0.20.0",
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "@types/ws": "^8.5.13",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/tools/zeus-support-cli/src/args.ts
+++ b/tools/zeus-support-cli/src/args.ts
@@ -1,0 +1,30 @@
+/** Tiny wrapper over node:util parseArgs with shared option groups. */
+
+import { parseArgs, type ParseArgsConfig } from 'node:util';
+
+export type Options = NonNullable<ParseArgsConfig['options']>;
+
+/** Options every command accepts (broker selection + token). */
+export const commonOptions: Options = {
+  broker: { type: 'string' },
+  token: { type: 'string' },
+  help: { type: 'boolean', short: 'h' },
+  json: { type: 'boolean' },
+};
+
+/**
+ * Parse argv for one subcommand. `args` should already have the program name +
+ * subcommand stripped. Throws on unknown options (strict) for clear errors.
+ */
+export function parse(args: string[], options: Options): {
+  values: Record<string, string | boolean | undefined>;
+  positionals: string[];
+} {
+  const { values, positionals } = parseArgs({
+    args,
+    options,
+    allowPositionals: true,
+    strict: true,
+  });
+  return { values: values as Record<string, string | boolean | undefined>, positionals };
+}

--- a/tools/zeus-support-cli/src/broker.ts
+++ b/tools/zeus-support-cli/src/broker.ts
@@ -1,0 +1,154 @@
+/**
+ * Thin HTTP client for the broker /admin/* surface. Uses the global `fetch`
+ * (Node 18+). Every method maps a non-2xx into a CliError with a useful message,
+ * preserving the few status codes the CLI must handle specially (e.g. 503
+ * "operator offline" from /admin/request).
+ */
+
+import { CliError } from './config.js';
+import type {
+  LoginResponse,
+  MintTokenResponse,
+  PresenceResponse,
+  RequestResponse,
+} from './types.js';
+
+export interface BrokerClientOptions {
+  /** Broker base URL, no trailing slash (see resolveBrokerUrl). */
+  baseUrl: string;
+  /** Admin Bearer token for protected routes (omit for /admin/login). */
+  token?: string;
+  /** Per-request timeout in ms. */
+  timeoutMs?: number;
+}
+
+export class BrokerClient {
+  private readonly baseUrl: string;
+  private readonly token?: string;
+  private readonly timeoutMs: number;
+
+  constructor(opts: BrokerClientOptions) {
+    this.baseUrl = opts.baseUrl.replace(/\/+$/, '');
+    this.token = opts.token;
+    this.timeoutMs = opts.timeoutMs ?? 15_000;
+  }
+
+  // --- POST /admin/login (no Bearer; QRZ headers + password) ----------------
+
+  async login(args: {
+    qrzSession: string;
+    callsign: string;
+    password: string;
+  }): Promise<LoginResponse> {
+    const res = await this.fetch('/admin/login', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'X-QRZ-Session': args.qrzSession,
+        'X-QRZ-Callsign': args.callsign,
+      },
+      body: JSON.stringify({ password: args.password }),
+    });
+    if (res.status === 401) {
+      throw new CliError('login failed: unauthorized (bad QRZ session, callsign, or password).');
+    }
+    if (res.status === 429) {
+      throw new CliError('login rate limited — wait a moment and retry.', 4);
+    }
+    return this.asJson<LoginResponse>(res, 'login');
+  }
+
+  // --- POST /admin/tokens (Bearer session token) ----------------------------
+
+  async mintToken(label = 'agent'): Promise<MintTokenResponse> {
+    const res = await this.fetch('/admin/tokens', {
+      method: 'POST',
+      headers: this.authHeaders({ 'content-type': 'application/json' }),
+      body: JSON.stringify({ label }),
+    });
+    this.assertAuthorized(res, 'mint token');
+    return this.asJson<MintTokenResponse>(res, 'mint token');
+  }
+
+  // --- GET /admin/presence (Bearer) -----------------------------------------
+
+  async presence(): Promise<PresenceResponse> {
+    const res = await this.fetch('/admin/presence', {
+      method: 'GET',
+      headers: this.authHeaders(),
+    });
+    this.assertAuthorized(res, 'presence');
+    return this.asJson<PresenceResponse>(res, 'presence');
+  }
+
+  // --- POST /admin/request (Bearer) -----------------------------------------
+
+  async request(callsign: string): Promise<RequestResponse> {
+    const res = await this.fetch('/admin/request', {
+      method: 'POST',
+      headers: this.authHeaders({ 'content-type': 'application/json' }),
+      body: JSON.stringify({ callsign }),
+    });
+    if (res.status === 503) {
+      // The broker returns this when the operator's sidecar is not online.
+      throw new CliError(`operator ${callsign} is offline (no support-available sidecar).`, 5);
+    }
+    this.assertAuthorized(res, 'request');
+    return this.asJson<RequestResponse>(res, 'request');
+  }
+
+  // --- internals ------------------------------------------------------------
+
+  private authHeaders(extra: Record<string, string> = {}): Record<string, string> {
+    if (!this.token) throw new CliError('internal: Bearer token required for this route.', 2);
+    return { Authorization: `Bearer ${this.token}`, ...extra };
+  }
+
+  private assertAuthorized(res: Response, what: string): void {
+    if (res.status === 401) {
+      throw new CliError(`${what} failed: unauthorized (token missing, expired, or revoked).`);
+    }
+    if (res.status === 403) {
+      throw new CliError(`${what} failed: forbidden.`);
+    }
+  }
+
+  private async fetch(path: string, init: RequestInit): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      return await fetch(`${this.baseUrl}${path}`, { ...init, signal: controller.signal });
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw new CliError(`request to ${path} timed out after ${this.timeoutMs}ms.`, 6);
+      }
+      throw new CliError(`request to ${path} failed: ${(err as Error).message}.`, 6);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private async asJson<T>(res: Response, what: string): Promise<T> {
+    const text = await res.text();
+    if (!res.ok) {
+      const detail = safeErrorMessage(text);
+      throw new CliError(`${what} failed: HTTP ${res.status}${detail ? ` (${detail})` : ''}.`);
+    }
+    try {
+      return JSON.parse(text) as T;
+    } catch {
+      throw new CliError(`${what} failed: broker returned non-JSON response.`);
+    }
+  }
+}
+
+/** Pull a short `{error:"..."}` message out of a broker error body, if present. */
+function safeErrorMessage(text: string): string {
+  try {
+    const v = JSON.parse(text) as { error?: unknown };
+    if (v && typeof v.error === 'string') return v.error;
+  } catch {
+    /* not JSON */
+  }
+  return '';
+}

--- a/tools/zeus-support-cli/src/cli.ts
+++ b/tools/zeus-support-cli/src/cli.ts
@@ -1,0 +1,79 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * zeus-support — non-interactive admin CLI for the Zeus remote-diagnostics
+ * broker. Authenticate with an admin token, see which consented operators are
+ * online, request a read-only diagnostics session, and pull a consenting
+ * operator's logs + diagnostics over WebRTC.
+ *
+ * All secrets come from flags or env (ZEUS_ADMIN_TOKEN, ZEUS_REMOTE_BROKER_URL,
+ * QRZ creds for `login`). Nothing is written to disk by default.
+ */
+
+import { CliError } from './config.js';
+import { runLogin } from './commands/login.js';
+import { runToken } from './commands/token.js';
+import { runPresence } from './commands/presence.js';
+import { runRequest } from './commands/request.js';
+import { runPull } from './commands/pull.js';
+
+const TOP_HELP = `
+zeus-support — Zeus remote-diagnostics admin CLI
+
+Usage:
+  zeus-support <command> [options]
+
+Commands:
+  login                 authenticate (QRZ + password); print a session token (--mint for agent token)
+  token mint            exchange a session token for a long-lived agent token
+  presence | list | whoami   list online, support-available operators
+  request <callsign>    ask an operator to Allow a read-only diagnostics session
+  pull <callsign>       request + connect + collect a diagnostics report (--mock for offline shaping)
+
+Global env:
+  ZEUS_ADMIN_TOKEN          Bearer token for protected commands
+  ZEUS_REMOTE_BROKER_URL    broker base url (default https://remote.openhpsdrzeus.com)
+
+Run "zeus-support <command> --help" for command-specific options.
+`;
+
+async function main(argv: string[]): Promise<number> {
+  const [command, ...rest] = argv;
+
+  switch (command) {
+    case 'login':
+      return runLogin(rest);
+    case 'token':
+      return runToken(rest);
+    case 'presence':
+    case 'list':
+    case 'whoami':
+      return runPresence(rest);
+    case 'request':
+      return runRequest(rest);
+    case 'pull':
+      return runPull(rest);
+    case undefined:
+    case 'help':
+    case '-h':
+    case '--help':
+      process.stdout.write(`${TOP_HELP}\n`);
+      return command === undefined ? 2 : 0;
+    default:
+      process.stderr.write(`unknown command: ${command}\n${TOP_HELP}\n`);
+      return 2;
+  }
+}
+
+main(process.argv.slice(2))
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((err: unknown) => {
+    if (err instanceof CliError) {
+      process.stderr.write(`error: ${err.message}\n`);
+      process.exitCode = err.code;
+    } else {
+      process.stderr.write(`unexpected error: ${(err as Error)?.stack ?? String(err)}\n`);
+      process.exitCode = 1;
+    }
+  });

--- a/tools/zeus-support-cli/src/commands/login.ts
+++ b/tools/zeus-support-cli/src/commands/login.ts
@@ -1,0 +1,99 @@
+/**
+ * `login` — interactive-ish credential login. Proves callsign ownership (QRZ
+ * session) + admin password, prints the ~12h session token. With `--mint` it
+ * immediately exchanges that session token for a long-lived agent token (the
+ * non-interactive path automated agents should use).
+ *
+ * Secrets are read from flags or env and NEVER written to disk.
+ */
+
+import { parse, commonOptions } from '../args.js';
+import { resolveBrokerUrl, CliError, normCallsign } from '../config.js';
+import { BrokerClient } from '../broker.js';
+
+export const loginHelp = `
+zeus-support login — authenticate and print an admin token
+
+Usage:
+  zeus-support login --callsign <CALL> [--qrz-session <SID>] [--password <PW>] [--mint]
+
+Options:
+  --callsign <CALL>     your admin callsign           (or env ZEUS_QRZ_CALLSIGN)
+  --qrz-session <SID>   QRZ XML session key           (or env ZEUS_QRZ_SESSION)
+  --password <PW>       your admin password           (or env ZEUS_ADMIN_PASSWORD)
+  --mint                also mint a long-lived agent token (recommended for agents)
+  --label <L>           label for the minted token    (default: agent)
+  --broker <URL>        broker base url                (or env ZEUS_REMOTE_BROKER_URL)
+  --json                print machine-readable JSON
+
+Tip: export the printed token as ZEUS_ADMIN_TOKEN for the other commands.
+`;
+
+export async function runLogin(argv: string[]): Promise<number> {
+  const { values } = parse(argv, {
+    ...commonOptions,
+    callsign: { type: 'string' },
+    'qrz-session': { type: 'string' },
+    password: { type: 'string' },
+    mint: { type: 'boolean' },
+    label: { type: 'string' },
+  });
+
+  if (values.help) {
+    process.stdout.write(`${loginHelp}\n`);
+    return 0;
+  }
+
+  const callsign = normCallsign(
+    str(values.callsign) || process.env.ZEUS_QRZ_CALLSIGN || '',
+  );
+  const qrzSession = str(values['qrz-session']) || process.env.ZEUS_QRZ_SESSION || '';
+  const password = str(values.password) || process.env.ZEUS_ADMIN_PASSWORD || '';
+
+  if (!callsign) throw new CliError('missing --callsign (or ZEUS_QRZ_CALLSIGN).', 2);
+  if (!qrzSession) throw new CliError('missing --qrz-session (or ZEUS_QRZ_SESSION).', 2);
+  if (!password) throw new CliError('missing --password (or ZEUS_ADMIN_PASSWORD).', 2);
+
+  const baseUrl = resolveBrokerUrl(str(values.broker));
+  const client = new BrokerClient({ baseUrl });
+
+  const session = await client.login({ qrzSession, callsign, password });
+
+  let agentToken: { id: string; token: string } | undefined;
+  if (values.mint) {
+    const minted = new BrokerClient({ baseUrl, token: session.token });
+    agentToken = await minted.mintToken(str(values.label) || 'agent');
+  }
+
+  if (values.json) {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          callsign: session.callsign,
+          sessionToken: session.token,
+          expiresAt: session.expiresAt,
+          agentToken: agentToken ?? null,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    return 0;
+  }
+
+  const expiry = new Date(session.expiresAt).toISOString();
+  process.stdout.write(`Logged in as ${session.callsign}.\n`);
+  process.stdout.write(`Session token (expires ${expiry}):\n  ${session.token}\n`);
+  if (agentToken) {
+    process.stdout.write(`\nAgent token (id ${agentToken.id}, shown once — store it now):\n  ${agentToken.token}\n`);
+    process.stdout.write(`\nUse it with other commands:\n  export ZEUS_ADMIN_TOKEN=${agentToken.token}\n`);
+  } else {
+    process.stdout.write(`\nUse it with other commands:\n  export ZEUS_ADMIN_TOKEN=${session.token}\n`);
+    process.stdout.write(`(or re-run with --mint for a non-expiring agent token)\n`);
+  }
+  return 0;
+}
+
+function str(v: string | boolean | undefined): string {
+  return typeof v === 'string' ? v : '';
+}

--- a/tools/zeus-support-cli/src/commands/presence.ts
+++ b/tools/zeus-support-cli/src/commands/presence.ts
@@ -1,0 +1,60 @@
+/**
+ * `presence` (aliases: `list`, `whoami`) — print the operators currently online
+ * and support-available, from GET /admin/presence (Bearer ZEUS_ADMIN_TOKEN).
+ */
+
+import { parse, commonOptions } from '../args.js';
+import { resolveBrokerUrl, requireAdminToken } from '../config.js';
+import { BrokerClient } from '../broker.js';
+
+export const presenceHelp = `
+zeus-support presence — list online, support-available operators
+
+Usage:
+  ZEUS_ADMIN_TOKEN=<token> zeus-support presence
+
+Options:
+  --token <T>     Bearer token (or env ZEUS_ADMIN_TOKEN)
+  --broker <URL>  broker base url (or env ZEUS_REMOTE_BROKER_URL)
+  --json          print machine-readable JSON
+`;
+
+export async function runPresence(argv: string[]): Promise<number> {
+  const { values } = parse(argv, commonOptions);
+  if (values.help) {
+    process.stdout.write(`${presenceHelp}\n`);
+    return 0;
+  }
+
+  const baseUrl = resolveBrokerUrl(str(values.broker));
+  const token = requireAdminToken(str(values.token));
+  const client = new BrokerClient({ baseUrl, token });
+
+  const { operators } = await client.presence();
+
+  if (values.json) {
+    process.stdout.write(`${JSON.stringify({ operators }, null, 2)}\n`);
+    return 0;
+  }
+
+  if (operators.length === 0) {
+    process.stdout.write('No operators are online / support-available.\n');
+    return 0;
+  }
+  process.stdout.write(`Online operators (${operators.length}):\n`);
+  for (const op of operators) {
+    const since = fmt(op.since);
+    const seen = fmt(op.lastSeen);
+    process.stdout.write(`  ${op.callsign.padEnd(10)} since ${since}  last-seen ${seen}\n`);
+  }
+  return 0;
+}
+
+function fmt(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return '?';
+  return new Date(ms).toISOString().replace('T', ' ').replace(/\.\d+Z$/, 'Z');
+}
+
+function str(v: string | boolean | undefined): string {
+  return typeof v === 'string' ? v : '';
+}

--- a/tools/zeus-support-cli/src/commands/pull.ts
+++ b/tools/zeus-support-cli/src/commands/pull.ts
@@ -1,0 +1,186 @@
+/**
+ * `pull <callsign>` — the full read-only diagnostics flow:
+ *   request → open support WS with the ticket → wait for the operator's Allow →
+ *   WebRTC connect → fetch a fixed set of diagnostics over the `api` channel →
+ *   capture the `log` backlog + N seconds of live log → write a tidy report.
+ *
+ * Handles operator-offline (503) and operator-denied/timeout (no grant) cleanly
+ * via CliError (the broker/session layers throw those). `--mock` runs the report
+ * shaping against synthetic channel data with zero network, so the end-to-end
+ * formatting is testable without the deployed broker + a consenting operator.
+ */
+
+import { writeFileSync } from 'node:fs';
+import { parse, commonOptions } from '../args.js';
+import {
+  resolveBrokerUrl,
+  brokerWsBase,
+  requireAdminToken,
+  normCallsign,
+  CliError,
+} from '../config.js';
+import { BrokerClient } from '../broker.js';
+import { SupportSession } from '../session.js';
+import {
+  DEFAULT_PULL_PATHS,
+  buildReport,
+  renderJson,
+  renderText,
+  type SupportReport,
+} from '../report.js';
+import type { ApiChannelResponse } from '../types.js';
+
+export const pullHelp = `
+zeus-support pull <callsign> — request + connect + collect a diagnostics report
+
+Usage:
+  ZEUS_ADMIN_TOKEN=<token> zeus-support pull <CALLSIGN> [options]
+
+Options:
+  --out <FILE>        write the report to FILE (default: stdout)
+  --format <fmt>      json | text                         (default: json)
+  --log-seconds <N>   seconds of live log to capture      (default: 5)
+  --paths <list>      comma-separated api paths to fetch
+                      (default: ${DEFAULT_PULL_PATHS.join(',')})
+  --grant-timeout <N> seconds to wait for the operator's Allow (default: 90)
+  --mock              run report shaping on synthetic data (no network)
+  --token <T>         Bearer token (or env ZEUS_ADMIN_TOKEN)
+  --broker <URL>      broker base url (or env ZEUS_REMOTE_BROKER_URL)
+`;
+
+export async function runPull(argv: string[]): Promise<number> {
+  const { values, positionals } = parse(argv, {
+    ...commonOptions,
+    out: { type: 'string' },
+    format: { type: 'string' },
+    'log-seconds': { type: 'string' },
+    paths: { type: 'string' },
+    'grant-timeout': { type: 'string' },
+    mock: { type: 'boolean' },
+  });
+
+  if (values.help) {
+    process.stdout.write(`${pullHelp}\n`);
+    return 0;
+  }
+
+  const callsign = normCallsign(positionals[0] ?? '');
+  if (!callsign) throw new CliError('usage: zeus-support pull <callsign>', 2);
+
+  const format = (str(values.format) || 'json').toLowerCase();
+  if (format !== 'json' && format !== 'text') {
+    throw new CliError(`--format must be json or text (got ${format}).`, 2);
+  }
+  const paths = parsePaths(str(values.paths));
+  const logSeconds = parseNum(str(values['log-seconds']), 5);
+  const grantSeconds = parseNum(str(values['grant-timeout']), 90);
+
+  const report = values.mock
+    ? mockReport(callsign, paths)
+    : await livePull(callsign, paths, logSeconds, grantSeconds, values);
+
+  const rendered = format === 'json' ? renderJson(report) : renderText(report);
+  const out = str(values.out);
+  if (out) {
+    writeFileSync(out, `${rendered}\n`, 'utf8');
+    process.stderr.write(`wrote report to ${out}\n`);
+  } else {
+    process.stdout.write(`${rendered}\n`);
+  }
+  return 0;
+}
+
+async function livePull(
+  callsign: string,
+  paths: string[],
+  logSeconds: number,
+  grantSeconds: number,
+  values: Record<string, string | boolean | undefined>,
+): Promise<SupportReport> {
+  const baseUrl = resolveBrokerUrl(str(values.broker));
+  const token = requireAdminToken(str(values.token));
+  const client = new BrokerClient({ baseUrl, token });
+
+  // 1) request — 503 here means the operator is offline.
+  const req = await client.request(callsign);
+  process.stderr.write(`requested (requestId=${req.requestId}); awaiting Allow…\n`);
+
+  // 2-5) open WS, wait for grant, WebRTC connect, control handshake.
+  const session = await SupportSession.connect({
+    wsBase: brokerWsBase(baseUrl),
+    callsign,
+    ticket: req.ticket,
+    requestId: req.requestId,
+    grantTimeoutMs: grantSeconds * 1000,
+  });
+
+  try {
+    // 6) fetch diagnostics over the api channel (best-effort per path).
+    const responses: (ApiChannelResponse & { path: string })[] = [];
+    for (const path of paths) {
+      try {
+        const r = await session.apiGet(path);
+        responses.push({ ...r, path });
+      } catch (err) {
+        responses.push({
+          id: '',
+          status: 0,
+          path,
+          body: `error: ${(err as Error).message}`,
+        });
+      }
+    }
+
+    // 7) capture log backlog + N seconds of live log.
+    const { backlog, live } = await session.collectLogs(logSeconds * 1000);
+
+    return buildReport({
+      operator: callsign,
+      requestId: session.requestId,
+      admin: session.admin,
+      responses,
+      backlog,
+      live,
+    });
+  } finally {
+    session.close();
+  }
+}
+
+/** Synthetic report so `--mock` exercises the shaping path with no network. */
+function mockReport(callsign: string, paths: string[]): SupportReport {
+  const responses: (ApiChannelResponse & { path: string })[] = paths.map((path) => ({
+    id: `mock-${path}`,
+    status: 200,
+    contentType: 'application/json',
+    path,
+    body: JSON.stringify({ mock: true, path }),
+  }));
+  return buildReport({
+    operator: callsign,
+    requestId: 'mock-request-id',
+    admin: 'MOCK-ADMIN',
+    responses,
+    backlog: ['[mock] backlog line 1', '[mock] backlog line 2'],
+    live: ['[mock] live line 1'],
+    now: new Date(0),
+  });
+}
+
+function parsePaths(raw: string): string[] {
+  if (!raw) return [...DEFAULT_PULL_PATHS];
+  const paths = raw
+    .split(',')
+    .map((p) => p.trim())
+    .filter(Boolean);
+  return paths.length ? paths : [...DEFAULT_PULL_PATHS];
+}
+
+function parseNum(raw: string, fallback: number): number {
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+function str(v: string | boolean | undefined): string {
+  return typeof v === 'string' ? v : '';
+}

--- a/tools/zeus-support-cli/src/commands/request.ts
+++ b/tools/zeus-support-cli/src/commands/request.ts
@@ -1,0 +1,54 @@
+/**
+ * `request <callsign>` — ask the operator to Allow a read-only diagnostics
+ * session (POST /admin/request). Prints the requestId + single-use ticket and
+ * explains that the operator must press Allow on their radio before the ticket
+ * can be used with `pull`. 503 → "operator offline".
+ */
+
+import { parse, commonOptions } from '../args.js';
+import { resolveBrokerUrl, requireAdminToken, normCallsign, CliError } from '../config.js';
+import { BrokerClient } from '../broker.js';
+
+export const requestHelp = `
+zeus-support request <callsign> — request a diagnostics session
+
+Usage:
+  ZEUS_ADMIN_TOKEN=<token> zeus-support request <CALLSIGN>
+
+Options:
+  --token <T>     Bearer token (or env ZEUS_ADMIN_TOKEN)
+  --broker <URL>  broker base url (or env ZEUS_REMOTE_BROKER_URL)
+  --json          print machine-readable JSON
+`;
+
+export async function runRequest(argv: string[]): Promise<number> {
+  const { values, positionals } = parse(argv, commonOptions);
+  if (values.help) {
+    process.stdout.write(`${requestHelp}\n`);
+    return 0;
+  }
+
+  const callsign = normCallsign(positionals[0] ?? '');
+  if (!callsign) throw new CliError('usage: zeus-support request <callsign>', 2);
+
+  const baseUrl = resolveBrokerUrl(str(values.broker));
+  const token = requireAdminToken(str(values.token));
+  const client = new BrokerClient({ baseUrl, token });
+
+  const res = await client.request(callsign);
+
+  if (values.json) {
+    process.stdout.write(`${JSON.stringify(res, null, 2)}\n`);
+    return 0;
+  }
+  process.stdout.write(`Requested a diagnostics session with ${res.callsign}.\n`);
+  process.stdout.write(`  requestId : ${res.requestId}\n`);
+  process.stdout.write(`  ticket    : ${res.ticket}\n`);
+  process.stdout.write(`\n${res.callsign} must press Allow on their radio. Then run:\n`);
+  process.stdout.write(`  zeus-support pull ${res.callsign}\n`);
+  return 0;
+}
+
+function str(v: string | boolean | undefined): string {
+  return typeof v === 'string' ? v : '';
+}

--- a/tools/zeus-support-cli/src/commands/token.ts
+++ b/tools/zeus-support-cli/src/commands/token.ts
@@ -1,0 +1,58 @@
+/**
+ * `token mint` — exchange the current Bearer token (ZEUS_ADMIN_TOKEN, typically
+ * a session token from `login`) for a long-lived agent token. The agent token is
+ * shown ONCE; store it as ZEUS_ADMIN_TOKEN for non-interactive use.
+ */
+
+import { parse, commonOptions } from '../args.js';
+import { resolveBrokerUrl, requireAdminToken, CliError } from '../config.js';
+import { BrokerClient } from '../broker.js';
+
+export const tokenHelp = `
+zeus-support token mint — mint a long-lived agent token
+
+Usage:
+  ZEUS_ADMIN_TOKEN=<session-token> zeus-support token mint [--label agent]
+
+Options:
+  --label <L>     token label (default: agent)
+  --token <T>     Bearer token (or env ZEUS_ADMIN_TOKEN)
+  --broker <URL>  broker base url (or env ZEUS_REMOTE_BROKER_URL)
+  --json          print machine-readable JSON
+`;
+
+export async function runToken(argv: string[]): Promise<number> {
+  const sub = argv[0];
+  const rest = argv.slice(1);
+
+  const { values } = parse(rest, {
+    ...commonOptions,
+    label: { type: 'string' },
+  });
+
+  if (values.help || !sub) {
+    process.stdout.write(`${tokenHelp}\n`);
+    return sub ? 0 : 2;
+  }
+  if (sub !== 'mint') {
+    throw new CliError(`unknown token subcommand: ${sub} (expected: mint).`, 2);
+  }
+
+  const baseUrl = resolveBrokerUrl(str(values.broker));
+  const token = requireAdminToken(str(values.token));
+  const client = new BrokerClient({ baseUrl, token });
+
+  const minted = await client.mintToken(str(values.label) || 'agent');
+
+  if (values.json) {
+    process.stdout.write(`${JSON.stringify(minted, null, 2)}\n`);
+    return 0;
+  }
+  process.stdout.write(`Agent token (id ${minted.id}, shown once — store it now):\n  ${minted.token}\n`);
+  process.stdout.write(`\n  export ZEUS_ADMIN_TOKEN=${minted.token}\n`);
+  return 0;
+}
+
+function str(v: string | boolean | undefined): string {
+  return typeof v === 'string' ? v : '';
+}

--- a/tools/zeus-support-cli/src/config.ts
+++ b/tools/zeus-support-cli/src/config.ts
@@ -1,0 +1,60 @@
+/** Shared config + small helpers (broker URL resolution, env tokens, errors). */
+
+export const DEFAULT_BROKER_URL = 'https://remote.openhpsdrzeus.com';
+
+/** A user-facing failure: printed cleanly to stderr, exits non-zero, no stack. */
+export class CliError extends Error {
+  constructor(
+    message: string,
+    /** Process exit code. */
+    public readonly code = 1,
+  ) {
+    super(message);
+    this.name = 'CliError';
+  }
+}
+
+/**
+ * Resolve the broker base URL from (in priority order) an explicit `--broker`
+ * flag, the `ZEUS_REMOTE_BROKER_URL` env var, then the default. Returns it with
+ * any trailing slashes stripped so callers can append `/admin/...` safely.
+ */
+export function resolveBrokerUrl(flag?: string): string {
+  const raw = flag || process.env.ZEUS_REMOTE_BROKER_URL || DEFAULT_BROKER_URL;
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new CliError(`invalid broker URL: ${raw}`, 2);
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new CliError(`broker URL must be http(s): ${raw}`, 2);
+  }
+  return raw.replace(/\/+$/, '');
+}
+
+/** Map an http(s) broker base to its ws(s) origin for the /signal WebSocket. */
+export function brokerWsBase(httpBase: string): string {
+  return httpBase.replace(/^http/i, 'ws');
+}
+
+/**
+ * Read the admin Bearer token from `--token` or `ZEUS_ADMIN_TOKEN`. Throws a
+ * CliError (rather than returning empty) so every Bearer command fails the same
+ * clear way when no token is configured.
+ */
+export function requireAdminToken(flag?: string): string {
+  const token = flag || process.env.ZEUS_ADMIN_TOKEN || '';
+  if (!token) {
+    throw new CliError(
+      'no admin token: pass --token or set ZEUS_ADMIN_TOKEN (mint one with `zeus-support token mint`).',
+      2,
+    );
+  }
+  return token;
+}
+
+/** Normalise a callsign the way the broker does (trim + uppercase). */
+export function normCallsign(callsign: string): string {
+  return callsign.trim().toUpperCase();
+}

--- a/tools/zeus-support-cli/src/report.ts
+++ b/tools/zeus-support-cli/src/report.ts
@@ -1,0 +1,107 @@
+/**
+ * Report shaping for `pull`: turns the raw api-channel responses + captured log
+ * into a tidy JSON or text report. Kept pure (no I/O, no network) so it is unit
+ * testable and reused by the `--mock` path.
+ */
+
+import type { ApiChannelResponse } from './types.js';
+
+/** The default set of read-only diagnostics endpoints `pull` fetches. */
+export const DEFAULT_PULL_PATHS = [
+  '/api/version',
+  '/api/state',
+  '/api/diagnostics/v2',
+] as const;
+
+export interface DiagnosticEntry {
+  path: string;
+  status: number;
+  contentType?: string;
+  /** Parsed JSON body if the contentType was JSON and it parsed; else raw string. */
+  body: unknown;
+}
+
+export interface SupportReport {
+  schema: 'zeus-support-pull/1';
+  generatedAt: string;
+  operator: string;
+  requestId: string;
+  admin: string;
+  diagnostics: DiagnosticEntry[];
+  log: {
+    backlog: string[];
+    live: string[];
+  };
+}
+
+export interface BuildReportArgs {
+  operator: string;
+  requestId: string;
+  admin: string;
+  responses: ApiChannelResponse[];
+  backlog: string[];
+  live: string[];
+  now?: Date;
+}
+
+/** Build the structured report object from raw channel data. */
+export function buildReport(args: BuildReportArgs): SupportReport {
+  return {
+    schema: 'zeus-support-pull/1',
+    generatedAt: (args.now ?? new Date()).toISOString(),
+    operator: args.operator,
+    requestId: args.requestId,
+    admin: args.admin,
+    diagnostics: args.responses.map(toEntry),
+    log: { backlog: args.backlog, live: args.live },
+  };
+}
+
+function toEntry(r: ApiChannelResponse & { path?: string }): DiagnosticEntry {
+  return {
+    path: r.path ?? '(unknown)',
+    status: r.status,
+    contentType: r.contentType,
+    body: maybeJson(r.body, r.contentType),
+  };
+}
+
+/** Parse a body as JSON when the contentType says JSON; otherwise keep the string. */
+function maybeJson(body: string, contentType?: string): unknown {
+  if (contentType && /json/i.test(contentType)) {
+    try {
+      return JSON.parse(body);
+    } catch {
+      return body;
+    }
+  }
+  return body;
+}
+
+/** Render the report as pretty JSON. */
+export function renderJson(report: SupportReport): string {
+  return JSON.stringify(report, null, 2);
+}
+
+/** Render the report as a human-readable text summary. */
+export function renderText(report: SupportReport): string {
+  const lines: string[] = [];
+  lines.push(`Zeus support pull — ${report.operator}`);
+  lines.push(`  generated : ${report.generatedAt}`);
+  lines.push(`  admin     : ${report.admin}`);
+  lines.push(`  requestId : ${report.requestId}`);
+  lines.push('');
+  lines.push('Diagnostics');
+  for (const d of report.diagnostics) {
+    lines.push(`  [${d.status}] ${d.path}${d.contentType ? ` (${d.contentType})` : ''}`);
+    const rendered = typeof d.body === 'string' ? d.body : JSON.stringify(d.body, null, 2);
+    for (const l of rendered.split('\n')) lines.push(`      ${l}`);
+  }
+  lines.push('');
+  lines.push(`Log backlog (${report.log.backlog.length} lines)`);
+  for (const l of report.log.backlog) lines.push(`  ${l}`);
+  lines.push('');
+  lines.push(`Live log (${report.log.live.length} lines)`);
+  for (const l of report.log.live) lines.push(`  ${l}`);
+  return lines.join('\n');
+}

--- a/tools/zeus-support-cli/src/session.ts
+++ b/tools/zeus-support-cli/src/session.ts
@@ -1,0 +1,467 @@
+/**
+ * Support-session client: drives the full P3b flow once a `ticket` is in hand.
+ *
+ *   1. open  wss://<broker>/signal?role=support&callsign=<OP>&ticket=<ticket>
+ *   2. wait  for {t:"support-grant", requestId} (operator pressed Allow)
+ *   3. WebRTC: create `control`/`api`/`log` data channels, build an offer,
+ *      send {t:"offer", sdp} (broker stamps support+requestId — we never do)
+ *   4. recv  {t:"answer", sdp, support:true}; set remote description
+ *   5. use   the data channels: control hello → support-ready, api GETs, log stream
+ *
+ * The broker auto-answers our {t:"ping"} with {t:"pong"}; we heartbeat to keep
+ * the (hibernating) signaling socket warm. werift gives us a pure-JS WebRTC stack
+ * so this runs headless under Node with no browser / native deps.
+ */
+
+import { WebSocket } from 'ws';
+import { RTCPeerConnection } from 'werift';
+import type { RTCDataChannel } from 'werift';
+import { CliError } from './config.js';
+import type {
+  ApiChannelRequest,
+  ApiChannelResponse,
+  ControlInbound,
+  LogInbound,
+  SupportWsInbound,
+} from './types.js';
+
+export interface SupportSessionOptions {
+  /** ws(s) broker base, no trailing slash (see brokerWsBase). */
+  wsBase: string;
+  /** Target operator callsign (already normalised). */
+  callsign: string;
+  /** Single-use ticket from POST /admin/request. */
+  ticket: string;
+  /** Expected requestId (for sanity-checking the grant); optional. */
+  requestId?: string;
+  /** Max time to wait for the operator to Allow (support-grant). Default 90s. */
+  grantTimeoutMs?: number;
+  /** Max time to wait for the WebRTC answer + connection. Default 30s. */
+  connectTimeoutMs?: number;
+  /** Optional structured logger; defaults to stderr. */
+  log?: (msg: string) => void;
+}
+
+interface OpenChannels {
+  control: RTCDataChannel;
+  api: RTCDataChannel;
+  log: RTCDataChannel;
+}
+
+/** A connected support session: issue API GETs, collect logs, then close(). */
+export class SupportSession {
+  private constructor(
+    private readonly ws: WebSocket,
+    private readonly pc: RTCPeerConnection,
+    private readonly chans: OpenChannels,
+    readonly requestId: string,
+    readonly admin: string,
+    private readonly heartbeat: ReturnType<typeof setInterval>,
+    private readonly logFn: (msg: string) => void,
+  ) {}
+
+  /**
+   * Run the whole connect handshake and resolve with a live SupportSession.
+   * Throws CliError on offline/denied/timeout so the CLI can exit cleanly.
+   */
+  static async connect(opts: SupportSessionOptions): Promise<SupportSession> {
+    const log = opts.log ?? ((m: string) => process.stderr.write(`${m}\n`));
+    const grantTimeout = opts.grantTimeoutMs ?? 90_000;
+    const connectTimeout = opts.connectTimeoutMs ?? 30_000;
+
+    const url =
+      `${opts.wsBase}/signal?role=support` +
+      `&callsign=${encodeURIComponent(opts.callsign)}` +
+      `&ticket=${encodeURIComponent(opts.ticket)}`;
+
+    const ws = new WebSocket(url);
+    const pc = new RTCPeerConnection({
+      iceServers: [{ urls: 'stun:stun.l.google.com:19302' }],
+    });
+
+    // Buffer everything received per-channel before the consumer attaches.
+    const logBacklog: string[] = [];
+    const logLive: string[] = [];
+    let logStarted = false;
+
+    const chans: OpenChannels = {
+      control: pc.createDataChannel('control'),
+      api: pc.createDataChannel('api'),
+      log: pc.createDataChannel('log'),
+    };
+
+    const apiWaiters = new Map<string, (r: ApiChannelResponse) => void>();
+    let controlReady: ((c: { requestId: string; admin: string }) => void) | null = null;
+
+    chans.control.onMessage.subscribe((data) => {
+      const msg = parse<ControlInbound>(data);
+      if (msg?.t === 'support-ready' && controlReady) {
+        controlReady({ requestId: String(msg.requestId), admin: String(msg.admin) });
+        controlReady = null;
+      }
+    });
+    chans.api.onMessage.subscribe((data) => {
+      const msg = parse<ApiChannelResponse>(data);
+      if (msg && typeof msg.id === 'string') {
+        const w = apiWaiters.get(msg.id);
+        if (w) {
+          apiWaiters.delete(msg.id);
+          w(msg);
+        }
+      }
+    });
+    chans.log.onMessage.subscribe((data) => {
+      const msg = parse<LogInbound>(data);
+      if (!msg) return;
+      if (msg.t === 'backlog' && Array.isArray(msg.lines)) {
+        for (const l of msg.lines) logBacklog.push(String(l));
+        logStarted = true;
+      } else if (msg.t === 'line' && typeof msg.line === 'string') {
+        logLive.push(msg.line);
+      }
+    });
+
+    try {
+      await waitOpen(ws, connectTimeout);
+    } catch (err) {
+      safeClose(ws, pc);
+      throw err;
+    }
+
+    // Heartbeat the signaling socket (broker auto-pongs without waking the DO).
+    const heartbeat = setInterval(() => {
+      if (ws.readyState === ws.OPEN) trySend(ws, { t: 'ping' });
+    }, 20_000);
+
+    try {
+      // --- 1) wait for the operator to Allow --------------------------------
+      log(`waiting up to ${Math.round(grantTimeout / 1000)}s for ${opts.callsign} to Allow…`);
+      const grant = await waitForGrant(ws, grantTimeout, opts.requestId);
+      const requestId = grant.requestId;
+      log(`granted (requestId=${requestId}); negotiating WebRTC…`);
+
+      // --- 2) offer (ICE-gather to completion, then send full SDP) ----------
+      const offer = await pc.createOffer();
+      await pc.setLocalDescription(offer);
+      await waitIceComplete(pc, connectTimeout);
+      const localSdp = pc.localDescription?.sdp;
+      if (!localSdp) throw new CliError('failed to produce a local SDP offer.', 7);
+      // The broker stamps support+requestId; we send ONLY t+sdp.
+      trySend(ws, { t: 'offer', sdp: localSdp });
+
+      // --- 3) answer --------------------------------------------------------
+      const answer = await waitForAnswer(ws, connectTimeout);
+      await pc.setRemoteDescription({ type: 'answer', sdp: answer.sdp });
+
+      // --- 4) data-channel + connection establishment -----------------------
+      await waitConnected(pc, connectTimeout);
+      await Promise.all([
+        waitChannelOpen(chans.control, connectTimeout),
+        waitChannelOpen(chans.api, connectTimeout),
+        waitChannelOpen(chans.log, connectTimeout),
+      ]);
+
+      // --- 5) control handshake → support-ready -----------------------------
+      const ready = await new Promise<{ requestId: string; admin: string }>((resolve, reject) => {
+        const t = setTimeout(() => reject(new CliError('no support-ready from the radio.', 7)), connectTimeout);
+        controlReady = (c) => {
+          clearTimeout(t);
+          resolve(c);
+        };
+        trySend(chans.control, { t: 'hello' });
+      });
+
+      // Kick the log channel so the radio sends its backlog + live stream.
+      trySend(chans.log, { t: 'hello' });
+
+      const session = new SupportSession(ws, pc, chans, requestId, ready.admin, heartbeat, log);
+      // expose internal buffers to instance methods via closure-bound getters
+      session.attachLogBuffers(() => logBacklog, () => logLive, () => logStarted);
+      session.attachApiWaiters(apiWaiters);
+      return session;
+    } catch (err) {
+      clearInterval(heartbeat);
+      safeClose(ws, pc);
+      throw err;
+    }
+  }
+
+  // --- buffers wired in by connect() -----------------------------------------
+
+  private getBacklog: () => string[] = () => [];
+  private getLive: () => string[] = () => [];
+  private apiWaiters: Map<string, (r: ApiChannelResponse) => void> = new Map();
+
+  private attachLogBuffers(
+    backlog: () => string[],
+    live: () => string[],
+    _started: () => boolean,
+  ): void {
+    this.getBacklog = backlog;
+    this.getLive = live;
+  }
+
+  private attachApiWaiters(m: Map<string, (r: ApiChannelResponse) => void>): void {
+    this.apiWaiters = m;
+  }
+
+  // --- public API ------------------------------------------------------------
+
+  /** Issue one GET over the `api` data channel and await the radio's response. */
+  async apiGet(path: string, timeoutMs = 15_000): Promise<ApiChannelResponse> {
+    const id = randomId();
+    const req: ApiChannelRequest = { id, method: 'GET', path };
+    return await new Promise<ApiChannelResponse>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.apiWaiters.delete(id);
+        reject(new CliError(`api GET ${path} timed out.`, 7));
+      }, timeoutMs);
+      this.apiWaiters.set(id, (r) => {
+        clearTimeout(timer);
+        resolve(r);
+      });
+      trySend(this.chans.api, req);
+    });
+  }
+
+  /** Snapshot the log backlog received so far. */
+  logBacklog(): string[] {
+    return [...this.getBacklog()];
+  }
+
+  /** Collect live log lines for `ms`, then return everything captured. */
+  async collectLogs(ms: number): Promise<{ backlog: string[]; live: string[] }> {
+    if (ms > 0) {
+      this.logFn(`capturing ${Math.round(ms / 1000)}s of live log…`);
+      await delay(ms);
+    }
+    return { backlog: [...this.getBacklog()], live: [...this.getLive()] };
+  }
+
+  /** Tear the session down: bye on control, close channels, peer, socket. */
+  close(): void {
+    clearInterval(this.heartbeat);
+    trySend(this.ws, { t: 'bye' });
+    safeClose(this.ws, this.pc);
+  }
+}
+
+// --- WebSocket / WebRTC wait helpers ------------------------------------------
+
+function waitOpen(ws: WebSocket, timeoutMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new CliError('timed out opening the support WebSocket.', 6));
+    }, timeoutMs);
+    const onOpen = () => {
+      cleanup();
+      resolve();
+    };
+    const onErr = (err: Error) => {
+      cleanup();
+      reject(new CliError(`support WebSocket error: ${err.message}.`, 6));
+    };
+    const onClose = () => {
+      cleanup();
+      reject(new CliError('support WebSocket closed before opening (bad ticket?).', 6));
+    };
+    function cleanup() {
+      clearTimeout(timer);
+      ws.off('open', onOpen);
+      ws.off('error', onErr);
+      ws.off('close', onClose);
+    }
+    ws.on('open', onOpen);
+    ws.on('error', onErr);
+    ws.on('close', onClose);
+  });
+}
+
+function waitForGrant(
+  ws: WebSocket,
+  timeoutMs: number,
+  expectRequestId?: string,
+): Promise<{ requestId: string }> {
+  return waitForFrame(
+    ws,
+    timeoutMs,
+    (m) => {
+      if (m.t === 'offline') throw new CliError('operator went offline before granting.', 5);
+      if (m.t === 'support-grant') {
+        const requestId = String((m as { requestId?: unknown }).requestId ?? '');
+        if (expectRequestId && requestId && requestId !== expectRequestId) return undefined;
+        return { requestId };
+      }
+      return undefined;
+    },
+    'operator did not Allow in time (denied or timed out).',
+    8,
+  );
+}
+
+function waitForAnswer(ws: WebSocket, timeoutMs: number): Promise<{ sdp: string }> {
+  return waitForFrame(
+    ws,
+    timeoutMs,
+    (m) => {
+      if (m.t === 'offline') throw new CliError('operator went offline during negotiation.', 5);
+      if (m.t === 'answer' && typeof (m as { sdp?: unknown }).sdp === 'string') {
+        return { sdp: (m as { sdp: string }).sdp };
+      }
+      return undefined;
+    },
+    'no WebRTC answer received.',
+    7,
+  );
+}
+
+/**
+ * Generic single-frame waiter over the support WS: resolves with the first
+ * frame for which `match` returns a value; rejects on timeout. `match` may throw
+ * a CliError to fail fast (e.g. an `offline` frame).
+ */
+function waitForFrame<T>(
+  ws: WebSocket,
+  timeoutMs: number,
+  match: (m: SupportWsInbound) => T | undefined,
+  timeoutMsg: string,
+  timeoutCode: number,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new CliError(timeoutMsg, timeoutCode));
+    }, timeoutMs);
+    const onMsg = (raw: WsData) => {
+      const m = parse<SupportWsInbound>(raw);
+      if (!m || typeof m.t !== 'string') return;
+      try {
+        const v = match(m);
+        if (v !== undefined) {
+          cleanup();
+          resolve(v);
+        }
+      } catch (err) {
+        cleanup();
+        reject(err);
+      }
+    };
+    const onClose = () => {
+      cleanup();
+      reject(new CliError('support WebSocket closed unexpectedly.', 6));
+    };
+    function cleanup() {
+      clearTimeout(timer);
+      ws.off('message', onMsg);
+      ws.off('close', onClose);
+    }
+    ws.on('message', onMsg);
+    ws.on('close', onClose);
+  });
+}
+
+function waitIceComplete(pc: RTCPeerConnection, timeoutMs: number): Promise<void> {
+  if (pc.iceGatheringState === 'complete') return Promise.resolve();
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(), timeoutMs); // proceed with what we have
+    const sub = pc.iceGatheringStateChange.subscribe((state) => {
+      if (state === 'complete') {
+        clearTimeout(timer);
+        sub.unSubscribe();
+        resolve();
+      }
+    });
+  });
+}
+
+function waitConnected(pc: RTCPeerConnection, timeoutMs: number): Promise<void> {
+  if (pc.connectionState === 'connected') return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      sub.unSubscribe();
+      reject(new CliError('WebRTC peer connection did not establish.', 7));
+    }, timeoutMs);
+    const sub = pc.connectionStateChange.subscribe((state) => {
+      if (state === 'connected') {
+        clearTimeout(timer);
+        sub.unSubscribe();
+        resolve();
+      } else if (state === 'failed' || state === 'closed') {
+        clearTimeout(timer);
+        sub.unSubscribe();
+        reject(new CliError(`WebRTC connection ${state}.`, 7));
+      }
+    });
+  });
+}
+
+function waitChannelOpen(dc: RTCDataChannel, timeoutMs: number): Promise<void> {
+  if (dc.readyState === 'open') return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      sub.unSubscribe();
+      reject(new CliError(`data channel "${dc.label}" did not open.`, 7));
+    }, timeoutMs);
+    const sub = dc.stateChanged.subscribe((state) => {
+      if (state === 'open') {
+        clearTimeout(timer);
+        sub.unSubscribe();
+        resolve();
+      } else if (state === 'closed') {
+        clearTimeout(timer);
+        sub.unSubscribe();
+        reject(new CliError(`data channel "${dc.label}" closed before opening.`, 7));
+      }
+    });
+  });
+}
+
+// --- small utilities ----------------------------------------------------------
+
+type WsData = string | Buffer | ArrayBuffer | Buffer[];
+
+function parse<T>(raw: WsData | string | Buffer): T | null {
+  try {
+    const text =
+      typeof raw === 'string'
+        ? raw
+        : Buffer.isBuffer(raw)
+          ? raw.toString('utf8')
+          : Array.isArray(raw)
+            ? Buffer.concat(raw).toString('utf8')
+            : Buffer.from(raw as ArrayBuffer).toString('utf8');
+    return JSON.parse(text) as T;
+  } catch {
+    return null;
+  }
+}
+
+function trySend(target: WebSocket | RTCDataChannel, msg: unknown): void {
+  try {
+    target.send(JSON.stringify(msg));
+  } catch {
+    /* socket/channel gone */
+  }
+}
+
+function safeClose(ws: WebSocket, pc: RTCPeerConnection): void {
+  try {
+    ws.close();
+  } catch {
+    /* already closing */
+  }
+  try {
+    void pc.close();
+  } catch {
+    /* already closing */
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function randomId(): string {
+  return `req_${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`;
+}

--- a/tools/zeus-support-cli/src/types.ts
+++ b/tools/zeus-support-cli/src/types.ts
@@ -1,0 +1,94 @@
+/**
+ * Wire shapes for the broker /admin/* HTTP surface and the support-session
+ * WebSocket + data-channel protocol. The CLI is a pure CONSUMER of these — they
+ * are defined by the deployed broker (cloud/zeus-remote-broker, ADMIN_AUTH_DESIGN.md)
+ * and the P3b support-session protocol. We never mutate them, only model them.
+ */
+
+// --- /admin/login -----------------------------------------------------------
+
+export interface LoginResponse {
+  /** Short-lived (~12h) session token, prefix `zsa_`. */
+  token: string;
+  callsign: string;
+  /** Unix ms expiry of the session token. */
+  expiresAt: number;
+}
+
+// --- /admin/tokens (POST) ---------------------------------------------------
+
+export interface MintTokenResponse {
+  /** Public, listable token id. */
+  id: string;
+  /** The secret agent token (shown ONCE), prefix `zsa_`. */
+  token: string;
+}
+
+// --- /admin/presence --------------------------------------------------------
+
+export interface PresenceOperator {
+  callsign: string;
+  /** Unix ms the operator registered as support-available. */
+  since: number;
+  /** Unix ms of the last heartbeat. */
+  lastSeen: number;
+}
+
+export interface PresenceResponse {
+  operators: PresenceOperator[];
+}
+
+// --- /admin/request ---------------------------------------------------------
+
+export interface RequestResponse {
+  ok: boolean;
+  /** Correlates the request with the later `support-grant` over the WS. */
+  requestId: string;
+  /** Single-use ticket to open the support WebSocket. */
+  ticket: string;
+  callsign: string;
+}
+
+// --- support WebSocket frames (JSON text) -----------------------------------
+
+/** Frames the CLI may receive on the support WebSocket. */
+export type SupportWsInbound =
+  | { t: 'pong' }
+  | { t: 'support-grant'; requestId: string }
+  | { t: 'answer'; sdp: string; support?: boolean }
+  | { t: 'candidate'; candidate?: unknown }
+  | { t: 'offline' }
+  | { t: 'bye' }
+  | { t: string; [k: string]: unknown };
+
+/** Frames the CLI may send on the support WebSocket. */
+export type SupportWsOutbound =
+  | { t: 'ping' }
+  | { t: 'offer'; sdp: string }
+  | { t: 'candidate'; candidate: unknown }
+  | { t: 'bye' };
+
+// --- data-channel messages --------------------------------------------------
+
+/** `control` channel. */
+export type ControlInbound = { t: 'support-ready'; requestId: string; admin: string } | { t: string; [k: string]: unknown };
+
+/** `api` channel request (GET-only allowlist enforced at the radio). */
+export interface ApiChannelRequest {
+  id: string;
+  method: 'GET';
+  path: string;
+}
+
+export interface ApiChannelResponse {
+  id: string;
+  status: number;
+  contentType?: string;
+  body: string;
+}
+
+/** `log` channel. */
+export type LogInbound =
+  | { t: 'backlog'; lines: string[] }
+  | { t: 'line'; line: string }
+  | { t: string; [k: string]: unknown };

--- a/tools/zeus-support-cli/test/config.test.ts
+++ b/tools/zeus-support-cli/test/config.test.ts
@@ -1,0 +1,56 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  resolveBrokerUrl,
+  brokerWsBase,
+  normCallsign,
+  requireAdminToken,
+  CliError,
+  DEFAULT_BROKER_URL,
+} from '../src/config.js';
+
+test('resolveBrokerUrl prefers the flag, strips trailing slashes', () => {
+  assert.equal(resolveBrokerUrl('https://example.com/'), 'https://example.com');
+  assert.equal(resolveBrokerUrl('https://example.com///'), 'https://example.com');
+});
+
+test('resolveBrokerUrl falls back to env then default', () => {
+  const prev = process.env.ZEUS_REMOTE_BROKER_URL;
+  try {
+    process.env.ZEUS_REMOTE_BROKER_URL = 'https://env.example.com';
+    assert.equal(resolveBrokerUrl(), 'https://env.example.com');
+    delete process.env.ZEUS_REMOTE_BROKER_URL;
+    assert.equal(resolveBrokerUrl(), DEFAULT_BROKER_URL);
+  } finally {
+    if (prev === undefined) delete process.env.ZEUS_REMOTE_BROKER_URL;
+    else process.env.ZEUS_REMOTE_BROKER_URL = prev;
+  }
+});
+
+test('resolveBrokerUrl rejects non-http(s) and garbage', () => {
+  assert.throws(() => resolveBrokerUrl('ftp://x'), CliError);
+  assert.throws(() => resolveBrokerUrl('not a url'), CliError);
+});
+
+test('brokerWsBase maps http(s) → ws(s)', () => {
+  assert.equal(brokerWsBase('https://remote.example.com'), 'wss://remote.example.com');
+  assert.equal(brokerWsBase('http://localhost:8787'), 'ws://localhost:8787');
+});
+
+test('normCallsign trims and uppercases', () => {
+  assert.equal(normCallsign('  n9war '), 'N9WAR');
+});
+
+test('requireAdminToken prefers flag, then env, else throws', () => {
+  const prev = process.env.ZEUS_ADMIN_TOKEN;
+  try {
+    assert.equal(requireAdminToken('zsa_flag'), 'zsa_flag');
+    delete process.env.ZEUS_ADMIN_TOKEN;
+    assert.throws(() => requireAdminToken(), CliError);
+    process.env.ZEUS_ADMIN_TOKEN = 'zsa_env';
+    assert.equal(requireAdminToken(), 'zsa_env');
+  } finally {
+    if (prev === undefined) delete process.env.ZEUS_ADMIN_TOKEN;
+    else process.env.ZEUS_ADMIN_TOKEN = prev;
+  }
+});

--- a/tools/zeus-support-cli/test/report.test.ts
+++ b/tools/zeus-support-cli/test/report.test.ts
@@ -1,0 +1,106 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildReport,
+  renderJson,
+  renderText,
+  DEFAULT_PULL_PATHS,
+} from '../src/report.js';
+import type { ApiChannelResponse } from '../src/types.js';
+
+const sampleResponses: (ApiChannelResponse & { path: string })[] = [
+  {
+    id: 'a',
+    status: 200,
+    contentType: 'application/json',
+    path: '/api/version',
+    body: JSON.stringify({ version: '1.2.3' }),
+  },
+  {
+    id: 'b',
+    status: 500,
+    contentType: 'text/plain',
+    path: '/api/state',
+    body: 'boom',
+  },
+];
+
+test('buildReport parses JSON bodies and keeps text bodies raw', () => {
+  const report = buildReport({
+    operator: 'N9WAR',
+    requestId: 'rq1',
+    admin: 'KB2UKA',
+    responses: sampleResponses,
+    backlog: ['line a'],
+    live: ['line b'],
+    now: new Date('2026-01-01T00:00:00.000Z'),
+  });
+
+  assert.equal(report.schema, 'zeus-support-pull/1');
+  assert.equal(report.operator, 'N9WAR');
+  assert.equal(report.admin, 'KB2UKA');
+  assert.equal(report.requestId, 'rq1');
+  assert.equal(report.generatedAt, '2026-01-01T00:00:00.000Z');
+
+  // JSON body parsed into an object…
+  assert.deepEqual(report.diagnostics[0].body, { version: '1.2.3' });
+  assert.equal(report.diagnostics[0].path, '/api/version');
+  // …text body kept as a string.
+  assert.equal(report.diagnostics[1].body, 'boom');
+  assert.equal(report.diagnostics[1].status, 500);
+
+  assert.deepEqual(report.log.backlog, ['line a']);
+  assert.deepEqual(report.log.live, ['line b']);
+});
+
+test('buildReport tolerates malformed JSON bodies (keeps the raw string)', () => {
+  const responses: (ApiChannelResponse & { path: string })[] = [
+    { id: 'x', status: 200, contentType: 'application/json', path: '/api/diagnostics/v2', body: '{not json' },
+  ];
+  const report = buildReport({
+    operator: 'OP',
+    requestId: 'r',
+    admin: 'A',
+    responses,
+    backlog: [],
+    live: [],
+  });
+  assert.equal(report.diagnostics[0].body, '{not json');
+});
+
+test('renderJson round-trips to a valid object', () => {
+  const report = buildReport({
+    operator: 'OP',
+    requestId: 'r',
+    admin: 'A',
+    responses: sampleResponses,
+    backlog: [],
+    live: [],
+  });
+  const parsed = JSON.parse(renderJson(report));
+  assert.equal(parsed.schema, 'zeus-support-pull/1');
+  assert.equal(parsed.diagnostics.length, 2);
+});
+
+test('renderText includes diagnostics + log section headers', () => {
+  const report = buildReport({
+    operator: 'N9WAR',
+    requestId: 'rq1',
+    admin: 'KB2UKA',
+    responses: sampleResponses,
+    backlog: ['backlog-1'],
+    live: ['live-1'],
+  });
+  const text = renderText(report);
+  assert.match(text, /Zeus support pull — N9WAR/);
+  assert.match(text, /\[200\] \/api\/version/);
+  assert.match(text, /\[500\] \/api\/state/);
+  assert.match(text, /Log backlog \(1 lines\)/);
+  assert.match(text, /Live log \(1 lines\)/);
+});
+
+test('DEFAULT_PULL_PATHS covers the spec-required endpoints', () => {
+  for (const p of ['/api/version', '/api/state', '/api/diagnostics/v2']) {
+    assert.ok(DEFAULT_PULL_PATHS.includes(p as (typeof DEFAULT_PULL_PATHS)[number]), `${p} missing`);
+  }
+});

--- a/tools/zeus-support-cli/tsconfig.build.json
+++ b/tools/zeus-support-cli/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["test/**/*.ts"]
+}

--- a/tools/zeus-support-cli/tsconfig.json
+++ b/tools/zeus-support-cli/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "lib": ["es2022", "dom"],
+    "types": ["node"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
## Phase 4b — agent-accessible admin support CLI

Adds `tools/zeus-support-cli`, a non-interactive Node + TypeScript CLI that an automated agent (or a maintainer at a terminal) uses to drive the remote-diagnostics broker. It is a **pure consumer** of the already-deployed broker HTTP / WebSocket / data-channel APIs — **no backend or broker code is changed** (the only non-tool edit is a short pointer section appended to `cloud/ADMIN_AUTH_DESIGN.md`). PureSignal is untouched.

### Subcommands
- **`login`** — QRZ session + admin-password login via `POST /admin/login` → ~12h session token; `--mint` immediately exchanges it for a long-lived **agent token** (the non-interactive path). No secret is written to disk; tokens come from flags/env.
- **`token mint`** — exchange a session token (`ZEUS_ADMIN_TOKEN`) for an agent token via `POST /admin/tokens`.
- **`presence`** (aliases `list`, `whoami`) — list consented online operators via `GET /admin/presence`.
- **`request <callsign>`** — `POST /admin/request`; prints `requestId` + single-use `ticket`; clean exit on `503 operator offline`.
- **`pull <callsign>`** — the full flow: request → open `wss://<broker>/signal?role=support&callsign=…&ticket=…` → wait for `{t:"support-grant"}` (operator presses **Allow**) → WebRTC connect via `werift` (creates `control`/`api`/`log` channels, sends `{t:"offer",sdp}`, applies `{t:"answer"}`) → `control` hello → fetch `/api/version`, `/api/state`, `/api/diagnostics/v2` over the GET-only `api` channel → capture the `log` backlog + N seconds of live log → write a tidy JSON/text report. Handles *operator offline* and *denied/timeout* gracefully. `--mock` shapes a report with zero network.

### Tooling / tests
Mirrors `cloud/zeus-remote-broker` (typescript, tsx, `typecheck`/`test` scripts, ES modules). `npm run typecheck` is green; unit tests cover the report + config/URL shaping (11 passing). `pull --mock` exercises the full formatting path offline.

### What needs the live broker to verify
The authenticated commands and the live `pull` path need the deployed broker — and, for `pull`, an online operator who presses Allow — so they can't be fully e2e'd in CI, matching the project's "live needs the deployed broker" convention. The WS / WebRTC / data-channel protocol is implemented exactly per the Phase-4b spec.
