### PR TITLE
fix(broker): admin login by callsign + password (+ PBKDF2 Workers-cap fix)

### DIFF
--- a/cloud/zeus-remote-broker/src/admin-api.ts
+++ b/cloud/zeus-remote-broker/src/admin-api.ts
@@ -9,7 +9,6 @@
  */
 
 import type { Env } from './types';
-import { verifyQrzSessionCached } from './qrz';
 import {
   hashPassword,
   verifyPassword,
@@ -64,7 +63,7 @@ export async function handleAdmin(
   try {
     // --- public: interactive login (mints a session token) -------------------
     if (path === '/admin/login' && request.method === 'POST') {
-      return await handleLogin(request, env, ctx, cors);
+      return await handleLogin(request, env, cors);
     }
 
     // --- everything else is Bearer-token protected ---------------------------
@@ -132,19 +131,22 @@ export async function handleAdmin(
 async function handleLogin(
   request: Request,
   env: Env,
-  ctx: ExecutionContext,
   cors: Record<string, string>,
 ): Promise<Response> {
   const body = await safeJson(request);
   const password = typeof body.password === 'string' ? body.password : '';
-  const callsign = norm(request.headers.get('X-QRZ-Callsign') ?? '');
-  const sessionKey = request.headers.get('X-QRZ-Session') ?? '';
+  // Callsign comes from the body; the legacy X-QRZ-Callsign header is still
+  // accepted as a fallback so older clients keep working.
+  const callsign = norm(
+    (typeof body.callsign === 'string' ? body.callsign : '') ||
+      (request.headers.get('X-QRZ-Callsign') ?? ''),
+  );
 
-  // Generic failure for ALL of: missing inputs, bad QRZ, unknown/disabled admin,
+  // Generic failure for ALL of: missing inputs, unknown/disabled admin,
   // wrong/absent password. No oracle on which factor failed.
   const fail = () => json({ error: 'unauthorized' }, 401, cors);
 
-  if (!password || !callsign || !sessionKey) return fail();
+  if (!password || !callsign) return fail();
 
   // Per-callsign throttle on top of the per-IP gate in index.ts, so a botnet
   // spread across many IPs still can't brute-force one admin's password (each
@@ -153,11 +155,9 @@ async function handleLogin(
     return json({ error: 'rate limited' }, 429, cors);
   }
 
-  // 1) QRZ: caller owns the callsign.
-  const verify = (env.QRZ_VERIFY ?? 'on').toLowerCase() !== 'off';
-  if (verify && !(await verifyQrzSessionCached(sessionKey, callsign, ctx))) return fail();
-
-  // 2) Admin store: callsign is an enabled admin with a password set, and it matches.
+  // Admin store: callsign is an enabled admin with a password set, and it
+  // matches. The admin password is the sole secret — callsigns are public, so
+  // the strong password + rate limiting are what gate access here.
   const admin = await getAdmin(env.ADMIN_DB, callsign);
   if (!admin || admin.disabled === 1 || !admin.pw_hash || !admin.pw_salt || admin.pw_iter == null) {
     return fail();

--- a/cloud/zeus-remote-broker/src/admin-auth.ts
+++ b/cloud/zeus-remote-broker/src/admin-auth.ts
@@ -3,9 +3,11 @@
  * or native deps). Pure functions so they're unit-testable under `node --test`.
  *
  * Two secret kinds:
- *  - Passwords: PBKDF2-HMAC-SHA256, 210k iters, 16-byte salt, 32-byte key. We
+ *  - Passwords: PBKDF2-HMAC-SHA256, 100k iters, 16-byte salt, 32-byte key. We
  *    store base64(hash)/base64(salt)/iter and verify with a constant-time
- *    compare of the derived bytes.
+ *    compare of the derived bytes. (Cloudflare Workers' WebCrypto rejects
+ *    PBKDF2 iteration counts above 100000 — exceeding it throws at runtime, so
+ *    100k is the hard ceiling here, not a tuning choice.)
  *  - API/session tokens: 32 random bytes → base64url, presented once as
  *    `zsa_<...>`. We persist only SHA-256(token) hex and verify by hashing the
  *    presented token and constant-time-comparing to the stored hash.
@@ -13,8 +15,13 @@
  * Never log or return secrets; only hashes leave this module.
  */
 
-/** PBKDF2 cost. Stored per-row (pw_iter) so it can be bumped without a flag-day. */
-export const PBKDF2_ITER = 210_000;
+/**
+ * PBKDF2 cost. Stored per-row (pw_iter) so it can be bumped without a flag-day.
+ * Capped at 100000: Cloudflare Workers' WebCrypto throws "iteration counts above
+ * 100000 are not supported" for anything higher, which would break hash + verify
+ * at runtime (Node has no such cap, so unit tests don't catch it).
+ */
+export const PBKDF2_ITER = 100_000;
 const SALT_BYTES = 16;
 const KEY_BYTES = 32;
 const TOKEN_BYTES = 32;

--- a/cloud/zeus-remote-broker/test/admin-auth.test.ts
+++ b/cloud/zeus-remote-broker/test/admin-auth.test.ts
@@ -27,6 +27,13 @@ test('password hash + verify round-trip', async () => {
   assert.equal(await verifyPassword('correct horse battery staple', rec), true);
 });
 
+test('PBKDF2_ITER stays within the Cloudflare Workers cap (100000)', () => {
+  // Workers' WebCrypto throws "iteration counts above 100000 are not supported"
+  // at runtime; Node has no such cap, so this guard is the only thing that
+  // catches a too-high value before it ships and breaks every hash + verify.
+  assert.ok(PBKDF2_ITER <= 100_000, `PBKDF2_ITER ${PBKDF2_ITER} exceeds the Workers limit`);
+});
+
 test('wrong password fails', async () => {
   const rec = await hashPassword('s3cret-password');
   assert.equal(await verifyPassword('s3cret-passwor', rec), false);


### PR DESCRIPTION
## What

Makes the maintainer admin dashboard sign-in work. Two fixes:

### 1. Login with callsign + admin password (no QRZ session key)
`/admin/login` no longer requires an `X-QRZ-Session` / QRZ-XML session. The admin **password** is the credential; the **callsign** now comes from the JSON body (`{callsign, password}`). The legacy `X-QRZ-Callsign` header is still accepted as a fallback. QRZ host-registration gating (radio side, `index.ts`) is unchanged.

Trade-off (intended): admin login is now single-factor — the password is the only secret (callsigns are public). The per-IP gate (`index.ts`) + per-callsign throttle + PBKDF2 still guard against brute force.

### 2. PBKDF2 iteration cap (the real blocker)
Cloudflare Workers' WebCrypto rejects PBKDF2 iteration counts **above 100000** (`"iteration counts above 100000 are not supported"`). The code used `PBKDF2_ITER = 210_000`, so in the Workers runtime **every** `hashPassword`/`verifyPassword` threw — `ensureBootstrap` silently no-op'd (caught) and every login 401'd (verify threw → false). The unit tests passed because Node's WebCrypto has no such cap.

Lowered `PBKDF2_ITER` to `100_000` (the hard ceiling) and added a guard test asserting it stays `<= 100000`, since Node can't catch the runtime throw.

## Migration note
Password rows hashed at 210k can't be verified by the Workers runtime — affected admins must set a new password (re-hash at 100k). Verified live: re-hashing N9WAR's password via `POST /admin/admins/:cs/password` then `POST /admin/login {callsign,password}` → 200 + token; wrong password / unknown callsign / missing password → 401.

## Verification
- `npm run typecheck` clean; `npm test` 23/23 (added the iter guard).
- Deployed + verified end-to-end on the live broker.

Pairs with the dashboard login-form change (zeus-webpage) which now collects just callsign + password.