### PR TITLE
DO NOT MERGE: Zeus Digital pop-out — match global Zeus palette (colors only)

### DIFF
--- a/docs/designs/ft8-ui.md
+++ b/docs/designs/ft8-ui.md
@@ -66,7 +66,11 @@ REUSE wiring to existing panels:
 Station list beautification: vibrant colour-coded lines (CQ / directed-at-me /
 new-grid / worked-before / your-TX), the user's own TX line including the report
 being sent, and a small colour **key/legend** (`Ft8DecodeLegend`). Tokens only
-(`--hud-*` / `--tx`, `color-mix`) — no raw hex.
+(`--hud-*` / `--tx`, `color-mix`) — no raw hex. As of 2026-06-27 the `--hud-*`
+tokens are aliases of the global Zeus palette (see the palette-theme decision
+below — Option A's bespoke dark-HUD theme is reversed), so the colour-coded
+decode lines (CQ → `--ok` green, directed-at-me → `--power` amber, new →
+`--accent-bright`, worked → `--fg-2`, your-TX → `--tx`) read in the global hues.
 
 Note (PR-level): the pop-out no longer mounts its own spectrum surfaces, so the
 old App.tsx WebGL-context-release optimization (which unmounted the main
@@ -188,12 +192,37 @@ Three columns under a top status strip; status bar across the bottom.
 Maps cleanly onto the planned seam reuse: waterfall = existing panadapter,
 logbook = existing `LogService`/`AdifParser`, freq/CAT = existing VFO plumbing.
 
-## DECISION — palette / theme: **Option A, APPROVED (KB2UKA 2026-06-25)**
+## DECISION — palette / theme: **REVERSED (KB2UKA 2026-06-27) — matches the global palette**
 
-The FT8 workspace gets its **own dedicated dark-HUD theme** faithful to the
-mockup — cyan/teal-on-near-black-navy, color-coded decodes, monospaced data.
-Approved by KB2UKA (authority on Zeus visual design). KB2UKA further noted Zeus
-**may adopt this palette globally** at some later point.
+> **REVERSAL (2026-06-27, KB2UKA, visual authority):** Option A below is
+> superseded. The pop-out no longer uses a bespoke dark-HUD cyan/teal theme; it
+> now **matches the global Zeus palette** (`zeus-web/src/styles/tokens.css`).
+> The `--hud-*` layer survives only as a thin ALIAS set that points at global
+> tokens (`--hud-cyan → --accent-bright`, `--hud-bg → --bg-app`, `--hud-cq →
+> --ok`, `--hud-me → --power`, etc.), so the re-skin was colors-only with zero
+> component/markup change. Because the pop-out already tracks the global palette,
+> the "promote the HUD theme app-wide" path below is moot. The original Option A
+> text is retained for history.
+>
+> **Light-theme behaviour (2026-06-27):** the pop-out renders as an in-tree
+> `<div class="digital-window">` (not a portal), so it inherits the global
+> `:root[data-theme="light"]` chassis flip. Because the decode/status hues
+> (`--ok` green, `--power` amber, `--accent-bright` blue) have **no
+> dark-on-silver palette variants** and Zeus has no light-staying body-text
+> token, the pop-out is treated as a **lit instrument** (same doctrine as the
+> panadapter / VFO / S-meter / LED-meter wells, which `tokens.css` keeps dark in
+> light theme): a `:root[data-theme="light"] .digital-window` override keeps its
+> readout surfaces dark (`--bg-inset` / `--bg-meter`, the non-flipping
+> display-well tokens) and re-lights its text via `--btn-active-text` (the one
+> `#fff`-in-both-themes token). Dark theme — the default — is unchanged. This is
+> a light-theme **visual** decision (red-light territory): flagged for Brian
+> (EI6LF) / KB2UKA sign-off.
+
+The (historical) FT8 workspace direction gave it its **own dedicated dark-HUD
+theme** faithful to the mockup — cyan/teal-on-near-black-navy, color-coded
+decodes, monospaced data. Originally approved by KB2UKA (authority on Zeus
+visual design), who further noted Zeus **may adopt this palette globally** at
+some later point — now superseded by the reversal above.
 
 ### Engineering consequence — build it as a token LAYER, not hex
 Because this theme may later become Zeus-wide, do NOT hard-code the HUD colors

--- a/zeus-web/src/styles/ft8-theme.css
+++ b/zeus-web/src/styles/ft8-theme.css
@@ -1,9 +1,11 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later
  *
- * FT8/FT4/WSPR pop-out dark-HUD theme — KB2UKA-approved (Option A) token LAYER
- * scoped to .digital-window, extending the global tokens in tokens.css. Defined
- * as its own variable set so the look can later be promoted app-wide by
- * re-pointing root tokens, without rewriting components (see docs/designs/ft8-ui.md).
+ * FT8/FT4/WSPR pop-out theme — token LAYER scoped to .digital-window. The
+ * pop-out now MATCHES the global Zeus palette (tokens.css): the earlier bespoke
+ * dark-HUD cyan/teal theme (Option A) is REVERSED. The --hud-* names survive as
+ * a thin ALIAS set that points at global tokens, so components were re-skinned
+ * with zero markup/class changes and a future app-wide promotion is moot
+ * (see docs/designs/ft8-ui.md).
  *
  * The FT8/FT4/WSPR UI is now a floating DigitalWindow pop-out (FreeDV-style),
  * NOT a full-screen workspace — the operator keeps their normal Zeus console
@@ -17,32 +19,64 @@
  */
 
 .digital-window {
-  /* Surfaces — near-black navy with a faint cyan cast. */
-  --hud-bg:        #05080d;
-  --hud-panel:     #0a0f17;
-  --hud-panel-2:   #0e141d;
-  --hud-inset:     #04070b;
-  --hud-grid:      rgba(64, 160, 200, 0.08);
+  /* Palette re-skin: the --hud-* layer is now a thin ALIAS set that points at
+     the global Zeus tokens (tokens.css). Components still consume only --hud-*,
+     so the whole pop-out matches the global palette with zero component edits.
+     The earlier bespoke dark-HUD cyan/teal theme (Option A) is superseded —
+     see docs/designs/ft8-ui.md. */
 
-  /* Glow + lines — the cyan/teal HUD signature. */
-  --hud-cyan:      #38d6f0;
-  --hud-cyan-soft: rgba(56, 214, 240, 0.14);
-  --hud-cyan-line: rgba(56, 214, 240, 0.45);
-  --hud-line:      rgba(120, 160, 190, 0.16);
+  /* Surfaces. */
+  --hud-bg:        var(--bg-app);
+  --hud-panel:     var(--bg-1);
+  --hud-panel-2:   var(--bg-2);
+  --hud-inset:     var(--bg-inset);
+
+  /* Accent + lines — global blue accent replaces the cyan/teal signature. */
+  --hud-cyan:      var(--accent-bright);
+  --hud-cyan-soft: var(--accent-soft);
+  --hud-cyan-line: var(--accent-line);
+  --hud-line:      var(--line);
 
   /* Text. */
-  --hud-text:      #c8e4ef;
-  --hud-text-dim:  #6f8a98;
-  --hud-ink:       #06121a;  /* dark foreground on filled cyan/amber chips */
+  --hud-text:      var(--fg-1);
+  --hud-text-dim:  var(--fg-2);
+  --hud-ink:       var(--bg-inset);  /* dark ink on filled accent/amber/red chips — stays dark in BOTH themes (bg-inset is a display-well token, never flips to silver) so chip text keeps contrast in light theme */
 
   /* Decode-row classes (color-coded message table). */
-  --hud-cq:        #45e08a;  /* CQ calls — green */
-  --hud-me:        #ffd23a;  /* directed at my call — amber-gold */
-  --hud-worked:    #6f8a98;  /* worked-before — muted */
-  --hud-eu:        #d06bff;  /* EU continent tint (band-map parity) */
-  --hud-new:       #38d6f0;  /* new DXCC/grid — cyan */
+  --hud-cq:        var(--ok);            /* CQ calls — green */
+  --hud-me:        var(--power);         /* directed at my call — amber */
+  --hud-worked:    var(--fg-2);          /* worked-before — muted */
+  --hud-new:       var(--accent-bright); /* new DXCC/grid — accent blue */
 
   color: var(--hud-text);
+}
+
+/* Light theme: the pop-out is a "lit instrument" — like the panadapter / VFO /
+   S-meter / LED-meter wells (tokens.css "display surfaces stay DARK"), its
+   readout SURFACES stay dark in light theme instead of flipping to the silver
+   chassis. That keeps the decode hues (CQ green / me amber / new blue) and
+   status colours legible — they have no dark-on-silver palette variants — and
+   reads as a back-lit screen floating over the silver console. Dark theme (the
+   default) is unchanged: it keeps the layered bg-app/bg-1/bg-2 lift from the
+   base block above. Colours only — no markup/layout change. */
+:root[data-theme="light"] .digital-window {
+  --hud-bg:       var(--bg-meter);  /* deep backdrop — display-well token, never flips to silver */
+  --hud-panel:    var(--bg-inset);  /* panel lift */
+  --hud-panel-2:  var(--bg-inset);  /* control rest */
+  --hud-inset:    var(--bg-meter);  /* deepest wells */
+  /* Text flips back to light: fg-1/fg-2 go near-black in light theme and would
+     vanish on the dark screen. --btn-active-text is #fff in BOTH themes (the
+     one light-staying text token); the dim tiers mix it toward the dark-theme
+     fg-2 grey. */
+  --hud-text:      var(--btn-active-text);
+  --hud-text-dim:  color-mix(in srgb, var(--btn-active-text) 58%, transparent);
+  --hud-worked:    color-mix(in srgb, var(--btn-active-text) 42%, transparent);
+}
+/* Keep the drag-bar dark too so the title/gear read as part of the screen, not
+   the silver chassis (the base header uses the global silver panel gradient in
+   light theme). */
+:root[data-theme="light"] .dw-header {
+  background: linear-gradient(180deg, var(--bg-inset), var(--bg-meter));
 }
 
 /* ---- Pop-out chrome (DigitalWindow) ---- */
@@ -264,7 +298,7 @@
   margin-right: 4px;
   border-radius: 2px;
   background: var(--tx);
-  color: #1a0604;
+  color: var(--hud-ink);
   font-size: 9px;
   font-weight: 700;
   letter-spacing: 0.08em;
@@ -338,7 +372,7 @@
   padding: 1px 6px;
   border-radius: 2px;
   background: var(--tx);
-  color: #1a0604;
+  color: var(--hud-ink);
   font-size: 10px;
   font-weight: 700;
   letter-spacing: 0.06em;
@@ -519,7 +553,7 @@
   background: var(--hud-inset);
 }
 .ft8-tx__lamp.is-armed { color: var(--hud-ink); background: var(--hud-me); border-color: var(--hud-me); font-weight: 700; }
-.ft8-tx__lamp.is-tx { color: #1a0604; background: var(--tx); border-color: var(--tx); font-weight: 700; }
+.ft8-tx__lamp.is-tx { color: var(--hud-ink); background: var(--tx); border-color: var(--tx); font-weight: 700; }
 .ft8-tx__wdt { font-size: 10px; color: var(--hud-text-dim); font-variant-numeric: tabular-nums; }
 
 /* ENABLE-TX master. */
@@ -602,7 +636,7 @@
   color: var(--tx);
   font-weight: 700;
 }
-.ft8-tx__halt:hover { background: var(--tx); color: #1a0604; }
+.ft8-tx__halt:hover { background: var(--tx); color: var(--hud-ink); }
 
 /* ---- TX power (TX CONTROL cluster) ---- */
 .ft8-power { display: flex; flex-direction: column; gap: 6px; padding: 6px 0 2px; }


### PR DESCRIPTION
## ⛔ DO NOT MERGE — visual sign-off (KB2UKA) required

**Stack: on top of `ft8/fix-operating` (#1102).** Re-skins the "Zeus Digital" pop-out to match the **global Zeus palette** (`tokens.css`) instead of its bespoke dark-HUD cyan/teal theme. **Colors only — every feature, layout, and control is unchanged.**

### How
Every `--hud-*` token in `ft8-theme.css` now resolves to a global token, so the whole pop-out re-skins with **zero component edits** (only 2 files changed: `ft8-theme.css` + the design doc):
- surfaces → `--bg-app`/`--bg-1`/`--bg-2`/`--bg-inset`; cyan signature → `--accent`/`--accent-bright` (Zeus blue); borders → `--line`; text → `--fg-1`/`--fg-2`
- decode classes: CQ → `--ok` (green), directed-at-me → `--power` (amber), worked-before → `--fg-2`, new-DXCC → `--accent-bright`, your-TX → `--tx`
- the 4 raw-hex chip-ink literals routed through `--hud-ink` (= `--bg-inset`); 2 dead tokens removed

### Audit caught & fixed
A **light-theme** legibility regression (the pop-out inherits `data-theme`): fixed with a `[data-theme=light] .digital-window` override that keeps the pop-out a "lit instrument" (dark wells, like the panadapter) so hues/text stay legible on the silver theme — without flattening the dark default.

### Status
**Zero raw hex** introduced; amber `#FFA028` stays panadapter-trace-only; no feature/layout change. typecheck + build + 12 pop-out tests green. PureSignal untouched. Eyeball on the G2 in both themes before merge.
