### PR TITLE
chore(cloud): bind the created zeus-admin D1 in broker + relay wrangler

### DIFF
--- a/cloud/zeus-remote-broker/wrangler.toml
+++ b/cloud/zeus-remote-broker/wrangler.toml
@@ -59,7 +59,7 @@ class_name = "CrashStore"
 [[d1_databases]]
 binding = "ADMIN_DB"
 database_name = "zeus-admin"
-database_id = "REPLACE_WITH_d1_create_OUTPUT"
+database_id = "7a25a1a9-7b4a-474f-93ae-fdf9b003da55"
 
 # SQLite-backed DO namespaces (free-plan compatible).
 [[migrations]]

--- a/cloud/zeuschat-relay/wrangler.toml
+++ b/cloud/zeuschat-relay/wrangler.toml
@@ -35,7 +35,7 @@ class_name = "RateLimiter"
 [[d1_databases]]
 binding = "ADMIN_DB"
 database_name = "zeus-admin"
-database_id = "REPLACE_WITH_d1_create_OUTPUT"
+database_id = "7a25a1a9-7b4a-474f-93ae-fdf9b003da55"
 
 # SQLite-backed DO namespaces (free-plan compatible).
 [[migrations]]


### PR DESCRIPTION
Sets the real `database_id` for the shared `zeus-admin` D1 in both `cloud/zeus-remote-broker/wrangler.toml` and `cloud/zeuschat-relay/wrangler.toml`, replacing the `REPLACE_WITH_d1_create_OUTPUT` placeholder.

The `zeus-admin` D1 has now been created (`wrangler d1 create`), migrated (`migrations/0001_admin.sql`), and both Workers are deployed and live against it. This commit just persists the binding so future `wrangler deploy` runs pick up the shared admin DB without a manual edit.

The id is a public Cloudflare resource identifier, not a secret.

Part of the remote-diagnostics support epic deploy (broker + relay now serving the credential-based admin store).