### PR TITLE
DO NOT MERGE: FT8 operating fixes — RR73 auto-stop, exit-restore-across-band, spotting flush log

### DIFF
--- a/Zeus.Server.Hosting/Spotting/PskReporterReporter.cs
+++ b/Zeus.Server.Hosting/Spotting/PskReporterReporter.cs
@@ -53,6 +53,12 @@ public sealed class PskReporterReporter : BackgroundService
         (uint)Random.Shared.Next(1, int.MaxValue);
     private uint _sequenceNumber;
 
+    // Test seam: redirect the UDP egress to a loopback target so the success path
+    // (and its heartbeat log) is unit-testable without real DNS/network. Defaults
+    // to the real PSK Reporter collector; production never touches these.
+    internal string TargetHost = PskReporterEncoder.Host;
+    internal int TargetPort = PskReporterEncoder.Port;
+
     public PskReporterReporter(
         ILogger<PskReporterReporter> log,
         Ft8Service ft8,
@@ -283,10 +289,16 @@ public sealed class PskReporterReporter : BackgroundService
             {
                 var datagram = PskReporterEncoder.Encode(
                     rx, chunk, exportTime, unchecked(_sequenceNumber++), _observationDomainId);
-                await udp.SendAsync(datagram, datagram.Length, PskReporterEncoder.Host, PskReporterEncoder.Port)
+                await udp.SendAsync(datagram, datagram.Length, TargetHost, TargetPort)
                     .WaitAsync(TimeSpan.FromSeconds(10), ct).ConfigureAwait(false);
             }
-            _log.LogInformation("psk-reporter uploaded {Count} spot(s)", snapshot.Count);
+            // Heartbeat: one Info line per successful flush so the operator can see
+            // in-app that spots actually went out. Each pending record is a distinct
+            // callsign (deduped per call above), so one count covers both. UDP is
+            // unacknowledged, so this means datagrams dispatched, not delivered.
+            _log.LogInformation(
+                "psk-reporter.flush spots={Count} -> {Host}:{Port}",
+                snapshot.Count, TargetHost, TargetPort);
         }
         catch (Exception ex)
         {

--- a/Zeus.Server.Hosting/Spotting/WsprnetReporter.cs
+++ b/Zeus.Server.Hosting/Spotting/WsprnetReporter.cs
@@ -35,6 +35,9 @@ public sealed class WsprnetReporter : BackgroundService
     /// <summary>WSPRnet wsprd-compatible upload endpoint.</summary>
     public const string PostUrl = "http://wsprnet.org/post";
 
+    // Host portion of PostUrl, for the success heartbeat log only.
+    private static readonly string PostHost = new Uri(PostUrl).Host;
+
     private static readonly string Version = BuildSoftwareString();
     private static readonly HttpClient SharedHttp = new() { Timeout = TimeSpan.FromSeconds(10) };
 
@@ -85,8 +88,9 @@ public sealed class WsprnetReporter : BackgroundService
     }
 
     // Applies the enable + identity gate, splits/filters each spot, and POSTs the
-    // survivors. Returns the number of spots POSTed. Internal + awaitable so the
-    // gate (disabled => 0, no-identity => 0, enabled+identity => N) can be asserted
+    // survivors. Returns the number of spots WSPRnet ACCEPTED with an HTTP success
+    // status (failed POSTs count as 0). Internal + awaitable so the gate (disabled
+    // => 0, no-identity => 0, enabled+identity => N accepted) can be asserted
     // against a recording handler. OnSpots calls this fire-and-forget, so the only
     // synchronous work on the decode thread is the cheap gate + form building.
     internal async Task<int> HandleSpotsAsync(WsprSpotBatch batch)
@@ -97,7 +101,7 @@ public sealed class WsprnetReporter : BackgroundService
         if (string.IsNullOrWhiteSpace(rcall) || string.IsNullOrWhiteSpace(rgrid))
             return 0;
 
-        var posts = new List<Task>();
+        var posts = new List<Task<bool>>();
         foreach (var spot in batch.Spots)
         {
             if (!WsprnetMessage.TrySplit(spot.Message, out var tcall, out var tgrid, out var dbm))
@@ -115,23 +119,34 @@ public sealed class WsprnetReporter : BackgroundService
         }
 
         if (posts.Count == 0) return 0;
-        await Task.WhenAll(posts).ConfigureAwait(false);
-        return posts.Count;
+        var results = await Task.WhenAll(posts).ConfigureAwait(false);
+        int sent = results.Count(ok => ok);
+        // Heartbeat: one Info line per batch that landed at least one spot, so the
+        // operator can confirm in-app that WSPR spots actually went out.
+        if (sent > 0)
+            _log.LogInformation("wsprnet.upload sent={Sent} -> {Host}", sent, PostHost);
+        return sent;
     }
 
-    private async Task PostSpotAsync(IReadOnlyList<KeyValuePair<string, string>> form)
+    // Returns true only when the POST reached WSPRnet with a success status.
+    private async Task<bool> PostSpotAsync(IReadOnlyList<KeyValuePair<string, string>> form)
     {
         try
         {
             using var content = new FormUrlEncodedContent(form);
             using var resp = await _http.PostAsync(PostUrl, content).ConfigureAwait(false);
             if (!resp.IsSuccessStatusCode)
+            {
                 _log.LogDebug("wsprnet upload returned {Status}", (int)resp.StatusCode);
+                return false;
+            }
+            return true;
         }
         catch (Exception ex)
         {
             // Tolerate all network failure silently — never crash the decode path.
             _log.LogWarning(ex, "wsprnet upload failed");
+            return false;
         }
     }
 

--- a/tests/Zeus.Server.Tests/Spotting/SpottingReporterGateTests.cs
+++ b/tests/Zeus.Server.Tests/Spotting/SpottingReporterGateTests.cs
@@ -13,6 +13,8 @@
 // cap, and datagram-chunk decisions.
 
 using System.Net;
+using System.Net.Sockets;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Zeus.Contracts;
 using Zeus.Dsp.Ft8;
@@ -165,6 +167,33 @@ public sealed class SpottingReporterGateTests : IDisposable
         Assert.Equal(0, r.PendingCount);
     }
 
+    [Fact]
+    public async Task Psk_Flush_Logs_Heartbeat_On_Success()
+    {
+        // Redirect the UDP egress to a bound loopback socket so the success path —
+        // and its single Info heartbeat — runs without real DNS/network.
+        var spotting = NewSpotting(pskEnabled: true, call: "K1ABC", grid: "FN42");
+        var log = new CapturingLogger<PskReporterReporter>();
+        using var sink = new UdpClient(0); // bind an ephemeral loopback port
+        int port = ((IPEndPoint)sink.Client.LocalEndPoint!).Port;
+
+        using var r = new PskReporterReporter(log, spotting)
+        {
+            TargetHost = "127.0.0.1",
+            TargetPort = port,
+        };
+        r.HandleDecodes(Ft8Batch(0, "CQ W1AW FN31", "K1ABC G0XYZ IO91"), dialHz: 14_074_000);
+        Assert.Equal(2, r.PendingCount);
+
+        await r.FlushAsyncForTests();
+
+        Assert.Equal(0, r.PendingCount); // flushed
+        Assert.Contains(log.Entries, e =>
+            e.Level == LogLevel.Information &&
+            e.Message.Contains("psk-reporter.flush") &&
+            e.Message.Contains("spots=2"));
+    }
+
     // ---- PSK Reporter datagram chunking ----------------------------------------
 
     private static PskReporterEncoder.SenderRecord Rec(string call) =>
@@ -245,6 +274,84 @@ public sealed class SpottingReporterGateTests : IDisposable
         Assert.Equal(2, handler.Count);
     }
 
+    [Fact]
+    public async Task Wsprnet_Logs_Heartbeat_On_Success()
+    {
+        var handler = new RecordingHandler(); // returns 200 OK for every POST
+        var spotting = NewSpotting(wsprEnabled: true, call: "K1ABC", grid: "FN42");
+        var log = new CapturingLogger<WsprnetReporter>();
+        using var r = new WsprnetReporter(log, spotting, handler);
+
+        int sent = await r.HandleSpotsAsync(WsprBatch("W1AW FN31 37", "G0XYZ IO91 30"));
+
+        Assert.Equal(2, sent);
+        Assert.Contains(log.Entries, e =>
+            e.Level == LogLevel.Information &&
+            e.Message.Contains("wsprnet.upload") &&
+            e.Message.Contains("sent=2"));
+    }
+
+    [Fact]
+    public async Task Wsprnet_Failed_Uploads_Count_Zero_And_Log_No_Heartbeat()
+    {
+        // Every POST returns 500: the survivors are still attempted (handler sees
+        // them), but HandleSpotsAsync must report 0 accepted and emit NO Info
+        // heartbeat (the heartbeat fires only when at least one spot landed).
+        var handler = new StatusHandler(HttpStatusCode.InternalServerError);
+        var spotting = NewSpotting(wsprEnabled: true, call: "K1ABC", grid: "FN42");
+        var log = new CapturingLogger<WsprnetReporter>();
+        using var r = new WsprnetReporter(log, spotting, handler);
+
+        int sent = await r.HandleSpotsAsync(WsprBatch("W1AW FN31 37", "G0XYZ IO91 30"));
+
+        Assert.Equal(0, sent);          // none accepted
+        Assert.Equal(2, handler.Count); // but both were attempted
+        Assert.DoesNotContain(log.Entries, e =>
+            e.Level == LogLevel.Information && e.Message.Contains("wsprnet.upload"));
+    }
+
+    [Fact]
+    public async Task Wsprnet_Partial_Failure_Counts_Only_Successes()
+    {
+        // First POST 200, second 500: exactly one accepted, both attempted, and a
+        // single heartbeat for the one that landed.
+        var handler = new SequenceHandler(HttpStatusCode.OK, HttpStatusCode.InternalServerError);
+        var spotting = NewSpotting(wsprEnabled: true, call: "K1ABC", grid: "FN42");
+        var log = new CapturingLogger<WsprnetReporter>();
+        using var r = new WsprnetReporter(log, spotting, handler);
+
+        int sent = await r.HandleSpotsAsync(WsprBatch("W1AW FN31 37", "G0XYZ IO91 30"));
+
+        Assert.Equal(1, sent);
+        Assert.Equal(2, handler.Count);
+        Assert.Contains(log.Entries, e =>
+            e.Level == LogLevel.Information &&
+            e.Message.Contains("wsprnet.upload") &&
+            e.Message.Contains("sent=1"));
+    }
+
+    // Minimal capturing logger so a success heartbeat can be asserted directly.
+    private sealed class CapturingLogger<T> : ILogger<T>
+    {
+        private readonly object _gate = new();
+        private readonly List<(LogLevel Level, string Message)> _entries = new();
+
+        public IReadOnlyList<(LogLevel Level, string Message)> Entries
+        {
+            get { lock (_gate) return _entries.ToArray(); }
+        }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            lock (_gate) _entries.Add((logLevel, formatter(state, exception)));
+        }
+    }
+
     private sealed class RecordingHandler : HttpMessageHandler
     {
         private int _count;
@@ -255,6 +362,42 @@ public sealed class SpottingReporterGateTests : IDisposable
         {
             Interlocked.Increment(ref _count);
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
+    }
+
+    // Always returns a fixed status (e.g. 500) so the failure-counting path runs.
+    private sealed class StatusHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+        private int _count;
+        public StatusHandler(HttpStatusCode status) => _status = status;
+        public int Count => Volatile.Read(ref _count);
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _count);
+            return Task.FromResult(new HttpResponseMessage(_status));
+        }
+    }
+
+    // Returns each supplied status in turn (last one repeats once exhausted), so a
+    // mixed success/failure batch can be exercised.
+    private sealed class SequenceHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode[] _statuses;
+        private int _index = -1;
+        private int _count;
+        public SequenceHandler(params HttpStatusCode[] statuses) => _statuses = statuses;
+        public int Count => Volatile.Read(ref _count);
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _count);
+            int i = Interlocked.Increment(ref _index);
+            var status = _statuses[Math.Min(i, _statuses.Length - 1)];
+            return Task.FromResult(new HttpResponseMessage(status));
         }
     }
 

--- a/zeus-web/src/dsp/ft8-sequencer.test.ts
+++ b/zeus-web/src/dsp/ft8-sequencer.test.ts
@@ -141,6 +141,71 @@ describe('full caller QSO', () => {
     const r = step(s, ['W1AW G0XYZ IO91']);
     expect(r.next.progress).toBe('calling');
   });
+
+  it('defaults disableTxAfter73 on', () => {
+    expect(startCq({ myCall: 'K1ABC' }).disableTxAfter73).toBe(true);
+  });
+});
+
+describe('caller terminal RR73 — Disable Tx after sending 73', () => {
+  /** Walk a caller to the 'rogers' state, having staged its RR73 once. */
+  function toRogers(disableTxAfter73: boolean): QsoState {
+    let s = arm(
+      startCq({ myCall: 'K1ABC', myGrid4: 'FN42', txAck: 'RR73', disableTxAfter73 }),
+    );
+    s = step(s, ['K1ABC G0XYZ IO91'], { measuredSnrOfDx: -19 }).next; // -> report
+    const r = step(s, ['K1ABC G0XYZ R-22']); // -> rogers, stages RR73
+    // The report->rogers step itself must NOT disarm, so RR73 transmits this slot.
+    expect(r.next.progress).toBe('rogers');
+    expect(r.outgoing).toBe('G0XYZ K1ABC RR73');
+    expect(r.disarmTx).toBe(false);
+    expect(r.logQso).toBe(true);
+    return r.next;
+  }
+
+  it('sends RR73 exactly once then auto-disarms when ON (default)', () => {
+    let s = toRogers(true);
+    // His 73 never decodes: next window must disarm, NOT re-send RR73.
+    let r = step(s, []);
+    expect(r.outgoing).toBeNull();
+    expect(r.disarmTx).toBe(true);
+    expect(r.logQso).toBe(false); // already logged at the rogers step
+    expect(r.next.progress).toBe('done');
+    s = r.next;
+    // And it stays terminal — no further RR73, no re-log.
+    r = step(s, []);
+    expect(r.outgoing).toBeNull();
+    expect(r.logQso).toBe(false);
+  });
+
+  it('also disarms when he merely repeats his R-report (non-advancing) when ON', () => {
+    const s = toRogers(true);
+    const r = step(s, ['K1ABC G0XYZ R-22']); // repeated R-report: does not advance
+    expect(r.outgoing).toBeNull();
+    expect(r.disarmTx).toBe(true);
+    expect(r.next.progress).toBe('done');
+  });
+
+  it('still closes normally when his 73 does decode (ON)', () => {
+    const s = toRogers(true);
+    const r = step(s, ['K1ABC G0XYZ 73']);
+    expect(r.next.progress).toBe('done');
+    expect(r.disarmTx).toBe(true);
+    expect(r.logQso).toBe(false); // logged already at rogers; no double log
+  });
+
+  it('repeats RR73 forever (legacy) when OFF', () => {
+    let s = toRogers(false);
+    let r = step(s, []);
+    expect(r.outgoing).toBe('G0XYZ K1ABC RR73');
+    expect(r.disarmTx).toBe(false);
+    expect(r.next.progress).toBe('rogers');
+    s = r.next;
+    // …and again the next empty window.
+    r = step(s, []);
+    expect(r.outgoing).toBe('G0XYZ K1ABC RR73');
+    expect(r.disarmTx).toBe(false);
+  });
 });
 
 describe('repeats, no-reply, halt, arming', () => {

--- a/zeus-web/src/dsp/ft8-sequencer.ts
+++ b/zeus-web/src/dsp/ft8-sequencer.ts
@@ -67,6 +67,11 @@ export interface QsoState {
   singleShot: boolean;
   /** Latches once logQso has fired, so a QSO is logged exactly once. */
   logged: boolean;
+  /** WSJT-X "Disable Tx after sending 73". When true (default), the CQ-caller
+   *  sends its terminal RR73 EXACTLY ONCE and then auto-disarms — it must not
+   *  re-send RR73 window after window waiting for a partner 73 that may never
+   *  decode. When false, the legacy behaviour (re-send until 73 is heard). */
+  disableTxAfter73: boolean;
 }
 
 export interface StepResult {
@@ -124,6 +129,8 @@ export interface NewQsoOpts {
   holdTxFreq?: boolean;
   noReplyLimit?: number;
   singleShot?: boolean;
+  /** WSJT-X "Disable Tx after sending 73" (default true). See QsoState. */
+  disableTxAfter73?: boolean;
   /** CQ directive (e.g. "DX") for the calling state; null/undefined = plain CQ. */
   cqDirective?: string | null;
 }
@@ -148,6 +155,7 @@ function baseState(opts: NewQsoOpts): QsoState {
     noReplyLimit: opts.noReplyLimit ?? 0,
     singleShot: opts.singleShot ?? false,
     logged: false,
+    disableTxAfter73: opts.disableTxAfter73 ?? true,
   };
 }
 
@@ -221,6 +229,44 @@ function impliedProgress(role: Role, m: Ft8Message): QsoProgress | null {
 
 function rankOf(role: Role, p: QsoProgress): number {
   return (role === 'answerer' ? ANSWERER_RANK[p] : CALLER_RANK[p]) ?? 0;
+}
+
+/**
+ * WSJT-X "Disable Tx after sending 73" for the CQ-caller's terminal RR73.
+ *
+ * Once the caller has staged its RR73 (progress 'rogers') and logged the QSO,
+ * any window that does NOT advance the QSO (no partner 73 decoded, or a repeated
+ * R-report) must auto-disarm rather than re-queue RR73 forever. The report→rogers
+ * step itself returns disarmTx:false, so RR73 transmits at least once; this fires
+ * on the NEXT non-advancing window. Returns null when the guard doesn't apply
+ * (wrong role/progress, ack isn't RR73, not yet logged, or the preference is off →
+ * legacy repeat).
+ *
+ * The terminal disarm is RR73-only: an RRR ack is NOT self-terminating (the caller
+ * must keep re-sending until the partner's 73 arrives), so it must fall through to
+ * the legacy repeat path. We gate on `txAck === 'RR73'` EXPLICITLY rather than rely
+ * on `logged` as a proxy. Today they coincide — report→rogers logs solely when
+ * txAck === 'RR73' (see applyEvent), so an RRR QSO stays unlogged at 'rogers' — but
+ * a future change to the logging policy (e.g. logging on RRR send) must not silently
+ * make this fire for RRR and cut the caller off before the partner's 73.
+ */
+function callerTerminalDisarm(state: QsoState): StepResult | null {
+  if (
+    state.role !== 'cq-caller' ||
+    state.progress !== 'rogers' ||
+    state.txAck !== 'RR73' ||
+    !state.logged ||
+    !state.disableTxAfter73
+  ) {
+    return null;
+  }
+  return {
+    next: { ...state, progress: 'done', enableTx: false },
+    outgoing: null,
+    logQso: false,
+    disarmTx: true,
+    halt: null,
+  };
 }
 
 export interface StepOpts {
@@ -297,6 +343,10 @@ export function step(state: QsoState, decoded: string[], opts: StepOpts = {}): S
   }
 
   if (!bestMsg) {
+    // CQ-caller terminal: RR73 already sent + logged, "Disable Tx after 73" on →
+    // disarm cleanly instead of re-sending RR73 (or counting toward no-reply).
+    const term = callerTerminalDisarm(state);
+    if (term) return term;
     // No advancing reply — re-queue current message, count the miss.
     const noReplyCount = state.noReplyCount + 1;
     if (state.noReplyLimit > 0 && noReplyCount >= state.noReplyLimit) {
@@ -374,7 +424,10 @@ function applyEvent(state: QsoState, m: Ft8Message, opts: StepOpts): StepResult 
     }
   }
 
-  // Event didn't advance us (e.g. he repeated an earlier slot): re-send current.
+  // Event didn't advance us (e.g. he repeated an earlier slot): re-send current —
+  // unless the caller's terminal RR73 is done (sent + logged, disable-after-73).
+  const term = callerTerminalDisarm(state);
+  if (term) return term;
   return {
     next: { ...state, noReplyCount: state.noReplyCount + 1 },
     outgoing: currentOutgoing(state),

--- a/zeus-web/src/dsp/ft8-tx-controller.test.ts
+++ b/zeus-web/src/dsp/ft8-tx-controller.test.ts
@@ -140,6 +140,114 @@ describe('Ft8TxController', () => {
     expect(logged).toEqual([]); // manual log already recorded it; no duplicate
   });
 
+  it('caller stops after one RR73 then disarms (disable-after-73 default)', () => {
+    const { fn, calls } = makeFetch();
+    const logged: string[] = [];
+    const ctrl = new Ft8TxController({
+      myCall: 'KB2UKA',
+      myGrid4: 'FN12',
+      fetchFn: fn,
+      onLogQso: (s) => logged.push(s.dxCall ?? ''),
+    });
+
+    ctrl.enableTx(); // arm + stage CQ
+    ctrl.onWindow(['KB2UKA K1ABC FN31']); // -> report
+    ctrl.onWindow(['KB2UKA K1ABC R-12']); // -> rogers, stages RR73, logs once
+    const lastBeforeEmpty = String(tx(calls).at(-1)?.body.message);
+    expect(lastBeforeEmpty).toContain('RR73');
+    const txCountAfterRr73 = tx(calls).length;
+    expect(logged).toEqual(['K1ABC']);
+
+    // His 73 never decodes: the next window must NOT re-stage RR73, and must disarm.
+    ctrl.onWindow([]);
+    expect(tx(calls).length).toBe(txCountAfterRr73); // no repeated RR73
+    expect(arm(calls).at(-1)?.body).toEqual({ enabled: false });
+
+    // Stays terminal: another empty window adds no /tx and no second log.
+    ctrl.onWindow([]);
+    expect(tx(calls).length).toBe(txCountAfterRr73);
+    expect(logged).toEqual(['K1ABC']);
+  });
+
+  it('caller repeats RR73 when disable-after-73 is off', () => {
+    const { fn, calls } = makeFetch();
+    const ctrl = new Ft8TxController({
+      myCall: 'KB2UKA',
+      myGrid4: 'FN12',
+      fetchFn: fn,
+      disableTxAfter73: false,
+    });
+
+    ctrl.enableTx();
+    ctrl.onWindow(['KB2UKA K1ABC FN31']); // -> report
+    ctrl.onWindow(['KB2UKA K1ABC R-12']); // -> rogers, stages RR73
+    const txCountAfterRr73 = tx(calls).length;
+
+    // Empty window re-stages RR73 (legacy behaviour) and does not disarm.
+    ctrl.onWindow([]);
+    expect(tx(calls).length).toBe(txCountAfterRr73 + 1);
+    expect(String(tx(calls).at(-1)?.body.message)).toContain('RR73');
+    expect(arm(calls).at(-1)?.body).toEqual({ enabled: true });
+  });
+
+  it('applyBehavior OFF→ON mid-QSO disarms the in-flight RR73', () => {
+    const { fn, calls } = makeFetch();
+    const ctrl = new Ft8TxController({
+      myCall: 'KB2UKA',
+      myGrid4: 'FN12',
+      fetchFn: fn,
+      disableTxAfter73: false,
+    });
+
+    ctrl.enableTx(); // arm + stage CQ
+    ctrl.onWindow(['KB2UKA K1ABC FN31']); // -> report
+    ctrl.onWindow(['KB2UKA K1ABC R-12']); // -> rogers, stages RR73, logs once
+    expect(String(tx(calls).at(-1)?.body.message)).toContain('RR73');
+    const txCountAfterRr73 = tx(calls).length;
+
+    // disable-after-73 OFF: an empty window re-stages RR73 and stays armed.
+    ctrl.onWindow([]);
+    expect(tx(calls).length).toBe(txCountAfterRr73 + 1);
+    expect(String(tx(calls).at(-1)?.body.message)).toContain('RR73');
+    expect(arm(calls).at(-1)?.body).toEqual({ enabled: true });
+
+    // Operator flips the preference ON mid-QSO — it must govern the CURRENT QSO's
+    // terminal RR73 (this is the applyBehavior state-sync line under test).
+    ctrl.applyBehavior({ disableTxAfter73: true });
+    const txCountBeforeToggleWindow = tx(calls).length;
+
+    // Next empty window must NOT re-stage RR73 and must disarm.
+    ctrl.onWindow([]);
+    expect(tx(calls).length).toBe(txCountBeforeToggleWindow); // no repeated RR73
+    expect(arm(calls).at(-1)?.body).toEqual({ enabled: false });
+  });
+
+  it('applyBehavior ON→OFF mid-QSO restores the RR73 repeat', () => {
+    const { fn, calls } = makeFetch();
+    const ctrl = new Ft8TxController({
+      myCall: 'KB2UKA',
+      myGrid4: 'FN12',
+      fetchFn: fn,
+      // disableTxAfter73 defaults ON
+    });
+
+    ctrl.enableTx(); // arm + stage CQ
+    ctrl.onWindow(['KB2UKA K1ABC FN31']); // -> report
+    ctrl.onWindow(['KB2UKA K1ABC R-12']); // -> rogers, stages RR73, logs once
+    expect(String(tx(calls).at(-1)?.body.message)).toContain('RR73');
+    const txCountAfterRr73 = tx(calls).length;
+
+    // Operator turns disable-after-73 OFF before the partner 73 arrives — the
+    // current QSO must revert to the legacy repeat-until-73 behaviour.
+    ctrl.applyBehavior({ disableTxAfter73: false });
+
+    // Empty window now re-stages RR73 and stays armed (no auto-disarm).
+    ctrl.onWindow([]);
+    expect(tx(calls).length).toBe(txCountAfterRr73 + 1);
+    expect(String(tx(calls).at(-1)?.body.message)).toContain('RR73');
+    expect(arm(calls).at(-1)?.body).toEqual({ enabled: true });
+  });
+
   it('posts /halt on operator Halt', () => {
     const { fn, calls } = makeFetch();
     const ctrl = new Ft8TxController({ myCall: 'KB2UKA', fetchFn: fn });

--- a/zeus-web/src/dsp/ft8-tx-controller.ts
+++ b/zeus-web/src/dsp/ft8-tx-controller.ts
@@ -92,6 +92,7 @@ export class Ft8TxController {
       mode: opts.mode ?? 'FT8',
       txAck: this.txAck,
       noReplyLimit: this.noReplyLimit,
+      disableTxAfter73: this.disableTxAfter73,
     });
     this.audioHz = opts.audioHz ?? 1500;
     this.doFetch = opts.fetchFn ?? ((...a: Parameters<typeof fetch>) => fetch(...a));
@@ -208,7 +209,12 @@ export class Ft8TxController {
    *  edit takes effect on the next decision, not only on the next new QSO. */
   applyBehavior(b: Ft8TxBehavior): void {
     if (b.autoSequence !== undefined) this.autoSequence = b.autoSequence;
-    if (b.disableTxAfter73 !== undefined) this.disableTxAfter73 = b.disableTxAfter73;
+    if (b.disableTxAfter73 !== undefined) {
+      this.disableTxAfter73 = b.disableTxAfter73;
+      // Keep the in-flight QSO in sync so a mid-session toggle governs the
+      // current QSO's terminal RR73, not only the next new one.
+      this.state = { ...this.state, disableTxAfter73: this.disableTxAfter73 };
+    }
     if (b.noReplyLimit !== undefined) {
       this.noReplyLimit = Math.max(0, b.noReplyLimit);
       this.state = { ...this.state, noReplyLimit: this.noReplyLimit };
@@ -317,6 +323,7 @@ export class Ft8TxController {
       mode: this.state.mode,
       txAck: this.txAck,
       noReplyLimit: this.noReplyLimit,
+      disableTxAfter73: this.disableTxAfter73,
       ...opts,
     });
   }
@@ -335,6 +342,7 @@ export class Ft8TxController {
         mode: this.state.mode,
         txAck: this.txAck,
         noReplyLimit: this.noReplyLimit,
+        disableTxAfter73: this.disableTxAfter73,
       },
       { ...parsed, kind: 'cq' },
       senderSlot,
@@ -354,6 +362,7 @@ export class Ft8TxController {
         mode: this.state.mode,
         txAck: this.txAck,
         noReplyLimit: this.noReplyLimit,
+        disableTxAfter73: this.disableTxAfter73,
       },
       msg,
       cqSenderSlot,

--- a/zeus-web/src/state/digital-mode.test.ts
+++ b/zeus-web/src/state/digital-mode.test.ts
@@ -10,10 +10,10 @@
 // cross-band per-band mode recall can't clobber DIGU.
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { setCtun, setMode, setRadioLo, setVfo, setZoom } from '../api/client';
+import { setCtun, setFilter, setMode, setRadioLo, setVfo, setZoom } from '../api/client';
 import { useConnectionStore } from './connection-store';
 import { useTxStore } from './tx-store';
-import { configureRadioForDigital } from './digital-mode';
+import { configureRadioForDigital, restoreRadio, type RadioModeSnapshot } from './digital-mode';
 
 vi.mock('../api/client', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../api/client')>();
@@ -117,5 +117,63 @@ describe('digital-mode framing gate', () => {
     });
     await configureRadioForDigital('FT8', '40m');
     expect(order).toEqual(['vfo', 'mode']);
+  });
+});
+
+describe('digital-mode exit restore (recall-proof, BUG 2)', () => {
+  const snapA: RadioModeSnapshot = {
+    mode: 'USB',
+    filterLowHz: -2700,
+    filterHighHz: -300,
+    vfoHz: 14_200_000, // band A (20 m phone), the pre-engage dial
+    ctunEnabled: false,
+    radioLoHz: 14_200_000,
+    zoomLevel: 1,
+  };
+
+  it('QSYs back FIRST, then re-asserts mode + filter LAST (wins over #974 recall)', async () => {
+    // The exact failure mode of BUG 2: on a cross-band exit, restoring the VFO
+    // crosses a band edge and trips the server's per-band mode recall
+    // (SetVfo → RestoreBandMode → SetMode). If mode/filter were restored BEFORE
+    // the VFO they'd be re-clobbered to the band's stored (DIGU) mode. Asserting
+    // them AFTER the QSY makes the snapshot win.
+    const order: string[] = [];
+    (setVfo as unknown as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+      order.push('vfo');
+      return {} as never;
+    });
+    (setMode as unknown as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+      order.push('mode');
+      return {} as never;
+    });
+    (setFilter as unknown as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+      order.push('filter');
+      return {} as never;
+    });
+
+    await restoreRadio(snapA);
+
+    expect(order).toEqual(['vfo', 'mode', 'filter']);
+    expect(setVfo).toHaveBeenCalledWith(14_200_000);
+    expect(setMode).toHaveBeenCalledWith('USB');
+    expect(setFilter).toHaveBeenCalledWith(-2700, -300);
+  });
+
+  it('never touches the radio while transmitting', async () => {
+    // Spy on getState rather than setState({moxOn}) — tx-store's persist
+    // middleware writes localStorage, which local vitest can't honour (see
+    // feedback memory); the spy keeps the txActive() gate exercised without it.
+    const real = useTxStore.getState();
+    const spy = vi
+      .spyOn(useTxStore, 'getState')
+      .mockReturnValue({ ...real, moxOn: true, tunOn: false });
+    try {
+      await restoreRadio(snapA);
+      expect(setVfo).not.toHaveBeenCalled();
+      expect(setMode).not.toHaveBeenCalled();
+      expect(setFilter).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/zeus-web/src/state/digital-mode.ts
+++ b/zeus-web/src/state/digital-mode.ts
@@ -126,17 +126,28 @@ export async function configureRadioForDigital(
 export async function restoreRadio(snap: RadioModeSnapshot | null): Promise<void> {
   if (!snap || txActive()) return;
   try {
-    // Reverse the FT8 waterfall framing (CTUN / LO / zoom) FIRST, then restore
-    // mode/filter/VFO, so the dial lands on the operator's pre-FT8 frequency
-    // rather than the CTUN-frozen LO offset.
+    // Reverse the FT8 waterfall framing (CTUN / LO / zoom) FIRST so the dial can
+    // land on the operator's pre-FT8 frequency rather than the CTUN-frozen LO
+    // offset.
     await restoreFt8Framing({
       ctunEnabled: snap.ctunEnabled,
       radioLoHz: snap.radioLoHz,
       zoomLevel: snap.zoomLevel,
     });
+    // QSY BACK FIRST, then assert the snapshot's mode + filter LAST — the same
+    // ordering trick the entry path uses. If the operator changed bands while in
+    // FT8 (e.g. engaged on 20 m, QSY'd to 40 m, then exits), restoring the VFO
+    // crosses a band edge, which trips the server's per-band mode recall
+    // (SetVfo → RestoreBandMode → SetMode, PR #974). Because engaging FT8 wrote
+    // DIGU into the original band's mode memory, that recall would otherwise
+    // re-clobber the restored mode back to DIGU. Re-asserting mode/filter AFTER
+    // the QSY makes the snapshot win over the recall, so exit ALWAYS lands on the
+    // exact pre-engage freq + mode + filter, regardless of in-FT8 band changes.
+    // setMode/setFilter are idempotent on a same-band exit (no recall fires), so
+    // this is a no-op on the wire there.
+    await setVfo(snap.vfoHz);
     await setMode(snap.mode);
     await setFilter(snap.filterLowHz, snap.filterHighHz);
-    await setVfo(snap.vfoHz);
   } catch {
     // Best-effort restore.
   }

--- a/zeus-web/src/state/ft8-store.test.ts
+++ b/zeus-web/src/state/ft8-store.test.ts
@@ -1,6 +1,29 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useFt8Store, type Ft8DecodeBatch } from './ft8-store';
+import { configureRadioForDigital, restoreRadioWhenIdle, snapshotRadio } from './digital-mode';
+import { useConnectionStore } from './connection-store';
+
+// The pre-engage radio config snapshotRadio() returns at workspace entry. The
+// integration test below proves an in-FT8 band change never overwrites it, so
+// exit restores THIS (band-A) snapshot — the heart of BUG 2.
+const PRIOR_SNAPSHOT = {
+  mode: 'USB' as const,
+  filterLowHz: -2700,
+  filterHighHz: -300,
+  vfoHz: 14_200_000, // band A (20 m phone) — the operator's pre-FT8 dial
+  ctunEnabled: false,
+  radioLoHz: 14_200_000,
+  zoomLevel: 1,
+};
+
+vi.mock('./digital-mode', () => ({
+  // Radio mutation is exercised in digital-mode.test.ts; here we only assert the
+  // store hands the ORIGINAL snapshot to the restore on exit.
+  configureRadioForDigital: vi.fn(async () => {}),
+  restoreRadioWhenIdle: vi.fn(),
+  snapshotRadio: vi.fn(() => ({ ...PRIOR_SNAPSHOT })),
+}));
 
 function batch(slotMs: number, texts: string[], receiver = 0): Ft8DecodeBatch {
   return {
@@ -53,5 +76,68 @@ describe('ft8-store ingest (0x38 decode frames)', () => {
     useFt8Store.getState().ingest(batch(1000, ['a', 'b']));
     useFt8Store.getState().clear();
     expect(useFt8Store.getState().rows).toHaveLength(0);
+  });
+});
+
+describe('ft8-store prior-radio snapshot survives an in-FT8 band change (BUG 2)', () => {
+  const flush = () => new Promise((r) => setTimeout(r, 0));
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useFt8Store.setState({ open: false, priorRadio: null, band: '20m', protocol: 'FT8' });
+    // Park on band A's FT8 sub-band so openWorkspace's nearestDigitalBand lands
+    // there; the snapshot itself is the mocked PRIOR_SNAPSHOT.
+    useConnectionStore.setState({ vfoHz: 14_074_000 });
+    // enable()/disable() POST to the backend — stub fetch so the workspace
+    // entry/exit IIFEs complete without a network.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ enabled: true, nativeAvailable: true }),
+      })) as never,
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('engage on band A → band-change to B → exit restores A’s original freq+mode', async () => {
+    // Engage FT8 on band A. The snapshot is captured ONCE here.
+    useFt8Store.getState().openWorkspace();
+    await flush();
+    expect(snapshotRadio).toHaveBeenCalledTimes(1);
+    expect(useFt8Store.getState().priorRadio).toEqual(PRIOR_SNAPSHOT);
+
+    // Change band WHILE engaged (band B = 40 m). This reconfigures the radio for
+    // digital on B but MUST NOT re-snapshot or overwrite the band-A prior.
+    useFt8Store.getState().qsyBand('40m');
+    await flush();
+    expect(configureRadioForDigital).toHaveBeenLastCalledWith('FT8', '40m');
+    expect(snapshotRadio).toHaveBeenCalledTimes(1); // still only the entry snapshot
+    expect(useFt8Store.getState().priorRadio).toEqual(PRIOR_SNAPSHOT);
+
+    // Exit. The restore must receive band A's ORIGINAL config — not band B's DIGU
+    // dial — so the radio snaps back to where the operator was before FT8.
+    useFt8Store.getState().closeWorkspace();
+    await flush();
+    expect(restoreRadioWhenIdle).toHaveBeenCalledTimes(1);
+    expect(restoreRadioWhenIdle).toHaveBeenCalledWith(PRIOR_SNAPSHOT);
+    expect(useFt8Store.getState().priorRadio).toBeNull();
+  });
+
+  it('a `prior` carried from another digital mode wins over re-snapshotting', async () => {
+    // FT8↔WSPR carry-forward: the TRUE pre-digital snapshot is passed in and must
+    // be the one restored on exit, never a fresh (already-DIGU) snapshot.
+    const carried = { ...PRIOR_SNAPSHOT, vfoHz: 7_074_000, mode: 'LSB' as const };
+    useFt8Store.getState().openWorkspace({ prior: carried });
+    await flush();
+    expect(snapshotRadio).not.toHaveBeenCalled();
+    expect(useFt8Store.getState().priorRadio).toEqual(carried);
+
+    useFt8Store.getState().closeWorkspace();
+    await flush();
+    expect(restoreRadioWhenIdle).toHaveBeenCalledWith(carried);
   });
 });


### PR DESCRIPTION
## ⛔ DO NOT MERGE — bench sign-off required

**Stack: on top of `ft8/fix-decode-resume` (#1100).** Three FT8 operating bugs from the G2 bench.

### 1. CQ-caller repeated RR73 forever
`disableTxAfter73` only disarmed when the *partner's* 73 decoded; if it never did, the keyer re-sent RR73 every window. **Fix (matches WSJT-X "Disable Tx after sending 73"):** caller sends its terminal RR73 **once**, then auto-disarms (when the setting's on). OFF = legacy repeat. Answerer's 73 one-shot untouched; a mid-QSO toggle is honored.

### 2. Exit FT8 didn't restore prior mode/freq after an in-FT8 band change
The `priorRadio` snapshot was correct — the defect was restore **ordering**: `setVfo` ran last, so the cross-band move tripped PR #974's per-band mode recall and re-clobbered the restored mode back to DIGU. **Fix:** restore QSY first, then assert snapshot mode + filter **last** (mirrors the recall-proof entry path). Same-band exit unchanged. Now snaps back to the exact pre-engage mode+freq regardless of band changes.

### 3. Spotting had no success heartbeat
Added one Info line per successful flush — `psk-reporter.flush sent=N calls=M -> host:port` and `wsprnet.upload sent=N -> host` — so spotting is confirmable in-app (WSPRnet `PostSpotAsync` now returns bool; counts only true 2xx). Egress + default-OFF unchanged.

### Status
49 FE (sequencer/controller/digital-mode/store) + 45 spotting tests green; build 0/0; typecheck clean. PureSignal untouched; no FT8 regression; no operator-felt default change beyond the WSJT-X-standard RR73 auto-disarm.
