### PR TITLE
fix(web): normalize noise floors across RX panes on the WebGPU waterfall

### DIFF
--- a/zeus-web/src/components/Waterfall.tsx
+++ b/zeus-web/src/components/Waterfall.tsx
@@ -56,7 +56,6 @@ import {
   registerEstimatorConsumer,
   useSignalEnhanceStore,
 } from '../dsp/signal-estimator';
-import { normalizeStitchedBins, stitchFloorShiftDb } from '../dsp/stitch-normalizer';
 import { getReceiverVfoHz, KIWI_RECEIVER_INDEX, rxIndexOf, type ReceiverKey } from '../state/receiver-state';
 import { estimateRowFloorDb, forgetReceiverFloor, reportReceiverFloorDb } from '../dsp/floor-normalization';
 import { effectiveRxWfWindow, useRxDbWindowStore } from '../state/rx-db-window-store';
@@ -232,7 +231,6 @@ export function Waterfall({
     // is safe — there's no deferred reference-identity dirty check here.
     let enhBuf: Float32Array | null = null;
     let terrainBuf: Float32Array | null = null;
-    let stitchBuf: Float32Array | null = null;
     // Scroll speed is a rare toggle; cache the last value pushed to the renderer
     // so a steady redraw loop skips the store read + GL uniform update per frame.
     let lastScrollSpeed = -1;
@@ -446,14 +444,6 @@ export function Waterfall({
       if (wfDb) {
         const { moxOn, tunOn } = useTxStore.getState();
         let rowForPush = wfDb;
-        if (stitched && !moxOn && !tunOn) {
-          rowForPush = normalizeStitchedBins(
-            wfDb,
-            stitchBuf,
-            stitchFloorShiftDb(receiver, 'waterfall'),
-          );
-          if (rowForPush !== wfDb) stitchBuf = rowForPush;
-        }
         if (!moxOn && !tunOn) {
           if (!enhBuf || enhBuf.length !== rowForPush.length) enhBuf = new Float32Array(rowForPush.length);
           if (!terrainBuf || terrainBuf.length !== rowForPush.length) terrainBuf = new Float32Array(rowForPush.length);

--- a/zeus-web/src/components/WaterfallHeightfield.tsx
+++ b/zeus-web/src/components/WaterfallHeightfield.tsx
@@ -30,7 +30,8 @@ import { probeWebGpu, resetWebGpuProbe } from '../gl/webgpu/caps';
 import { createHeightfieldRenderer, type HeightfieldRenderer } from '../gl/webgpu/heightfield';
 import { registerFrameConsumer, selectDisplaySlice, useDisplayStore } from '../state/display-store';
 import { enhanceInto, registerEstimatorConsumer, useSignalEnhanceStore } from '../dsp/signal-estimator';
-import { normalizeStitchedBins, stitchFloorShiftDb } from '../dsp/stitch-normalizer';
+import { estimateRowFloorDb, forgetReceiverFloor, reportReceiverFloorDb } from '../dsp/floor-normalization';
+import { effectiveRxWfWindow, useRxDbWindowStore } from '../state/rx-db-window-store';
 import { useDisplaySettingsStore } from '../state/display-settings-store';
 import { useConnectionStore } from '../state/connection-store';
 import { useTxStore } from '../state/tx-store';
@@ -106,8 +107,6 @@ export function WaterfallHeightfield({
     // Signal-Pop enhance scratch (floor-subtracted 0..1 row + terrain evidence).
     let enhBuf: Float32Array | null = null;
     let terrainScratch: Float32Array | null = null;
-    // Stitched dual-RX per-half floor-normalisation scratch.
-    let stitchBuf: Float32Array | null = null;
     // Tracks the value domain ('pop' = 0..1, 'rx-db', 'tx-db') so a wholesale
     // domain change clears the history instead of rendering a clipped band.
     let valueDomain = '';
@@ -128,18 +127,20 @@ export function WaterfallHeightfield({
     const pushFrame = (wfDb: Float32Array, centerHz: bigint, hzPerPixel: number) => {
       if (!renderer) return;
       const dom = domainNow();
+      // Report this pane's noise floor for cross-band normalization (RX domain,
+      // i.e. not keyed). Cheap downsampled percentile, EMA-smoothed in the
+      // registry; consumed by draw() via effectiveRxWfWindow so every band's
+      // floor lands at the same colour and one dB slider fits them all. Measured
+      // on the RAW dB row, before any Pop floor-subtraction.
+      if (dom !== 'tx-db') {
+        const floorDb = estimateRowFloorDb(wfDb);
+        if (floorDb != null) reportReceiverFloorDb(rxIndex, floorDb);
+      }
       if (dom !== valueDomain) {
         valueDomain = dom;
         renderer.clearHistory();
       }
       let row = wfDb;
-      // Stitched dual-RX: normalise this half's floor so the two panels join
-      // seamlessly (parity with the WebGL waterfall). Skip while keyed (TX).
-      if (stitched && dom !== 'tx-db') {
-        const normalized = normalizeStitchedBins(row, stitchBuf, stitchFloorShiftDb(receiver, 'waterfall'));
-        if (normalized !== row) stitchBuf = normalized;
-        row = normalized;
-      }
       if (dom === 'pop') {
         if (!enhBuf || !terrainScratch || enhBuf.length !== row.length) {
           enhBuf = new Float32Array(row.length);
@@ -200,14 +201,19 @@ export function WaterfallHeightfield({
     const draw = () => {
       if (!renderer || lost) return;
       // Read settings LIVE every draw so the sliders take effect immediately.
-      const { wfDbMin, wfDbMax, wfTxDbMin, wfTxDbMax, waterfallScrollSpeed } =
+      const { wfTxDbMin, wfTxDbMax, waterfallScrollSpeed } =
         useDisplaySettingsStore.getState();
       const enhance = useSignalEnhanceStore.getState();
       const dom = domainNow();
       // Pop rows are normalised 0..1; RX/TX keep their dB windows. Mirrors the
-      // WebGL waterfall's redraw() window selection.
-      const dbMin = dom === 'pop' ? 0 : dom === 'tx-db' ? wfTxDbMin : wfDbMin;
-      const dbMax = dom === 'pop' ? 1 : dom === 'tx-db' ? wfTxDbMax : wfDbMax;
+      // WebGL waterfall's redraw() window selection. For the RX domain the window
+      // is the per-receiver one: RX1 uses the global window; every other RX uses
+      // its own measured floor offset (median-anchored across all panes) or an
+      // operator override, so each band's noise floor lands at the same colour and
+      // the single dB slider evens them all out. Keyed/Pop are absolute.
+      const rxWin = dom === 'rx-db' ? effectiveRxWfWindow(rxIndex) : null;
+      const dbMin = dom === 'pop' ? 0 : dom === 'tx-db' ? wfTxDbMin : rxWin!.wfDbMin;
+      const dbMax = dom === 'pop' ? 1 : dom === 'tx-db' ? wfTxDbMax : rxWin!.wfDbMax;
       renderer.setScrollSpeed(waterfallScrollSpeed);
       renderer.setReliefDepth(Math.max(0, Math.min(1, enhance.waterfallReliefDepth / 100)));
       // Temporal de-speckle only in Pop (where floor subtraction creates speckle);
@@ -263,6 +269,7 @@ export function WaterfallHeightfield({
     let unsubViewZoom: (() => void) | null = null;
     let unsubTx: (() => void) | null = null;
     let unsubEnhance: (() => void) | null = null;
+    let unsubRxWin: (() => void) | null = null;
 
     const fail = (reason: string) => {
       setStatus('unsupported');
@@ -370,6 +377,13 @@ export function WaterfallHeightfield({
           requestRedraw();
         }
       });
+
+      // Repaint when this receiver's per-RX dB window override changes (operator
+      // dragged the WfDbScale while this RX was focused). The median-anchored
+      // floor offset itself is picked up live each frame via effectiveRxWfWindow.
+      unsubRxWin = useRxDbWindowStore.subscribe((state, prev) => {
+        if (state.overrides[rxIndex] !== prev.overrides[rxIndex]) requestRedraw();
+      });
     });
 
     return () => {
@@ -380,12 +394,16 @@ export function WaterfallHeightfield({
       unsubViewZoom?.();
       unsubTx?.();
       unsubEnhance?.();
+      unsubRxWin?.();
       cancelDrawBusFrame(draw);
       ro.disconnect();
       io.disconnect();
       document.removeEventListener('visibilitychange', onVisibilityChange);
       releaseFrameConsumer();
       releaseEstimatorConsumer();
+      // Drop this pane's floor from the median anchor — a removed band shouldn't
+      // keep skewing the cross-RX normalization with its last reading.
+      forgetReceiverFloor(rxIndex);
       renderer?.dispose();
     };
   }, [receiver, showStats, stitched]);


### PR DESCRIPTION
## Problem

When multiple RX panes are open on different bands, their waterfall noise floors should normalize so every pane reads at the same brightness. The operator reported this **looked like it wasn't working** — e.g. a busy 40m pane shows bright while a quiet 20m pane is near-black.

## Root cause

The cross-RX floor normalization (`dsp/floor-normalization.ts` + `state/rx-db-window-store.ts` `effectiveRxWfWindow`) was only wired into the **legacy WebGL** `Waterfall.tsx`. The **default** surface is the **WebGPU heightfield** (`WaterfallHeightfield.tsx`), which drew every receiver with the raw global `wfDbMin/wfDbMax` and never touched the floor registry — so the whole feature was effectively dead on the renderer people actually see.

The only normalization the heightfield applied was the older `stitch-normalizer`, clamped to **±18 dB** — not enough to close a busy-vs-dead inter-band gap.

## Fix

Wire the same median-anchored floor normalization into the heightfield:
- report each pane's noise floor every RX frame (`estimateRowFloorDb` → `reportReceiverFloorDb`), measured on the raw dB row before any Pop floor-subtraction;
- draw the RX domain through `effectiveRxWfWindow(rxIndex)` so each band's floor lands at the same colour and one dB slider evens them all out;
- repaint on per-RX override changes; `forgetReceiverFloor` on unmount.

Drop the older ±18 dB stitch **brightness** shift from **both** waterfall renderers — it couldn't close wide inter-band gaps and double-corrected against the floor window on the RX1+RX2 pair. The Panadapter trace keeps its own stitch join (separate concern). Both renderers now normalize through the single floor-window path.

## Test

- `tsc --noEmit`: clean (verified on a clean `develop`-based worktree)
- ESLint: 0 errors
- `vitest`: 40 passed across `floor-normalization`, `rx-db-window-store`, `stitch-normalizer`, `Waterfall`

Visual confirmation against live hardware is left to the reviewer: with RX1+RX2 on different bands, both floors should sit at the same brightness, and one drag of the master dB scale should even out every band.