### PR TITLE
feat(support): sidecar presence + crash auto-share (Phase 3c)

### DIFF
--- a/OpenhpsdrZeus/Program.cs
+++ b/OpenhpsdrZeus/Program.cs
@@ -352,7 +352,7 @@ public partial class Program
         // Spawn the out-of-process support sidecar now the backend is up. It runs
         // detached so it survives a backend crash and can capture the crash logs
         // the in-memory ring would lose. Best-effort — never blocks launch.
-        SupportSidecarLauncher.TryLaunch();
+        SupportSidecarLauncher.TryLaunch(app.Services);
 
         // Resolve the bound URLs after Start — Kestrel writes the OS-assigned
         // loopback port (plus the LAN HTTPS port we configured) into

--- a/OpenhpsdrZeus/SupportSidecarLauncher.cs
+++ b/OpenhpsdrZeus/SupportSidecarLauncher.cs
@@ -11,6 +11,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
 using Zeus.Server;
 using Zeus.Support.Contracts;
 
@@ -28,7 +29,23 @@ namespace OpenhpsdrZeus;
 /// </summary>
 internal static class SupportSidecarLauncher
 {
-    public static void TryLaunch()
+    /// <summary>
+    /// Same broker default + override as <c>RemoteBrokerClient</c>: a <c>wss</c>
+    /// signaling URL. The sidecar derives the <c>https</c> origin for its
+    /// presence/crash POSTs from it. Honour <c>ZEUS_REMOTE_BROKER_URL</c> so a
+    /// staging broker can be pointed at without a rebuild.
+    /// </summary>
+    private static string BrokerUrl() =>
+        Environment.GetEnvironmentVariable("ZEUS_REMOTE_BROKER_URL")
+            ?? "wss://remote.openhpsdrzeus.com/signal?role=host";
+
+    /// <param name="services">
+    /// The running host's service provider, used to resolve the operator's QRZ
+    /// identity (callsign + session key) so the sidecar can authenticate its
+    /// presence/crash calls. May be null (e.g. a host build without DI wired);
+    /// the sidecar then runs local-only crash capture.
+    /// </param>
+    public static void TryLaunch(IServiceProvider? services = null)
     {
         try
         {
@@ -61,12 +78,49 @@ internal static class SupportSidecarLauncher
             Add("--crash-dir", PrefsDbPath.CrashDir());
             Add("--app-version", ResolveAppVersion());
 
+            // Remote presence/crash identity. Resolve the operator's QRZ identity
+            // best-effort; if they are signed in, hand the sidecar the broker URL +
+            // callsign (args) and the session key (env var, kept off the process
+            // table). Availability + crash auto-share START OFF — the backend turns
+            // them on at runtime via the SupportStateChanged IPC, so presence never
+            // advertises and crashes never upload until the operator opts in.
+            Add("--broker-url", BrokerUrl());
+            var identity = TryResolveQrzIdentity(services);
+            if (identity is not null)
+            {
+                Add("--operator-callsign", identity.Value.Callsign);
+                psi.Environment[SupportIpc.SidecarQrzSessionEnvVar] = identity.Value.SessionKey;
+            }
+            Add("--remote-diagnostics", "off");
+            Add("--auto-share-crash", "off");
+
             Process.Start(psi);
             StartupDiagnostics.Log($"support-agent: launched sidecar to supervise pid {Environment.ProcessId}");
         }
         catch (Exception ex)
         {
             Console.Error.WriteLine($"support-agent: launch failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Best-effort QRZ identity for the sidecar's broker auth. Bounded so a slow
+    /// QRZ session-key fetch never delays launch; any failure just leaves the
+    /// sidecar local-only.
+    /// </summary>
+    private static (string Callsign, string SessionKey)? TryResolveQrzIdentity(IServiceProvider? services)
+    {
+        if (services is null) return null;
+        try
+        {
+            var qrz = services.GetService<QrzService>();
+            if (qrz is null) return null;
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+            return qrz.GetChatIdentityAsync(cts.Token).GetAwaiter().GetResult();
+        }
+        catch
+        {
+            return null;
         }
     }
 

--- a/Zeus.Support.Contracts/SupportIpc.cs
+++ b/Zeus.Support.Contracts/SupportIpc.cs
@@ -62,6 +62,14 @@ public static class SupportIpc
 
     /// <summary>Environment variable the desktop host uses to hand the session token to the backend.</summary>
     public const string SessionTokenEnvVar = "ZEUS_SUPPORT_SESSION";
+
+    /// <summary>
+    /// Environment variable the desktop host uses to hand the operator's QRZ
+    /// session key to the SIDECAR (for its broker presence/crash auth). Passed via
+    /// the environment rather than a command-line argument so the short-lived
+    /// secret never appears in the process table.
+    /// </summary>
+    public const string SidecarQrzSessionEnvVar = "ZEUS_SUPPORT_QRZ_SESSION";
 }
 
 /// <summary>An operator's decision on an admin's request for a live support session.</summary>

--- a/Zeus.SupportAgent/BrokerEndpoints.cs
+++ b/Zeus.SupportAgent/BrokerEndpoints.cs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.SupportAgent;
+
+/// <summary>
+/// Resolves the broker's HTTPS origin and the presence/crash REST endpoints from
+/// whatever broker URL the host hands the sidecar. The host passes the SAME value
+/// the backend's RemoteBrokerClient uses — a WebSocket signaling URL such as
+/// <c>wss://remote.openhpsdrzeus.com/signal?role=host</c> (or the
+/// <c>ZEUS_REMOTE_BROKER_URL</c> override) — so this maps the <c>ws/wss</c> scheme
+/// to <c>http/https</c> and drops the signaling path, yielding the plain origin
+/// the <c>/presence/*</c> and <c>/crash</c> routes live under.
+///
+/// A null/blank/unparseable input yields null endpoints, which disables all
+/// remote presence/crash sharing (Phase-1 local-only fallback) rather than
+/// guessing a URL.
+/// </summary>
+public sealed class BrokerEndpoints
+{
+    private BrokerEndpoints(Uri origin)
+    {
+        Origin = origin;
+        PresenceRegister = new Uri(origin, "/presence/register");
+        PresenceHeartbeat = new Uri(origin, "/presence/heartbeat");
+        PresenceDrop = new Uri(origin, "/presence/drop");
+        Crash = new Uri(origin, "/crash");
+    }
+
+    /// <summary>The broker's HTTPS (or HTTP, for local dev) origin, e.g. <c>https://remote.openhpsdrzeus.com/</c>.</summary>
+    public Uri Origin { get; }
+
+    public Uri PresenceRegister { get; }
+    public Uri PresenceHeartbeat { get; }
+    public Uri PresenceDrop { get; }
+    public Uri Crash { get; }
+
+    /// <summary>
+    /// Derive endpoints from a broker URL, or null if it is missing/unparseable.
+    /// Accepts ws/wss/http/https; ws→http and wss→https. The path and query are
+    /// discarded — only scheme + authority define the origin the REST routes hang
+    /// off.
+    /// </summary>
+    public static BrokerEndpoints? FromBrokerUrl(string? brokerUrl)
+    {
+        if (string.IsNullOrWhiteSpace(brokerUrl)) return null;
+        if (!Uri.TryCreate(brokerUrl.Trim(), UriKind.Absolute, out var uri)) return null;
+
+        var scheme = uri.Scheme.ToLowerInvariant() switch
+        {
+            "wss" or "https" => "https",
+            "ws" or "http" => "http",
+            _ => null,
+        };
+        if (scheme is null) return null;
+
+        var builder = new UriBuilder(scheme, uri.Host)
+        {
+            Path = "/",
+            Query = string.Empty,
+        };
+        // Preserve a non-default port (e.g. a local `wrangler dev` on 8787).
+        if (!uri.IsDefaultPort) builder.Port = uri.Port;
+
+        return new BrokerEndpoints(builder.Uri);
+    }
+}

--- a/Zeus.SupportAgent/CrashAutoShare.cs
+++ b/Zeus.SupportAgent/CrashAutoShare.cs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.SupportAgent;
+
+/// <summary>Outcome of the post-crash auto-share decision (for logging/tests).</summary>
+public enum CrashShareOutcome
+{
+    /// <summary>The auto-share flag was OFF — nothing was uploaded (the default, safe path).</summary>
+    SkippedNotOptedIn,
+    /// <summary>Opted in but no broker identity was available (no callsign/session/URL).</summary>
+    SkippedNoBroker,
+    /// <summary>Opted in but the freshly written crash record could not be read back.</summary>
+    SkippedNoRecord,
+    /// <summary>Uploaded successfully.</summary>
+    Uploaded,
+    /// <summary>Upload was attempted but the broker rejected it / was unreachable.</summary>
+    UploadFailed,
+}
+
+/// <summary>
+/// Decides whether a freshly captured crash record should be auto-shared to the
+/// broker, and performs the upload. This runs AFTER the supervised backend has
+/// died, so it cannot consult a live IPC — the authoritative gate is the
+/// auto-share posture the host pre-authorised at launch
+/// (<see cref="SidecarOptions.AutoShareOnCrash"/>), which defaults to OFF.
+///
+/// Strict opt-in: with the flag off, <see cref="TryShareAsync"/> returns
+/// <see cref="CrashShareOutcome.SkippedNotOptedIn"/> WITHOUT touching the broker,
+/// so a crash never leaves the operator's machine unless they explicitly enabled
+/// auto-share. The record is already redacted server-side by the backend's
+/// diagnostics layer; the sidecar uploads it verbatim.
+/// </summary>
+public static class CrashAutoShare
+{
+    /// <summary>
+    /// Apply the auto-share gate and, if it passes, upload the crash record JSON.
+    /// <paramref name="broker"/> is null when no broker identity/URL is configured
+    /// (which yields <see cref="CrashShareOutcome.SkippedNoBroker"/> when opted in).
+    /// </summary>
+    /// <param name="autoShareEnabled">The launch-time auto-share pre-authorisation.</param>
+    /// <param name="crashRecordJson">The crash record JSON to upload, or null/blank if unwritten/unreadable.</param>
+    /// <param name="broker">Configured broker client, or null when remote sharing is unavailable.</param>
+    public static async Task<CrashShareOutcome> TryShareAsync(
+        bool autoShareEnabled,
+        string? crashRecordJson,
+        ISupportBrokerClient? broker,
+        CancellationToken ct)
+    {
+        // Gate FIRST — never read identity or touch the broker when opted out.
+        if (!autoShareEnabled) return CrashShareOutcome.SkippedNotOptedIn;
+        if (broker is null) return CrashShareOutcome.SkippedNoBroker;
+        if (string.IsNullOrWhiteSpace(crashRecordJson)) return CrashShareOutcome.SkippedNoRecord;
+
+        var ok = await broker.UploadCrashAsync(crashRecordJson, ct).ConfigureAwait(false);
+        return ok ? CrashShareOutcome.Uploaded : CrashShareOutcome.UploadFailed;
+    }
+}

--- a/Zeus.SupportAgent/HttpSupportBrokerClient.cs
+++ b/Zeus.SupportAgent/HttpSupportBrokerClient.cs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Net.Http;
+using System.Text;
+using Zeus.Support.Contracts;
+
+namespace Zeus.SupportAgent;
+
+/// <summary>
+/// Production <see cref="ISupportBrokerClient"/>: QRZ-authenticated POSTs to the
+/// broker's <c>/presence/*</c> and <c>/crash</c> routes. Mirrors the host side of
+/// signaling (<c>RemoteBrokerClient</c>): every request carries the
+/// <c>X-QRZ-Callsign</c> + <c>X-QRZ-Session</c> headers the broker verifies before
+/// trusting the callsign.
+///
+/// The QRZ session key is a short-lived secret. The host passes it to the sidecar
+/// out of band via the <see cref="QrzSessionEnvVar"/> environment variable (NOT a
+/// command-line argument, which would be visible in the process table), alongside
+/// the operator callsign. A blank session key disables remote calls (all methods
+/// return false) rather than sending an unauthenticated request.
+/// </summary>
+public sealed class HttpSupportBrokerClient : ISupportBrokerClient
+{
+    /// <summary>Env var the host uses to hand the QRZ session key to the sidecar (kept off the command line).</summary>
+    public const string QrzSessionEnvVar = SupportIpc.SidecarQrzSessionEnvVar;
+
+    private readonly HttpClient _http;
+    private readonly BrokerEndpoints _endpoints;
+    private readonly string _callsign;
+    private readonly string _sessionKey;
+
+    public HttpSupportBrokerClient(HttpClient http, BrokerEndpoints endpoints, string callsign, string sessionKey)
+    {
+        _http = http;
+        _endpoints = endpoints;
+        _callsign = callsign;
+        _sessionKey = sessionKey;
+    }
+
+    /// <summary>True only when we have the identity needed to make an authenticated call.</summary>
+    public bool IsConfigured =>
+        !string.IsNullOrWhiteSpace(_callsign) && !string.IsNullOrWhiteSpace(_sessionKey);
+
+    public Task<bool> RegisterAsync(CancellationToken ct) => PostAsync(_endpoints.PresenceRegister, null, ct);
+    public Task<bool> HeartbeatAsync(CancellationToken ct) => PostAsync(_endpoints.PresenceHeartbeat, null, ct);
+    public Task<bool> DropAsync(CancellationToken ct) => PostAsync(_endpoints.PresenceDrop, null, ct);
+
+    public Task<bool> UploadCrashAsync(string crashRecordJson, CancellationToken ct) =>
+        PostAsync(_endpoints.Crash, crashRecordJson, ct);
+
+    private async Task<bool> PostAsync(Uri uri, string? jsonBody, CancellationToken ct)
+    {
+        if (!IsConfigured) return false;
+        try
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Post, uri);
+            req.Headers.TryAddWithoutValidation("X-QRZ-Callsign", _callsign);
+            req.Headers.TryAddWithoutValidation("X-QRZ-Session", _sessionKey);
+            if (jsonBody is not null)
+                req.Content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
+
+            using var res = await _http.SendAsync(req, ct).ConfigureAwait(false);
+            return res.IsSuccessStatusCode;
+        }
+        catch
+        {
+            // Best-effort: a broker outage or transient network error must never
+            // throw out of the sidecar's presence/crash path.
+            return false;
+        }
+    }
+}

--- a/Zeus.SupportAgent/ISupportBrokerClient.cs
+++ b/Zeus.SupportAgent/ISupportBrokerClient.cs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.SupportAgent;
+
+/// <summary>
+/// The sidecar's outbound calls to the broker's operator-authenticated REST
+/// surface (<c>/presence/*</c>, <c>/crash</c>). Abstracted behind an interface so
+/// <see cref="PresenceClient"/> and the crash-upload path are unit-testable
+/// without a live broker — the production implementation is
+/// <see cref="HttpSupportBrokerClient"/>.
+///
+/// Every method is best-effort: it returns success/failure rather than throwing,
+/// so a transient broker outage never destabilises the sidecar (whose first duty
+/// is local crash capture).
+/// </summary>
+public interface ISupportBrokerClient
+{
+    /// <summary>Register this operator as support-available (first heartbeat of an online streak).</summary>
+    Task<bool> RegisterAsync(CancellationToken ct);
+
+    /// <summary>Refresh the operator's presence (keeps them inside the broker's expiry window).</summary>
+    Task<bool> HeartbeatAsync(CancellationToken ct);
+
+    /// <summary>Drop the operator's presence immediately (clean shutdown / availability off).</summary>
+    Task<bool> DropAsync(CancellationToken ct);
+
+    /// <summary>Upload a (server-redacted) crash record JSON to the broker's crash store.</summary>
+    Task<bool> UploadCrashAsync(string crashRecordJson, CancellationToken ct);
+}

--- a/Zeus.SupportAgent/PresenceClient.cs
+++ b/Zeus.SupportAgent/PresenceClient.cs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.SupportAgent;
+
+/// <summary>
+/// Drives the operator's broker presence: while the L1 "remote diagnostics
+/// available" switch is ON, it registers once and then heartbeats on a fixed
+/// cadence (well inside the broker's ~90s expiry) so a maintainer sees the
+/// operator as online. When availability goes OFF it drops the presence and goes
+/// quiet; it never registers while OFF.
+///
+/// Availability is a live flag (<see cref="SetAvailable"/>) flipped by the
+/// backend's <c>SupportStateChanged</c> IPC. The loop is a single long-running
+/// task; the delay between heartbeats is injectable so tests can step it
+/// deterministically without real time passing.
+/// </summary>
+public sealed class PresenceClient
+{
+    /// <summary>Default heartbeat cadence: ~30s, comfortably inside the broker's 90s expiry.</summary>
+    public static readonly TimeSpan DefaultHeartbeatInterval = TimeSpan.FromSeconds(30);
+
+    private readonly ISupportBrokerClient _broker;
+    private readonly TimeSpan _interval;
+    private readonly Func<TimeSpan, CancellationToken, Task> _delay;
+    private readonly Action<string>? _log;
+
+    private volatile bool _available;
+    private bool _registered;
+
+    public PresenceClient(
+        ISupportBrokerClient broker,
+        bool initiallyAvailable,
+        TimeSpan? interval = null,
+        Func<TimeSpan, CancellationToken, Task>? delay = null,
+        Action<string>? log = null)
+    {
+        _broker = broker;
+        _available = initiallyAvailable;
+        _interval = interval ?? DefaultHeartbeatInterval;
+        _delay = delay ?? Task.Delay;
+        _log = log;
+    }
+
+    /// <summary>Whether presence is currently being advertised (L1 switch on).</summary>
+    public bool IsAvailable => _available;
+
+    /// <summary>
+    /// Flip the live availability. Going ON makes the next loop iteration register
+    /// + heartbeat; going OFF makes the loop drop presence and idle. Safe to call
+    /// from the IPC reader thread while the loop runs.
+    /// </summary>
+    public void SetAvailable(bool available) => _available = available;
+
+    /// <summary>
+    /// Run the presence loop until cancelled. Each iteration: if available, ensure
+    /// we are registered then heartbeat; if not, drop any standing presence. The
+    /// loop owns the register/heartbeat/drop sequencing so callers only flip the
+    /// flag. Returns on cancellation, after a best-effort final drop.
+    /// </summary>
+    public async Task RunAsync(CancellationToken ct)
+    {
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                await TickAsync(ct).ConfigureAwait(false);
+                await _delay(_interval, ct).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal shutdown.
+        }
+
+        // Best-effort drop on the way out so the operator goes offline promptly
+        // rather than waiting out the broker's expiry window.
+        await DropQuietlyAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// One presence iteration, exposed for unit tests so cadence/stop-on-off can be
+    /// asserted without driving the full timed loop. Registers on the first
+    /// available tick, heartbeats thereafter, and drops once when availability
+    /// turns off.
+    /// </summary>
+    public async Task TickAsync(CancellationToken ct)
+    {
+        if (_available)
+        {
+            if (!_registered)
+            {
+                if (await _broker.RegisterAsync(ct).ConfigureAwait(false))
+                {
+                    _registered = true;
+                    _log?.Invoke("presence: registered (remote diagnostics available)");
+                }
+            }
+            else
+            {
+                await _broker.HeartbeatAsync(ct).ConfigureAwait(false);
+            }
+        }
+        else if (_registered)
+        {
+            // Availability went off — drop once and stop advertising.
+            await _broker.DropAsync(ct).ConfigureAwait(false);
+            _registered = false;
+            _log?.Invoke("presence: dropped (remote diagnostics unavailable)");
+        }
+    }
+
+    private async Task DropQuietlyAsync()
+    {
+        if (!_registered) return;
+        try
+        {
+            await _broker.DropAsync(CancellationToken.None).ConfigureAwait(false);
+            _registered = false;
+        }
+        catch
+        {
+            // Shutdown drop is best-effort; the broker expires us regardless.
+        }
+    }
+}

--- a/Zeus.SupportAgent/Program.cs
+++ b/Zeus.SupportAgent/Program.cs
@@ -8,20 +8,24 @@
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 
+using System.Net.Http;
 using System.Runtime.InteropServices;
 using Zeus.Support.Contracts;
 using Zeus.SupportAgent;
 
-// The Zeus support sidecar. Phase 1 scope is LOCAL ONLY: supervise the backend
-// PID, and on an unexpected death capture the tail of the on-disk logs into a
-// crash record. No broker / remote exposure yet — that arrives in later phases,
-// at which point this process (which survives the backend) will own the broker
-// connection.
+// The Zeus support sidecar. It supervises the backend PID and, on an unexpected
+// death, captures the tail of the on-disk logs into a crash record (the in-memory
+// log ring dies with the in-process backend). Because it OUTLIVES the backend it
+// also owns the broker connection for remote diagnostics:
 //
-// Lifecycle: wait for the supervised backend to exit, classify it via the
-// clean-exit marker the backend writes at a deliberate shutdown, capture a crash
-// record if it died unexpectedly, then exit. The sidecar must NEVER add its own
-// crash to the operator's machine, so every step is best-effort.
+//   * Presence (Phase 3c): while the operator's L1 "remote diagnostics available"
+//     switch is on, it registers + heartbeats to the broker so a maintainer sees
+//     them online. It learns the live switch state over IPC from the backend.
+//   * Crash auto-share (Phase 3c): if the operator pre-authorised auto-share, a
+//     captured crash record is uploaded to the broker AFTER the backend dies.
+//
+// Everything remote is strictly opt-in and best-effort: the sidecar must NEVER add
+// its own crash to the operator's machine, so every step is guarded.
 
 if (!SidecarOptions.TryParse(args, out var opts, out var error) || opts is null)
 {
@@ -29,18 +33,68 @@ if (!SidecarOptions.TryParse(args, out var opts, out var error) || opts is null)
     return 2;
 }
 
-Breadcrumb(opts, $"start: supervising pid={opts.SupervisePid} session={opts.SessionToken ?? "-"}");
+Breadcrumb(opts, $"start: supervising pid={opts.SupervisePid} session={opts.SessionToken ?? "-"} " +
+                 $"remoteDiag={opts.RemoteDiagnosticsEnabled} autoShare={opts.AutoShareOnCrash}");
 
 using var cts = new CancellationTokenSource();
 using var sigint = SafeSignal(PosixSignal.SIGINT, cts);
 using var sigterm = SafeSignal(PosixSignal.SIGTERM, cts);
 Console.CancelKeyPress += (_, e) => { e.Cancel = true; cts.Cancel(); };
 
+// --- Remote presence wiring -------------------------------------------------
+// Build the broker client from the launch identity (callsign + QRZ session env)
+// and the broker URL. Null when any piece is missing → remote stays inert and the
+// sidecar behaves exactly as the Phase-1 local-only crash capturer.
+var endpoints = BrokerEndpoints.FromBrokerUrl(opts.BrokerUrl);
+var qrzSession = Environment.GetEnvironmentVariable(HttpSupportBrokerClient.QrzSessionEnvVar) ?? "";
+using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(15) };
+
+HttpSupportBrokerClient? broker = null;
+if (endpoints is not null && !string.IsNullOrWhiteSpace(opts.OperatorCallsign) && !string.IsNullOrWhiteSpace(qrzSession))
+{
+    broker = new HttpSupportBrokerClient(http, endpoints, opts.OperatorCallsign!, qrzSession);
+}
+
+// Live posture, seeded from launch args and updated by the backend over IPC. The
+// crash path reads autoShare at the end, so keep the latest value here.
+var autoShareEnabled = opts.AutoShareOnCrash;
+
+PresenceClient? presence = null;
+Task presenceTask = Task.CompletedTask;
+Task ipcTask = Task.CompletedTask;
+
+if (broker is not null)
+{
+    // Presence is gated on remote diagnostics being on AND a callsign being set;
+    // the IPC listener flips availability live.
+    presence = new PresenceClient(
+        broker,
+        initiallyAvailable: opts.RemoteDiagnosticsEnabled,
+        log: msg => Breadcrumb(opts, msg));
+    presenceTask = presence.RunAsync(cts.Token);
+
+    var listener = new SupportIpcListener(
+        opts.SessionToken,
+        onState: state =>
+        {
+            autoShareEnabled = state.AutoShareOnCrash;
+            // Available only when the master switch is on AND a callsign is present.
+            var available = state.RemoteDiagnosticsEnabled && !string.IsNullOrWhiteSpace(state.QrzCallsign);
+            presence!.SetAvailable(available);
+            Breadcrumb(opts, $"ipc: state remoteDiag={state.RemoteDiagnosticsEnabled} " +
+                             $"autoShare={state.AutoShareOnCrash} callsign={(string.IsNullOrWhiteSpace(state.QrzCallsign) ? "-" : "set")}");
+        },
+        log: msg => Breadcrumb(opts, msg));
+    ipcTask = listener.RunAsync(cts.Token);
+}
+
+// --- Supervise the backend --------------------------------------------------
 var result = await ProcessSupervisor.WaitForExitAsync(opts.SupervisePid, cts.Token).ConfigureAwait(false);
 
 if (result.Cancelled)
 {
     Breadcrumb(opts, "stop: cancelled while supervising; backend still alive");
+    await ShutdownRemoteAsync(cts, presenceTask, ipcTask).ConfigureAwait(false);
     return 0;
 }
 
@@ -51,6 +105,7 @@ if (File.Exists(markerPath))
 {
     TryDelete(markerPath);
     Breadcrumb(opts, $"clean exit: pid={opts.SupervisePid} exitCode={Fmt(result.ExitCode)}");
+    await ShutdownRemoteAsync(cts, presenceTask, ipcTask).ConfigureAwait(false);
     return 0;
 }
 
@@ -62,9 +117,46 @@ Breadcrumb(opts,
     written is null
         ? $"crash detected: pid={opts.SupervisePid} exitCode={Fmt(result.ExitCode)} (record write FAILED)"
         : $"crash detected: pid={opts.SupervisePid} exitCode={Fmt(result.ExitCode)} -> {Path.GetFileName(written)}");
+
+// Crash auto-share: strictly gated on the operator's opt-in (default OFF). With
+// the flag off this never reads the record back or touches the broker.
+try
+{
+    string? recordJson = written is not null ? TryReadAllText(written) : null;
+    var outcome = await CrashAutoShare.TryShareAsync(autoShareEnabled, recordJson, broker, CancellationToken.None)
+        .ConfigureAwait(false);
+    Breadcrumb(opts, $"crash auto-share: {outcome}");
+}
+catch (Exception ex)
+{
+    Breadcrumb(opts, $"crash auto-share: error ({ex.GetType().Name})");
+}
+
+await ShutdownRemoteAsync(cts, presenceTask, ipcTask).ConfigureAwait(false);
 return 0;
 
 static string Fmt(int? code) => code?.ToString() ?? "<unknown>";
+
+// Cancel the presence/IPC loops and let them finish their best-effort drop. Bounded
+// so a stuck network call can't hang sidecar exit.
+static async Task ShutdownRemoteAsync(CancellationTokenSource cts, Task presenceTask, Task ipcTask)
+{
+    try { cts.Cancel(); } catch { /* already disposed */ }
+    try
+    {
+        await Task.WhenAny(Task.WhenAll(presenceTask, ipcTask), Task.Delay(TimeSpan.FromSeconds(5)))
+            .ConfigureAwait(false);
+    }
+    catch
+    {
+        // Shutdown is best-effort.
+    }
+}
+
+static string? TryReadAllText(string path)
+{
+    try { return File.ReadAllText(path); } catch { return null; }
+}
 
 // Register a POSIX signal handler without throwing on a platform/runtime that
 // doesn't support it (the sidecar still works; it just relies on Ctrl+C / exit).

--- a/Zeus.SupportAgent/SidecarOptions.cs
+++ b/Zeus.SupportAgent/SidecarOptions.cs
@@ -16,13 +16,44 @@ namespace Zeus.SupportAgent;
 /// arguments — the sidecar never re-derives <c>%LOCALAPPDATA%/Zeus</c> on its own
 /// (that keeps the ZEUS_PREFS_PATH override and profile rules in one place).
 /// </summary>
+/// <param name="SupervisePid">PID of the Zeus backend to supervise.</param>
+/// <param name="SessionToken">Per-session IPC token (pipe name disambiguator).</param>
+/// <param name="AppLogPath">Path to the runtime log the crash record tails.</param>
+/// <param name="StartupLogPath">Path to the startup log the crash record tails.</param>
+/// <param name="CrashDir">Directory for crash records, markers, and the breadcrumb log.</param>
+/// <param name="AppVersion">Zeus version string stamped into crash records.</param>
+/// <param name="BrokerUrl">
+/// Broker base URL for presence/crash POSTs. The host passes the SAME value
+/// <see cref="RemoteBrokerClient"/> uses (a <c>wss://…/signal</c> URL or the
+/// <c>ZEUS_REMOTE_BROKER_URL</c> override); the sidecar derives the https origin
+/// from it via <see cref="BrokerEndpoints"/>. Null disables all remote presence/
+/// crash sharing (the Phase-1 local-only behaviour).
+/// </param>
+/// <param name="OperatorCallsign">
+/// The operator's QRZ callsign, resolved by the backend at launch. Required for
+/// presence/crash (it is the broker's identity key). Null/blank ⇒ no remote
+/// sharing even if a broker URL is set.
+/// </param>
+/// <param name="RemoteDiagnosticsEnabled">
+/// Initial L1 master-switch posture at launch. The live value can change at
+/// runtime via a <c>SupportStateChanged</c> IPC; this is only the seed.
+/// </param>
+/// <param name="AutoShareOnCrash">
+/// Initial crash auto-share posture at launch (default OFF). Gates the post-crash
+/// upload, which runs AFTER the backend is dead and so cannot consult live IPC —
+/// the launch-time value is the authoritative pre-authorisation for that path.
+/// </param>
 public sealed record SidecarOptions(
     int SupervisePid,
     string? SessionToken,
     string? AppLogPath,
     string? StartupLogPath,
     string CrashDir,
-    string? AppVersion)
+    string? AppVersion,
+    string? BrokerUrl = null,
+    string? OperatorCallsign = null,
+    bool RemoteDiagnosticsEnabled = false,
+    bool AutoShareOnCrash = false)
 {
     /// <summary>
     /// Parse <c>--key value</c> arguments. Only <c>--supervise-pid</c> and
@@ -37,6 +68,8 @@ public sealed record SidecarOptions(
 
         int? pid = null;
         string? session = null, appLog = null, startupLog = null, crashDir = null, appVersion = null;
+        string? brokerUrl = null, operatorCallsign = null;
+        bool remoteDiagnostics = false, autoShare = false;
 
         for (int i = 0; i < args.Length; i++)
         {
@@ -63,6 +96,14 @@ public sealed record SidecarOptions(
                 case "--startup-log": startupLog = Next(); break;
                 case "--crash-dir": crashDir = Next(); break;
                 case "--app-version": appVersion = Next(); break;
+                case "--broker-url": brokerUrl = Next(); break;
+                case "--operator-callsign": operatorCallsign = Next(); break;
+                case "--remote-diagnostics":
+                    if (!TryParseBool(Next(), out remoteDiagnostics, out error, key)) return false;
+                    break;
+                case "--auto-share-crash":
+                    if (!TryParseBool(Next(), out autoShare, out error, key)) return false;
+                    break;
                 default:
                     error = $"Unknown argument '{key}'.";
                     return false;
@@ -80,7 +121,24 @@ public sealed record SidecarOptions(
             return false;
         }
 
-        options = new SidecarOptions(pid.Value, session, appLog, startupLog, crashDir, appVersion);
+        options = new SidecarOptions(
+            pid.Value, session, appLog, startupLog, crashDir, appVersion,
+            brokerUrl, operatorCallsign, remoteDiagnostics, autoShare);
         return true;
+    }
+
+    // Accept on/off/true/false/1/0 for the boolean opt-in flags.
+    private static bool TryParseBool(string? value, out bool result, out string? error, string key)
+    {
+        result = false;
+        error = null;
+        switch (value?.Trim().ToLowerInvariant())
+        {
+            case "on" or "true" or "1" or "yes": result = true; return true;
+            case "off" or "false" or "0" or "no" or null or "": result = false; return true;
+            default:
+                error = $"{key} expects on/off (got '{value}').";
+                return false;
+        }
     }
 }

--- a/Zeus.SupportAgent/SupportIpcListener.cs
+++ b/Zeus.SupportAgent/SupportIpcListener.cs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.IO.Pipes;
+using Zeus.Support.Contracts;
+
+namespace Zeus.SupportAgent;
+
+/// <summary>
+/// The sidecar's RECEIVE side of the support IPC channel. The sidecar owns the
+/// named-pipe SERVER (it outlives the backend, so it must be listening before the
+/// backend connects); the backend is the client that connects and pushes
+/// identity/opt-in updates.
+///
+/// This phase consumes exactly the two backend → sidecar messages the presence /
+/// crash subsystem needs: <see cref="SupportHello"/> (initial identity + posture)
+/// and <see cref="SupportStateChanged"/> (the operator flipped the L1 master
+/// switch or the crash auto-share sub-toggle, or signed in/out of QRZ). Each is
+/// surfaced to the caller via <see cref="OnState"/> so the presence loop and the
+/// crash-share gate stay in sync with the operator's live decision. Unrelated
+/// message kinds are ignored (forward-compatible).
+///
+/// Best-effort and resilient: a dropped pipe (backend restart) just loops back to
+/// waiting for the next connection; nothing here ever throws out to the sidecar's
+/// main flow.
+/// </summary>
+public sealed class SupportIpcListener
+{
+    /// <summary>A snapshot of the operator's live support posture, as learned over IPC.</summary>
+    /// <param name="QrzCallsign">Operator callsign, or null when signed out.</param>
+    /// <param name="RemoteDiagnosticsEnabled">L1 master switch.</param>
+    /// <param name="AutoShareOnCrash">Crash auto-share sub-toggle.</param>
+    public readonly record struct SupportState(
+        string? QrzCallsign,
+        bool RemoteDiagnosticsEnabled,
+        bool AutoShareOnCrash);
+
+    private readonly string _pipeName;
+    private readonly Action<SupportState> _onState;
+    private readonly Action<string>? _log;
+
+    /// <param name="sessionToken">The per-session token; same value the backend derives its connect target from.</param>
+    /// <param name="onState">Invoked whenever a hello/state message updates the operator's posture.</param>
+    /// <param name="log">Optional breadcrumb sink.</param>
+    public SupportIpcListener(string? sessionToken, Action<SupportState> onState, Action<string>? log = null)
+    {
+        _pipeName = SupportIpc.PipeNameForSession(sessionToken);
+        _onState = onState;
+        _log = log;
+    }
+
+    /// <summary>
+    /// Listen for backend connections until cancelled. Accepts one client at a
+    /// time (a single backend), reads framed messages, and forwards posture updates
+    /// to <see cref="_onState"/>. On any pipe error it loops back to accept the next
+    /// connection (e.g. after a backend restart).
+    /// </summary>
+    public async Task RunAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                using var server = new NamedPipeServerStream(
+                    _pipeName,
+                    PipeDirection.InOut,
+                    maxNumberOfServerInstances: 1,
+                    PipeTransmissionMode.Byte,
+                    PipeOptions.Asynchronous);
+
+                await server.WaitForConnectionAsync(ct).ConfigureAwait(false);
+                _log?.Invoke("ipc: backend connected");
+                await ReadLoopAsync(server, ct).ConfigureAwait(false);
+                _log?.Invoke("ipc: backend disconnected");
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                // A pipe in use / transient error: pause briefly and re-listen so a
+                // backend restart reconnects without spinning the CPU.
+                _log?.Invoke($"ipc: listener error ({ex.GetType().Name}); retrying");
+                try { await Task.Delay(TimeSpan.FromSeconds(1), ct).ConfigureAwait(false); }
+                catch (OperationCanceledException) { break; }
+            }
+        }
+    }
+
+    private async Task ReadLoopAsync(Stream stream, CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            SupportIpcMessage? message;
+            try
+            {
+                message = await SupportIpcFraming.ReadAsync(stream, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch
+            {
+                // Framing/desync error — drop this connection and re-listen.
+                return;
+            }
+
+            if (message is null) return; // clean EOF: backend closed the pipe
+
+            switch (message)
+            {
+                case SupportHello hello:
+                    _onState(new SupportState(
+                        hello.QrzCallsign, hello.RemoteDiagnosticsEnabled, hello.AutoShareOnCrash));
+                    break;
+                case SupportStateChanged state:
+                    _onState(new SupportState(
+                        state.QrzCallsign, state.RemoteDiagnosticsEnabled, state.AutoShareOnCrash));
+                    break;
+                // Heartbeats and other kinds are not needed by the presence/crash
+                // subsystem; ignore them so the contract can grow without breaking us.
+            }
+        }
+    }
+}

--- a/cloud/zeus-remote-broker/package.json
+++ b/cloud/zeus-remote-broker/package.json
@@ -8,7 +8,7 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
     "typecheck": "tsc --noEmit",
-    "test": "node --import tsx --test test/admin-auth.test.ts",
+    "test": "node --import tsx --test test/admin-auth.test.ts test/crash-validate.test.ts",
     "cf-typegen": "wrangler types"
   },
   "devDependencies": {

--- a/cloud/zeus-remote-broker/src/admin-api.ts
+++ b/cloud/zeus-remote-broker/src/admin-api.ts
@@ -37,7 +37,7 @@ import {
 } from './admin-db';
 
 /** Resolved identity of an authenticated caller. */
-interface AuthCtx {
+export interface AuthCtx {
   callsign: string;
   tokenId: string;
   label: string;
@@ -308,7 +308,15 @@ async function handleDisableAdmin(
  * Resolve a `Authorization: Bearer zsa_…` header to an admin identity, or null.
  * Rejects (as null) on: missing/malformed token, unknown/revoked token, expired
  * session token, or disabled admin. Bumps last_used_at on success.
+ *
+ * Exported as {@link verifyAdminToken} so sibling routes (e.g. /admin/crashes,
+ * which lives outside this module's path-dispatch) can gate on the SAME
+ * credential-based admin auth without re-implementing the token-hash/expiry/
+ * disabled-admin checks. Callers that do their own bootstrap-independent routing
+ * should call {@link ensureAdminBootstrap} once first.
  */
+export { authenticate as verifyAdminToken, ensureBootstrap as ensureAdminBootstrap };
+
 async function authenticate(request: Request, env: Env): Promise<AuthCtx | null> {
   const header = request.headers.get('Authorization') ?? '';
   const m = /^Bearer\s+(.+)$/i.exec(header.trim());

--- a/cloud/zeus-remote-broker/src/crash-store.ts
+++ b/cloud/zeus-remote-broker/src/crash-store.ts
@@ -1,0 +1,75 @@
+import { DurableObject } from 'cloudflare:workers';
+import type { Env } from './types';
+import { MAX_CRASH_PER_CALLSIGN, retainNewest } from './crash-validate';
+
+/**
+ * Single Durable Object holding the most recent auto-shared crash records, keyed
+ * by operator callsign.
+ *
+ * Data flow (Phase 3c "crash auto-share"):
+ *   1. An operator opts in to BOTH the L1 "remote diagnostics" master switch AND
+ *      the "auto-share crash reports" sub-toggle (default OFF).
+ *   2. When the Zeus backend dies WITHOUT a clean-exit marker, the out-of-process
+ *      sidecar (Zeus.SupportAgent) — which survives the crash — writes a
+ *      SupportCrashRecord to disk and, only if auto-share is on, POSTs it to the
+ *      broker's `/crash` endpoint (QRZ-authenticated as the operator's callsign).
+ *   3. index.ts verifies the QRZ headers, then forwards the body here under the
+ *      verified callsign. The record is ALREADY redacted server-side by the
+ *      backend's diagnostics layer; the broker stores it verbatim and adds nothing.
+ *   4. A maintainer lists/fetches a consented operator's crashes via the
+ *      admin-only `GET /admin/crashes?callsign=<cs>` route (Bearer admin auth).
+ *
+ * Storage policy: in-DO transactional SQLite-free map persisted via the DO storage
+ * API would be ideal, but to stay free-plan/SQLite-class friendly and simple we
+ * keep an in-memory ring per callsign capped at MAX_CRASH_PER_CALLSIGN. Crash
+ * records are a best-effort diagnostic convenience, not a system of record, so a
+ * DO eviction simply loses the oldest unsent history — acceptable for this use.
+ * Each upload is size-capped (MAX_CRASH_BYTES) at the edge before it reaches here.
+ */
+
+/** A stored crash entry: the raw record JSON plus broker-side receipt metadata. */
+interface StoredCrash {
+  /** Broker receive time (unix ms) — authoritative ordering, independent of the record's own clock. */
+  receivedAt: number;
+  /** The verbatim SupportCrashRecord JSON as uploaded (already redacted by the backend). */
+  record: unknown;
+}
+
+export class CrashStore extends DurableObject<Env> {
+  /** callsign -> newest-last list of crash entries (bounded to MAX_PER_CALLSIGN). */
+  private byCallsign = new Map<string, StoredCrash[]>();
+
+  override async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    const action = url.pathname.replace(/^\/+/, '');
+    const callsign = (url.searchParams.get('callsign') ?? '').trim().toUpperCase();
+    const now = Date.now();
+
+    switch (action) {
+      case 'put': {
+        if (!callsign) return new Response('callsign required', { status: 400 });
+        let record: unknown;
+        try {
+          record = await request.json();
+        } catch {
+          return new Response('invalid json', { status: 400 });
+        }
+        const list = this.byCallsign.get(callsign) ?? [];
+        list.push({ receivedAt: now, record });
+        // Bound the history — drop the oldest beyond the cap.
+        retainNewest(list);
+        this.byCallsign.set(callsign, list);
+        return Response.json({ ok: true, count: list.length });
+      }
+      case 'list': {
+        if (!callsign) return new Response('callsign required', { status: 400 });
+        const list = this.byCallsign.get(callsign) ?? [];
+        // Newest first for the maintainer view.
+        const crashes = [...list].reverse().map((e) => ({ receivedAt: e.receivedAt, record: e.record }));
+        return Response.json({ callsign, count: crashes.length, crashes });
+      }
+      default:
+        return new Response('not found', { status: 404 });
+    }
+  }
+}

--- a/cloud/zeus-remote-broker/src/crash-validate.ts
+++ b/cloud/zeus-remote-broker/src/crash-validate.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure (runtime-free) validation for an uploaded crash record body and the
+ * per-callsign retention policy. Kept out of index.ts / crash-store.ts — which
+ * pull in `cloudflare:workers` globals — so it is unit-testable under plain
+ * `node --test` exactly as the admin-auth crypto core is.
+ */
+
+/** Hard cap on a single uploaded crash record (~256 KiB). Shared by the edge check. */
+export const MAX_CRASH_BYTES = 256 * 1024;
+
+/** Max retained crash records per operator callsign (newest win). */
+export const MAX_CRASH_PER_CALLSIGN = 20;
+
+export type CrashBodyVerdict =
+  | { ok: true }
+  | { ok: false; status: 400 | 413; message: string };
+
+/**
+ * Validate the raw request body of a POST /crash: non-empty, within the size
+ * cap, and a JSON object (not array/primitive/null). Returns a tagged verdict so
+ * the caller can map directly to an HTTP status without re-deriving it.
+ */
+export function validateCrashBody(body: string): CrashBodyVerdict {
+  if (body.length === 0) return { ok: false, status: 400, message: 'empty body' };
+  if (body.length > MAX_CRASH_BYTES) return { ok: false, status: 413, message: 'payload too large' };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return { ok: false, status: 400, message: 'invalid json' };
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { ok: false, status: 400, message: 'expected a JSON object' };
+  }
+  return { ok: true };
+}
+
+/**
+ * Apply the bounded-history retention to a per-callsign list after appending a
+ * new entry: keep only the newest {@link MAX_CRASH_PER_CALLSIGN}. Mutates and
+ * returns the same array for convenience.
+ */
+export function retainNewest<T>(list: T[]): T[] {
+  while (list.length > MAX_CRASH_PER_CALLSIGN) list.shift();
+  return list;
+}

--- a/cloud/zeus-remote-broker/src/index.ts
+++ b/cloud/zeus-remote-broker/src/index.ts
@@ -1,11 +1,13 @@
 import type { Env } from './types';
 import { verifyQrzSessionCached } from './qrz';
 import { mintIceServers } from './turn';
-import { handleAdmin } from './admin-api';
+import { handleAdmin, verifyAdminToken, ensureAdminBootstrap } from './admin-api';
+import { validateCrashBody } from './crash-validate';
 
 export { SignalRoom } from './signal-room';
 export { RateLimiter } from './rate-limiter';
 export { PresenceRoom } from './presence';
+export { CrashStore } from './crash-store';
 
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
@@ -40,7 +42,55 @@ export default {
       if (request.method !== 'OPTIONS' && (await rateLimited(env, clientIp(request)))) {
         return new Response('rate limited', { status: 429, headers: corsHeaders(env) });
       }
+      // /admin/crashes lives in index.ts (it reaches the CrashStore DO, not the
+      // D1 admin store), but reuses the SAME credential-based admin auth as the
+      // rest of /admin via verifyAdminToken. Everything else falls through to the
+      // admin-api dispatcher.
+      if (url.pathname === '/admin/crashes') {
+        return handleAdminCrashes(request, env, ctx);
+      }
       return handleAdmin(request, env, ctx);
+    }
+
+    // Operator presence: the radio's sidecar registers/heartbeats/drops here so a
+    // maintainer can see it as "online" (read back via /admin/presence). Mirrors
+    // the host-signaling QRZ gate in /signal: the verified callsign is the only
+    // identity the broker trusts. Per-IP rate-limited like /turn and /signal.
+    if (url.pathname === '/presence/register'
+        || url.pathname === '/presence/heartbeat'
+        || url.pathname === '/presence/drop') {
+      if (request.method !== 'POST') return new Response('method not allowed', { status: 405 });
+      if (await rateLimited(env, clientIp(request))) return new Response('rate limited', { status: 429 });
+      const verified = await verifyOperator(request, env, ctx);
+      if (!verified) return new Response('qrz auth required', { status: 401 });
+      const presenceAction = url.pathname.slice('/presence/'.length); // register | heartbeat | drop
+      const id = env.PRESENCE.idFromName('global');
+      return env.PRESENCE.get(id).fetch(
+        `https://presence.internal/${presenceAction}?callsign=${encodeURIComponent(verified)}`,
+      );
+    }
+
+    // Crash auto-share upload: the sidecar POSTs a (already-redacted)
+    // SupportCrashRecord here after an unexpected backend death, ONLY when the
+    // operator pre-authorised auto-share. QRZ-gated as the operator; size-capped.
+    if (url.pathname === '/crash') {
+      if (request.method !== 'POST') return new Response('method not allowed', { status: 405 });
+      if (await rateLimited(env, clientIp(request))) return new Response('rate limited', { status: 429 });
+      const verified = await verifyOperator(request, env, ctx);
+      if (!verified) return new Response('qrz auth required', { status: 401 });
+
+      const body = await request.text();
+      const verdict = validateCrashBody(body);
+      if (!verdict.ok) return new Response(verdict.message, { status: verdict.status });
+
+      const id = env.CRASH_STORE.idFromName('global');
+      return env.CRASH_STORE.get(id).fetch(
+        new Request(`https://crash.internal/put?callsign=${encodeURIComponent(verified)}`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body,
+        }),
+      );
     }
 
     // Mint short-lived TURN credentials (clients call this before connecting).
@@ -97,6 +147,80 @@ export default {
 
 function clientIp(request: Request): string {
   return request.headers.get('cf-connecting-ip') ?? 'unknown';
+}
+
+/**
+ * QRZ-gate an operator-authenticated request (presence/crash), returning the
+ * verified upper-cased callsign or null. Identical model to the host side of
+ * /signal: when QRZ_VERIFY is on (default), the X-QRZ-Session must validate the
+ * X-QRZ-Callsign via the cached QRZ lookup; with QRZ_VERIFY off (local dev) the
+ * asserted callsign is trusted as-is. Fails closed on any missing field.
+ */
+async function verifyOperator(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+): Promise<string | null> {
+  const callsign = (request.headers.get('X-QRZ-Callsign') ?? '').trim().toUpperCase();
+  if (!callsign) return null;
+  const verify = (env.QRZ_VERIFY ?? 'on').toLowerCase() !== 'off';
+  if (!verify) return callsign;
+  const sessionKey = request.headers.get('X-QRZ-Session') ?? '';
+  if (!sessionKey) return null;
+  if (!(await verifyQrzSessionCached(sessionKey, callsign, ctx))) return null;
+  return callsign;
+}
+
+/**
+ * GET /admin/crashes?callsign=<cs> — maintainer view of a consented operator's
+ * auto-shared crash records. Admin-only: same Bearer-token credential auth as the
+ * rest of /admin (reused via verifyAdminToken), NOT the operator's QRZ identity.
+ * The operator opted in by enabling auto-share; the admin store proves the caller
+ * is authorised to read it.
+ */
+async function handleAdminCrashes(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+): Promise<Response> {
+  const cors = adminCorsHeaders(env);
+  if (request.method === 'OPTIONS') return new Response(null, { status: 204, headers: cors });
+  if (request.method !== 'GET') {
+    return Response.json({ error: 'method not allowed' }, { status: 405, headers: cors });
+  }
+
+  // Match handleAdmin's contract: bootstrap the admin store, then Bearer-gate.
+  await ensureAdminBootstrap(env);
+  const auth = await verifyAdminToken(request, env);
+  if (!auth) return Response.json({ error: 'unauthorized' }, { status: 401, headers: cors });
+
+  const callsign = (new URL(request.url).searchParams.get('callsign') ?? '').trim().toUpperCase();
+  if (!callsign) return Response.json({ error: 'callsign required' }, { status: 400, headers: cors });
+
+  void ctx; // reserved (audit logging could go here as the admin-api routes do)
+  const id = env.CRASH_STORE.idFromName('global');
+  const res = await env.CRASH_STORE.get(id).fetch(
+    `https://crash.internal/list?callsign=${encodeURIComponent(callsign)}`,
+  );
+  const body = await res.json<unknown>();
+  return Response.json(body, { status: res.status, headers: cors });
+}
+
+/**
+ * CORS for the dashboard's cross-origin /admin/crashes fetch. Mirrors
+ * admin-api's fail-closed policy: name exactly WEB_APP_ORIGIN, never '*', and
+ * omit the header entirely if it is unset so a misconfigured deploy can't expose
+ * the admin surface to every site.
+ */
+function adminCorsHeaders(env: Env): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Access-Control-Allow-Headers': 'content-type, authorization, x-qrz-session, x-qrz-callsign',
+    'Access-Control-Max-Age': '86400',
+    Vary: 'Origin',
+  };
+  if (env.WEB_APP_ORIGIN) headers['Access-Control-Allow-Origin'] = env.WEB_APP_ORIGIN;
+  return headers;
 }
 
 // CORS for the browser web client's cross-origin /turn fetch. Allow exactly the

--- a/cloud/zeus-remote-broker/src/types.ts
+++ b/cloud/zeus-remote-broker/src/types.ts
@@ -1,6 +1,7 @@
 import type { SignalRoom } from './signal-room';
 import type { RateLimiter } from './rate-limiter';
 import type { PresenceRoom } from './presence';
+import type { CrashStore } from './crash-store';
 
 /** Worker environment bindings (see wrangler.toml). */
 export interface Env {
@@ -22,6 +23,13 @@ export interface Env {
    * as support-available (heartbeats, ~90s expiry). Listed via /admin/presence.
    */
   PRESENCE: DurableObjectNamespace<PresenceRoom>;
+
+  /**
+   * Crash-share store DO: a single object holding the most-recent auto-shared
+   * crash records per operator callsign. Written by /crash (operator, QRZ-gated),
+   * read by /admin/crashes (maintainer, Bearer-gated). See crash-store.ts.
+   */
+  CRASH_STORE: DurableObjectNamespace<CrashStore>;
 
   /**
    * Bootstrap admin seeded on first /admin request when `admins` is empty

--- a/cloud/zeus-remote-broker/test/crash-validate.test.ts
+++ b/cloud/zeus-remote-broker/test/crash-validate.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Unit tests for the crash-share validation + retention core. These are the pure,
+ * runtime-free pieces of the POST /crash + CrashStore path, exercised under plain
+ * Node (no Workers/miniflare) exactly as deployed.
+ *
+ *   node --import tsx --test test/crash-validate.test.ts
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  validateCrashBody,
+  retainNewest,
+  MAX_CRASH_BYTES,
+  MAX_CRASH_PER_CALLSIGN,
+} from '../src/crash-validate.ts';
+
+test('accepts a well-formed JSON object body', () => {
+  const v = validateCrashBody(JSON.stringify({ schemaVersion: 1, pid: 4321, crashed: true }));
+  assert.equal(v.ok, true);
+});
+
+test('rejects an empty body', () => {
+  const v = validateCrashBody('');
+  assert.equal(v.ok, false);
+  if (!v.ok) assert.equal(v.status, 400);
+});
+
+test('rejects a body over the size cap with 413', () => {
+  // A JSON string whose serialised length exceeds the cap.
+  const big = JSON.stringify({ note: 'x'.repeat(MAX_CRASH_BYTES + 10) });
+  assert.ok(big.length > MAX_CRASH_BYTES);
+  const v = validateCrashBody(big);
+  assert.equal(v.ok, false);
+  if (!v.ok) assert.equal(v.status, 413);
+});
+
+test('rejects invalid JSON', () => {
+  const v = validateCrashBody('{ not json ');
+  assert.equal(v.ok, false);
+  if (!v.ok) assert.equal(v.status, 400);
+});
+
+test('rejects a JSON array (must be an object)', () => {
+  const v = validateCrashBody(JSON.stringify([1, 2, 3]));
+  assert.equal(v.ok, false);
+  if (!v.ok) assert.equal(v.status, 400);
+});
+
+test('rejects a bare JSON primitive / null', () => {
+  assert.equal(validateCrashBody('null').ok, false);
+  assert.equal(validateCrashBody('42').ok, false);
+  assert.equal(validateCrashBody('"a string"').ok, false);
+});
+
+test('retainNewest keeps only the newest N, dropping the oldest', () => {
+  const list: number[] = [];
+  for (let i = 0; i < MAX_CRASH_PER_CALLSIGN + 5; i++) {
+    list.push(i);
+    retainNewest(list);
+  }
+  assert.equal(list.length, MAX_CRASH_PER_CALLSIGN);
+  // The five oldest (0..4) were dropped; the list ends at the latest pushed value.
+  assert.equal(list[0], 5);
+  assert.equal(list[list.length - 1], MAX_CRASH_PER_CALLSIGN + 4);
+});
+
+test('retainNewest is a no-op below the cap', () => {
+  const list = [1, 2, 3];
+  retainNewest(list);
+  assert.deepEqual(list, [1, 2, 3]);
+});

--- a/cloud/zeus-remote-broker/wrangler.toml
+++ b/cloud/zeus-remote-broker/wrangler.toml
@@ -42,6 +42,12 @@ class_name = "RateLimiter"
 name = "PRESENCE"
 class_name = "PresenceRoom"
 
+# Crash auto-share store (single global object; last ~20 records per callsign).
+# Written by /crash (operator, QRZ-gated), read by /admin/crashes (admin Bearer).
+[[durable_objects.bindings]]
+name = "CRASH_STORE"
+class_name = "CrashStore"
+
 # Credential-based admin store, shared with the chat relay. Create it once and
 # copy the printed id into BOTH wrangler.toml files (broker + zeuschat-relay):
 #   wrangler d1 create zeus-admin
@@ -63,6 +69,10 @@ new_sqlite_classes = ["RateLimiter"]
 [[migrations]]
 tag = "v3"
 new_sqlite_classes = ["PresenceRoom"]
+
+[[migrations]]
+tag = "v4"
+new_sqlite_classes = ["CrashStore"]
 
 # TURN credentials are minted from Cloudflare Realtime. Provide the key out of
 # band so it stays out of source control:

--- a/tests/Zeus.Server.Tests/SupportAgentTests.cs
+++ b/tests/Zeus.Server.Tests/SupportAgentTests.cs
@@ -197,6 +197,265 @@ public class SupportPathsTests
     }
 }
 
+/// <summary>
+/// A scriptable <see cref="ISupportBrokerClient"/> for the presence/crash tests:
+/// records every call and lets each method's success be forced.
+/// </summary>
+internal sealed class FakeBrokerClient : ISupportBrokerClient
+{
+    public int Registers;
+    public int Heartbeats;
+    public int Drops;
+    public int Uploads;
+    public string? LastUploadedJson;
+
+    public bool RegisterResult = true;
+    public bool UploadResult = true;
+
+    public Task<bool> RegisterAsync(CancellationToken ct) { Registers++; return Task.FromResult(RegisterResult); }
+    public Task<bool> HeartbeatAsync(CancellationToken ct) { Heartbeats++; return Task.FromResult(true); }
+    public Task<bool> DropAsync(CancellationToken ct) { Drops++; return Task.FromResult(true); }
+    public Task<bool> UploadCrashAsync(string json, CancellationToken ct)
+    {
+        Uploads++;
+        LastUploadedJson = json;
+        return Task.FromResult(UploadResult);
+    }
+}
+
+public class SidecarOptionsRemoteFlagsTests
+{
+    [Fact]
+    public void Parse_RemoteFlags_PopulatesPresenceFields()
+    {
+        var ok = SidecarOptions.TryParse(
+            ["--supervise-pid", "10", "--crash-dir", "c",
+             "--broker-url", "wss://example.test/signal?role=host",
+             "--operator-callsign", "n9war", "--remote-diagnostics", "on",
+             "--auto-share-crash", "on"],
+            out var opts, out var err);
+
+        Assert.True(ok, err);
+        Assert.Equal("wss://example.test/signal?role=host", opts!.BrokerUrl);
+        Assert.Equal("n9war", opts.OperatorCallsign);
+        Assert.True(opts.RemoteDiagnosticsEnabled);
+        Assert.True(opts.AutoShareOnCrash);
+    }
+
+    [Fact]
+    public void Parse_RemoteFlags_DefaultOff()
+    {
+        Assert.True(SidecarOptions.TryParse(["--supervise-pid", "10", "--crash-dir", "c"], out var opts, out _));
+        Assert.False(opts!.RemoteDiagnosticsEnabled);
+        Assert.False(opts.AutoShareOnCrash);
+        Assert.Null(opts.BrokerUrl);
+        Assert.Null(opts.OperatorCallsign);
+    }
+
+    [Theory]
+    [InlineData("on", true)]
+    [InlineData("true", true)]
+    [InlineData("1", true)]
+    [InlineData("off", false)]
+    [InlineData("false", false)]
+    [InlineData("0", false)]
+    public void Parse_BoolFlag_AcceptsAliases(string value, bool expected)
+    {
+        Assert.True(SidecarOptions.TryParse(
+            ["--supervise-pid", "1", "--crash-dir", "c", "--auto-share-crash", value], out var opts, out _));
+        Assert.Equal(expected, opts!.AutoShareOnCrash);
+    }
+
+    [Fact]
+    public void Parse_BadBoolFlag_Fails()
+    {
+        Assert.False(SidecarOptions.TryParse(
+            ["--supervise-pid", "1", "--crash-dir", "c", "--remote-diagnostics", "maybe"], out _, out var err));
+        Assert.Contains("remote-diagnostics", err);
+    }
+}
+
+public class BrokerEndpointsTests
+{
+    [Fact]
+    public void FromBrokerUrl_DerivesHttpsOriginFromWss()
+    {
+        var ep = BrokerEndpoints.FromBrokerUrl("wss://remote.openhpsdrzeus.com/signal?role=host");
+        Assert.NotNull(ep);
+        Assert.Equal("https://remote.openhpsdrzeus.com/", ep!.Origin.ToString());
+        Assert.Equal("https://remote.openhpsdrzeus.com/presence/register", ep.PresenceRegister.ToString());
+        Assert.Equal("https://remote.openhpsdrzeus.com/presence/heartbeat", ep.PresenceHeartbeat.ToString());
+        Assert.Equal("https://remote.openhpsdrzeus.com/presence/drop", ep.PresenceDrop.ToString());
+        Assert.Equal("https://remote.openhpsdrzeus.com/crash", ep.Crash.ToString());
+    }
+
+    [Fact]
+    public void FromBrokerUrl_WsBecomesHttp_AndPreservesNonDefaultPort()
+    {
+        var ep = BrokerEndpoints.FromBrokerUrl("ws://127.0.0.1:8787/signal");
+        Assert.NotNull(ep);
+        Assert.Equal("http://127.0.0.1:8787/", ep!.Origin.ToString());
+        Assert.Equal("http://127.0.0.1:8787/crash", ep.Crash.ToString());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not a url")]
+    [InlineData("ftp://example.test")]
+    public void FromBrokerUrl_InvalidOrUnsupported_ReturnsNull(string? url)
+        => Assert.Null(BrokerEndpoints.FromBrokerUrl(url));
+}
+
+public class PresenceClientTests
+{
+    [Fact]
+    public async Task Tick_AvailableFromStart_RegistersThenHeartbeats()
+    {
+        var broker = new FakeBrokerClient();
+        var presence = new PresenceClient(broker, initiallyAvailable: true);
+
+        await presence.TickAsync(CancellationToken.None); // registers
+        await presence.TickAsync(CancellationToken.None); // heartbeats
+        await presence.TickAsync(CancellationToken.None); // heartbeats
+
+        Assert.Equal(1, broker.Registers);
+        Assert.Equal(2, broker.Heartbeats);
+        Assert.Equal(0, broker.Drops);
+    }
+
+    [Fact]
+    public async Task Tick_NotAvailable_NeverRegisters()
+    {
+        var broker = new FakeBrokerClient();
+        var presence = new PresenceClient(broker, initiallyAvailable: false);
+
+        await presence.TickAsync(CancellationToken.None);
+        await presence.TickAsync(CancellationToken.None);
+
+        Assert.Equal(0, broker.Registers);
+        Assert.Equal(0, broker.Heartbeats);
+        Assert.Equal(0, broker.Drops);
+    }
+
+    [Fact]
+    public async Task Tick_AvailabilityGoesOff_DropsOnceThenStaysQuiet()
+    {
+        var broker = new FakeBrokerClient();
+        var presence = new PresenceClient(broker, initiallyAvailable: true);
+
+        await presence.TickAsync(CancellationToken.None); // register
+        await presence.TickAsync(CancellationToken.None); // heartbeat
+        presence.SetAvailable(false);
+        await presence.TickAsync(CancellationToken.None); // drop
+        await presence.TickAsync(CancellationToken.None); // quiet
+        await presence.TickAsync(CancellationToken.None); // quiet
+
+        Assert.Equal(1, broker.Registers);
+        Assert.Equal(1, broker.Heartbeats);
+        Assert.Equal(1, broker.Drops);
+    }
+
+    [Fact]
+    public async Task Tick_RegisterFails_RetriesRegisterUntilItSucceeds()
+    {
+        var broker = new FakeBrokerClient { RegisterResult = false };
+        var presence = new PresenceClient(broker, initiallyAvailable: true);
+
+        await presence.TickAsync(CancellationToken.None); // register fails
+        await presence.TickAsync(CancellationToken.None); // retries register (still not heartbeat)
+        Assert.Equal(2, broker.Registers);
+        Assert.Equal(0, broker.Heartbeats);
+
+        broker.RegisterResult = true;
+        await presence.TickAsync(CancellationToken.None); // register succeeds
+        await presence.TickAsync(CancellationToken.None); // now heartbeats
+        Assert.Equal(3, broker.Registers);
+        Assert.Equal(1, broker.Heartbeats);
+    }
+
+    [Fact]
+    public async Task Run_DropsOnShutdownWhenRegistered()
+    {
+        var broker = new FakeBrokerClient();
+        // Immediate, non-blocking delay so the loop spins through ticks fast.
+        var presence = new PresenceClient(
+            broker, initiallyAvailable: true, interval: TimeSpan.Zero,
+            delay: (_, ct) => Task.Delay(1, ct));
+
+        using var cts = new CancellationTokenSource();
+        var run = presence.RunAsync(cts.Token);
+        // Let it register before cancelling.
+        await Task.Delay(50);
+        cts.Cancel();
+        await run;
+
+        Assert.True(broker.Registers >= 1);
+        Assert.True(broker.Drops >= 1, "expected a best-effort drop on shutdown");
+    }
+
+    [Fact]
+    public void DefaultInterval_IsWellInsideExpiry()
+    {
+        // 30s cadence vs the broker's 90s expiry — at least a 3x safety margin.
+        Assert.True(PresenceClient.DefaultHeartbeatInterval <= TimeSpan.FromSeconds(30));
+    }
+}
+
+public class CrashAutoShareTests
+{
+    [Fact]
+    public async Task FlagOff_NeverTouchesBroker()
+    {
+        var broker = new FakeBrokerClient();
+        var outcome = await CrashAutoShare.TryShareAsync(
+            autoShareEnabled: false, crashRecordJson: "{\"x\":1}", broker, CancellationToken.None);
+
+        Assert.Equal(CrashShareOutcome.SkippedNotOptedIn, outcome);
+        Assert.Equal(0, broker.Uploads);
+    }
+
+    [Fact]
+    public async Task FlagOn_NoBroker_SkipsNoBroker()
+    {
+        var outcome = await CrashAutoShare.TryShareAsync(
+            autoShareEnabled: true, crashRecordJson: "{\"x\":1}", broker: null, CancellationToken.None);
+        Assert.Equal(CrashShareOutcome.SkippedNoBroker, outcome);
+    }
+
+    [Fact]
+    public async Task FlagOn_NoRecord_SkipsNoRecord()
+    {
+        var broker = new FakeBrokerClient();
+        var outcome = await CrashAutoShare.TryShareAsync(
+            autoShareEnabled: true, crashRecordJson: "  ", broker, CancellationToken.None);
+        Assert.Equal(CrashShareOutcome.SkippedNoRecord, outcome);
+        Assert.Equal(0, broker.Uploads);
+    }
+
+    [Fact]
+    public async Task FlagOn_WithRecord_Uploads()
+    {
+        var broker = new FakeBrokerClient();
+        var outcome = await CrashAutoShare.TryShareAsync(
+            autoShareEnabled: true, crashRecordJson: "{\"pid\":1}", broker, CancellationToken.None);
+
+        Assert.Equal(CrashShareOutcome.Uploaded, outcome);
+        Assert.Equal(1, broker.Uploads);
+        Assert.Equal("{\"pid\":1}", broker.LastUploadedJson);
+    }
+
+    [Fact]
+    public async Task FlagOn_UploadRejected_ReportsFailure()
+    {
+        var broker = new FakeBrokerClient { UploadResult = false };
+        var outcome = await CrashAutoShare.TryShareAsync(
+            autoShareEnabled: true, crashRecordJson: "{\"pid\":1}", broker, CancellationToken.None);
+        Assert.Equal(CrashShareOutcome.UploadFailed, outcome);
+    }
+}
+
 public class ProcessSupervisorTests
 {
     // A short-lived child that sleeps briefly then exits with a known code, so the


### PR DESCRIPTION
## Phase 3c — sidecar presence + crash auto-share

Lets an **opted-in** operator show as **online** to maintainers, and (optionally) **auto-share crash records** after a Zeus backend crash. The support sidecar (`Zeus.SupportAgent`) survives a backend crash, so it owns the broker presence/crash transport.

This is the **RECEIVE side** in the sidecar + the presence/crash transport. The operator-facing L1 master switch (backend `SupportAvailabilityStore`, `/api/support/availability`, zeus-web UI) is the **P5 lane** and is intentionally untouched here — this branch consumes the existing `SupportStateChanged` IPC contract that P5 sends.

### Broker (`cloud/zeus-remote-broker`)
- **Presence:** public, operator-authenticated `POST /presence/{register,heartbeat,drop}`. QRZ-verifies `X-QRZ-Session` + `X-QRZ-Callsign` (same model as the host side of `/signal`), then drives the existing `PresenceRoom` DO (`idFromName('global')`) under the verified callsign. Per-IP rate-limited like `/turn` and `/signal`. `/admin/presence` (list, admin-only) unchanged.
- **Crash share:** new `CrashStore` DO + `POST /crash` (operator QRZ-gated, ~256 KiB cap, JSON-object only, last 20 per callsign) and admin-only `GET /admin/crashes?callsign=<cs>` (reuses admin Bearer auth via the newly-exported `verifyAdminToken`). Records are **already redacted server-side**; the broker stores them verbatim.
- Validation + retention factored into a runtime-free module (`crash-validate.ts`) so it is unit-testable under `node --test`.

### Sidecar (`Zeus.SupportAgent`)
- `PresenceClient` — registers + heartbeats on a ~30s cadence (well inside the 90s expiry) while available; drops on shutdown / availability-off; never registers while off.
- `SupportIpcListener` — named-pipe **server** that receives `SupportHello` / `SupportStateChanged` to learn the live L1 switch + auto-share posture.
- `CrashAutoShare` — gates the post-crash upload **strictly** on the opt-in flag (default OFF); never uploads without explicit operator authorisation.
- `BrokerEndpoints` — derives the `https` origin from the same `wss` broker URL / `ZEUS_REMOTE_BROKER_URL` override `RemoteBrokerClient` uses.

### Backend wiring (minimal)
- `SupportSidecarLauncher` resolves the operator's QRZ identity via `QrzService.GetChatIdentityAsync`, passes the broker URL + callsign as launch args and the QRZ session via an env var (`ZEUS_SUPPORT_QRZ_SESSION`, kept off the process table). **Availability + auto-share start OFF** and are turned on at runtime over the `SupportStateChanged` IPC.

### ⚠️ Maintainer action required — redeploy `zeus-remote-broker`
This adds a new Durable Object and migration:
- **New binding** `CRASH_STORE` (class `CrashStore`) in `wrangler.toml`.
- **New migration** `tag = "v4"` → `new_sqlite_classes = ["CrashStore"]`.
- No new secrets/D1 tables. `npx wrangler deploy` applies the DO migration. (Presence reuses the existing `PRESENCE` DO.)

### Verification
- Backend: `OpenhpsdrZeus` builds clean (0 warnings).
- Filtered Support tests: **133 passed / 0 failed** (`--filter` Support/Presence/BrokerEndpoints/CrashAutoShare/Sidecar/ProcessSupervisor/CrashCapture).
- Broker: `npm run typecheck` clean, `npm test` 15/15 pass.

### Notes / conflict risk with P5
- `ZeusHost.cs` is **not** touched. The only backend edits are `SupportSidecarLauncher.cs` and the one-line call site in `OpenhpsdrZeus/Program.cs`.
- A new shared constant `SupportIpc.SidecarQrzSessionEnvVar` was added in `Zeus.Support.Contracts/SupportIpc.cs` (additive). If P5 also extends `SupportIpc`, that file is the only shared touch-point.
- This branch relies on P5 sending `SupportStateChanged` with the current availability + auto-share fields (already present in the contract). No changes were made to the `SupportStateChanged` shape.