### PR TITLE
fix(ci): win-x64 nightly verify — invoke GUI-subsystem exe via Start-Process

### DIFF
--- a/tools/verify-windows-installer-payload.ps1
+++ b/tools/verify-windows-installer-payload.ps1
@@ -61,24 +61,47 @@ foreach ($nativeName in @("wdsp.dll", "miniaudio.dll", "zeus-vst-bridge.dll")) {
 # running the published app itself. Loading the net10.0 host assembly inside
 # PowerShell uses PowerShell's runtime context instead of the publish payload's
 # runtime context, which can fail before the VST resolver is exercised.
-# The win-x64 bridge load fails INTERMITTENTLY in CI (the same commit has both
-# passed and failed on different nightlies) — a transient native-load hiccup,
-# not a deterministic regression. Retry a few times so a one-off flake doesn't
-# red the whole nightly, but keep EVERY attempt's output visible and still fail
-# loudly if all attempts fail. That absorbs the flake without masking a genuine,
-# persistent bridge-load problem: a real regression fails all 3 with the real
-# exception printed, and a flake that needed a retry emits a ::warning:: so it
-# stays visible in the run summary.
+# OpenhpsdrZeus.exe is built GUI-subsystem (WinExe, so no console window pops up
+# on normal launch). That breaks the obvious `& exe 2>&1; $LASTEXITCODE` probe:
+# PowerShell's call operator does NOT wait for a GUI-subsystem process and
+# cannot capture its console, so BOTH the output and the exit code came back
+# EMPTY — every attempt looked like an exit-code-less failure even when the
+# bridge was fine. Start-Process -Wait reliably blocks until the GUI process
+# exits and -PassThru yields the real .ExitCode, while -RedirectStandard*
+# captures the exe's stdout/stderr (the managed verdict + any exception) to
+# files we can read and print.
 #
-# Always echo the probe's own output verbatim — PowerShell's `throw` renders a
-# truncated single-line view that previously swallowed the one diagnostic that
-# matters (the managed exception type the published exe writes to stderr).
+# Retry a few times so a one-off native-load hiccup doesn't red the whole
+# nightly, but keep EVERY attempt's output visible and still fail loudly if all
+# attempts fail: a real regression fails all 3 with the real exception printed,
+# and a flake that needed a retry emits a ::warning:: in the run summary.
+$exe = Join-Path $publishPath "OpenhpsdrZeus.exe"
+$tmp = [System.IO.Path]::GetTempPath()
+$outFile = Join-Path $tmp "zeus-vst-verify-out-$Arch.txt"
+$errFile = Join-Path $tmp "zeus-vst-verify-err-$Arch.txt"
 $maxAttempts = 3
 $probeExit = 1
 for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
-    $probeOutput = & (Join-Path $publishPath "OpenhpsdrZeus.exe") --verify-vst-bridge 2>&1
-    $probeExit = $LASTEXITCODE
+    Remove-Item -LiteralPath $outFile, $errFile -ErrorAction SilentlyContinue
 
+    $spArgs = @{
+        FilePath               = $exe
+        ArgumentList           = '--verify-vst-bridge'
+        Wait                   = $true
+        PassThru               = $true
+        NoNewWindow            = $true
+        RedirectStandardOutput = $outFile
+        RedirectStandardError  = $errFile
+    }
+    $proc = Start-Process @spArgs
+    $probeExit = $proc.ExitCode
+
+    $probeOutput = @()
+    foreach ($f in @($outFile, $errFile)) {
+        if (Test-Path -LiteralPath $f) {
+            $probeOutput += (Get-Content -LiteralPath $f -ErrorAction SilentlyContinue)
+        }
+    }
     if ($probeOutput) {
         Write-Host "--- OpenhpsdrZeus --verify-vst-bridge output (attempt $attempt/$maxAttempts, exit $probeExit) ---"
         $probeOutput | ForEach-Object { Write-Host $_ }


### PR DESCRIPTION
Follow-up to #1116. With the diagnostics live, the win-x64 nightly verify revealed the real failure mode: an **empty exit code and no output** across all retry attempts. Root cause: `OpenhpsdrZeus.exe` is GUI-subsystem (WinExe, #1020), and PowerShell's `&` operator doesn't wait for GUI processes or capture their console — so `$LASTEXITCODE`/output were always empty and every attempt read as failure.

Fix: invoke the probe with `Start-Process -Wait -PassThru` (reliably waits for a GUI process and yields the real `.ExitCode`) + `-RedirectStandardOutput/Error` to files we read back. Retry + diagnostics behaviour preserved. PowerShell-only; no C# / payload change.

This is the area Christian's `d9c8c1aa` (attach console before --verify-vst-bridge) was also addressing.