### PR TITLE
fix(hamclock): allow in-app downloads + don't run on untested-newer system Node [DRAFT]

### DIFF
--- a/Zeus.Server.Hosting/HamClockService.cs
+++ b/Zeus.Server.Hosting/HamClockService.cs
@@ -443,16 +443,27 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
         }
     }
 
-    /// <summary>True if a "vX.Y.Z" Node version string is at least
-    /// <see cref="MinNodeVersion"/>. Tolerant of a missing 'v' prefix and any
-    /// prerelease/build suffix; an unparseable string fails closed (false).</summary>
+    // Highest system-Node MAJOR we trust to run HamClock's deps. HamClock is
+    // pinned/tested on v22 LTS; v24 is the next LTS. A newer, odd/non-LTS major
+    // (e.g. v25) regularly breaks native deps (@electron/rebuild, ERR_REQUIRE_ESM
+    // edge cases), so we fall back to the known-good bundled copy instead of using
+    // it. Without an upper bound the resolver previously accepted ANY Node >=
+    // 22.12, so a box with v25 on PATH would run HamClock on an untested runtime.
+    private const int MaxSystemNodeMajor = 24;
+
+    /// <summary>True if a "vX.Y.Z" Node version string is within the tested range
+    /// [<see cref="MinNodeVersion"/>, major &lt;= <see cref="MaxSystemNodeMajor"/>].
+    /// Tolerant of a missing 'v' prefix and any prerelease/build suffix; an
+    /// unparseable string fails closed (false) so we fall back to the bundled Node.</summary>
     internal static bool NodeMeetsMinimum(string? version)
     {
         if (string.IsNullOrWhiteSpace(version)) return false;
         var v = version.Trim().TrimStart('v', 'V');
         var cut = v.IndexOfAny(['-', '+']);
         if (cut >= 0) v = v[..cut];
-        return Version.TryParse(v, out var parsed) && parsed >= MinNodeVersion;
+        return Version.TryParse(v, out var parsed)
+            && parsed >= MinNodeVersion
+            && parsed.Major <= MaxSystemNodeMajor;
     }
 
     /// <summary>Cached Node availability for Snapshot — probes once, then reuses
@@ -498,7 +509,7 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
             return true;
         }
         if (ok)
-            Append($"System Node {ver} is older than the required {MinNodeVersion} — using a private copy for HamClock.");
+            Append($"System Node {ver} is outside the tested range ({MinNodeVersion}..v{MaxSystemNodeMajor}.x) — using a private copy for HamClock.");
 
         // (2) A private Node from a previous install.
         var portable = FindPortableNodeBinDir();

--- a/tests/Zeus.Server.Tests/HamClockServiceTests.cs
+++ b/tests/Zeus.Server.Tests/HamClockServiceTests.cs
@@ -170,6 +170,8 @@ public sealed class HamClockServiceTests
     [InlineData("v22.12.0-nightly", true)] // suffix stripped before compare
     [InlineData("v22.11.0", false)]  // the version that throws ERR_REQUIRE_ESM
     [InlineData("v20.18.0", false)]
+    [InlineData("v25.9.0", false)]   // too new (odd/non-LTS) — fall back to the bundled v22
+    [InlineData("v26.0.0", false)]   // future major — untested, use the bundled copy
     [InlineData("", false)]
     [InlineData(null, false)]
     [InlineData("not-a-version", false)]

--- a/zeus-web/src/layout/panels/HamClockPanel.tsx
+++ b/zeus-web/src/layout/panels/HamClockPanel.tsx
@@ -160,8 +160,11 @@ export function HamClockPanel() {
         src={url}
         style={{ flex: 1, width: '100%', height: '100%', border: 'none', display: 'block', minHeight: 0 }}
         // HamClock is a trusted local sidecar; allow scripts + same-origin so
-        // its app (storage, its own /api fetches) works.
-        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
+        // its app (storage, its own /api fetches) works. allow-downloads is
+        // REQUIRED for any in-app download (e.g. the rig-bridge component, map
+        // data) — without it a sandboxed iframe silently blocks every download,
+        // which reads to the operator as "clicking download does nothing".
+        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals allow-downloads"
       />
     );
   }


### PR DESCRIPTION
DRAFT — bench-verify the download actually saves in the Photino webview before merging.

Came out of a team investigation into "I can't access OpenHamClock features that require download (e.g. rig bridge) — clicking download does nothing."

## Root cause (high confidence)
The HamClock iframe sandbox was:
```
sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
```
Per the HTML sandbox spec, a sandboxed iframe **blocks all downloads unless `allow-downloads` is present**. So every download triggered *inside* OpenHamClock (the separate **rig-bridge** component, map data, etc.) silently no-ops — exactly "clicking download does nothing." Fix: add `allow-downloads`.

## Secondary (real latent bug, robustness)
`NodeMeetsMinimum` accepted **any** system Node `>= 22.12` with no upper bound. This box has **Node v25.9.0** on PATH, which would be used for a v22-LTS-pinned app on an untested runtime (odd/non-LTS majors routinely break `@electron/rebuild` / ESM edge cases). Cap accepted system Node at major `<= 24`; newer → fall back to the known-good **bundled v22**. Tests added (`v25.9.0`/`v26.0.0` → bundled).

## Honest caveats
- `allow-downloads` is **necessary** but may not be **sufficient**: the Photino macOS WebKit / WebView2 webview also has to handle the download (save dialog). **Bench-verify**: open OpenHamClock, trigger a download (e.g. rig-bridge), confirm a file actually saves. If the webview still swallows it, a Photino download-delegate change is the follow-up.
- The Node cap is a latent fix, not proven to be the user's issue (HamClock built fine here on v25) — included as hardening.

## Gates
`dotnet build Zeus.slnx` clean · HamClock tests pass (24) · `npm run typecheck` + `build` clean.

## Bigger picture (no code here — see the discussion in the issue/report)
The FT8↔companion-app integration goal does **not** need a rig bridge (that only buys inbound map-click-to-tune). The path is **WSJT-X UDP**, which already exists in the FT8 logging branch (send-only, default-OFF). GridTracker **cannot** be embedded like OpenHamClock (it's an Electron desktop app, BSD-3) — point an externally-installed GridTracker at Zeus's UDP (127.0.0.1:2237 / multicast 224.0.0.73).