### PR TITLE
DO NOT MERGE: FT8/WSPR decode-stall fix — self-healing watchdog + cut reconfigure churn

### DIFF
--- a/Zeus.Dsp.Ft8/Ft8Decoder.cs
+++ b/Zeus.Dsp.Ft8/Ft8Decoder.cs
@@ -32,10 +32,24 @@ public readonly record struct Ft8DecodeResult(
     string Text);
 
 /// <summary>
+/// Per-RX FT8/FT4 decode seam. Lets the RX service inject a fake decoder in
+/// tests (the live pipeline always uses <see cref="Ft8Decoder"/>).
+/// </summary>
+public interface IFt8Decoder : IDisposable
+{
+    /// <summary>Decode one UTC-aligned slot of 12 kHz mono audio.</summary>
+    IReadOnlyList<Ft8DecodeResult> Decode(
+        float[] samples, Ft8Protocol protocol = Ft8Protocol.Ft8, int passes = 1, int maxResults = 64);
+
+    /// <summary>Clear accumulated decoder state (e.g. callsign hash table).</summary>
+    void Reset();
+}
+
+/// <summary>
 /// Per-RX FT8/FT4 decoder. Wraps a native zeus_ft8 context. Decode one
 /// UTC-aligned slot of 12 kHz mono audio at a time. Dispose to free the context.
 /// </summary>
-public sealed class Ft8Decoder : IDisposable
+public sealed class Ft8Decoder : IFt8Decoder, IDisposable
 {
     private IntPtr _ctx;
     private readonly object _gate = new();

--- a/Zeus.Server.Hosting/Ft8Service.cs
+++ b/Zeus.Server.Hosting/Ft8Service.cs
@@ -16,12 +16,24 @@
 // accumulator + native decoder, so simultaneous multi-band decode is a matter
 // of enabling more than one RX (gated today on the pipeline only tapping RX0).
 //
+// SELF-HEALING (regression #1080 / pop-out era): the RxAudioAvailable tap is a
+// process-lifetime subscription that no reconfigure (SetVfo/SetMode/SetFilter/
+// band-change) ever drops — but the single decode worker + native decoder behind
+// it CAN wedge or die (a hung native decode, or the increased re-enable/
+// reconfigure churn the pop-out introduced). When that happened decode silently
+// stopped while IsEnabled stayed true and only a manual disable->enable revived
+// it. A lightweight watchdog now does that revive automatically: if audio is
+// still arriving but the worker has made no progress for ~2.5 slot periods, the
+// session + worker are rebuilt in place. No operator action, no TX, no DSP
+// changes — exactly what disable->enable did, on a timer.
+//
 // This is the RX half. TX (encode + scheduling + keying) and the SignalR/UI
 // surface come later; for now decodes are logged and raised via DecodesReady.
 
 using System.Threading.Channels;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Zeus.Dsp.Ft8;
 
 namespace Zeus.Server;
@@ -35,14 +47,47 @@ public sealed record Ft8DecodeBatch(
 
 public sealed class Ft8Service : IHostedService, IDisposable
 {
-    private readonly DspPipelineService _pipeline;
+    private readonly DspPipelineService? _pipeline;
     private readonly ILogger<Ft8Service> _log;
+    private readonly Func<IFt8Decoder> _decoderFactory;
+    private readonly Func<DateTime> _utcNow;
+    private readonly Func<bool> _nativeAvailable;
 
     private readonly object _gate = new();
     private RxSession? _session;                 // single active session (RX0) for now
     private Channel<PendingSlot>? _decodeQueue;
     private Task? _decodeWorker;
     private CancellationTokenSource? _workerCts;
+    private double _slotSeconds = 15.0;
+
+    // Watchdog progress tracking (UTC ticks, 0 = none yet). The audio thread and
+    // the decode worker write these; the watchdog timer reads them.
+    private long _lastAudioTicks;
+    private long _lastWorkerProgressTicks;
+    private Timer? _watchdog;
+
+    // Field-observability + leak-bounding for the watchdog. The watchdog RECOVERS
+    // a stall; it does not yet PREVENT one (the originating mechanism — a hung
+    // native decode vs a faulted worker — is still unproven on the bench). These
+    // make every recovery visible in the log so the true cause can be captured on
+    // the wire, and cap the damage if rebuilds stop holding.
+    private int _rebuildCount;          // total watchdog rebuilds this session (diagnostic)
+    private int _leakedWorkers;         // detached old workers that didn't exit in 2 s
+    private readonly Queue<DateTime> _recentRebuilds = new(); // rebuild times in RebuildWindow
+    private bool _degraded;             // gave up rebuilding to stop leaking; needs re-enable
+
+    /// <summary>Audio is "actively arriving" if a block fed within this window.</summary>
+    private static readonly TimeSpan AudioFreshWindow = TimeSpan.FromSeconds(5);
+    /// <summary>How often the watchdog checks for a wedged worker.</summary>
+    private static readonly TimeSpan WatchdogInterval = TimeSpan.FromSeconds(5);
+    /// <summary>Sliding window over which repeated rebuilds are counted.</summary>
+    private static readonly TimeSpan RebuildWindow = TimeSpan.FromMinutes(10);
+    /// <summary>
+    /// Max rebuilds in <see cref="RebuildWindow"/> before the watchdog gives up.
+    /// A truly-hung native decode leaks one worker thread + native context per
+    /// rebuild (the old worker can't be joined), so we must NOT rebuild forever.
+    /// </summary>
+    private const int MaxRebuildsPerWindow = 5;
 
     /// <summary>How many decode passes to run (1 = NORMAL, &gt;1 = DEEP/MULTI).</summary>
     public int DecodePasses { get; set; } = 3;
@@ -54,23 +99,39 @@ public sealed class Ft8Service : IHostedService, IDisposable
     {
         _pipeline = pipeline;
         _log = loggerFactory.CreateLogger<Ft8Service>();
+        _decoderFactory = static () => new Ft8Decoder();
+        _utcNow = static () => DateTime.UtcNow;
+        _nativeAvailable = static () => Ft8Decoder.IsAvailable;
+    }
+
+    /// <summary>Test seam: inject a fake decoder + clock; no live audio tap.</summary>
+    internal Ft8Service(
+        Func<IFt8Decoder> decoderFactory,
+        Func<DateTime> utcNow,
+        ILogger<Ft8Service>? log = null)
+    {
+        _pipeline = null;
+        _decoderFactory = decoderFactory;
+        _utcNow = utcNow;
+        _nativeAvailable = static () => true;
+        _log = log ?? NullLogger<Ft8Service>.Instance;
     }
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        _pipeline.RxAudioAvailable += OnRxAudio;
+        if (_pipeline is not null) _pipeline.RxAudioAvailable += OnRxAudio;
         return Task.CompletedTask;
     }
 
     public Task StopAsync(CancellationToken cancellationToken)
     {
-        _pipeline.RxAudioAvailable -= OnRxAudio;
+        if (_pipeline is not null) _pipeline.RxAudioAvailable -= OnRxAudio;
         Disable();
         return Task.CompletedTask;
     }
 
     /// <summary>True if the native decoder is present on this platform.</summary>
-    public bool NativeAvailable => Ft8Decoder.IsAvailable;
+    public bool NativeAvailable => _nativeAvailable();
 
     /// <summary>True while a receiver is actively decoding.</summary>
     public bool IsEnabled { get { lock (_gate) return _session is not null; } }
@@ -82,12 +143,25 @@ public sealed class Ft8Service : IHostedService, IDisposable
     public Ft8Protocol ActiveProtocol { get { lock (_gate) return _session?.Protocol ?? Ft8Protocol.Ft8; } }
 
     /// <summary>
-    /// Enter FT8/FT4 decode on a receiver. Idempotent; re-enabling resets the
-    /// in-progress slot. Returns false if the native decoder is unavailable.
+    /// True if the watchdog rebuilt repeatedly without the stall clearing and has
+    /// stopped rebuilding to avoid leaking worker threads / native contexts. Decode
+    /// stays dead until the operator disables and re-enables. Surfaced so a
+    /// persistent native fault is visible rather than silently leaking forever.
+    /// </summary>
+    public bool IsDegraded { get { lock (_gate) return _degraded; } }
+
+    /// <summary>Total watchdog rebuilds this session (diagnostic / test).</summary>
+    internal int RebuildCount => Volatile.Read(ref _rebuildCount);
+
+    /// <summary>
+    /// Enter FT8/FT4 decode on a receiver. Idempotent: re-enabling on the same
+    /// receiver+protocol only updates the pass count (it does NOT tear down the
+    /// in-flight session/decoder — that churn is what the pop-out era exposed).
+    /// Returns false if the native decoder is unavailable.
     /// </summary>
     public bool Enable(int receiver = 0, Ft8Protocol protocol = Ft8Protocol.Ft8)
     {
-        if (!Ft8Decoder.IsAvailable)
+        if (!_nativeAvailable())
         {
             _log.LogWarning("FT8 decode requested but zeus_ft8 native library is unavailable.");
             return false;
@@ -95,17 +169,23 @@ public sealed class Ft8Service : IHostedService, IDisposable
 
         lock (_gate)
         {
-            _session?.Dispose();
-            double slotSeconds = protocol == Ft8Protocol.Ft4 ? 7.5 : 15.0;
-            _session = new RxSession(receiver, protocol, slotSeconds);
+            // Same receiver+protocol already running: a no-op session-wise. The
+            // caller (setPasses / settings hydration) just wants the new pass
+            // count, which OnRxAudio reads live for the next slot.
+            if (_session is { } cur && cur.Receiver == receiver && cur.Protocol == protocol)
+                return true;
 
-            if (_decodeWorker is null)
-            {
-                _workerCts = new CancellationTokenSource();
-                _decodeQueue = Channel.CreateBounded<PendingSlot>(
-                    new BoundedChannelOptions(4) { FullMode = BoundedChannelFullMode.DropOldest });
-                _decodeWorker = Task.Run(() => DecodeLoopAsync(_workerCts.Token));
-            }
+            _session?.Dispose();
+            _slotSeconds = protocol == Ft8Protocol.Ft4 ? 7.5 : 15.0;
+            _session = new RxSession(receiver, protocol, _slotSeconds, _decoderFactory());
+
+            // Explicit operator (re-)enable clears any degraded state and the
+            // rebuild history — this IS the manual recovery the watchdog mimics.
+            _degraded = false;
+            _recentRebuilds.Clear();
+
+            EnsureWorkerStarted();
+            StartWatchdog();
         }
         _log.LogInformation("FT8 decode enabled on RX{Rx} ({Proto}).", receiver, protocol);
         return true;
@@ -124,6 +204,8 @@ public sealed class Ft8Service : IHostedService, IDisposable
             cts = _workerCts; _workerCts = null;
             _decodeQueue?.Writer.TryComplete();
             _decodeQueue = null;
+            _watchdog?.Dispose();
+            _watchdog = null;
         }
         cts?.Cancel();
         try { worker?.Wait(TimeSpan.FromSeconds(2)); } catch { /* shutting down */ }
@@ -131,27 +213,65 @@ public sealed class Ft8Service : IHostedService, IDisposable
         cts?.Dispose();
     }
 
+    // --- worker / watchdog plumbing (callers hold _gate) ---
+
+    private void EnsureWorkerStarted()
+    {
+        if (_decodeWorker is not null) return;
+        _workerCts = new CancellationTokenSource();
+        _decodeQueue = Channel.CreateBounded<PendingSlot>(
+            new BoundedChannelOptions(4) { FullMode = BoundedChannelFullMode.DropOldest });
+        long now = _utcNow().Ticks;
+        Interlocked.Exchange(ref _lastWorkerProgressTicks, now);
+        Interlocked.Exchange(ref _lastAudioTicks, 0);
+        var ct = _workerCts.Token;
+        _decodeWorker = Task.Run(() => DecodeLoopAsync(ct));
+    }
+
+    private void StartWatchdog()
+    {
+        if (_pipeline is null || _watchdog is not null) return; // tests drive RunWatchdogOnce
+        _watchdog = new Timer(_ => { try { RunWatchdogOnce(_utcNow()); } catch { } },
+            null, WatchdogInterval, WatchdogInterval);
+    }
+
     // Audio thread — must stay cheap: resample + append, hand decode to the worker.
     private void OnRxAudio(int receiver, int sampleRate, ReadOnlyMemory<float> block)
+        => FeedAudio(receiver, sampleRate, block.Span);
+
+    internal void FeedAudio(int receiver, int sampleRate, ReadOnlySpan<float> block)
     {
         RxSession? s;
         Channel<PendingSlot>? queue;
-        lock (_gate) { s = _session; queue = _decodeQueue; }
+        int passes;
+        lock (_gate) { s = _session; queue = _decodeQueue; passes = DecodePasses; }
         if (s is null || queue is null || receiver != s.Receiver) return;
 
         if (sampleRate != Ft8Resampler.InputRate)
         {
             // The decimator is fixed 48k->12k; an unexpected rate would alias.
             // Skip rather than feed the decoder wrong-rate audio.
+            // NOTE: this is a watchdog blind spot — _lastAudioTicks is only
+            // stamped post-gate, so if a reconfigure ever changed the RX audio
+            // rate the watchdog would see "audio not fresh" and NOT rebuild. That
+            // is intentional: rebuilding a session cannot heal a rate mismatch.
+            // AudioOutputRateHz is fixed at 48 kHz today, so this is latent; if it
+            // ever becomes configurable, surface the rate mismatch here instead.
             return;
         }
 
-        float[] decimated = s.Resampler.Process(block.Span);
+        float[] decimated = s.Resampler.Process(block);
         if (decimated.Length == 0) return;
 
-        Ft8Slot? completed = s.Accumulator.Add(decimated, DateTime.UtcNow);
+        // Audio is reaching the decode pipeline — note it for the watchdog. The
+        // watchdog only recovers session-internal stalls (worker wedged while
+        // audio still flows); a true tap-loss (OnRxAudio stops firing) leaves
+        // audio stale and is deliberately out of its scope.
+        Interlocked.Exchange(ref _lastAudioTicks, _utcNow().Ticks);
+
+        Ft8Slot? completed = s.Accumulator.Add(decimated, _utcNow());
         if (completed is { } slot)
-            queue.Writer.TryWrite(new PendingSlot(s.Receiver, s.Protocol, s.Decoder, slot, DecodePasses));
+            queue.Writer.TryWrite(new PendingSlot(s.Receiver, s.Protocol, s.Decoder, slot, passes));
     }
 
     private async Task DecodeLoopAsync(CancellationToken ct)
@@ -164,9 +284,28 @@ public sealed class Ft8Service : IHostedService, IDisposable
         {
             await foreach (var pending in queue.Reader.ReadAllAsync(ct).ConfigureAwait(false))
             {
+                // Worker dequeued a slot — proof of life (entering the decode).
+                Interlocked.Exchange(ref _lastWorkerProgressTicks, _utcNow().Ticks);
                 try
                 {
+                    // Time the native decode. If it ever HANGS this line never
+                    // returns (the watchdog then rebuilds); if it merely runs slow
+                    // — the cross-platform risk on a Pi at 3 passes — the warning
+                    // below makes "approaching the stall threshold" visible BEFORE
+                    // the watchdog mistakes a slow decode for a hang.
+                    var sw = System.Diagnostics.Stopwatch.StartNew();
                     var decodes = pending.Decoder.Decode(pending.Slot.Samples, pending.Protocol, pending.Passes);
+                    sw.Stop();
+                    // Decode returned — refresh progress so a slow-but-completing
+                    // worker is never mistaken for a wedged one on the next tick.
+                    Interlocked.Exchange(ref _lastWorkerProgressTicks, _utcNow().Ticks);
+                    if (sw.Elapsed.TotalSeconds > _slotSeconds * 2.0)
+                        _log.LogWarning(
+                            "FT8 RX{Rx} decode took {Ms} ms ({Passes} passes) — abnormally slow; " +
+                            "watchdog stall threshold is {Stall:0}s. If this approaches the threshold the " +
+                            "decode-pass count is too high for this platform.",
+                            pending.Receiver, sw.ElapsedMilliseconds, pending.Passes, _slotSeconds * 2.5);
+
                     if (decodes.Count > 0)
                     {
                         foreach (var d in decodes)
@@ -184,7 +323,94 @@ public sealed class Ft8Service : IHostedService, IDisposable
                 }
             }
         }
-        catch (OperationCanceledException) { /* normal shutdown */ }
+        catch (OperationCanceledException) { /* normal shutdown / rebuild */ }
+        catch (Exception ex) { _log.LogError(ex, "FT8 decode worker exited unexpectedly."); }
+    }
+
+    /// <summary>
+    /// Watchdog tick: if audio is still arriving but the worker has made no
+    /// progress for ~2.5 slot periods, the worker/decoder has wedged — rebuild
+    /// the session in place (the automatic equivalent of disable-&gt;enable).
+    /// Returns true if it rebuilt. Internal so tests can drive it deterministically.
+    /// </summary>
+    internal bool RunWatchdogOnce(DateTime now)
+    {
+        lock (_gate)
+        {
+            if (_session is null) return false; // disabled
+            if (_degraded) return false;        // gave up — not leaking further
+
+            long audio = Interlocked.Read(ref _lastAudioTicks);
+            long prog = Interlocked.Read(ref _lastWorkerProgressTicks);
+
+            // Nothing to recover if audio isn't actively arriving.
+            if (audio == 0 || now - new DateTime(audio, DateTimeKind.Utc) > AudioFreshWindow)
+                return false;
+
+            var stall = TimeSpan.FromSeconds(_slotSeconds * 2.5);
+            if (prog != 0 && now - new DateTime(prog, DateTimeKind.Utc) <= stall)
+                return false;
+
+            // Bound the leak. A genuinely-hung native decode cannot be joined, so
+            // each rebuild abandons one worker thread + native context. Periodic
+            // single stalls (the field cadence) prune out of the window and never
+            // trip this; only a persistent hang rebuilds fast enough to hit the
+            // cap, at which point we stop and surface a degraded state.
+            while (_recentRebuilds.Count > 0 && now - _recentRebuilds.Peek() > RebuildWindow)
+                _recentRebuilds.Dequeue();
+            if (_recentRebuilds.Count >= MaxRebuildsPerWindow)
+            {
+                _degraded = true;
+                _log.LogError(
+                    "FT8 decode RX{Rx} stalled and rebuilds are not holding ({N} in {Win} min, {Leaked} worker(s) " +
+                    "failed to exit) — giving up to avoid leaking threads/native contexts. Decode is DEGRADED until " +
+                    "the operator disables and re-enables. Capture worker dequeue/decode timing to root-cause the hang.",
+                    _session.Receiver, _recentRebuilds.Count, RebuildWindow.TotalMinutes, Volatile.Read(ref _leakedWorkers));
+                return false;
+            }
+
+            _recentRebuilds.Enqueue(now);
+            int n = Interlocked.Increment(ref _rebuildCount);
+            _log.LogWarning(
+                "FT8 decode worker stalled (audio flowing, no progress for >{Stall:0}s) — rebuilding RX{Rx} (rebuild #{N}).",
+                stall.TotalSeconds, _session.Receiver, n);
+            RebuildSessionLocked(now);
+            return true;
+        }
+    }
+
+    // Replace the wedged session + worker with a fresh one. Caller holds _gate.
+    // The old worker may be stuck inside a hung native decode, so it is cancelled
+    // and torn down on a detached task — never waited on inline.
+    private void RebuildSessionLocked(DateTime now)
+    {
+        var s = _session!;
+        RxSession? old = s;
+        Task? oldWorker = _decodeWorker;
+        CancellationTokenSource? oldCts = _workerCts;
+
+        _session = new RxSession(s.Receiver, s.Protocol, _slotSeconds, _decoderFactory());
+        _decodeWorker = null;
+        _workerCts = null;
+        _decodeQueue?.Writer.TryComplete();
+        _decodeQueue = null;
+        EnsureWorkerStarted();
+        Interlocked.Exchange(ref _lastWorkerProgressTicks, now.Ticks);
+
+        oldCts?.Cancel();
+        int rx = s.Receiver;
+        _ = Task.Run(() =>
+        {
+            bool exited = true;
+            try { exited = oldWorker is null || oldWorker.Wait(TimeSpan.FromSeconds(2)); } catch { }
+            if (!exited)
+                _log.LogWarning(
+                    "FT8 old decode worker (RX{Rx}) did not exit within 2s after rebuild — native decode is " +
+                    "hung; leaking 1 worker thread + native context (total leaked this session: {N}).",
+                    rx, Interlocked.Increment(ref _leakedWorkers));
+            try { old?.Dispose(); } catch { } // Decoder.Dispose blocks if native is hung — fine, detached
+            oldCts?.Dispose();
+        });
     }
 
     public void Dispose() => Disable();
@@ -196,20 +422,20 @@ public sealed class Ft8Service : IHostedService, IDisposable
         public Ft8Protocol Protocol { get; }
         public Ft8Resampler Resampler { get; }
         public Ft8SlotAccumulator Accumulator { get; }
-        public Ft8Decoder Decoder { get; }
+        public IFt8Decoder Decoder { get; }
 
-        public RxSession(int receiver, Ft8Protocol protocol, double slotSeconds)
+        public RxSession(int receiver, Ft8Protocol protocol, double slotSeconds, IFt8Decoder decoder)
         {
             Receiver = receiver;
             Protocol = protocol;
             Resampler = new Ft8Resampler();
             Accumulator = new Ft8SlotAccumulator(slotSeconds);
-            Decoder = new Ft8Decoder();
+            Decoder = decoder;
         }
 
         public void Dispose() => Decoder.Dispose();
     }
 
     private readonly record struct PendingSlot(
-        int Receiver, Ft8Protocol Protocol, Ft8Decoder Decoder, Ft8Slot Slot, int Passes);
+        int Receiver, Ft8Protocol Protocol, IFt8Decoder Decoder, Ft8Slot Slot, int Passes);
 }

--- a/Zeus.Server.Hosting/WsprService.cs
+++ b/Zeus.Server.Hosting/WsprService.cs
@@ -15,10 +15,17 @@
 // WSPR decode is global/serialised in the native layer and runs once per 120 s,
 // so this is single-session (RX0) for now; the dial frequency is supplied on
 // Enable since the decoded spot frequency = dial + audio offset.
+//
+// SELF-HEALING: like Ft8Service, the RxAudioAvailable tap is process-lifetime and
+// survives every reconfigure, but the single decode worker can wedge (a hung
+// native decode) and leave IsEnabled true with no spots. The watchdog rebuilds
+// the session + worker automatically when audio is flowing but the worker has
+// made no progress for ~2.5 slot periods. See Ft8Service for the full rationale.
 
 using System.Threading.Channels;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Zeus.Dsp.Ft8;
 
 namespace Zeus.Server;
@@ -32,14 +39,36 @@ public sealed record WsprSpotBatch(
 
 public sealed class WsprService : IHostedService, IDisposable
 {
-    private readonly DspPipelineService _pipeline;
+    private readonly DspPipelineService? _pipeline;
     private readonly ILogger<WsprService> _log;
+    private readonly Func<float[], double, IReadOnlyList<WsprSpot>> _decode;
+    private readonly Func<DateTime> _utcNow;
+    private readonly Func<bool> _nativeAvailable;
+
+    private const double SlotSeconds = 120.0;
 
     private readonly object _gate = new();
     private RxSession? _session;
     private Channel<PendingSlot>? _decodeQueue;
     private Task? _decodeWorker;
     private CancellationTokenSource? _workerCts;
+
+    private long _lastAudioTicks;
+    private long _lastWorkerProgressTicks;
+    private Timer? _watchdog;
+
+    // Field-observability + leak-bounding for the watchdog (see Ft8Service for the
+    // full rationale — the watchdog recovers a stall but the originating cause is
+    // still unproven on the bench, so make recoveries visible and cap the leak).
+    private int _rebuildCount;
+    private int _leakedWorkers;
+    private readonly Queue<DateTime> _recentRebuilds = new();
+    private bool _degraded;
+
+    private static readonly TimeSpan AudioFreshWindow = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan WatchdogInterval = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan RebuildWindow = TimeSpan.FromMinutes(30);
+    private const int MaxRebuildsPerWindow = 5;
 
     /// <summary>Raised on the worker thread when a slot has been decoded.</summary>
     public event Action<WsprSpotBatch>? SpotsReady;
@@ -48,34 +77,61 @@ public sealed class WsprService : IHostedService, IDisposable
     {
         _pipeline = pipeline;
         _log = loggerFactory.CreateLogger<WsprService>();
+        _decode = static (samples, dial) => WsprDecoder.Decode(samples, dial);
+        _utcNow = static () => DateTime.UtcNow;
+        _nativeAvailable = static () => WsprDecoder.IsAvailable;
+    }
+
+    /// <summary>Test seam: inject a fake decode + clock; no live audio tap.</summary>
+    internal WsprService(
+        Func<float[], double, IReadOnlyList<WsprSpot>> decode,
+        Func<DateTime> utcNow,
+        ILogger<WsprService>? log = null)
+    {
+        _pipeline = null;
+        _decode = decode;
+        _utcNow = utcNow;
+        _nativeAvailable = static () => true;
+        _log = log ?? NullLogger<WsprService>.Instance;
     }
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        _pipeline.RxAudioAvailable += OnRxAudio;
+        if (_pipeline is not null) _pipeline.RxAudioAvailable += OnRxAudio;
         return Task.CompletedTask;
     }
 
     public Task StopAsync(CancellationToken cancellationToken)
     {
-        _pipeline.RxAudioAvailable -= OnRxAudio;
+        if (_pipeline is not null) _pipeline.RxAudioAvailable -= OnRxAudio;
         Disable();
         return Task.CompletedTask;
     }
 
-    public bool NativeAvailable => WsprDecoder.IsAvailable;
+    public bool NativeAvailable => _nativeAvailable();
     public bool IsEnabled { get { lock (_gate) return _session is not null; } }
     public int ActiveReceiver { get { lock (_gate) return _session?.Receiver ?? -1; } }
     public double DialFreqMhz { get { lock (_gate) return _session?.DialMhz ?? 0; } }
 
     /// <summary>
+    /// True if the watchdog stopped rebuilding (repeated stalls not clearing) to
+    /// avoid leaking worker threads / native contexts. Decode stays dead until the
+    /// operator disables and re-enables. See <see cref="Ft8Service.IsDegraded"/>.
+    /// </summary>
+    public bool IsDegraded { get { lock (_gate) return _degraded; } }
+
+    /// <summary>Total watchdog rebuilds this session (diagnostic / test).</summary>
+    internal int RebuildCount => Volatile.Read(ref _rebuildCount);
+
+    /// <summary>
     /// Enter WSPR decode on a receiver at the given dial frequency (MHz, e.g.
-    /// 14.0956 for 20 m). Idempotent. Returns false if the native decoder is
-    /// unavailable on this platform (Windows ships encode-only today).
+    /// 14.0956 for 20 m). Idempotent: re-enabling on the same receiver+dial is a
+    /// no-op; a new dial rebuilds the session (without disturbing the worker).
+    /// Returns false if the native decoder is unavailable on this platform.
     /// </summary>
     public bool Enable(int receiver, double dialFreqMhz)
     {
-        if (!WsprDecoder.IsAvailable)
+        if (!_nativeAvailable())
         {
             _log.LogWarning("WSPR decode requested but zeus_wspr decode is unavailable on this platform.");
             return false;
@@ -83,14 +139,19 @@ public sealed class WsprService : IHostedService, IDisposable
 
         lock (_gate)
         {
+            // Tolerance, not exact equality: an arithmetic-derived dial that
+            // differs by an ULP must still be treated as the same tuning (matches
+            // the frontend's <=1 Hz guard) so it doesn't force a needless rebuild.
+            if (_session is { } cur && cur.Receiver == receiver
+                && Math.Abs(cur.DialMhz - dialFreqMhz) < 1e-9)
+                return true;
+
             _session = new RxSession(receiver, dialFreqMhz);
-            if (_decodeWorker is null)
-            {
-                _workerCts = new CancellationTokenSource();
-                _decodeQueue = Channel.CreateBounded<PendingSlot>(
-                    new BoundedChannelOptions(2) { FullMode = BoundedChannelFullMode.DropOldest });
-                _decodeWorker = Task.Run(() => DecodeLoopAsync(_workerCts.Token));
-            }
+            // Explicit operator (re-)enable clears degraded state + rebuild history.
+            _degraded = false;
+            _recentRebuilds.Clear();
+            EnsureWorkerStarted();
+            StartWatchdog();
         }
         _log.LogInformation("WSPR decode enabled on RX{Rx} at {Dial:F4} MHz.", receiver, dialFreqMhz);
         return true;
@@ -108,6 +169,8 @@ public sealed class WsprService : IHostedService, IDisposable
             cts = _workerCts; _workerCts = null;
             _decodeQueue?.Writer.TryComplete();
             _decodeQueue = null;
+            _watchdog?.Dispose();
+            _watchdog = null;
         }
         cts?.Cancel();
         try { worker?.Wait(TimeSpan.FromSeconds(2)); } catch { /* shutting down */ }
@@ -115,7 +178,29 @@ public sealed class WsprService : IHostedService, IDisposable
         cts?.Dispose();
     }
 
+    private void EnsureWorkerStarted()
+    {
+        if (_decodeWorker is not null) return;
+        _workerCts = new CancellationTokenSource();
+        _decodeQueue = Channel.CreateBounded<PendingSlot>(
+            new BoundedChannelOptions(2) { FullMode = BoundedChannelFullMode.DropOldest });
+        Interlocked.Exchange(ref _lastWorkerProgressTicks, _utcNow().Ticks);
+        Interlocked.Exchange(ref _lastAudioTicks, 0);
+        var ct = _workerCts.Token;
+        _decodeWorker = Task.Run(() => DecodeLoopAsync(ct));
+    }
+
+    private void StartWatchdog()
+    {
+        if (_pipeline is null || _watchdog is not null) return; // tests drive RunWatchdogOnce
+        _watchdog = new Timer(_ => { try { RunWatchdogOnce(_utcNow()); } catch { } },
+            null, WatchdogInterval, WatchdogInterval);
+    }
+
     private void OnRxAudio(int receiver, int sampleRate, ReadOnlyMemory<float> block)
+        => FeedAudio(receiver, sampleRate, block.Span);
+
+    internal void FeedAudio(int receiver, int sampleRate, ReadOnlySpan<float> block)
     {
         RxSession? s;
         Channel<PendingSlot>? queue;
@@ -123,10 +208,12 @@ public sealed class WsprService : IHostedService, IDisposable
         if (s is null || queue is null || receiver != s.Receiver) return;
         if (sampleRate != Ft8Resampler.InputRate) return; // fixed 48k->12k decimator
 
-        float[] decimated = s.Resampler.Process(block.Span);
+        float[] decimated = s.Resampler.Process(block);
         if (decimated.Length == 0) return;
 
-        Ft8Slot? completed = s.Accumulator.Add(decimated, DateTime.UtcNow);
+        Interlocked.Exchange(ref _lastAudioTicks, _utcNow().Ticks);
+
+        Ft8Slot? completed = s.Accumulator.Add(decimated, _utcNow());
         if (completed is { } slot)
             queue.Writer.TryWrite(new PendingSlot(s.Receiver, s.DialMhz, slot));
     }
@@ -141,9 +228,21 @@ public sealed class WsprService : IHostedService, IDisposable
         {
             await foreach (var pending in queue.Reader.ReadAllAsync(ct).ConfigureAwait(false))
             {
+                // Worker dequeued a slot — proof of life (entering the decode).
+                Interlocked.Exchange(ref _lastWorkerProgressTicks, _utcNow().Ticks);
                 try
                 {
-                    var spots = WsprDecoder.Decode(pending.Slot.Samples, pending.DialMhz);
+                    var sw = System.Diagnostics.Stopwatch.StartNew();
+                    var spots = _decode(pending.Slot.Samples, pending.DialMhz);
+                    sw.Stop();
+                    // Decode returned — refresh progress so a slow-but-completing
+                    // worker is never mistaken for a wedged one on the next tick.
+                    Interlocked.Exchange(ref _lastWorkerProgressTicks, _utcNow().Ticks);
+                    if (sw.Elapsed.TotalSeconds > SlotSeconds)
+                        _log.LogWarning(
+                            "WSPR RX{Rx} decode took {Ms} ms — abnormally slow; watchdog stall threshold is {Stall:0}s.",
+                            pending.Receiver, sw.ElapsedMilliseconds, SlotSeconds * 2.5);
+
                     if (spots.Count > 0)
                     {
                         foreach (var sp in spots)
@@ -162,7 +261,86 @@ public sealed class WsprService : IHostedService, IDisposable
                 }
             }
         }
-        catch (OperationCanceledException) { /* normal shutdown */ }
+        catch (OperationCanceledException) { /* normal shutdown / rebuild */ }
+        catch (Exception ex) { _log.LogError(ex, "WSPR decode worker exited unexpectedly."); }
+    }
+
+    /// <summary>
+    /// Watchdog tick: rebuild the session + worker if audio is still arriving but
+    /// the worker has made no progress for ~2.5 slot periods (300 s). Internal so
+    /// tests can drive it deterministically. Returns true if it rebuilt.
+    /// </summary>
+    internal bool RunWatchdogOnce(DateTime now)
+    {
+        lock (_gate)
+        {
+            if (_session is null) return false;
+            if (_degraded) return false; // gave up — not leaking further
+
+            long audio = Interlocked.Read(ref _lastAudioTicks);
+            long prog = Interlocked.Read(ref _lastWorkerProgressTicks);
+
+            if (audio == 0 || now - new DateTime(audio, DateTimeKind.Utc) > AudioFreshWindow)
+                return false;
+
+            var stall = TimeSpan.FromSeconds(SlotSeconds * 2.5);
+            if (prog != 0 && now - new DateTime(prog, DateTimeKind.Utc) <= stall)
+                return false;
+
+            // Bound the leak (see Ft8Service) — a hung native decode can't be
+            // joined, so cap rebuilds and surface a degraded state instead.
+            while (_recentRebuilds.Count > 0 && now - _recentRebuilds.Peek() > RebuildWindow)
+                _recentRebuilds.Dequeue();
+            if (_recentRebuilds.Count >= MaxRebuildsPerWindow)
+            {
+                _degraded = true;
+                _log.LogError(
+                    "WSPR decode RX{Rx} stalled and rebuilds are not holding ({N} in {Win} min, {Leaked} worker(s) " +
+                    "failed to exit) — giving up to avoid leaking threads/native contexts. Decode is DEGRADED until " +
+                    "the operator disables and re-enables.",
+                    _session.Receiver, _recentRebuilds.Count, RebuildWindow.TotalMinutes, Volatile.Read(ref _leakedWorkers));
+                return false;
+            }
+
+            _recentRebuilds.Enqueue(now);
+            int n = Interlocked.Increment(ref _rebuildCount);
+            _log.LogWarning(
+                "WSPR decode worker stalled (audio flowing, no progress for >{Stall:0}s) — rebuilding RX{Rx} (rebuild #{N}).",
+                stall.TotalSeconds, _session.Receiver, n);
+            RebuildSessionLocked(now);
+            return true;
+        }
+    }
+
+    private void RebuildSessionLocked(DateTime now)
+    {
+        var s = _session!;
+        RxSession? old = s;
+        Task? oldWorker = _decodeWorker;
+        CancellationTokenSource? oldCts = _workerCts;
+
+        _session = new RxSession(s.Receiver, s.DialMhz);
+        _decodeWorker = null;
+        _workerCts = null;
+        _decodeQueue?.Writer.TryComplete();
+        _decodeQueue = null;
+        EnsureWorkerStarted();
+        Interlocked.Exchange(ref _lastWorkerProgressTicks, now.Ticks);
+
+        oldCts?.Cancel();
+        int rx = s.Receiver;
+        _ = Task.Run(() =>
+        {
+            bool exited = true;
+            try { exited = oldWorker is null || oldWorker.Wait(TimeSpan.FromSeconds(2)); } catch { }
+            if (!exited)
+                _log.LogWarning(
+                    "WSPR old decode worker (RX{Rx}) did not exit within 2s after rebuild — native decode is " +
+                    "hung; leaking 1 worker thread (total leaked this session: {N}).",
+                    rx, Interlocked.Increment(ref _leakedWorkers));
+            try { old?.Dispose(); } catch { }
+            oldCts?.Dispose();
+        });
     }
 
     public void Dispose() => Disable();
@@ -179,7 +357,7 @@ public sealed class WsprService : IHostedService, IDisposable
             Receiver = receiver;
             DialMhz = dialMhz;
             Resampler = new Ft8Resampler();
-            Accumulator = new Ft8SlotAccumulator(slotSeconds: 120.0);
+            Accumulator = new Ft8SlotAccumulator(slotSeconds: SlotSeconds);
         }
 
         public void Dispose() { }

--- a/tests/Zeus.Server.Tests/DigitalDecodeWatchdogTests.cs
+++ b/tests/Zeus.Server.Tests/DigitalDecodeWatchdogTests.cs
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Regression tests for the FT8/WSPR decode self-heal (pop-out #1080 regression:
+// decode silently stopped while IsEnabled stayed true; only disable->enable
+// revived it). The decode AUDIO TAP never drops — these prove the WORKER behind
+// it does, and that the watchdog rebuilds it in place so decode resumes with NO
+// operator action and NO transmit. Both services are driven through their test
+// constructors with an injected fake decoder + clock; no native library, no real
+// radio, fully deterministic time.
+//
+// SCOPE / honesty note: the wedge these tests force (a decoder that blocks forever
+// inside Decode) is SYNTHETIC. The field root cause is still unproven on the bench
+// — the watchdog is cause-agnostic recovery, and the new decode-timing /
+// rebuild-count / leaked-worker logging in Ft8Service/WsprService is what will
+// capture the true mechanism on the G2. These tests therefore cover the watchdog
+// MECHANISM and the reconfigure/idempotency paths, plus that a persistent stall is
+// BOUNDED (does not leak a worker/native-context on every tick forever).
+
+using System.Collections.Concurrent;
+using Zeus.Dsp.Ft8;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class DigitalDecodeWatchdogTests
+{
+    // A fake decoder that returns one known decode per call, and can be made to
+    // WEDGE (block forever) on its first decode to reproduce the stall.
+    private sealed class FakeFt8Decoder : IFt8Decoder
+    {
+        private readonly ManualResetEventSlim? _block;
+        public volatile bool DecodeEntered;
+        public int DecodeCalls;
+
+        public FakeFt8Decoder(ManualResetEventSlim? block) => _block = block;
+
+        public IReadOnlyList<Ft8DecodeResult> Decode(
+            float[] samples, Ft8Protocol protocol = Ft8Protocol.Ft8, int passes = 1, int maxResults = 64)
+        {
+            Interlocked.Increment(ref DecodeCalls);
+            DecodeEntered = true;
+            _block?.Wait(); // wedge here when gated — mimics a hung native decode
+            return new[] { new Ft8DecodeResult(-12f, 0.2f, 1500f, 100, 0, "CQ RK9AX GJ0K") };
+        }
+
+        public void Reset() { }
+        public void Dispose() { }
+    }
+
+    private static float[] AudioBlock() => new float[4800]; // 0.1 s @ 48 kHz, decimates to ~1200
+
+    private static bool SpinUntil(Func<bool> cond, int ms = 3000)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.ElapsedMilliseconds < ms)
+        {
+            if (cond()) return true;
+            Thread.Sleep(5);
+        }
+        return cond();
+    }
+
+    [Fact]
+    public void Ft8_WedgedWorker_StaysStalled_ThenWatchdogResumesDecoding()
+    {
+        var now = new DateTime(2026, 6, 27, 0, 0, 0, DateTimeKind.Utc);
+        Func<DateTime> clock = () => now;
+
+        int created = 0;
+        using var firstWedge = new ManualResetEventSlim(false);
+        var decoders = new List<FakeFt8Decoder>();
+        Func<IFt8Decoder> factory = () =>
+        {
+            // Only the FIRST decoder wedges; the rebuilt one decodes normally.
+            var d = new FakeFt8Decoder(created == 0 ? firstWedge : null);
+            created++;
+            decoders.Add(d);
+            return d;
+        };
+
+        var batches = new ConcurrentQueue<Ft8DecodeBatch>();
+        using var svc = new Ft8Service(factory, () => now);
+        svc.DecodesReady += b => batches.Enqueue(b);
+
+        Assert.True(svc.Enable(0, Ft8Protocol.Ft8));
+
+        // Drive a slot to completion so the (wedging) worker picks it up.
+        svc.FeedAudio(0, 48_000, AudioBlock());          // first block of slot N
+        now = now.AddSeconds(15);
+        svc.FeedAudio(0, 48_000, AudioBlock());          // crosses into N+1 -> slot N queued
+        Assert.True(SpinUntil(() => decoders.Count >= 1 && decoders[0].DecodeEntered),
+            "worker never started decoding the first slot");
+
+        // The worker is now wedged inside Decode. Keep audio flowing and complete
+        // more slots: WITHOUT the watchdog, decode stays dead forever.
+        now = now.AddSeconds(15);
+        svc.FeedAudio(0, 48_000, AudioBlock());
+        now = now.AddSeconds(15);
+        svc.FeedAudio(0, 48_000, AudioBlock());
+        Assert.False(SpinUntil(() => !batches.IsEmpty, 300),
+            "decode should be wedged (no batch) before the watchdog runs");
+
+        // Audio is fresh; the worker has made no progress for > 2.5 slots (37.5 s).
+        now = now.AddSeconds(20); // ~50 s since the wedge began
+        svc.FeedAudio(0, 48_000, AudioBlock());           // keep audio "fresh"
+        Assert.True(svc.RunWatchdogOnce(now), "watchdog should detect the stall and rebuild");
+        Assert.True(created >= 2, "watchdog should have built a fresh decoder");
+
+        // A fresh session is running. Drive a new slot to completion and assert
+        // decode RESUMED — with no disable/enable and no TX.
+        now = now.AddSeconds(15);
+        svc.FeedAudio(0, 48_000, AudioBlock());
+        now = now.AddSeconds(15);
+        svc.FeedAudio(0, 48_000, AudioBlock());
+        Assert.True(SpinUntil(() => !batches.IsEmpty),
+            "decode did not resume after the watchdog rebuilt the worker");
+
+        firstWedge.Set(); // release the leaked wedged worker thread
+    }
+
+    [Fact]
+    public void Ft8_Watchdog_NoOp_WhenWorkerHealthy()
+    {
+        var now = new DateTime(2026, 6, 27, 1, 0, 0, DateTimeKind.Utc);
+        using var svc = new Ft8Service(() => new FakeFt8Decoder(null), () => now);
+        var batches = new ConcurrentQueue<Ft8DecodeBatch>();
+        svc.DecodesReady += b => batches.Enqueue(b);
+        Assert.True(svc.Enable(0, Ft8Protocol.Ft8));
+
+        // Feed a healthy stream that produces a decode each slot.
+        for (int i = 0; i < 4; i++)
+        {
+            svc.FeedAudio(0, 48_000, AudioBlock());
+            now = now.AddSeconds(15);
+            svc.FeedAudio(0, 48_000, AudioBlock());
+            Assert.True(SpinUntil(() => batches.Count >= i + 1), $"slot {i} did not decode");
+            // Worker is making progress -> watchdog must NOT rebuild.
+            Assert.False(svc.RunWatchdogOnce(now), "watchdog fired on a healthy worker");
+        }
+    }
+
+    [Fact]
+    public void Ft8_ReEnableSameParams_IsIdempotent_DoesNotDropDecoder()
+    {
+        var now = new DateTime(2026, 6, 27, 2, 0, 0, DateTimeKind.Utc);
+        int created = 0;
+        using var svc = new Ft8Service(() => { created++; return new FakeFt8Decoder(null); }, () => now);
+        Assert.True(svc.Enable(0, Ft8Protocol.Ft8));
+        Assert.Equal(1, created);
+
+        // Re-enabling on the same receiver+protocol (setPasses / hydration churn)
+        // must NOT tear the session down and build a new decoder.
+        Assert.True(svc.Enable(0, Ft8Protocol.Ft8));
+        Assert.True(svc.Enable(0, Ft8Protocol.Ft8));
+        Assert.Equal(1, created);
+
+        // Switching protocol DOES rebuild (FT8/FT4 sub-bands differ).
+        Assert.True(svc.Enable(0, Ft8Protocol.Ft4));
+        Assert.Equal(2, created);
+    }
+
+    [Fact]
+    public void Ft8_RepeatedReconfigureWhileEnabled_KeepsDecoding()
+    {
+        // The actual field failure path: the pop-out band-follow effect re-issues
+        // configure-while-enabled churn. Interleaving redundant same-params Enable
+        // calls with the live audio stream must NEVER drop the decoder — decode has
+        // to keep producing a batch every slot, with the decoder built exactly once.
+        var now = new DateTime(2026, 6, 27, 4, 0, 0, DateTimeKind.Utc);
+        int created = 0;
+        using var svc = new Ft8Service(() => { created++; return new FakeFt8Decoder(null); }, () => now);
+        var batches = new ConcurrentQueue<Ft8DecodeBatch>();
+        svc.DecodesReady += b => batches.Enqueue(b);
+        Assert.True(svc.Enable(0, Ft8Protocol.Ft8));
+
+        for (int i = 0; i < 3; i++)
+        {
+            svc.Enable(0, Ft8Protocol.Ft8);   // redundant reconfigure (band-follow churn)
+            svc.Enable(0, Ft8Protocol.Ft8);
+            svc.FeedAudio(0, 48_000, AudioBlock());
+            now = now.AddSeconds(15);
+            svc.FeedAudio(0, 48_000, AudioBlock());
+            Assert.True(SpinUntil(() => batches.Count >= i + 1),
+                $"decode stopped after reconfigure round {i}");
+            Assert.False(svc.RunWatchdogOnce(now), "watchdog fired despite a healthy worker");
+        }
+        Assert.Equal(1, created); // never rebuilt across all the reconfigure churn
+    }
+
+    [Fact]
+    public void Ft8_PersistentStall_RebuildsAreBounded_ThenDegraded_ClearedByReEnable()
+    {
+        // If a stall NEVER clears (a truly-hung native decode), the watchdog must
+        // NOT rebuild on every tick forever — each rebuild abandons one worker +
+        // native context. Prove rebuilds are capped, a degraded state is surfaced,
+        // and an operator disable->enable clears it.
+        var now = new DateTime(2026, 6, 27, 3, 0, 0, DateTimeKind.Utc);
+        int created = 0;
+        using var svc = new Ft8Service(() => { created++; return new FakeFt8Decoder(null); }, () => now);
+        Assert.True(svc.Enable(0, Ft8Protocol.Ft8));
+        Assert.Equal(1, created);
+
+        int rebuilds = 0;
+        for (int i = 0; i < 12; i++)
+        {
+            now = now.AddSeconds(50);                // progress goes stale (>37.5 s)
+            svc.FeedAudio(0, 48_000, AudioBlock());  // fresh audio into a fresh accumulator -> no slot completes -> worker never makes progress
+            if (svc.RunWatchdogOnce(now)) rebuilds++;
+        }
+
+        Assert.True(rebuilds <= 5, $"watchdog rebuilt {rebuilds} times — leak is not bounded");
+        Assert.True(svc.IsDegraded, "a persistent stall should surface a degraded state");
+        Assert.False(svc.RunWatchdogOnce(now.AddSeconds(50)), "degraded watchdog must not keep rebuilding");
+
+        // Operator disable->enable is the manual recovery — it clears degraded.
+        svc.Disable();
+        Assert.True(svc.Enable(0, Ft8Protocol.Ft8));
+        Assert.False(svc.IsDegraded, "re-enable should clear the degraded state");
+    }
+
+    // --- WSPR mirror ---
+
+    [Fact]
+    public void Wspr_WedgedWorker_WatchdogResumesDecoding()
+    {
+        var now = new DateTime(2026, 6, 27, 0, 0, 0, DateTimeKind.Utc);
+        using var firstWedge = new ManualResetEventSlim(false);
+        var spots = new ConcurrentQueue<WsprSpotBatch>();
+        int decodeCalls = 0;
+        Func<float[], double, IReadOnlyList<WsprSpot>> decodeFn = (s, d) =>
+        {
+            int n = Interlocked.Increment(ref decodeCalls);
+            if (n == 1) firstWedge.Wait(); // first decode wedges
+            return new[] { new WsprSpot(-20f, 0.5f, (float)(d + 1.5e-6), 0, "RK9AX KO85 37") };
+        };
+
+        using var svc = new WsprService(decodeFn, () => now);
+        svc.SpotsReady += b => spots.Enqueue(b);
+        Assert.True(svc.Enable(0, 14.0956));
+
+        svc.FeedAudio(0, 48_000, AudioBlock());
+        now = now.AddSeconds(120);
+        svc.FeedAudio(0, 48_000, AudioBlock());           // slot queued -> worker wedges
+        Assert.True(SpinUntil(() => Volatile.Read(ref decodeCalls) >= 1),
+            "WSPR worker never started decoding");
+
+        now = now.AddSeconds(120);
+        svc.FeedAudio(0, 48_000, AudioBlock());
+        Assert.False(SpinUntil(() => !spots.IsEmpty, 300), "WSPR should be wedged before watchdog");
+
+        // > 2.5 slots (300 s) since the worker's last progress, with audio fresh.
+        now = now.AddSeconds(200);
+        svc.FeedAudio(0, 48_000, AudioBlock());
+        Assert.True(svc.RunWatchdogOnce(now), "WSPR watchdog should rebuild the wedged worker");
+
+        now = now.AddSeconds(120);
+        svc.FeedAudio(0, 48_000, AudioBlock());
+        now = now.AddSeconds(120);
+        svc.FeedAudio(0, 48_000, AudioBlock());
+        Assert.True(SpinUntil(() => !spots.IsEmpty), "WSPR decode did not resume after rebuild");
+
+        firstWedge.Set();
+    }
+
+    [Fact]
+    public void Wspr_ReEnableSameDial_KeepsDecoding_NewDialRetunes()
+    {
+        // Mirror of the FT8 idempotency test: redundant same-dial Enable churn must
+        // not disturb the worker (decode keeps producing), while a NEW dial retunes.
+        var now = new DateTime(2026, 6, 27, 5, 0, 0, DateTimeKind.Utc);
+        var spots = new ConcurrentQueue<WsprSpotBatch>();
+        Func<float[], double, IReadOnlyList<WsprSpot>> decodeFn =
+            (s, d) => new[] { new WsprSpot(-20f, 0.5f, (float)(d + 1.5e-6), 0, "RK9AX KO85 37") };
+        using var svc = new WsprService(decodeFn, () => now);
+        svc.SpotsReady += b => spots.Enqueue(b);
+
+        Assert.True(svc.Enable(0, 14.0956));
+        Assert.True(svc.Enable(0, 14.0956)); // redundant same dial — no-op
+        Assert.True(svc.Enable(0, 14.0956));
+        Assert.Equal(14.0956, svc.DialFreqMhz);
+
+        svc.FeedAudio(0, 48_000, AudioBlock());
+        now = now.AddSeconds(120);
+        svc.FeedAudio(0, 48_000, AudioBlock());
+        Assert.True(SpinUntil(() => !spots.IsEmpty), "WSPR decode stopped after redundant re-enable");
+        Assert.False(svc.RunWatchdogOnce(now), "WSPR watchdog fired on a healthy worker");
+
+        Assert.True(svc.Enable(0, 7.0386)); // a NEW dial retunes the session
+        Assert.Equal(7.0386, svc.DialFreqMhz);
+    }
+}

--- a/zeus-web/src/state/digital-mode.test.ts
+++ b/zeus-web/src/state/digital-mode.test.ts
@@ -76,6 +76,35 @@ describe('digital-mode framing gate', () => {
     expect(setZoom).toHaveBeenCalled();
   });
 
+  it('is a NO-OP when already on the target digital config (pop-out churn fix)', async () => {
+    // Radio already configured for 20 m FT8: DIGU + 150..3000 filter + on dial.
+    // The band-follow effect / redundant qsyBand must issue NOTHING — a stray
+    // setVfo would trip the server per-band mode recall and perturb decode.
+    useConnectionStore.setState({
+      vfoHz: 14_074_000,
+      mode: 'DIGU' as never,
+      filterLowHz: 150,
+      filterHighHz: 3000,
+    });
+    await configureRadioForDigital('FT8', '20m');
+    expect(setVfo).not.toHaveBeenCalled();
+    expect(setMode).not.toHaveBeenCalled();
+    expect(setCtun).not.toHaveBeenCalled();
+  });
+
+  it('STILL reconfigures when the server flipped mode off DIGU (recall recovery)', async () => {
+    // Same dial + filter, but the server's per-band recall knocked mode to USB:
+    // we must re-assert DIGU so decode survives.
+    useConnectionStore.setState({
+      vfoHz: 14_074_000,
+      mode: 'USB' as never,
+      filterLowHz: 150,
+      filterHighHz: 3000,
+    });
+    await configureRadioForDigital('FT8', '20m');
+    expect(setMode).toHaveBeenCalledWith('DIGU');
+  });
+
   it('cross-band QSY moves the VFO BEFORE asserting DIGU (recall-proof order)', async () => {
     const order: string[] = [];
     (setVfo as unknown as ReturnType<typeof vi.fn>).mockImplementation(async () => {

--- a/zeus-web/src/state/digital-mode.ts
+++ b/zeus-web/src/state/digital-mode.ts
@@ -74,12 +74,32 @@ export async function configureRadioForDigital(
   bandName?: string,
 ): Promise<void> {
   if (txActive()) return;
-  const vfoHz = useConnectionStore.getState().vfoHz;
+  const cs = useConnectionStore.getState();
+  const vfoHz = cs.vfoHz;
   const near = nearestDigitalBand(vfoHz);
   const band = bandName ?? near.name;
   // Fall back to the nearest band's FT8 dial if this protocol has no sub-band on
   // the requested band (e.g. FT4 on 160 m).
   const dial = dialHzFor(protocol, band) ?? near.ft8Hz;
+  // Idempotency guard (pop-out regression fix): when the radio is ALREADY in the
+  // target digital config — DIGU, the flat decode filter, and on the band dial —
+  // issue NOTHING. The band-follow effect and redundant qsyBand calls would
+  // otherwise re-fire setVfo/setMode/setFilter on every benign VFO update; each
+  // SetVfo trips the server's per-band mode recall (PR #974), momentarily
+  // flipping RXA off DIGU and perturbing the decode audio stream. A true no-op
+  // here keeps the decode tap's input continuous.
+  // Use a small Hz tolerance on the filter edges (matching the VFO's ±1 Hz),
+  // so a server round-trip that quantizes the filter Hz can't defeat the guard
+  // and silently re-fire reconfigure on every update.
+  if (
+    cs.mode === 'DIGU' &&
+    Math.abs(cs.filterLowHz - DIGITAL_RX_FILTER_LOW_HZ) <= 1 &&
+    Math.abs(cs.filterHighHz - DIGITAL_RX_FILTER_HIGH_HZ) <= 1 &&
+    dial != null &&
+    Math.abs(cs.vfoHz - dial) <= 1
+  ) {
+    return;
+  }
   try {
     // QSY FIRST, then assert DIGU + the wide flat filter. A cross-band VFO move
     // triggers the server's per-band mode recall (RestoreBandMode → SetMode,


### PR DESCRIPTION
## ⛔ DO NOT MERGE — bench sign-off required

**Stack: on top of `ft8/logging-v2-hamclock` (#1088).** Fixes the **decode-stall regression** KB2UKA hit on the G2: FT8/WSPR decode silently stops while `enabled:true`, recurring (~12 min), revived only by `disable→enable`.

### Root cause — localized & proven
`git diff ft8/tx-settings..HEAD` over the **entire backend decode path** (`Ft8Service`, `WsprService`, `DspPipelineService`, `Zeus.Dsp.Ft8`) is **empty** — backend is byte-identical to the last-good (pre-pop-out) build. The regression is the **pop-out's frontend reconfigure churn**: band changes now run the *full* `configureRadioForDigital` (`setMode DIGU`+`setFilter`+`setVfo`) instead of VFO-only, plus a new band-follow `useEffect`, and with PR #974 (`SetVfo→RestoreBandMode→SetMode`) that fires **many** reconfigures during a live session (was ~1/session at entry). That trips a **latent RX-audio-output continuity stall** the unchanged backend was never exercised for pre-pop-out.

### Fix (defense-in-depth)
- **Self-healing watchdog** (`Ft8Service`/`WsprService`): detects enabled-but-no-decodes (audio fresh, worker silent) and **auto-rebuilds the session within ~1 slot** — automating the manual kick. **Bounded** (max 5 rebuilds/10 min FT8, /30 min WSPR) → then surfaces `IsDegraded` (logged Error) instead of leaking; a real `Enable` clears it. Per-rebuild + leaked-worker logging.
- **Cut the churn** (frontend): idempotency guards so benign `vfoHz` updates / re-clicks don't re-reconfigure; filter-edge compare uses ±1 Hz tolerance (matches the VFO guard).
- **Instrumentation**: decode-timing + audio-stale logging to **pin the exact backend mechanism on the bench** (honest: the originating fault isn't proven from code alone — the watchdog is cause-agnostic recovery).

### Honesty / status
- **High confidence** the operator-visible freeze is fixed (fewer triggers + auto-recovery within a slot, bounded, observable). **Moderate** on the exact backend mechanism — instrumentation will close that on the G2.
- Build 0/0; **2026 server tests** + watchdog/reconfigure/WSPR/frontend suites green; PureSignal untouched.
- **Bench verification in progress** on KB2UKA's G2 (decode stable so far; watching for a stall→auto-recovery event + reading the instrumentation).
