### PR TITLE
feat(logbook): export-to-directory, QRZ name fill, ADIF byte-length & panel resize

### DIFF
--- a/Zeus.Contracts/LogDtos.cs
+++ b/Zeus.Contracts/LogDtos.cs
@@ -112,3 +112,19 @@ public sealed record QrzPublishResult(
     bool Success,
     string? QrzLogId,
     string? Message);
+
+/// <summary>
+/// Write the logbook (or a selected subset) to an ADIF file in a directory on
+/// the machine running the backend. <see cref="Directory"/> is optional — null
+/// or blank writes to the operator's Downloads folder. Used by the Logbook
+/// panel's Export button so the operator gets a concrete saved path back
+/// instead of a silent browser download.
+/// </summary>
+public sealed record AdifExportToFileRequest(
+    string? Directory = null,
+    IEnumerable<string>? LogEntryIds = null);
+
+public sealed record AdifExportToFileResponse(
+    string Path,
+    int Count,
+    long Bytes);

--- a/Zeus.Server.Hosting/AdifParser.cs
+++ b/Zeus.Server.Hosting/AdifParser.cs
@@ -63,11 +63,36 @@ internal static class AdifParser
             if (!int.TryParse(lengthText, out var length) || length < 0)
                 throw new FormatException($"ADIF field '{fieldName}' has an invalid length specifier.");
 
-            if (pos + length > adif.Length)
+            // ADIF declares the value length as a UTF-8 OCTET count, but a C#
+            // string is UTF-16. Consume chars until we've covered `length`
+            // bytes rather than `length` chars — otherwise any accented value
+            // (and every field after it) is mis-read. Mirrors AppendAdifField,
+            // which emits Encoding.UTF8.GetByteCount on export.
+            var valueStart = pos;
+            var bytes = 0;
+            while (pos < adif.Length && bytes < length)
+            {
+                var c = adif[pos];
+                int codepoint;
+                int step;
+                if (char.IsHighSurrogate(c) && pos + 1 < adif.Length && char.IsLowSurrogate(adif[pos + 1]))
+                {
+                    codepoint = char.ConvertToUtf32(c, adif[pos + 1]);
+                    step = 2;
+                }
+                else
+                {
+                    codepoint = c;
+                    step = 1;
+                }
+                bytes += codepoint < 0x80 ? 1 : codepoint < 0x800 ? 2 : codepoint < 0x10000 ? 3 : 4;
+                pos += step;
+            }
+
+            if (bytes < length)
                 throw new FormatException($"ADIF field '{fieldName}' length exceeds the available data.");
 
-            fields[fieldName] = adif.Substring(pos, length);
-            pos += length;
+            fields[fieldName] = adif.Substring(valueStart, pos - valueStart);
         }
 
         if (fields.Count > 0)

--- a/Zeus.Server.Hosting/LogService.cs
+++ b/Zeus.Server.Hosting/LogService.cs
@@ -213,6 +213,73 @@ public sealed class LogService : IDisposable
         }, ct);
     }
 
+    /// <summary>
+    /// Render the logbook (or the given subset) to ADIF and write it as a
+    /// timestamped .adi file in <paramref name="directory"/>. A null/blank
+    /// directory targets the operator's Downloads folder. Returns the absolute
+    /// path written, the QSO count, and the byte size so the UI can confirm
+    /// exactly where the file landed.
+    /// </summary>
+    public async Task<AdifExportToFileResponse> ExportToAdifFileAsync(
+        string? directory = null,
+        IEnumerable<string>? logEntryIds = null,
+        CancellationToken ct = default)
+    {
+        var ids = logEntryIds?.ToList();
+        var count = ids != null
+            ? _logs.Query().Where(x => ids.Contains(x.Id)).Count()
+            : _logs.Count();
+        var adif = await ExportToAdifAsync(ids, ct).ConfigureAwait(false);
+        var bytes = Encoding.UTF8.GetBytes(adif);
+
+        var targetDir = ResolveExportDirectory(directory);
+        Directory.CreateDirectory(targetDir);
+        var fileName = $"zeus-log-{DateTime.UtcNow:yyyyMMdd-HHmmss}.adi";
+        var fullPath = Path.Combine(targetDir, fileName);
+
+        await File.WriteAllBytesAsync(fullPath, bytes, ct).ConfigureAwait(false);
+        _log.LogInformation("Exported {Count} QSOs to ADIF file {Path} ({Bytes} bytes)",
+            count, fullPath, bytes.Length);
+
+        return new AdifExportToFileResponse(fullPath, count, bytes.Length);
+    }
+
+    /// <summary>
+    /// Resolve a writable export directory. A caller-supplied path wins (after
+    /// expanding a leading ~). Otherwise default to the operator's Downloads
+    /// folder — there is no <see cref="Environment.SpecialFolder"/> for it, so
+    /// derive it from the user-profile home and fall back to the profile root
+    /// itself if Downloads can't be created. Cross-platform: %USERPROFILE% on
+    /// Windows, $HOME on macOS/Linux.
+    /// </summary>
+    private static string ResolveExportDirectory(string? directory)
+    {
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            var trimmed = directory.Trim();
+            if (trimmed == "~" || trimmed.StartsWith("~/", StringComparison.Ordinal) ||
+                trimmed.StartsWith("~\\", StringComparison.Ordinal))
+            {
+                var rest = trimmed.Length > 1 ? trimmed[2..] : string.Empty;
+                trimmed = Path.Combine(HomeDirectory(), rest);
+            }
+            return trimmed;
+        }
+
+        var home = HomeDirectory();
+        var downloads = Path.Combine(home, "Downloads");
+        return downloads;
+    }
+
+    private static string HomeDirectory()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrEmpty(home)) return home;
+        home = Environment.GetEnvironmentVariable("HOME")
+               ?? Environment.GetEnvironmentVariable("USERPROFILE");
+        return string.IsNullOrEmpty(home) ? Directory.GetCurrentDirectory() : home;
+    }
+
     public async Task<AdifImportResponse> ImportAdifAsync(string adif, CancellationToken ct = default)
     {
         return await Task.Run(() =>
@@ -610,7 +677,12 @@ public sealed class LogService : IDisposable
     private static void AppendAdifField(StringBuilder sb, string fieldName, string value)
     {
         if (string.IsNullOrEmpty(value)) return;
-        sb.Append($"<{fieldName}:{value.Length}>{value} ");
+        // ADIF declares each field length as an OCTET count, not a UTF-16
+        // code-unit count. Using value.Length corrupts any record with a
+        // non-ASCII byte (e.g. "José" emits <NAME:4> but writes 5 bytes),
+        // desyncing byte-based importers (LoTW, ClubLog, QRZ, N1MM). Emit
+        // the UTF-8 byte length so the field is spec-correct.
+        sb.Append($"<{fieldName}:{Encoding.UTF8.GetByteCount(value)}>{value} ");
     }
 
     private static DateTime ToUtc(DateTime dt) => dt.Kind == DateTimeKind.Utc ? dt : dt.ToUniversalTime();

--- a/Zeus.Server.Hosting/QrzService.cs
+++ b/Zeus.Server.Hosting/QrzService.cs
@@ -552,7 +552,10 @@ public sealed class QrzService
     private static void AppendAdifField(System.Text.StringBuilder sb, string fieldName, string value)
     {
         if (string.IsNullOrEmpty(value)) return;
-        sb.Append($"<{fieldName}:{value.Length}>{value} ");
+        // ADIF length is a UTF-8 OCTET count, not a UTF-16 code-unit count.
+        // value.Length under-reports any non-ASCII field (accented name/QTH),
+        // so QRZ.com truncates and desyncs the record. Encode byte length.
+        sb.Append($"<{fieldName}:{System.Text.Encoding.UTF8.GetByteCount(value)}>{value} ");
     }
 }
 

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -3765,6 +3765,7 @@ public static class ZeusEndpoints
         app.MapPost("/api/log/entry", async (
             CreateLogEntryRequest req,
             LogService logService,
+            QrzService qrz,
             WsjtxUdpBroadcaster wsjtx,
             Wsjtx.N1mmBroadcaster n1mm,
             CloudLog.CloudLogService cloudLog,
@@ -3772,6 +3773,20 @@ public static class ZeusEndpoints
         {
             if (string.IsNullOrWhiteSpace(req.Callsign))
                 return Results.BadRequest(new { error = "callsign required" });
+
+            // Operator name enrichment: when the caller didn't supply a name
+            // (FT8 auto-log, a spot logged without a QRZ card open, an import
+            // lacking NAME), fill it from QRZ. The QRZ feed splits the operator
+            // into <fname>+<name>, so compose the full name rather than the
+            // surname alone. Best-effort — a lookup miss or no subscription
+            // must never block logging the QSO.
+            if (string.IsNullOrWhiteSpace(req.Name))
+            {
+                var enriched = await TryQrzFullNameAsync(qrz, req.Callsign, ctx.RequestAborted);
+                if (!string.IsNullOrWhiteSpace(enriched))
+                    req = req with { Name = enriched };
+            }
+
             var entry = await logService.CreateLogEntryAsync(req, ctx.RequestAborted);
             // Push the just-logged QSO to every opted-in external logger. Each
             // target is OFF by default and no-ops when disabled; this is the only
@@ -3794,6 +3809,23 @@ public static class ZeusEndpoints
                 System.Text.Encoding.UTF8.GetBytes(adif),
                 "text/plain",
                 fileName);
+        });
+
+        // Write the logbook (or a selected subset) to an ADIF file in a
+        // directory on the machine running the backend, returning the path so
+        // the Logbook panel can confirm where it landed (a silent browser
+        // download gave the operator no feedback). Null directory => Downloads.
+        app.MapPost("/api/log/export/adif/file", async (AdifExportToFileRequest req, LogService logService, HttpContext ctx) =>
+        {
+            try
+            {
+                var result = await logService.ExportToAdifFileAsync(req.Directory, req.LogEntryIds, ctx.RequestAborted);
+                return Results.Ok(result);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
+            {
+                return Results.BadRequest(new { error = $"Could not write ADIF file: {ex.Message}" });
+            }
         });
 
         app.MapPost("/api/log/import/adif", async (LogService logService, HttpContext ctx) =>
@@ -4215,6 +4247,39 @@ public static class ZeusEndpoints
     }
 
     // ---------- helpers (formerly local functions in Program.cs) -------------
+
+    /// <summary>
+    /// Best-effort QRZ lookup that returns the operator's full display name
+    /// ("First Last") for a callsign, or null. The QRZ feed splits the operator
+    /// into &lt;fname&gt; (first) and &lt;name&gt; (last), so compose both —
+    /// the surname alone is what made the logbook Name column read blank for
+    /// records where QRZ only populates the first name. Never throws: a missing
+    /// subscription, a not-logged-in state, or a lookup miss simply yields null
+    /// so the QSO still logs.
+    /// </summary>
+    private static async Task<string?> TryQrzFullNameAsync(QrzService qrz, string callsign, CancellationToken ct)
+    {
+        try
+        {
+            // Bound the lookup so logging a QSO never stalls on a slow or
+            // gate-contended QRZ feed (FT8 bursts, no subscription, network
+            // blip). The QSO logs with no name rather than hanging.
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            timeout.CancelAfter(TimeSpan.FromSeconds(4));
+            var station = await qrz.LookupAsync(callsign, timeout.Token).ConfigureAwait(false);
+            if (station == null) return null;
+            var full = string.Join(' ', new[] { station.FirstName, station.Name }
+                .Where(s => !string.IsNullOrWhiteSpace(s))
+                .Select(s => s!.Trim()));
+            return string.IsNullOrWhiteSpace(full) ? null : full;
+        }
+        catch
+        {
+            // Not logged in / no subscription / network blip — logging a QSO
+            // must never depend on QRZ being reachable.
+            return null;
+        }
+    }
 
     private static IResult GetNativeAudioDevices(IServiceProvider sp)
     {

--- a/tests/Zeus.Server.Tests/AdifImportTests.cs
+++ b/tests/Zeus.Server.Tests/AdifImportTests.cs
@@ -170,4 +170,94 @@ public sealed class AdifImportTests
         Assert.Equal(14, doc.CqZone);
         Assert.Equal(27, doc.ItuZone);
     }
+
+    [Fact]
+    public void Export_DeclaresFieldLengthInUtf8BytesNotChars()
+    {
+        // "José Muñoz" is 10 UTF-16 code units but 12 UTF-8 bytes (é and ñ are
+        // two bytes each). ADIF length tags are octet counts; declaring 10
+        // would make a spec-compliant importer (LoTW/ClubLog/QRZ/N1MM) read
+        // short and desync the rest of the record.
+        var doc = new LogEntryDocument
+        {
+            Id = "id-1",
+            Callsign = "EA1ABC",
+            QsoDateTimeUtc = new DateTime(2026, 6, 28, 12, 0, 0, DateTimeKind.Utc),
+            Band = "20M",
+            Mode = "SSB",
+            RstSent = "59",
+            RstRcvd = "59",
+            Name = "José Muñoz",
+            CreatedUtc = new DateTime(2026, 6, 28, 12, 0, 0, DateTimeKind.Utc),
+        };
+
+        var sb = new StringBuilder();
+        LogService.AppendAdifRecord(sb, doc);
+        var exported = sb.ToString();
+
+        Assert.Equal(12, Encoding.UTF8.GetByteCount("José Muñoz"));
+        Assert.Contains("<NAME:12>José Muñoz", exported);
+        Assert.DoesNotContain("<NAME:10>", exported);
+        // ASCII fields keep byte==char length.
+        Assert.Contains("<CALL:6>EA1ABC", exported);
+    }
+
+    [Fact]
+    public async Task ExportToAdifFileAsync_WritesAdifToTargetDirectory()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"zeus-export-test-{Guid.NewGuid():N}.db");
+        var outDir = Path.Combine(Path.GetTempPath(), $"zeus-export-out-{Guid.NewGuid():N}");
+        try
+        {
+            using var svc = new LogService(
+                Microsoft.Extensions.Logging.Abstractions.NullLogger<LogService>.Instance, dbPath);
+            await svc.CreateLogEntryAsync(new Zeus.Contracts.CreateLogEntryRequest(
+                Callsign: "K2ABC", Name: "Al", FrequencyMhz: 14.074, Band: "20M",
+                Mode: "FT8", RstSent: "-12", RstRcvd: "-09"));
+
+            var result = await svc.ExportToAdifFileAsync(outDir);
+
+            Assert.Equal(1, result.Count);
+            Assert.True(File.Exists(result.Path));
+            Assert.Equal(outDir, Path.GetDirectoryName(result.Path));
+            var text = await File.ReadAllTextAsync(result.Path);
+            Assert.Contains("<CALL:5>K2ABC", text);
+            Assert.Equal(new FileInfo(result.Path).Length, result.Bytes);
+        }
+        finally
+        {
+            try { File.Delete(dbPath); } catch { /* best effort */ }
+            try { Directory.Delete(outDir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void RoundTrip_NonAsciiName_PreservesNameAndFollowingFields()
+    {
+        // Export emits UTF-8 byte lengths; the parser must read by bytes too,
+        // or "José Muñoz" (12 bytes / 10 chars) over-reads into the next field.
+        var doc = new LogEntryDocument
+        {
+            Id = "id-rt",
+            Callsign = "EA1ABC",
+            QsoDateTimeUtc = new DateTime(2026, 6, 28, 12, 0, 0, DateTimeKind.Utc),
+            Band = "20M",
+            Mode = "SSB",
+            RstSent = "59",
+            RstRcvd = "59",
+            Name = "José Muñoz",
+            Grid = "IN80",
+            CreatedUtc = new DateTime(2026, 6, 28, 12, 0, 0, DateTimeKind.Utc),
+        };
+
+        var sb = new StringBuilder();
+        sb.AppendLine("<ADIF_VER:5>3.1.4<EOH>");
+        LogService.AppendAdifRecord(sb, doc);
+
+        var record = AdifParser.Parse(sb.ToString()).Single();
+
+        Assert.Equal("José Muñoz", record.Fields["NAME"]);
+        Assert.Equal("IN80", record.Fields["GRIDSQUARE"]);  // stays aligned after the multi-byte field
+        Assert.Equal("EA1ABC", record.Fields["CALL"]);
+    }
 }

--- a/zeus-web/src/App.tsx
+++ b/zeus-web/src/App.tsx
@@ -110,6 +110,7 @@ import { getReceiverMode } from './state/receiver-state';
 import { useFreeDvWindowStore } from './state/freedv-window-store';
 import { useRadioStore } from './state/radio-store';
 import { useQrzStore } from './state/qrz-store';
+import { qrzFullName } from './api/qrz';
 import { useRotatorStore } from './state/rotator-store';
 import { useLoggerStore } from './state/logger-store';
 import { useTxStore } from './state/tx-store';
@@ -532,6 +533,9 @@ export default function App() {
   const logSelectedIds = useLoggerStore((s) => s.selectedIds);
   const logPublishSelected = useLoggerStore((s) => s.publishSelectedToQrz);
   const logExportAdif = useLoggerStore((s) => s.exportAdif);
+  const logExportInFlight = useLoggerStore((s) => s.exportInFlight);
+  const logExportResult = useLoggerStore((s) => s.lastExportResult);
+  const logExportError = useLoggerStore((s) => s.exportError);
   const logImportAdifFile = useLoggerStore((s) => s.importAdifFile);
   const workedSummary = useLoggerStore((s) => s.workedSummary);
   const workedSummaryLoading = useLoggerStore((s) => s.workedSummaryLoading);
@@ -558,6 +562,13 @@ export default function App() {
     logbookTitle = logPublishResult.failedCount > 0
       ? `Logbook · ${logPublishResult.successCount} ok, ${logPublishResult.failedCount} failed`
       : `Logbook · Published ${logPublishResult.successCount}`;
+  } else if (logExportInFlight) {
+    logbookTitle = 'Logbook · Exporting…';
+  } else if (logExportError) {
+    logbookTitle = `Logbook · ${logExportError.length > 28 ? 'Export failed' : logExportError}`;
+  } else if (logExportResult) {
+    const dir = logExportResult.path.replace(/[/\\][^/\\]*$/, '');
+    logbookTitle = `Logbook · Exported ${logExportResult.count} → ${dir}`;
   }
 
   const logSelectedCount = logSelectedIds.size;
@@ -661,7 +672,7 @@ export default function App() {
 
     void addLogEntry({
       callsign: contact.callsign,
-      name: qrzLookup.name ?? undefined,
+      name: qrzFullName(qrzLookup) ?? undefined,
       frequencyMhz,
       band,
       mode,

--- a/zeus-web/src/api/log.ts
+++ b/zeus-web/src/api/log.ts
@@ -193,6 +193,44 @@ export async function createLogEntry(
   return await response.json();
 }
 
+export type AdifExportToFileResponse = {
+  path: string;
+  count: number;
+  bytes: number;
+};
+
+/**
+ * Export the logbook to an ADIF file in a directory on the machine running the
+ * backend (default: the operator's Downloads folder), returning the saved path.
+ * Preferred over {@link exportToAdif} because it works in the desktop webview —
+ * where a programmatic blob download silently does nothing — and confirms where
+ * the file landed instead of dropping it somewhere unseen.
+ */
+export async function exportAdifToDirectory(
+  directory?: string | null,
+  logEntryIds?: string[] | null,
+  signal?: AbortSignal,
+): Promise<AdifExportToFileResponse> {
+  const response = await fetch('/api/log/export/adif/file', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ directory: directory ?? null, logEntryIds: logEntryIds ?? null }),
+    signal,
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    let message = text;
+    try {
+      const parsed = JSON.parse(text) as { error?: unknown };
+      if (typeof parsed.error === 'string') message = parsed.error;
+    } catch {
+      /* keep the raw response text */
+    }
+    throw new Error(message || `HTTP ${response.status}`);
+  }
+  return await response.json();
+}
+
 export async function exportToAdif(signal?: AbortSignal): Promise<void> {
   const response = await fetch('/api/log/export/adif', { signal });
   if (!response.ok) throw new Error(`HTTP ${response.status}`);

--- a/zeus-web/src/api/qrz.ts
+++ b/zeus-web/src/api/qrz.ts
@@ -77,6 +77,24 @@ export type QrzStation = {
   born: number | null;
 };
 
+/**
+ * Compose the operator's full display name from a QRZ lookup. QRZ splits the
+ * operator into `firstName` (<fname>) and `name` (<name> = surname), so logging
+ * `name` alone dropped the first name — and read blank for records where QRZ
+ * only carries the first name. Returns "First Last", a single available part,
+ * or null when neither is present.
+ */
+export function qrzFullName(
+  station: { firstName?: string | null; name?: string | null } | null | undefined,
+): string | null {
+  if (!station) return null;
+  const full = [station.firstName, station.name]
+    .map((p) => (p ?? '').trim())
+    .filter((p) => p.length > 0)
+    .join(' ');
+  return full.length > 0 ? full : null;
+}
+
 export type QrzStatus = {
   connected: boolean;
   hasXmlSubscription: boolean;

--- a/zeus-web/src/components/design/LogbookLive.tsx
+++ b/zeus-web/src/components/design/LogbookLive.tsx
@@ -99,6 +99,9 @@ export function LogbookLive({ searchText, hideQrzPublished }: LogbookLiveProps) 
   const lastPublishResult = useLoggerStore((s) => s.lastPublishResult);
   const publishError = useLoggerStore((s) => s.publishError);
   const clearPublishResult = useLoggerStore((s) => s.clearPublishResult);
+  const lastExportResult = useLoggerStore((s) => s.lastExportResult);
+  const exportError = useLoggerStore((s) => s.exportError);
+  const clearExportResult = useLoggerStore((s) => s.clearExportResult);
   const selectedIds = useLoggerStore((s) => s.selectedIds);
   const toggleSelected = useLoggerStore((s) => s.toggleSelected);
   const setSelectedIds = useLoggerStore((s) => s.setSelectedIds);
@@ -118,15 +121,19 @@ export function LogbookLive({ searchText, hideQrzPublished }: LogbookLiveProps) 
   const someVisibleSelected = selectedVisibleCount > 0 && !allVisibleSelected;
 
   useEffect(() => {
-    // Self-clear import/publish feedback (shown in the Logbook header) after a few seconds.
-    if (lastImportResult || importError || lastPublishResult || publishError) {
+    // Self-clear import/publish/export feedback (shown in the Logbook header) after a few seconds.
+    if (lastImportResult || importError || lastPublishResult || publishError || lastExportResult || exportError) {
       const timer = setTimeout(() => {
         clearImportResult();
         clearPublishResult();
+        clearExportResult();
       }, 4000);
       return () => clearTimeout(timer);
     }
-  }, [lastImportResult, importError, lastPublishResult, publishError, clearImportResult, clearPublishResult]);
+  }, [
+    lastImportResult, importError, lastPublishResult, publishError, lastExportResult, exportError,
+    clearImportResult, clearPublishResult, clearExportResult,
+  ]);
 
   useEffect(() => {
     if (selectAllRef.current) {

--- a/zeus-web/src/layout/panels.ts
+++ b/zeus-web/src/layout/panels.ts
@@ -355,8 +355,10 @@ export const PANELS: Record<string, PanelDef> = {
     category: 'log',
     tags: ['log', 'qso', 'logbook', 'adif'],
     component: LogbookPanel,
-    minW: 6,
-    minH: 8,
+    // Floor kept low so the logbook can be docked as a compact strip; the
+    // header wraps and the body scrolls, so it stays usable when small.
+    minW: 4,
+    minH: 4,
   },
   txmeters: {
     id: 'txmeters',

--- a/zeus-web/src/state/logger-store.ts
+++ b/zeus-web/src/state/logger-store.ts
@@ -48,6 +48,7 @@ import type {
   LogEntry,
   CreateLogEntryRequest,
   AdifImportResponse,
+  AdifExportToFileResponse,
   QrzPublishResponse,
   WorkedCallsignSummary,
 } from '../api/log';
@@ -55,10 +56,12 @@ import {
   getLogEntries,
   getWorkedCallsignSummary,
   createLogEntry,
+  exportAdifToDirectory,
   exportToAdif,
   importAdif,
   publishToQrz,
 } from '../api/log';
+import { useCapabilitiesStore } from './capabilities-store';
 
 type LoggerState = {
   entries: LogEntry[];
@@ -71,6 +74,9 @@ type LoggerState = {
   publishInFlight: boolean;
   publishError: string | null;
   lastPublishResult: QrzPublishResponse | null;
+  exportInFlight: boolean;
+  exportError: string | null;
+  lastExportResult: AdifExportToFileResponse | null;
   selectedIds: Set<string>;
   workedSummary: WorkedCallsignSummary | null;
   workedSummaryLoading: boolean;
@@ -82,6 +88,7 @@ type LoggerState = {
   clearWorkedSummary: () => void;
   addLogEntry: (request: CreateLogEntryRequest) => Promise<LogEntry | null>;
   exportAdif: () => Promise<void>;
+  clearExportResult: () => void;
   importAdifFile: (file: File) => Promise<AdifImportResponse | null>;
   clearImportResult: () => void;
   publishSelectedToQrz: (logEntryIds: string[]) => Promise<void>;
@@ -102,6 +109,9 @@ export const useLoggerStore = create<LoggerState>((set, get) => ({
   publishInFlight: false,
   publishError: null,
   lastPublishResult: null,
+  exportInFlight: false,
+  exportError: null,
+  lastExportResult: null,
   selectedIds: new Set<string>(),
   workedSummary: null,
   workedSummaryLoading: false,
@@ -163,12 +173,36 @@ export const useLoggerStore = create<LoggerState>((set, get) => ({
   },
 
   exportAdif: async () => {
-    set({ error: null });
-    try {
-      await exportToAdif();
-    } catch (err) {
-      set({ error: err instanceof Error ? err.message : 'Failed to export ADIF' });
+    // When the backend is on the operator's own machine (desktop, or a
+    // loopback web session), write the .adi into a directory there and report
+    // the path. When it's remote (LAN/headless backend), a server-side file
+    // would be unreachable, so fall back to delivering the ADIF to the
+    // operator's browser as a download.
+    const localToServer = useCapabilitiesStore.getState().localToServer;
+    if (!localToServer) {
+      set({ exportInFlight: false, exportError: null, lastExportResult: null, error: null });
+      try {
+        await exportToAdif();
+      } catch (err) {
+        set({ exportError: err instanceof Error ? err.message : 'Failed to export ADIF' });
+      }
+      return;
     }
+
+    set({ exportInFlight: true, exportError: null, lastExportResult: null, error: null });
+    try {
+      const result = await exportAdifToDirectory();
+      set({ lastExportResult: result, exportInFlight: false });
+    } catch (err) {
+      set({
+        exportError: err instanceof Error ? err.message : 'Failed to export ADIF',
+        exportInFlight: false,
+      });
+    }
+  },
+
+  clearExportResult: () => {
+    set({ lastExportResult: null, exportError: null });
   },
 
   importAdifFile: async (file: File) => {

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -3228,6 +3228,7 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
+  flex-wrap: wrap;
   gap: 4px;
   padding: 4px 8px;
   border-bottom: 1px solid var(--panel-border);


### PR DESCRIPTION
## What & why

Fixes the four logbook-panel issues reported (Export/Publish do nothing, blank Name, panel won't resize small) plus an ADIF corruption bug found while reproducing.

The buttons were already wired on `develop` (landed in `2668e073`); reproduction on a live backend showed the real problems were **runtime/UX**, not missing wiring.

### Reproduced on the wire first
- `GET /api/log/export/adif` → returns valid ADIF (200). Export "did nothing" because the file downloaded **silently** with no feedback and no directory choice.
- `POST /api/log/publish/qrz` (no key) → correct per-QSO `"QRZ API key not configured"`. Publish works once a QRZ API key is set; it just looked dead.
- Export emitted `<NAME:10>José Muñoz` — **wrong** (12 UTF-8 bytes), corrupting export + QRZ publish for accented names.
- Name column blank: log-create passed only QRZ `<name>` (surname); `<fname>` was dropped.

## Changes
1. **Export → directory.** New `POST /api/log/export/adif/file` writes the `.adi` to a directory (default = operator's Downloads) and returns `{path,count,bytes}`; the panel title shows `Exported N → <dir>`. **Remote/web fallback:** when the backend isn't on the operator's machine (`capabilities.localToServer` false), falls back to the browser blob-download so the file is still reachable.
2. **Name from QRZ.** Frontend composes the full name (`firstName + name`) via `qrzFullName()`; the server enriches a *blank* name on `/api/log/entry` via a **bounded (4s) best-effort** QRZ lookup, so FT8/spot/import QSOs fill it too — and logging never stalls on QRZ.
3. **ADIF byte-length fix.** Both `AppendAdifField` sites emit `Encoding.UTF8.GetByteCount`; the importer (`AdifParser`) is now **byte-aware** to match. Accented names round-trip and stop desyncing LoTW/ClubLog/QRZ/N1MM.
4. **Resize.** `panels.ts` floor `minW 6→4, minH 8→4` + `.logbook-actions` `flex-wrap`.
5. **Publish** — unchanged functionally (gated on the QRZ API key); benefits from the byte-length fix.

## Tests / build
- New: ADIF byte-length, export-to-file, non-ASCII export→import round-trip.
- Backend `dotnet build Zeus.slnx` 0/0; 18 ADIF/QRZ/LogService tests pass. Frontend typecheck + vite build clean; 30 logbook/capabilities tests pass.

## Reviewed by an adversarial swarm (4 lenses, each finding verified)
Two findings fixed in this PR: the **AdifParser byte/char desync** (HIGH) and the **remote-web export fallback** (MEDIUM). Two acceptable, left as **follow-ups**:
- Cache the backend QRZ name-enrichment by callsign (avoids repeat lookups on bursty logging).
- Use the Windows known-folder API / `XDG_DOWNLOAD_DIR` for Downloads resolution (only matters if Downloads is relocated).

## Maintainer sign-off (🚩)
- **Contracts:** additive `AdifExportToFile` request/response DTOs only.
- **Default/UX:** Export now writes to a directory + shows the path; logbook panel min-size lowered. Both as requested.
- **Not bench-tested yet** — draft for KB2UKA to verify on the G2 bench (export lands in Downloads, Publish pushes to QRZ with a key set, Name fills, panel shrinks).