### PR TITLE
fix(broker): allow the maintainer dashboard origin on the /admin CORS allowlist

### DIFF
--- a/cloud/zeus-remote-broker/package.json
+++ b/cloud/zeus-remote-broker/package.json
@@ -8,7 +8,7 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
     "typecheck": "tsc --noEmit",
-    "test": "node --import tsx --test test/admin-auth.test.ts test/crash-validate.test.ts",
+    "test": "node --import tsx --test test/admin-auth.test.ts test/crash-validate.test.ts test/admin-cors.test.ts",
     "cf-typegen": "wrangler types"
   },
   "devDependencies": {

--- a/cloud/zeus-remote-broker/src/admin-api.ts
+++ b/cloud/zeus-remote-broker/src/admin-api.ts
@@ -51,7 +51,7 @@ export async function handleAdmin(
   env: Env,
   ctx: ExecutionContext,
 ): Promise<Response> {
-  const cors = corsHeaders(env);
+  const cors = corsHeaders(env, request);
   if (request.method === 'OPTIONS') return new Response(null, { status: 204, headers: cors });
 
   const url = new URL(request.url);
@@ -458,20 +458,42 @@ async function loginRateLimited(env: Env, callsign: string): Promise<boolean> {
 
 /**
  * CORS for the dashboard's cross-origin /admin fetches. The admin surface fails
- * CLOSED: we name exactly the configured web-app origin and NEVER fall back to
- * '*' (unlike /turn, which is public). If WEB_APP_ORIGIN is unset, no
+ * CLOSED: an allowlist is built from `WEB_APP_ORIGIN` + `ADMIN_ORIGINS` and we
+ * echo back ONLY the exact requesting origin when it matches — never '*' (unlike
+ * /turn, which is public), and never a list (CORS permits a single origin value).
+ * The maintainer dashboard runs at a different origin than the RX SPA, so naming
+ * just `WEB_APP_ORIGIN` is not enough; `ADMIN_ORIGINS` carries the dashboard
+ * origin(s). If neither is set, or the request's Origin is not allowlisted, no
  * Allow-Origin header is emitted, so a browser cannot read /admin responses
  * cross-origin — a misconfigured deploy can't silently expose the admin API to
  * every site. Authorization + QRZ headers are allowed; no cookies, so no
  * Allow-Credentials.
  */
-function corsHeaders(env: Env): Record<string, string> {
+export function corsHeaders(env: Env, request?: Request): Record<string, string> {
   const headers: Record<string, string> = {
     'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
     'Access-Control-Allow-Headers': 'content-type, authorization, x-qrz-session, x-qrz-callsign',
     'Access-Control-Max-Age': '86400',
     Vary: 'Origin',
   };
-  if (env.WEB_APP_ORIGIN) headers['Access-Control-Allow-Origin'] = env.WEB_APP_ORIGIN;
+  const allowed = allowedAdminOrigins(env);
+  const requestOrigin = request?.headers.get('Origin')?.trim();
+  if (requestOrigin && allowed.has(requestOrigin)) {
+    headers['Access-Control-Allow-Origin'] = requestOrigin;
+  }
   return headers;
+}
+
+/**
+ * The set of origins permitted to call /admin cross-origin: `WEB_APP_ORIGIN`
+ * plus the comma-separated `ADMIN_ORIGINS`, trimmed and with any trailing slash
+ * stripped (browsers send Origin without one). Empty entries are dropped.
+ */
+export function allowedAdminOrigins(env: Env): Set<string> {
+  const out = new Set<string>();
+  for (const raw of [env.WEB_APP_ORIGIN ?? '', ...(env.ADMIN_ORIGINS ?? '').split(',')]) {
+    const o = raw.trim().replace(/\/+$/, '');
+    if (o) out.add(o);
+  }
+  return out;
 }

--- a/cloud/zeus-remote-broker/src/types.ts
+++ b/cloud/zeus-remote-broker/src/types.ts
@@ -51,6 +51,16 @@ export interface Env {
   /** Origin of the web client (Cloudflare Pages) that /go/<callsign> redirects to. */
   WEB_APP_ORIGIN?: string;
 
+  /**
+   * Extra origin(s) allowed to call the credential-gated /admin API cross-origin,
+   * comma-separated. The maintainer dashboard lives at a DIFFERENT origin than the
+   * RX SPA (`WEB_APP_ORIGIN`), so its origin is named here. The /admin CORS layer
+   * builds an allowlist from `WEB_APP_ORIGIN` + this and echoes back the exact
+   * requesting origin only when it matches — it never falls back to '*'. Leave
+   * unset if the dashboard shares `WEB_APP_ORIGIN`.
+   */
+  ADMIN_ORIGINS?: string;
+
   /** Cloudflare Realtime TURN key id (set via `wrangler secret put`). */
   TURN_KEY_ID?: string;
   /** Cloudflare Realtime TURN API token (set via `wrangler secret put`). */

--- a/cloud/zeus-remote-broker/test/admin-cors.test.ts
+++ b/cloud/zeus-remote-broker/test/admin-cors.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Unit tests for the /admin CORS allowlist. The maintainer dashboard runs at a
+ * different origin than the RX SPA, so the allowlist is built from
+ * WEB_APP_ORIGIN + ADMIN_ORIGINS and the response echoes back ONLY the exact
+ * requesting origin when it matches — never '*', never a list.
+ *
+ *   node --import tsx --test test/admin-cors.test.ts
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { corsHeaders, allowedAdminOrigins } from '../src/admin-api.ts';
+import type { Env } from '../src/types.ts';
+
+// Only the CORS path is exercised, so a partial Env cast is sufficient.
+function env(partial: Partial<Env>): Env {
+  return partial as Env;
+}
+
+function req(origin?: string): Request {
+  const headers = new Headers();
+  if (origin !== undefined) headers.set('Origin', origin);
+  return new Request('https://remote.openhpsdrzeus.com/admin/presence', { headers });
+}
+
+test('allowlist combines WEB_APP_ORIGIN + ADMIN_ORIGINS, trims, strips trailing slash', () => {
+  const allowed = allowedAdminOrigins(
+    env({ WEB_APP_ORIGIN: 'https://app.openhpsdrzeus.com', ADMIN_ORIGINS: ' https://openhpsdrzeus.com/ , https://dash.example.com ' }),
+  );
+  assert.deepEqual(
+    [...allowed].sort(),
+    ['https://app.openhpsdrzeus.com', 'https://dash.example.com', 'https://openhpsdrzeus.com'].sort(),
+  );
+});
+
+test('empty / missing origins are dropped, no entries when unset', () => {
+  assert.equal(allowedAdminOrigins(env({})).size, 0);
+  assert.deepEqual([...allowedAdminOrigins(env({ ADMIN_ORIGINS: ' , ,, ' }))], []);
+});
+
+test('dashboard origin (in ADMIN_ORIGINS) is echoed back exactly', () => {
+  const cors = corsHeaders(
+    env({ WEB_APP_ORIGIN: 'https://app.openhpsdrzeus.com', ADMIN_ORIGINS: 'https://openhpsdrzeus.com' }),
+    req('https://openhpsdrzeus.com'),
+  );
+  assert.equal(cors['Access-Control-Allow-Origin'], 'https://openhpsdrzeus.com');
+  assert.equal(cors['Vary'], 'Origin');
+});
+
+test('RX SPA origin (WEB_APP_ORIGIN) still allowed — no regression', () => {
+  const cors = corsHeaders(
+    env({ WEB_APP_ORIGIN: 'https://app.openhpsdrzeus.com', ADMIN_ORIGINS: 'https://openhpsdrzeus.com' }),
+    req('https://app.openhpsdrzeus.com'),
+  );
+  assert.equal(cors['Access-Control-Allow-Origin'], 'https://app.openhpsdrzeus.com');
+});
+
+test('unlisted origin gets NO Allow-Origin header (fails closed, never *)', () => {
+  const cors = corsHeaders(
+    env({ WEB_APP_ORIGIN: 'https://app.openhpsdrzeus.com', ADMIN_ORIGINS: 'https://openhpsdrzeus.com' }),
+    req('https://evil.example.com'),
+  );
+  assert.equal(cors['Access-Control-Allow-Origin'], undefined);
+  // The header value is never the wildcard.
+  assert.notEqual(cors['Access-Control-Allow-Origin'], '*');
+});
+
+test('request with no Origin header gets no Allow-Origin (non-browser callers)', () => {
+  const cors = corsHeaders(env({ WEB_APP_ORIGIN: 'https://app.openhpsdrzeus.com' }), req());
+  assert.equal(cors['Access-Control-Allow-Origin'], undefined);
+});
+
+test('no allowlist configured → no Allow-Origin even for a real origin', () => {
+  const cors = corsHeaders(env({}), req('https://openhpsdrzeus.com'));
+  assert.equal(cors['Access-Control-Allow-Origin'], undefined);
+});

--- a/cloud/zeus-remote-broker/wrangler.toml
+++ b/cloud/zeus-remote-broker/wrangler.toml
@@ -26,6 +26,10 @@ QRZ_VERIFY = "on"
 # app.openhpsdrzeus.com is the zeus-web-app Pages project (the SPA); the apex
 # openhpsdrzeus.com stays the marketing site and must NOT be used here.
 WEB_APP_ORIGIN = "https://app.openhpsdrzeus.com"
+# Origin(s) of the maintainer remote-diagnostics dashboard, comma-separated. It
+# runs at a different origin than the RX SPA above, so its /admin cross-origin
+# fetches need it on the allowlist. Update once the dashboard's final URL is set.
+ADMIN_ORIGINS = "https://openhpsdrzeus.com"
 
 # Per-callsign WebRTC signaling room (WebSocket Hibernation).
 [[durable_objects.bindings]]


### PR DESCRIPTION
## What

The remote-diagnostics maintainer **dashboard** (`OpenHPSDR-Zeus-org/zeus-webpage#2`) runs at a **different origin** than the RX SPA. The broker's `/admin` CORS layer only named the single `WEB_APP_ORIGIN` (`https://app.openhpsdrzeus.com`), so the dashboard's cross-origin `/admin/*` fetches would be blocked by the browser.

This makes the `/admin` CORS an **allowlist**: built from `WEB_APP_ORIGIN` + a new comma-separated `ADMIN_ORIGINS` var, echoing back the **exact requesting origin** only when it matches.

## Why this shape

CORS permits a single `Access-Control-Allow-Origin` value — you can't return a list. So the correct multi-origin pattern is: keep an allowlist, read the request's `Origin`, and echo it back iff it's allowlisted. `corsHeaders` now takes the `Request` to do that.

Still **fails closed**, same as before:
- An **unlisted** origin → no `Allow-Origin` header.
- A request with **no `Origin`** (non-browser callers, e.g. the agent CLI) → no `Allow-Origin`.
- **Never** `*`, never a list.

## Changes
- `src/types.ts` — new `ADMIN_ORIGINS?: string` (documented).
- `src/admin-api.ts` — `corsHeaders(env, request)` + `allowedAdminOrigins(env)` helper; both exported for unit testing.
- `wrangler.toml` — `ADMIN_ORIGINS = "https://openhpsdrzeus.com"` (update once the dashboard's final URL is locked).
- `test/admin-cors.test.ts` — 7 focused tests (allowlist build/trim/trailing-slash, dashboard origin echoed, RX-SPA no-regression, unlisted denied, no-Origin denied, never `*`, empty config).

## Verification
- `npm run typecheck` clean.
- `npm test` — **22/22** pass (7 new).

## Deploy note
Deploying picks up the new `ADMIN_ORIGINS` var from `wrangler.toml`. No new secrets, no new bindings. Adjust the value if the dashboard lands on a different origin than `https://openhpsdrzeus.com`.

Follow-up to the remote-diagnostics support epic (P3b/P5/P3c/P4b merged; P4 dashboard PR open in `zeus-webpage`).