### PR TITLE
DO NOT MERGE — feat(ps): single-ADC time-mux PureSignal feedback for ANAN-G2E (HermesC10), wired behind burn-zone interlock (#960)

### DIFF
--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -1681,6 +1681,99 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         _                        => G2RxDdc,
     };
 
+    /// <summary>
+    /// True iff <b>Zeus</b> reserves the front DDC slots (DDC0/DDC1) for the
+    /// PureSignal feedback pair on this board — i.e. the dual-ADC
+    /// OrionMkII/Saturn/G2 family, where the user-visible RX lives at DDC2
+    /// (<see cref="RxBaseDdc"/> == 2). False for the single-ADC Hermes-class
+    /// radios (Hermes/0x01, HermesII/0x02, ANAN-G2E·HermesC10/0x14) where Zeus
+    /// maps the operator's only RX to DDC0 (<see cref="RxBaseDdc"/> == 0).
+    ///
+    /// This is the single board predicate that decides whether Zeus may put PS
+    /// feedback on DDC0 — both when composing the wire (compose side) and when
+    /// demuxing inbound IQ (receive side). Deriving it from
+    /// <see cref="RxBaseDdc"/> keeps the two sides from ever drifting: if a
+    /// board's RX base is DDC0, Zeus must not also treat that DDC as a feedback
+    /// slot. Issue #960 — on the single-ADC G2E the board-agnostic
+    /// "DDC0 == PS feedback" assumption diverted the operator's only RX stream
+    /// into the PS path the moment PS armed, killing RX audio.
+    ///
+    /// IMPORTANT — what this predicate does and does NOT mean: it does NOT mean
+    /// the G2E hardware is incapable of PureSignal. The N1GP G2E gateware
+    /// genuinely supports Orion-style PS on its single LTC2208 (Hermes.v: NR=2,
+    /// no DDC2): with command byte 1363 (SyncRx[0]) set to 0x02 — the exact
+    /// byte Zeus already writes to arm the Orion feedback pair — Rx_fifo_ctrl0
+    /// (Hermes.v:717-720) muxes the TX-DAC reference (rx_I[NR]) and the ADC
+    /// feedback (rx_I[0]) into DDC0 as the identical Orion interleaved pair, and
+    /// the firmware comments record "PS works" (Hermes.v:139, ported from
+    /// Angelia P2 v11.6, N1GP/Phil PS work at :174). The reason Zeus returns
+    /// <c>false</c> here for the G2E is a SOFTWARE choice, not a hardware limit:
+    /// because the G2E has only one ADC, arming that interleaved pair consumes
+    /// DDC0 and the operator's user RX would have to relocate to DDC1
+    /// (receiver_inst1, also fed from temp_ADC). Zeus does not yet implement
+    /// that single-ADC relocation, so this predicate DISABLES PS on the G2E to
+    /// protect RX audio — it does not make PS work. Making PS actually function
+    /// on the G2E (keep writing byte 1363 = 0x02 AND move user RX to DDC1 while
+    /// PS is armed) is a larger, G2E-bench-gated change tracked in #960.
+    /// </summary>
+    public static bool ReservesPsFeedbackDdcs(HpsdrBoardKind board)
+        => RxBaseDdc(board) != 0;
+
+    /// <summary>
+    /// RX-thread dispatch decision (issue #960): should an inbound DDC0 packet
+    /// (UDP src port 1035) be consumed as a PureSignal paired-feedback frame
+    /// instead of a user-RX IQ frame? True only when PS feedback is armed AND
+    /// the packet is on DDC0 AND the board actually reserves DDC0 for the PS
+    /// feedback pair (<see cref="ReservesPsFeedbackDdcs"/>).
+    ///
+    /// On the dual-ADC OrionMkII/Saturn/G2 family DDC0 is a genuine reserved
+    /// feedback slot (user RX lives at DDC2), so the board term is a constant
+    /// <c>true</c> and this is bit-for-bit the historical
+    /// <c>_psFeedbackEnabled &amp;&amp; ddcIndex == 0</c> behaviour. On the
+    /// single-ADC Hermes-class boards (HermesC10/ANAN-G2E, Hermes, HermesII)
+    /// Zeus maps DDC0 to the operator's only RX, so this returns <c>false</c>
+    /// and the packet stays on the user-RX audio path — without the gate,
+    /// arming PS diverted every RX0 packet into the feedback path and the WDSP
+    /// RX0 audio channel starved (1.4M-sample underrun, dead receive).
+    ///
+    /// Note (#960): returning <c>false</c> on the G2E DISABLES PureSignal there
+    /// to keep RX audio alive — it does NOT implement PS. The G2E gateware can
+    /// do Orion-style PS on DDC0 (byte 1363 SyncRx[0]=0x02 interleave); making
+    /// it work requires also relocating user RX to DDC1, a separate change.
+    /// See <see cref="ReservesPsFeedbackDdcs"/>.
+    /// </summary>
+    public static bool RoutesDdc0ToPsFeedback(
+        bool psFeedbackEnabled, int ddcIndex, HpsdrBoardKind board)
+        => psFeedbackEnabled && ddcIndex == 0 && ReservesPsFeedbackDdcs(board);
+
+    /// <summary>
+    /// Wire-compose decision (issue #960), the compose-side twin of
+    /// <see cref="RoutesDdc0ToPsFeedback"/>: may Zeus place PureSignal feedback
+    /// bytes on ANY outbound command for this board when PS feedback is armed?
+    /// True only when PS feedback is armed AND the board reserves the DDC0/DDC1
+    /// feedback pair (<see cref="ReservesPsFeedbackDdcs"/>).
+    ///
+    /// This is the single predicate every PS wire-compose site funnels through —
+    /// the RxSpecific DDC-enable/sync block, the TxSpecific PA-protection bytes
+    /// (p[57..59]), and the HighPriority DDC0/DDC1 phase mirror + ALEX_PS /
+    /// ALEX_RX_ANTENNA_BYPASS coupler bits. Routing them all through one board
+    /// predicate keeps them consistent: on the single-ADC Hermes-class boards
+    /// (incl. ANAN-G2E·HermesC10) NONE of those bytes ever reach the wire, so an
+    /// "armed" PS state can no longer flip the RX front-end onto the feedback
+    /// coupler (external K36 tap) during a TX burst for no benefit. On the
+    /// dual-ADC OrionMkII/Saturn/G2 family this equals the bare
+    /// <c>_psFeedbackEnabled</c> it replaces, so every wire command is
+    /// byte-for-byte unchanged there.
+    ///
+    /// NB: this gates only the WIRE bytes — it does not change PS arm/disarm
+    /// state, persistence, or the WDSP engine, all of which remain owned by the
+    /// burn-zone PS path. On the G2E it therefore DISABLES PS (protecting RX
+    /// audio); it does not implement it. See <see cref="ReservesPsFeedbackDdcs"/>.
+    /// </summary>
+    public static bool ComposesPsFeedbackWire(
+        bool psFeedbackEnabled, HpsdrBoardKind board)
+        => psFeedbackEnabled && ReservesPsFeedbackDdcs(board);
+
     internal static byte AdcOptionMask(byte numAdc)
     {
         // Thetis SetADCDither/SetADCRandom writes ADC0, ADC1, and ADC2
@@ -1736,16 +1829,17 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
 
         if (psEnabled)
         {
-            // PS feedback layout is OrionMkII/Saturn-specific (DDC0+DDC1
-            // paired with bit 1363 sync). Single-ADC Hermes-class radios
-            // (Hermes/0x01, HermesII/0x02, HermesC10/0x14) don't have this
-            // hardware — leave the PS block alone. psEnabled should never
-            // be set true for these boards upstream, but if it ever is we'd
-            // rather silently no-op than scribble bytes the radio will
-            // reject.
-            if (boardKind != HpsdrBoardKind.Hermes &&
-                boardKind != HpsdrBoardKind.HermesII &&
-                boardKind != HpsdrBoardKind.HermesC10)
+            // Zeus only composes the DDC0+DDC1 paired feedback layout (bit 1363
+            // sync) for boards where it reserves the front DDCs for feedback —
+            // the dual-ADC OrionMkII/Saturn/G2 family. On single-ADC Hermes-class
+            // radios (Hermes/0x01, HermesII/0x02, HermesC10/0x14) Zeus DISABLES
+            // PS (DDC0 is the operator's only RX), so leave the PS block alone.
+            // This is a Zeus software choice for the G2E, not a hardware limit —
+            // the G2E gateware can do Orion-style PS on DDC0 (byte 1363
+            // SyncRx[0]=0x02 interleave); see ReservesPsFeedbackDdcs. The same
+            // board set as the old `!= Hermes && != HermesII && != HermesC10`
+            // test (issue #960).
+            if (ReservesPsFeedbackDdcs(boardKind))
             {
                 ddcEnable |= 0x01;
                 p[17] = 0x00;
@@ -1832,11 +1926,17 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         int baseDdc = RxBaseDdc(boardKind);
         byte ddcEnable = 0;
 
-        // PS feedback pair is Orion-family-only (DDC0+DDC1, byte 1363 sync) —
-        // mirror the legacy composer exactly; no-op on single-ADC Hermes-class.
-        bool psHardware = boardKind != HpsdrBoardKind.Hermes &&
-                          boardKind != HpsdrBoardKind.HermesII &&
-                          boardKind != HpsdrBoardKind.HermesC10;
+        // PS feedback pair (DDC0+DDC1, byte 1363 sync) — Zeus only composes it
+        // for boards where it reserves the front DDCs for feedback (the dual-ADC
+        // OrionMkII/Saturn/G2 family). Mirror the legacy composer exactly there;
+        // no PS block on single-ADC Hermes-class. ReservesPsFeedbackDdcs is the
+        // same board set as the old explicit `!= Hermes && != HermesII &&
+        // != HermesC10` test (issue #960). NB: skipping the block on the G2E
+        // DISABLES PS to protect its single-ADC RX — it is not a hardware limit
+        // (the G2E gateware can do Orion-style PS on DDC0; see
+        // ReservesPsFeedbackDdcs). Implementing it needs user RX relocated off
+        // DDC0, a separate G2E-bench-gated change.
+        bool psHardware = ReservesPsFeedbackDdcs(boardKind);
         if (psEnabled && psHardware)
         {
             ddcEnable |= 0x01;
@@ -1934,7 +2034,14 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
             SidetoneHz = _cwSidetoneHz,
             SidetoneLevel = _cwSidetoneLevel,
         };
-        var p = ComposeCmdTxBuffer(_seqCmdTx++, (ushort)_sampleRateKhz, _txStepAttnDb, _paEnabled, _psFeedbackEnabled, _micControl, _lineInGain, cw);
+        // Board-gate the PS-armed TxSpecific shape (p[57..59] PA-protection /
+        // step-att for the TX-DAC reference) the same way every other PS wire
+        // site is gated (#960): only boards that reserve the feedback DDCs emit
+        // it. On the single-ADC G2E this keeps the TX command byte-identical to
+        // the non-PS path even when PS is "armed" upstream. Byte-for-byte
+        // unchanged on the dual-ADC OrionMkII/Saturn/G2 family.
+        bool psWire = ComposesPsFeedbackWire(_psFeedbackEnabled, _boardKind);
+        var p = ComposeCmdTxBuffer(_seqCmdTx++, (ushort)_sampleRateKhz, _txStepAttnDb, _paEnabled, psWire, _micControl, _lineInGain, cw);
         _sock!.SendTo(p, new IPEndPoint(_radioEndpoint!.Address, 1026));
     }
 
@@ -2119,6 +2226,18 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     {
         var p = new byte[BufLen];
         WriteBeU32(p, 0, _seqCmdHp++);
+        // PureSignal feedback bytes (DDC0/DDC1 phase mirror + ALEX_PS / bypass
+        // coupler bits) may go on the wire ONLY when Zeus reserves the front
+        // DDCs for feedback on this board (issue #960). On the single-ADC
+        // Hermes-class boards (incl. ANAN-G2E·HermesC10) DDC0 is the operator's
+        // only RX and Zeus disables PS, so this is false and NO PS bytes are
+        // composed — even if the engine/state "armed" PS upstream. Without this
+        // the ALEX_PS / bypass bits flipped the RX front-end onto the feedback
+        // coupler during every TX burst (external K36 tap) for no benefit. On
+        // the dual-ADC OrionMkII/Saturn/G2 family this is identical to the bare
+        // `_psFeedbackEnabled` it replaces, so the wire is byte-for-byte
+        // unchanged there.
+        bool psWire = ComposesPsFeedbackWire(_psFeedbackEnabled, _boardKind);
         // Byte 4 bit 0 = run, bit 1 = PTT. Thetis network.c:924-925 and
         // pihpsdr new_protocol.c:746-757 both set bit 1 whenever the radio
         // should key — covers both mic-MOX and TUN. Without this bit the
@@ -2173,7 +2292,9 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         // PureSignal — when armed, DDC0 + DDC1 phase words also need to
         // track the TX frequency during xmit so the feedback DDC samples
         // the actual TX coupler signal. pihpsdr new_protocol.c:827-839.
-        if (_psFeedbackEnabled && _moxOn)
+        // Board-gated via psWire so DDC0's phase is never overwritten on a
+        // single-ADC board where DDC0 carries the operator's RX (#960).
+        if (psWire && _moxOn)
         {
             // For now mirror the RX freq onto the TX side — the radio's
             // single-VFO assumption today means TX = RX. Multi-VFO support
@@ -2273,7 +2394,7 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
             txLpfFreqHz,
             rx2Enabled,
             xmit,
-            _psFeedbackEnabled,
+            psWire,          // board-gated PS arm (#960): no ALEX_PS on single-ADC
             _boardKind,
             txAntWire);
         // RX auxiliary input select (external-ports plan — antenna slice, #804).
@@ -2291,12 +2412,12 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         // into alex0 (during xmit) and alex1 (always-on while PS armed).
         // ComposeAlex1Word owns the alex1 side because it also owns ADC1/RX2
         // filter-bank selection.
-        if (_psFeedbackEnabled && xmit) alex0 |= AlexPsBit;
+        if (psWire && xmit) alex0 |= AlexPsBit;
         // External (Bypass) feedback antenna — pihpsdr new_protocol.c:1284-
         // 1296 ORs ALEX_RX_ANTENNA_BYPASS into alex0 only during xmit when
         // PS is armed and the operator selected the external path. Internal
         // coupler leaves this bit clear.
-        if (_psFeedbackEnabled && _psFeedbackExternal && xmit)
+        if (psWire && _psFeedbackExternal && xmit)
         {
             alex0 |= AlexRxAntennaBypass;
         }
@@ -2696,7 +2817,7 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
                 if (srcPort >= RxDataPortBase && srcPort < RxDataPortBase + MaxRxDdc && n == BufLen)
                 {
                     int ddcIndex = srcPort - RxDataPortBase;
-                    if (_psFeedbackEnabled && ddcIndex == 0)
+                    if (RoutesDdc0ToPsFeedback(_psFeedbackEnabled, ddcIndex, _boardKind))
                     {
                         // PS-armed paired-DDC packet: 6B DDC0 (TX-mod-IQ) + 6B
                         // DDC1 (feedback) interleaved per sample. pihpsdr

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -1196,7 +1196,7 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         // next HP frame carries the operator's new antenna. Only flush when fully
         // unkeyed (a TUNE could still be active).
         if (!on && !_tuneActive) FlushPendingAntennas();
-        if (_rxTask is not null) SendCmdHighPriority(run: true);
+        if (_rxTask is not null) PushTransmitEdge(on);
     }
 
     public void SetTune(bool on)
@@ -1204,7 +1204,51 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         _tuneActive = on;
         if (!on) ResetTxIq();
         if (!on && !_moxOn) FlushPendingAntennas();
-        if (_rxTask is not null) SendCmdHighPriority(run: true);
+        if (_rxTask is not null) PushTransmitEdge(on);
+    }
+
+    /// <summary>
+    /// Common MOX/TUNE transmit-edge wire push. For every board this re-pushes
+    /// HighPriority (run + the MOX/PTT bit derived from <c>_moxOn || _tuneActive</c>).
+    ///
+    /// On the single-ADC G2E (issue #960), and ONLY while PS is armed AND the
+    /// burn-zone time-mux interlock is lifted, DDC0's descriptor depends on the
+    /// transmit-burst state, so the edge also re-emits the Receive-Specific
+    /// command to swap DDC0 between the feedback interleave and the user RX:
+    ///   - key-DOWN: SendCmdRx FIRST (arm the DDC0 feedback descriptor,
+    ///     byte 1363 = 0x02) THEN SendCmdHighPriority (assert MOX) — reconfigure
+    ///     the DDC before keying.
+    ///   - key-UP: SendCmdHighPriority FIRST (drop the wire MOX, preserving the
+    ///     #870 kill-RF-before-teardown ordering) THEN SendCmdRx (revert DDC0 to
+    ///     the user-RX descriptor) so RX audio returns promptly.
+    /// <c>_psBlockFill</c> is reset on both edges so a partial feedback block is
+    /// never stitched across a user-RX/feedback transition. The keepalive
+    /// re-emits SendCmdRx ~5 Hz, so a single dropped edge self-heals within
+    /// ~200 ms. For every other board, and on the G2E with the interlock down or
+    /// PS disarmed, this emits NO extra CmdRx — the wire is byte-identical to the
+    /// historical single <c>SendCmdHighPriority(run: true)</c>.
+    /// </summary>
+    private void PushTransmitEdge(bool keyDown)
+    {
+        bool timeMuxEdge = _psFeedbackEnabled && TimeMuxesPsFeedbackOnDdc0(_boardKind);
+        if (!timeMuxEdge)
+        {
+            SendCmdHighPriority(run: true);
+            return;
+        }
+
+        if (keyDown)
+        {
+            _psBlockFill = 0;
+            SendCmdRx();                    // arm DDC0 feedback interleave first
+            SendCmdHighPriority(run: true); // then assert MOX
+        }
+        else
+        {
+            SendCmdHighPriority(run: true); // drop wire MOX first (#870)
+            _psBlockFill = 0;
+            SendCmdRx();                    // then revert DDC0 to user RX
+        }
     }
 
     /// <summary>
@@ -1742,9 +1786,91 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     /// it work requires also relocating user RX to DDC1, a separate change.
     /// See <see cref="ReservesPsFeedbackDdcs"/>.
     /// </summary>
+    /// <summary>
+    /// Burn-zone interlock (PureSignal hard rule, issue #960). The G2E
+    /// single-ADC time-multiplexed PS feedback path (compose + de-interleave,
+    /// below) is fully wired but held DARK in production until BOTH coupled
+    /// pre-conditions land with KB2UKA sign-off:
+    ///   (A) the byte-59 (Angelia_atten_Tx0) protective seed is pushed to the
+    ///       wire on connect/arm in
+    ///       <c>RadioService.ApplyPsHwPeakForConnection</c>. The single shared
+    ///       LTC2208's TX-time input attenuator is muxed by transmit state in
+    ///       gateware — Hermes.v:1704
+    ///       <c>assign atten0 = FPGA_PTT ? atten0_on_Tx : Attenuator0</c>, where
+    ///       <c>atten0_on_Tx = Angelia_atten_Tx0 =</c> TxSpecific byte 59
+    ///       (Tx_specific_C&amp;C.v:182-185). Zeus never pushes byte 59 today (it
+    ///       defaults 0), so a fresh G2E first key-down with PS armed would slam
+    ///       the PA coupler into the one ADC at 0 dB. Seeding it touches a PS
+    ///       calibration default — a PS-hard-rule change, NOT done autonomously.
+    ///   (B) OK1BR bench-verifies first-key-down ADC-overload on a real G2E
+    ///       (#289) — Zeus has no G2E bench.
+    /// With this <c>false</c> the G2E path is byte-identical to the
+    /// PS-disabled-on-single-ADC behaviour shipped in commit a7fc99b: RX audio
+    /// survives, <c>ps.correcting</c> stays false. Flipping it true autonomously
+    /// is forbidden — see CLAUDE.md "Hard Rules — PureSignal".
+    /// </summary>
+    internal static bool G2ePsTimeMuxOnAir;
+
+    /// <summary>
+    /// True iff this board does Orion-style PureSignal on a SINGLE ADC by
+    /// time-multiplexing DDC0 (issue #960) — the N1GP ANAN-G2E / HermesC10
+    /// gateware. With command byte 1363 (SyncRx[0]) bit 1 (0x02) the Rx0 FIFO
+    /// controller interleaves the ADC coupler (rx_I[0] = temp_ADC, emitted
+    /// FIRST) with the hardwired internal TX-DAC reference (rx_I[NR] =
+    /// temp_DACD, emitted SECOND) onto DDC0 — Hermes.v:717-720 / :1229 / :1241,
+    /// Rx_fifo_ctrl.v (Sync data first, then data), Rx_specific_C&amp;C.v:181
+    /// maps byte 1363 -> SyncRx[0]. That coupler-first/reference-second order
+    /// matches Zeus's existing paired decoder (<see cref="DecodePsPairForTest"/>:
+    /// first slot -> rx, second slot -> tx), so the de-interleave is reused
+    /// unchanged. Unlike the dual-ADC family (<see cref="ReservesPsFeedbackDdcs"/>)
+    /// DDC0 is also the operator's only RX, so the feedback descriptor may be
+    /// armed ONLY during a TX burst and DDC0 reverts to user RX at rest. Gated by
+    /// <see cref="G2ePsTimeMuxOnAir"/> so the on-air path stays dark until the
+    /// byte-59 safety seed lands and the G2E is bench-verified. Hermes/HermesII
+    /// are deliberately excluded — their single-ADC mux is not gateware-verified
+    /// here and has no bench.
+    /// </summary>
+    public static bool TimeMuxesPsFeedbackOnDdc0(HpsdrBoardKind board)
+        => G2ePsTimeMuxOnAir && board == HpsdrBoardKind.HermesC10;
+
+    /// <summary>
+    /// RX-thread dispatch decision (issue #960) — should an inbound DDC0 packet
+    /// (UDP src port 1035) be consumed as a PureSignal paired-feedback frame
+    /// instead of a user-RX IQ frame? True when PS feedback is armed AND the
+    /// packet is on DDC0 AND either:
+    ///   - the board permanently reserves DDC0 for the feedback pair
+    ///     (<see cref="ReservesPsFeedbackDdcs"/>, dual-ADC OrionMkII/Saturn/G2 —
+    ///     <paramref name="txKeyed"/> irrelevant, the user RX is at DDC2), or
+    ///   - the board time-multiplexes feedback onto DDC0
+    ///     (<paramref name="timeMuxOnDdc0"/>, single-ADC G2E) AND transmit is
+    ///     asserted (<paramref name="txKeyed"/> = MOX || TUNE). At rest DDC0 is
+    ///     the operator's only RX, so feedback must NEVER engage off-burst.
+    ///
+    /// <paramref name="timeMuxOnDdc0"/> is passed explicitly (rather than read
+    /// inside from <see cref="TimeMuxesPsFeedbackOnDdc0"/>) so the compose and
+    /// dispatch sites share one freshly-derived value and the pure logic stays
+    /// deterministically testable; production sites pass
+    /// <c>TimeMuxesPsFeedbackOnDdc0(board)</c>, which is dark until the burn-zone
+    /// interlock lifts.
+    /// </summary>
+    public static bool RoutesDdc0ToPsFeedback(
+        bool psFeedbackEnabled, int ddcIndex, HpsdrBoardKind board,
+        bool txKeyed, bool timeMuxOnDdc0)
+        => psFeedbackEnabled && ddcIndex == 0
+           && (ReservesPsFeedbackDdcs(board)
+               || (timeMuxOnDdc0 && txKeyed));
+
+    /// <summary>
+    /// Back-compat overload (dual-ADC semantics): no time-mux, not keyed. Equal
+    /// to the historical
+    /// <c>psFeedbackEnabled &amp;&amp; ddcIndex == 0 &amp;&amp; ReservesPsFeedbackDdcs(board)</c>
+    /// for every board, so existing callers and the dual-ADC G2 path stay
+    /// byte-identical.
+    /// </summary>
     public static bool RoutesDdc0ToPsFeedback(
         bool psFeedbackEnabled, int ddcIndex, HpsdrBoardKind board)
-        => psFeedbackEnabled && ddcIndex == 0 && ReservesPsFeedbackDdcs(board);
+        => RoutesDdc0ToPsFeedback(psFeedbackEnabled, ddcIndex, board,
+            txKeyed: false, timeMuxOnDdc0: false);
 
     /// <summary>
     /// Wire-compose decision (issue #960), the compose-side twin of
@@ -1816,7 +1942,8 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         HpsdrBoardKind boardKind = HpsdrBoardKind.OrionMkII,
         bool adcDitherEnabled = false,
         bool adcRandomEnabled = false,
-        bool rx2Enabled = false)
+        bool rx2Enabled = false,
+        bool g2eFeedbackBurst = false)
     {
         var p = new byte[BufLen];
         WriteBeU32(p, 0, seq);
@@ -1824,6 +1951,32 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         byte adcMask = AdcOptionMask(numAdc);
         p[5] = adcDitherEnabled ? adcMask : (byte)0;
         p[6] = adcRandomEnabled ? adcMask : (byte)0;
+
+        if (g2eFeedbackBurst)
+        {
+            // G2E single-ADC time-mux PS feedback descriptor (issue #960).
+            // During a TX burst DDC0 carries the coupler(ADC)+TX-DAC-reference
+            // interleave: byte 1363 = 0x02 arms the SyncRx[0][1] mux so the Rx0
+            // FIFO controller interleaves rx_I[0]=temp_ADC (coupler, emitted
+            // first) with rx_I[NR]=temp_DACD (the hardwired reference, emitted
+            // second) — Hermes.v:717-720 / :1229 / :1241, Rx_specific_C&C.v:181.
+            // ONLY DDC0 is enabled: the reference is the internal rx_I[NR]
+            // receiver synced into Rx0, NOT a separate DDC, so no DDC1 enable
+            // (Hermes.v Rx0_fifo_ctrl_inst .Sync_data_in_I(rx_I[0])). The user
+            // RX is relinquished for the burst (we are transmitting). 192 kHz /
+            // 24-bit, ADC0 — same feedback geometry the dual-ADC family uses.
+            // Single-ADC only; never composed for boards that reserve the
+            // DDC0/DDC1 pair. Caller gates this on
+            // TimeMuxesPsFeedbackOnDdc0(board) && txKeyed, so it is dark in
+            // production until the burn-zone interlock lifts.
+            p[7] = 0x01;            // DDC0 enable only (no DDC1)
+            p[17] = 0x00;           // DDC0 source = ADC0
+            WriteBeU16(p, 18, 192); // DDC0 sample rate = 192 kHz (0x00C0 BE)
+            p[22] = 24;             // DDC0 = 24-bit IQ
+            p[1363] = 0x02;         // SyncRx[0][1] coupler/reference interleave
+            return p;
+        }
+
         int rxDdc = RxBaseDdc(boardKind);
         byte ddcEnable = (byte)(1 << rxDdc);
 
@@ -1983,8 +2136,18 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         //   192 kHz / 24-bit, and sets byte 1363 = 0x02 to sync DDC1→DDC0
         //   (pihpsdr new_protocol.c:1611-1630).
         int extras = Volatile.Read(ref _extraReceiverCount);
+        // G2E single-ADC time-mux PS (#960): during a TX burst with PS armed,
+        // DDC0 carries the coupler+TX-DAC-reference interleave instead of the
+        // user RX. Derived fresh, nothing persisted; dark in production until the
+        // burn-zone interlock lifts (TimeMuxesPsFeedbackOnDdc0). The keepalive
+        // re-emits this command ~5 Hz, so a dropped MOX edge self-heals from the
+        // live state. The user RX (incl. RX2/extras) is relinquished for the
+        // burst, so the feedback descriptor takes priority over the extras path.
+        bool g2eFeedbackBurst = _psFeedbackEnabled
+            && TimeMuxesPsFeedbackOnDdc0(_boardKind)
+            && (_moxOn || _tuneActive);
         byte[] p;
-        if (extras > 0)
+        if (extras > 0 && !g2eFeedbackBurst)
         {
             // Full multi-DDC: RX1 + RX2 + RX3.. as a contiguous DDC run via the
             // N-receiver composer. For the RX1(+RX2)(+PS) subset this is
@@ -2019,7 +2182,8 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
                 _boardKind,
                 _adcDitherEnabled,
                 _adcRandomEnabled,
-                Volatile.Read(ref _rx2Enabled) != 0);
+                Volatile.Read(ref _rx2Enabled) != 0,
+                g2eFeedbackBurst);
         }
         _sock!.SendTo(p, new IPEndPoint(_radioEndpoint!.Address, 1025));
     }
@@ -2817,11 +2981,17 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
                 if (srcPort >= RxDataPortBase && srcPort < RxDataPortBase + MaxRxDdc && n == BufLen)
                 {
                     int ddcIndex = srcPort - RxDataPortBase;
-                    if (RoutesDdc0ToPsFeedback(_psFeedbackEnabled, ddcIndex, _boardKind))
+                    if (RoutesDdc0ToPsFeedback(_psFeedbackEnabled, ddcIndex, _boardKind,
+                            txKeyed: _moxOn || _tuneActive,
+                            timeMuxOnDdc0: TimeMuxesPsFeedbackOnDdc0(_boardKind)))
                     {
                         // PS-armed paired-DDC packet: 6B DDC0 (TX-mod-IQ) + 6B
                         // DDC1 (feedback) interleaved per sample. pihpsdr
-                        // process_ps_iq_data, new_protocol.c:2463-2510.
+                        // process_ps_iq_data, new_protocol.c:2463-2510. On the
+                        // single-ADC G2E (time-mux) the same paired layout arrives
+                        // on DDC0 ONLY during a TX burst; at rest this predicate is
+                        // false and the packet stays user RX (and the burn-zone
+                        // interlock keeps it dark in production entirely).
                         HandlePsPairedPacket(buf);
                     }
                     else

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -1795,12 +1795,14 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     ///       wire on connect/arm in
     ///       <c>RadioService.ApplyPsHwPeakForConnection</c>. The single shared
     ///       LTC2208's TX-time input attenuator is muxed by transmit state in
-    ///       gateware — Hermes.v:1704
+    ///       gateware — Hermes.v:1710
     ///       <c>assign atten0 = FPGA_PTT ? atten0_on_Tx : Attenuator0</c>, where
     ///       <c>atten0_on_Tx = Angelia_atten_Tx0 =</c> TxSpecific byte 59
-    ///       (Tx_specific_C&amp;C.v:182-185). Zeus never pushes byte 59 today (it
-    ///       defaults 0), so a fresh G2E first key-down with PS armed would slam
-    ///       the PA coupler into the one ADC at 0 dB. Seeding it touches a PS
+    ///       (Tx_specific_C&amp;C.v:182-185). Zeus emits byte 59 on every
+    ///       TxSpecific packet but only ever as <c>_txStepAttnDb</c>, which
+    ///       defaults to 0 — it never seeds a PS-protective value there, so a
+    ///       fresh G2E first key-down with PS armed would slam the PA coupler
+    ///       into the one ADC at 0 dB. Seeding it touches a PS
     ///       calibration default — a PS-hard-rule change, NOT done autonomously.
     ///   (B) OK1BR bench-verifies first-key-down ADC-overload on a real G2E
     ///       (#289) — Zeus has no G2E bench.

--- a/tests/Zeus.Protocol2.Tests/PsFeedbackDdcRoutingTests.cs
+++ b/tests/Zeus.Protocol2.Tests/PsFeedbackDdcRoutingTests.cs
@@ -294,4 +294,175 @@ public class PsFeedbackDdcRoutingTests
             board: HpsdrBoardKind.OrionMkII);
         Assert.Equal(AlexPsBit, g2 & AlexPsBit);
     }
+
+    // -----------------------------------------------------------------------
+    // G2E single-ADC time-multiplexed PS feedback (issue #960, the "make PS
+    // actually converge on the G2E" follow-up). The dead-receive fix above
+    // DISABLED PS on the single-ADC G2E. This evolves it to time-multiplex the
+    // coupler+TX-DAC-reference interleave onto DDC0 during a TX burst (and only
+    // then), reverting DDC0 to the user RX at rest.
+    //
+    // SAFETY — the on-air path is held DARK by the burn-zone interlock
+    // Protocol2Client.G2ePsTimeMuxOnAir (PureSignal hard rule): with it false
+    // (production default) the G2E behaviour is byte-identical to commit a7fc99b
+    // (PS disabled, RX survives). It must not be flipped true until the byte-59
+    // (Angelia_atten_Tx0) protective seed lands in RadioService with KB2UKA
+    // sign-off AND OK1BR bench-verifies first-key-down ADC-overload (#289).
+    //
+    // The PURE routing/compose logic below is tested by injecting the
+    // capability/txKeyed explicitly (deterministic, parallel-safe — no static
+    // mutation), independent of the production interlock.
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(HpsdrBoardKind.HermesC10)]
+    [InlineData(HpsdrBoardKind.OrionMkII)]
+    [InlineData(HpsdrBoardKind.Hermes)]
+    [InlineData(HpsdrBoardKind.HermesII)]
+    public void TimeMuxesPsFeedbackOnDdc0_DarkInProduction_ForEveryBoard(HpsdrBoardKind board)
+    {
+        // Burn-zone interlock: until KB2UKA signs off the byte-59 safety seed and
+        // the G2E is bench-verified, the on-air time-mux capability stays false
+        // for EVERY board — so production G2E is byte-identical to PS-disabled.
+        Assert.False(Protocol2Client.G2ePsTimeMuxOnAir);
+        Assert.False(Protocol2Client.TimeMuxesPsFeedbackOnDdc0(board));
+    }
+
+    [Fact]
+    public void Routes_G2E_TimeMux_FalseAtRest_TrueInBurst()
+    {
+        // With the time-mux capability injected (= future on-air state), DDC0 on
+        // the G2E is the user RX at rest and the PS feedback interleave only
+        // during a TX burst (txKeyed = MOX || TUNE). This is the core
+        // "feedback only during the burst, never at rest" safety property.
+        Assert.False(Protocol2Client.RoutesDdc0ToPsFeedback(
+            psFeedbackEnabled: true, ddcIndex: 0, HpsdrBoardKind.HermesC10,
+            txKeyed: false, timeMuxOnDdc0: true));   // at rest -> user RX
+        Assert.True(Protocol2Client.RoutesDdc0ToPsFeedback(
+            psFeedbackEnabled: true, ddcIndex: 0, HpsdrBoardKind.HermesC10,
+            txKeyed: true, timeMuxOnDdc0: true));    // in burst -> feedback
+    }
+
+    [Fact]
+    public void Routes_G2E_TimeMux_NeverEngagesWhenPsDisarmed()
+    {
+        // Even mid-burst with the capability on, an unarmed PS never routes DDC0
+        // to feedback — PsEnabled is the sole arm gate (no auto-arm).
+        Assert.False(Protocol2Client.RoutesDdc0ToPsFeedback(
+            psFeedbackEnabled: false, ddcIndex: 0, HpsdrBoardKind.HermesC10,
+            txKeyed: true, timeMuxOnDdc0: true));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Routes_DualAdc_IndependentOfTxKeyed_ByteIdentical(bool txKeyed)
+    {
+        // Dual-ADC G2/OrionMkII reserves DDC0 permanently (user RX at DDC2), so
+        // routing is independent of txKeyed and the time-mux term — exactly the
+        // historical _psFeedbackEnabled && ddc0 behaviour. Zero regression.
+        Assert.True(Protocol2Client.RoutesDdc0ToPsFeedback(
+            psFeedbackEnabled: true, ddcIndex: 0, HpsdrBoardKind.OrionMkII,
+            txKeyed: txKeyed, timeMuxOnDdc0: false));
+    }
+
+    [Theory]
+    [InlineData(HpsdrBoardKind.Hermes)]
+    [InlineData(HpsdrBoardKind.HermesII)]
+    public void Routes_OtherSingleAdc_NeverFeedback_EvenInBurst(HpsdrBoardKind board)
+    {
+        // Hermes/HermesII are excluded from the time-mux capability (no
+        // gateware verification, no bench), so they never route DDC0 to feedback
+        // regardless of txKeyed.
+        Assert.False(Protocol2Client.RoutesDdc0ToPsFeedback(
+            psFeedbackEnabled: true, ddcIndex: 0, board,
+            txKeyed: true, timeMuxOnDdc0: false));
+    }
+
+    [Fact]
+    public void Routes_G2E_Production_DarkEvenInBurst()
+    {
+        // End-to-end production wiring: feeding the GATED capability
+        // (TimeMuxesPsFeedbackOnDdc0, dark) into the routing predicate keeps the
+        // G2E on the user RX even mid-burst with PS armed — byte-identical to the
+        // PS-disabled fix until the interlock lifts.
+        Assert.False(Protocol2Client.RoutesDdc0ToPsFeedback(
+            psFeedbackEnabled: true, ddcIndex: 0, HpsdrBoardKind.HermesC10,
+            txKeyed: true,
+            timeMuxOnDdc0: Protocol2Client.TimeMuxesPsFeedbackOnDdc0(HpsdrBoardKind.HermesC10)));
+    }
+
+    [Fact]
+    public void Compose_G2E_FeedbackBurst_ByteExact()
+    {
+        // The G2E TX-burst feedback descriptor: DDC0 enable ONLY (no DDC1 — the
+        // TX-DAC reference is the hardwired rx_I[NR] receiver synced into Rx0,
+        // not a separate DDC; Hermes.v Rx0_fifo_ctrl_inst), ADC0, 192 kHz/24-bit,
+        // and byte 1363 = 0x02 to arm the SyncRx[0][1] coupler/reference
+        // interleave (Rx_specific_C&C.v:181, Hermes.v:717-720).
+        var p = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 9, numAdc: 1, sampleRateKhz: 192, psEnabled: true,
+            boardKind: HpsdrBoardKind.HermesC10, g2eFeedbackBurst: true);
+
+        Assert.Equal((byte)1, p[4]);        // single ADC
+        Assert.Equal((byte)0x01, p[7]);     // DDC0 enable only, NO DDC1
+        Assert.Equal((byte)0x00, p[17]);    // DDC0 ADC0
+        Assert.Equal((byte)0x00, p[18]);    // DDC0 192 kHz BE high
+        Assert.Equal((byte)0xC0, p[19]);    // DDC0 192 kHz BE low (0x00C0 = 192)
+        Assert.Equal((byte)24, p[22]);      // DDC0 24-bit
+        Assert.Equal((byte)0x02, p[1363]);  // SyncRx[0][1] interleave
+    }
+
+    [Fact]
+    public void Compose_G2E_AtRest_PsArmed_NoFeedbackDescriptor()
+    {
+        // PS armed but NOT in a burst (g2eFeedbackBurst = false): the single-ADC
+        // G2E descriptor stays the plain user-RX layout — DDC0 only, no sync
+        // byte. This is the "never at rest" compose-side guarantee.
+        var p = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 9, numAdc: 1, sampleRateKhz: 192, psEnabled: true,
+            boardKind: HpsdrBoardKind.HermesC10, g2eFeedbackBurst: false);
+
+        Assert.Equal((byte)0x01, p[7]);     // only DDC0 enable (user RX)
+        Assert.Equal((byte)0x00, p[1363]);  // no interleave sync
+    }
+
+    [Fact]
+    public void Compose_G2E_FeedbackBurst_DoesNotPerturb_DualAdc_Default()
+    {
+        // Regression guard: the new g2eFeedbackBurst parameter defaults false and
+        // a normal dual-ADC PS-armed compose is unchanged (DDC0|DDC2 = 0x05,
+        // sync 0x02), so adding the parameter cannot drift the bench-radio wire.
+        var p = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 9, numAdc: 2, sampleRateKhz: 192, psEnabled: true,
+            boardKind: HpsdrBoardKind.OrionMkII);
+        Assert.Equal((byte)0x05, p[7]);
+        Assert.Equal((byte)0x02, p[1363]);
+    }
+
+    [Fact]
+    public void Decode_G2E_Interleave_CouplerFirstToRx_ReferenceSecondToTx()
+    {
+        // The G2E gateware emits the SyncRx[0][1] interleave coupler-FIRST
+        // (rx_I[0] = temp_ADC, the PA coupler) then reference-SECOND
+        // (rx_I[NR] = temp_DACD, the TX-DAC reference) — Rx_fifo_ctrl.v emits the
+        // Sync data before the main data, and Hermes.v:717-720 wires Sync =
+        // rx_I[0], data = rx_I[NR]. That is exactly the slot order the existing
+        // paired decoder expects (first 6B -> rx, second 6B -> tx), so calcc gets
+        // coupler -> rx ('feedback') and reference -> tx, identical to the G2.
+        var pair = new byte[12]
+        {
+            0x7F, 0xFF, 0xFF,   // slot 0 (coupler) I = +full
+            0x40, 0x00, 0x00,   // slot 0 (coupler) Q = +~0.5
+            0x80, 0x00, 0x00,   // slot 1 (reference) I = -full
+            0xC0, 0x00, 0x00,   // slot 1 (reference) Q = -~0.5
+        };
+
+        var (rxI, rxQ, txI, txQ) = Protocol2Client.DecodePsPairForTest(pair);
+
+        Assert.True(rxI > 0.99f, $"coupler I should map to rx ~+1.0, got {rxI}");
+        Assert.True(rxQ > 0.49f && rxQ < 0.51f, $"coupler Q -> rx ~+0.5, got {rxQ}");
+        Assert.True(txI < -0.99f, $"reference I should map to tx ~-1.0, got {txI}");
+        Assert.True(txQ < -0.49f && txQ > -0.51f, $"reference Q -> tx ~-0.5, got {txQ}");
+    }
 }

--- a/tests/Zeus.Protocol2.Tests/PsFeedbackDdcRoutingTests.cs
+++ b/tests/Zeus.Protocol2.Tests/PsFeedbackDdcRoutingTests.cs
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Xunit;
+using Zeus.Contracts;
+
+namespace Zeus.Protocol2.Tests;
+
+/// <summary>
+/// Issue #960 — "PS dont work on Anan G2E, dead receive sound when on".
+///
+/// On the single-ADC HermesC10 / ANAN-G2E (and Hermes / HermesII), Zeus maps
+/// the user's only RX to DDC0 (<see cref="Protocol2Client.RxBaseDdc"/> == 0)
+/// and does NOT reserve PureSignal-feedback DDCs. The RX-thread dispatch used
+/// to test <c>_psFeedbackEnabled &amp;&amp; ddcIndex == 0</c> with no board
+/// term, so arming PS diverted every DDC0 user-RX packet (UDP src port 1035)
+/// into the PS paired-feedback path. The WDSP RX0 audio channel lost its only
+/// producer → 1.4M-sample underrun + rebuffering = dead receive audio.
+///
+/// The fix board-gates that dispatch (and every PS wire-compose site) on
+/// <see cref="Protocol2Client.ReservesPsFeedbackDdcs"/> (derived from
+/// <see cref="Protocol2Client.RxBaseDdc"/> != 0). On the dual-ADC
+/// OrionMkII/Saturn/G2 family DDC0 is a genuine reserved feedback slot, so the
+/// gate is a constant <c>true</c> and the dispatch is byte-/path-identical to
+/// the historical behaviour — zero regression.
+///
+/// SCOPE — what this fix does and does NOT do (issue #960): it stops PureSignal
+/// from killing RX audio on the G2E by DISABLING PS there. It does NOT make PS
+/// work on the G2E. The N1GP G2E gateware genuinely supports Orion-style PS on
+/// its single LTC2208 — with command byte 1363 (SyncRx[0]) = 0x02 (the exact
+/// byte Zeus already writes to arm the Orion pair), Rx_fifo_ctrl0
+/// (Hermes.v:717-720) muxes the TX-DAC reference (rx_I[NR]) and the ADC
+/// feedback (rx_I[0]) into DDC0 as the identical interleaved pair, and the
+/// firmware records "PS works" (Hermes.v:139; N1GP/Phil PS work at :174, ported
+/// from Angelia P2 v11.6). Zeus disables it only because the single ADC means
+/// arming that pair consumes DDC0 and the operator RX must relocate to DDC1
+/// (receiver_inst1, also fed from temp_ADC) — a larger, G2E-bench-gated change.
+/// So #960 closes as "PS no longer kills RX audio (PS itself disabled pending a
+/// single-ADC PS implementation)", NOT "PS works on G2E".
+///
+/// References:
+///  - deskhpsdr src/new_protocol.c:1692-1698 — only ANGELIA/ORION/ORION2/SATURN
+///    apply the ddc = 2 + i offset; Hermes-class fall through to ddc = i.
+///  - G2E P2 gateware Hermes_Protocol_2_C10_v11.0.5/Hermes.v:139 ("PS works"),
+///    :174 (N1GP PS work), :363 (NR = 2), :717-720 (Rx_fifo_ctrl0 interleaves
+///    rx_I[NR] TX-DAC ref + rx_I[0] ADC on DDC0, gated by C122_SyncRx[0][1]);
+///    Rx_specific_C&amp;C.v:181 maps command byte 1363 → SyncRx[0]. i.e. the G2E
+///    DOES present the Orion-style interleaved pair on DDC0 when byte 1363 is
+///    set — Zeus simply does not yet route around the single-ADC RX collision.
+///  - Thetis Console/console.cs groups HermesC10 with Hermes/HermesII in P2
+///    channel setup.
+/// </summary>
+public class PsFeedbackDdcRoutingTests
+{
+    // ---- ReservesPsFeedbackDdcs predicate (pins the board set) ----
+
+    [Theory]
+    [InlineData(HpsdrBoardKind.Hermes)]
+    [InlineData(HpsdrBoardKind.HermesII)]
+    [InlineData(HpsdrBoardKind.HermesC10)]
+    public void ReservesPsFeedbackDdcs_False_For_SingleAdc_HermesClass(HpsdrBoardKind board)
+    {
+        // Single-ADC boards put the operator's RX on DDC0 — that DDC can never
+        // also be a PS feedback slot.
+        Assert.False(Protocol2Client.ReservesPsFeedbackDdcs(board));
+    }
+
+    [Theory]
+    [InlineData(HpsdrBoardKind.OrionMkII)]
+    [InlineData(HpsdrBoardKind.Orion)]
+    [InlineData(HpsdrBoardKind.Angelia)]
+    [InlineData(HpsdrBoardKind.Metis)]
+    [InlineData(HpsdrBoardKind.HermesLite2)]
+    [InlineData(HpsdrBoardKind.Unknown)]
+    public void ReservesPsFeedbackDdcs_True_For_Everything_Else(HpsdrBoardKind board)
+    {
+        // The dual-ADC Orion/G2 family (and the OrionMkII default for every
+        // historically-shipped board) reserves DDC0/DDC1 for the feedback pair
+        // and runs user RX at DDC2.
+        Assert.True(Protocol2Client.ReservesPsFeedbackDdcs(board));
+    }
+
+    [Fact]
+    public void ReservesPsFeedbackDdcs_Tracks_RxBaseDdc_For_Every_Board()
+    {
+        // Structural invariant the fix relies on: a board reserves feedback
+        // DDCs iff its user-RX base DDC is not DDC0. Asserting this over the
+        // whole enum keeps the predicate and the DDC-base resolver from ever
+        // drifting apart if a new board kind is added.
+        foreach (HpsdrBoardKind board in System.Enum.GetValues<HpsdrBoardKind>())
+        {
+            bool expected = Protocol2Client.RxBaseDdc(board) != 0;
+            Assert.Equal(expected, Protocol2Client.ReservesPsFeedbackDdcs(board));
+        }
+    }
+
+    // ---- RX-thread dispatch decision (the dead-audio regression lock) ----
+
+    [Theory]
+    [InlineData(HpsdrBoardKind.HermesC10)]
+    [InlineData(HpsdrBoardKind.Hermes)]
+    [InlineData(HpsdrBoardKind.HermesII)]
+    public void Dispatch_SingleAdc_PsArmed_Ddc0_StaysOnUserRx(HpsdrBoardKind board)
+    {
+        // The headline #960 bug: PS armed (psFeedbackEnabled=true), a DDC0
+        // packet (port 1035) on a single-ADC board MUST route to the user-RX
+        // decoder, NOT the PS paired-feedback path. False here == RX audio lives.
+        Assert.False(Protocol2Client.RoutesDdc0ToPsFeedback(
+            psFeedbackEnabled: true, ddcIndex: 0, board));
+    }
+
+    [Fact]
+    public void Dispatch_G2_PsArmed_Ddc0_RoutesToPsFeedback_Unchanged()
+    {
+        // Zero-regression lock for the bench radio: on the dual-ADC G2/OrionMkII
+        // a DDC0 packet with PS armed still routes to the PS paired-feedback
+        // path exactly as before — DDC0 is a genuine reserved feedback slot
+        // there (user RX is at DDC2).
+        Assert.True(Protocol2Client.RoutesDdc0ToPsFeedback(
+            psFeedbackEnabled: true, ddcIndex: 0, HpsdrBoardKind.OrionMkII));
+    }
+
+    [Theory]
+    [InlineData(HpsdrBoardKind.OrionMkII)]
+    [InlineData(HpsdrBoardKind.HermesC10)]
+    public void Dispatch_PsDisarmed_Ddc0_AlwaysUserRx(HpsdrBoardKind board)
+    {
+        // With PS not armed, DDC0 is always user RX on every board.
+        Assert.False(Protocol2Client.RoutesDdc0ToPsFeedback(
+            psFeedbackEnabled: false, ddcIndex: 0, board));
+    }
+
+    [Theory]
+    [InlineData(HpsdrBoardKind.OrionMkII)]
+    [InlineData(HpsdrBoardKind.HermesC10)]
+    public void Dispatch_NonZeroDdc_NeverPsFeedback(HpsdrBoardKind board)
+    {
+        // Only DDC0 is ever the feedback slot; higher DDCs are always user RX,
+        // regardless of board or PS state.
+        Assert.False(Protocol2Client.RoutesDdc0ToPsFeedback(
+            psFeedbackEnabled: true, ddcIndex: 2, board));
+    }
+
+    // ---- Compose-side byte identity after the DRY refactor ----
+
+    [Fact]
+    public void Compose_RxSpecific_OrionMkII_PsArmed_ByteIdentical_To_LegacyShape()
+    {
+        // The compose guard was refactored from an explicit
+        // `!= Hermes && != HermesII && != HermesC10` test to call
+        // ReservesPsFeedbackDdcs. For the G2 the set is identical, so the
+        // PS-armed wire buffer must be byte-for-byte what PsWireFormatTests
+        // already pins (DDC0|DDC2 = 0x05, sync byte 1363 = 0x02, DDC0/DDC1
+        // config blocks). This locks the refactor as a no-op on the bench radio.
+        var p = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 9, numAdc: 2, sampleRateKhz: 192, psEnabled: true,
+            boardKind: HpsdrBoardKind.OrionMkII);
+
+        Assert.Equal((byte)0x05, p[7]);     // DDC0 (0x01) | DDC2 (0x04)
+        Assert.Equal((byte)0x02, p[1363]);  // DDC1 → DDC0 sync
+        Assert.Equal((byte)0x00, p[17]);    // DDC0 ADC0
+        Assert.Equal((byte)0x00, p[18]);    // DDC0 192 kHz BE high
+        Assert.Equal((byte)0xC0, p[19]);    // DDC0 192 kHz BE low
+        Assert.Equal((byte)24, p[22]);      // DDC0 24-bit
+        Assert.Equal((byte)2, p[23]);       // DDC1 ADC = numAdc
+        Assert.Equal((byte)24, p[28]);      // DDC1 24-bit
+    }
+
+    [Fact]
+    public void Compose_RxSpecific_HermesC10_PsArmed_NoPsBlock()
+    {
+        // Single-ADC board: even with psEnabled the PS DDC0/DDC1 block must
+        // stay clear after the DRY refactor (the radio rejects the packet
+        // otherwise). Only DDC0 enable, no sync byte.
+        var p = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 9, numAdc: 1, sampleRateKhz: 192, psEnabled: true,
+            boardKind: HpsdrBoardKind.HermesC10);
+
+        Assert.Equal((byte)0x01, p[7]);     // only DDC0 enable
+        Assert.Equal((byte)0x00, p[1363]);  // no DDC1 → DDC0 sync
+    }
+
+    // ---- Wire-compose gate (the consistent-across-all-PS-sites lock) ----
+    //
+    // #960 audit: the first cut gated only the RxSpecific DDC-enable block and
+    // the RX decode, leaving the TxSpecific PA-protection bytes and the
+    // HighPriority phase-mirror / ALEX_PS / bypass coupler bits firing on the
+    // G2E when PS was "armed". Every PS wire site now funnels through
+    // ComposesPsFeedbackWire(psFeedbackEnabled, board); these tests pin that
+    // predicate and the byte effect through the two exposed static composers so
+    // a regression that re-introduces a bare `_psFeedbackEnabled` at any site
+    // (or a board-set drift) is caught.
+
+    [Theory]
+    [InlineData(HpsdrBoardKind.HermesC10)]
+    [InlineData(HpsdrBoardKind.Hermes)]
+    [InlineData(HpsdrBoardKind.HermesII)]
+    public void ComposesPsFeedbackWire_False_For_SingleAdc_EvenWhenArmed(HpsdrBoardKind board)
+    {
+        // Single-ADC boards never put PS bytes on any wire command, even with
+        // PS feedback armed — that is what keeps DDC0 (the operator's only RX)
+        // and the RX-coupler relay clear on the G2E.
+        Assert.False(Protocol2Client.ComposesPsFeedbackWire(
+            psFeedbackEnabled: true, board));
+    }
+
+    [Fact]
+    public void ComposesPsFeedbackWire_Tracks_BareFlag_On_DualAdc()
+    {
+        // Zero-regression lock: on the dual-ADC G2/OrionMkII the gate equals the
+        // bare _psFeedbackEnabled it replaced, so every wire site is unchanged.
+        Assert.True(Protocol2Client.ComposesPsFeedbackWire(
+            psFeedbackEnabled: true, HpsdrBoardKind.OrionMkII));
+        Assert.False(Protocol2Client.ComposesPsFeedbackWire(
+            psFeedbackEnabled: false, HpsdrBoardKind.OrionMkII));
+    }
+
+    [Fact]
+    public void ComposesPsFeedbackWire_Matches_RoutesDdc0_On_Ddc0_For_Every_Board()
+    {
+        // The compose-side and receive-side PS decisions must agree on DDC0 for
+        // every board, or the wire and the demux drift (compose feedback bytes
+        // the RX path won't consume, or vice-versa).
+        foreach (HpsdrBoardKind board in System.Enum.GetValues<HpsdrBoardKind>())
+        {
+            Assert.Equal(
+                Protocol2Client.RoutesDdc0ToPsFeedback(true, 0, board),
+                Protocol2Client.ComposesPsFeedbackWire(true, board));
+        }
+    }
+
+    [Fact]
+    public void Compose_TxSpecific_HermesC10_GatedFlag_KeepsNonPsShape()
+    {
+        // The SendCmdTx call site now passes ComposesPsFeedbackWire(...) as the
+        // psEnabled arg. On the G2E that gate is false, so the TxSpecific
+        // PA-protection bytes p[57..59] stay the historical non-PS shape
+        // (all == step-att) rather than the PS shape (p[57]=0, p[58]=PA flag).
+        bool gate = Protocol2Client.ComposesPsFeedbackWire(
+            psFeedbackEnabled: true, HpsdrBoardKind.HermesC10);
+        Assert.False(gate);
+
+        var p = Protocol2Client.ComposeCmdTxBuffer(
+            seq: 1, sampleRateKhz: 192, txStepAttnDb: 7, paEnabled: true,
+            psEnabled: gate);
+        Assert.Equal((byte)7, p[57]);   // non-PS: == step-att
+        Assert.Equal((byte)7, p[58]);   // non-PS: == step-att (no PA-prot flag)
+        Assert.Equal((byte)7, p[59]);
+    }
+
+    [Fact]
+    public void Compose_TxSpecific_OrionMkII_GatedFlag_KeepsPsShape()
+    {
+        // On the dual-ADC bench radio the gate is true, so the PS-armed
+        // PA-protection shape is byte-identical to before (p[57]=0, p[58]=31).
+        bool gate = Protocol2Client.ComposesPsFeedbackWire(
+            psFeedbackEnabled: true, HpsdrBoardKind.OrionMkII);
+        Assert.True(gate);
+
+        var p = Protocol2Client.ComposeCmdTxBuffer(
+            seq: 1, sampleRateKhz: 192, txStepAttnDb: 7, paEnabled: true,
+            psEnabled: gate);
+        Assert.Equal((byte)0, p[57]);
+        Assert.Equal((byte)31, p[58]);  // PA-protection for the TX-DAC reference
+        Assert.Equal((byte)7, p[59]);   // dynamic step-att
+    }
+
+    [Fact]
+    public void Compose_Alex1_GatedFlag_DropsPsBit_On_G2E_KeepsIt_On_G2()
+    {
+        // The alex1 word (HighPriority offset 1428) ORs ALEX_PS only when its
+        // psEnabled arg is set. The call site now passes the board-gated flag,
+        // so the PS coupler bit is present on the G2 and absent on the G2E.
+        const uint AlexPsBit = 0x00040000;
+
+        uint g2e = Protocol2Client.ComposeAlex1Word(
+            rxFreqHz: 14_100_000, rx2FreqHz: 14_100_000, txLpfFreqHz: 14_100_000,
+            rx2Enabled: false, moxOn: true,
+            psEnabled: Protocol2Client.ComposesPsFeedbackWire(true, HpsdrBoardKind.HermesC10),
+            board: HpsdrBoardKind.HermesC10);
+        Assert.Equal(0u, g2e & AlexPsBit);
+
+        uint g2 = Protocol2Client.ComposeAlex1Word(
+            rxFreqHz: 14_100_000, rx2FreqHz: 14_100_000, txLpfFreqHz: 14_100_000,
+            rx2Enabled: false, moxOn: true,
+            psEnabled: Protocol2Client.ComposesPsFeedbackWire(true, HpsdrBoardKind.OrionMkII),
+            board: HpsdrBoardKind.OrionMkII);
+        Assert.Equal(AlexPsBit, g2 & AlexPsBit);
+    }
+}


### PR DESCRIPTION
**DO NOT MERGE** — the on-air path is wired but held DARK behind a burn-zone interlock; bench-test on a real ANAN-G2E is required before this can be lit. See **Safety** and **Bench test REQUIRED** below.

Fixes #960.

## What this does

The first cut of this branch (commit `a7fc99b`) *disabled* PureSignal on the single-ADC ANAN-G2E (HermesC10) to stop it hijacking the operator's only RX. This PR evolves that into the real thing: **PureSignal feedback that functions on the G2E's single ADC** by time-multiplexing DDC0 — feedback during the TX burst, user RX at rest.

## Verified single-ADC mechanism (gateware + Thetis/piHPSDR evidence)

The N1GP G2E gateware can do Orion-style PS on one LTC2208 ADC by interleaving two sources onto DDC0:

- **Command byte 1363 = `0x02`** sets `SyncRx[0][1]`, which tells the Rx0 FIFO controller to interleave the PA **coupler** (`rx_I[0]` = `temp_ADC`, emitted **first**) with the **hardwired internal TX-DAC reference** (`rx_I[NR]` = `temp_DACD`, emitted **second**) onto a single DDC0 stream — `Hermes.v:717-720` / `:1229` / `:1241`, `Rx_fifo_ctrl.v` (Sync data first, then data), `Rx_specific_C&C.v:181` maps byte 1363 → `SyncRx[0]`.
- The reference is the internal `rx_I[NR]` receiver **synced into Rx0**, NOT a second DDC — so the burst descriptor enables **DDC0 only** (no DDC1).
- That coupler-first / reference-second slot order is exactly what Zeus's existing paired decoder already expects (`DecodePsPairForTest`: slot 0 → rx, slot 1 → tx), so the de-interleave and the downstream `calcc` path are reused unchanged — identical geometry to the dual-ADC G2.
- The paired-packet RX dispatch follows piHPSDR `process_ps_iq_data` (`new_protocol.c:2463-2510`); the 192 kHz/24-bit feedback descriptor follows the same shape piHPSDR uses (`new_protocol.c:1611-1630`).

## MOX-gated time-mux design

DDC0 is the operator's **only** receiver, so the feedback descriptor is armed **only for the duration of a TX burst** and reverted immediately on unkey:

- **key-DOWN** (MOX or TUNE): `SendCmdRx()` **first** (arm the DDC0 feedback interleave, byte 1363 = `0x02`) **then** `SendCmdHighPriority(run:true)` (assert MOX) — reconfigure the DDC before keying.
- **key-UP**: `SendCmdHighPriority(run:true)` **first** (drop the wire MOX, preserving the #870 kill-RF-before-teardown ordering) **then** `SendCmdRx()` (revert DDC0 to the user-RX descriptor) so RX audio returns promptly.
- `_psBlockFill` is reset on both edges so a partial feedback block is never stitched across a user-RX↔feedback transition.
- The HighPriority/CmdRx keepalive re-emits the descriptor ~5 Hz, so a single dropped MOX edge self-heals within ~200 ms from live state.

## Why no regression

The change is gated by one freshly-derived predicate at every site; the existing bench radio (G2) never takes the new branch:

- **Dual-ADC OrionMkII / Saturn / G2 family** (`RxBaseDdc == 2`): `TimeMuxesPsFeedbackOnDdc0(board)` is `false`, so `PushTransmitEdge` collapses to the historical single `SendCmdHighPriority(run:true)`; `RoutesDdc0ToPsFeedback(...)` collapses to the historical `_psFeedbackEnabled && ddcIndex == 0 && ReservesPsFeedbackDdcs(board)`; and the new `g2eFeedbackBurst` compose parameter defaults `false`. Every wire command and demux decision is **byte-for-byte / decision-for-decision unchanged** — covered by `Compose_G2E_FeedbackBurst_DoesNotPerturb_DualAdc_Default` and `Routes_DualAdc_IndependentOfTxKeyed_ByteIdentical`.
- **Single-ADC path is itself TX-burst-only**: `RoutesDdc0ToPsFeedback` requires `txKeyed (MOX||TUNE)` AND the time-mux capability AND `psFeedbackEnabled`. At rest the predicate is `false` and DDC0 stays user RX (`Routes_G2E_TimeMux_FalseAtRest_TrueInBurst`).
- **Hermes / HermesII** are deliberately excluded (no gateware verification, no bench) — they never time-mux (`Routes_OtherSingleAdc_NeverFeedback_EvenInBurst`).

The gate (the actual production wiring):

```csharp
public static bool TimeMuxesPsFeedbackOnDdc0(HpsdrBoardKind board)
    => G2ePsTimeMuxOnAir && board == HpsdrBoardKind.HermesC10;

bool g2eFeedbackBurst = _psFeedbackEnabled
    && TimeMuxesPsFeedbackOnDdc0(_boardKind)
    && (_moxOn || _tuneActive);
```

## Safety (PureSignal burn-zone)

- **Feedback only during TX.** The coupler interleave is composed and dispatched **only** when transmit is asserted (`_moxOn || _tuneActive`). At rest DDC0 carries the plain user-RX descriptor — the ADC cannot see PA feedback off-burst (`Compose_G2E_AtRest_PsArmed_NoFeedbackDescriptor`).
- **Held DARK by a burn-zone interlock.** `G2ePsTimeMuxOnAir` defaults `false`, so in production `TimeMuxesPsFeedbackOnDdc0(...)` is `false` for **every** board and the G2E remains byte-identical to the PS-disabled fix in `a7fc99b` (RX survives, `ps.correcting` stays false). The interlock is NOT flipped here. It must not be lit until **both**: (A) the byte-59 (`Angelia_atten_Tx0`) protective input-attenuator seed is pushed on connect/arm in `RadioService` with KB2UKA sign-off — gateware muxes the shared ADC's TX-time attenuator by transmit state (`Hermes.v:1704 assign atten0 = FPGA_PTT ? atten0_on_Tx : Attenuator0`, `atten0_on_Tx = Angelia_atten_Tx0 =` TxSpecific byte 59, `Tx_specific_C&C.v:182-185`), and Zeus does not push byte 59 today (defaults 0); and (B) OK1BR bench-verifies first-key-down ADC handling on a real G2E (#289). Seeding byte 59 touches a PS calibration default — a PS-hard-rule change, deliberately NOT done autonomously.
- **PsEnabled still false-init, no auto-arm.** This PR touches only Protocol-2 DDC routing/wire-compose in `Zeus.Protocol2`. It does not modify `PsEnabled` persistence, startup rehydration, `PsSettingsStore`, the `/api/tx/ps` endpoints, or any arm/disarm/calibration state. `PsEnabled` still initialises `false` every server start; the operator arms manually (`Routes_G2E_TimeMux_NeverEngagesWhenPsDisarmed`).

## Tests added (`tests/Zeus.Protocol2.Tests/PsFeedbackDdcRoutingTests.cs`)

The pure routing/compose/decode logic is exercised by injecting the capability/`txKeyed` explicitly (deterministic, parallel-safe, no static mutation), independent of the production interlock:

- `TimeMuxesPsFeedbackOnDdc0_DarkInProduction_ForEveryBoard` — interlock keeps the on-air capability `false` for HermesC10/OrionMkII/Hermes/HermesII.
- `Routes_G2E_TimeMux_FalseAtRest_TrueInBurst` — core "feedback only in the burst, never at rest".
- `Routes_G2E_TimeMux_NeverEngagesWhenPsDisarmed` — PsEnabled is the sole arm gate.
- `Routes_DualAdc_IndependentOfTxKeyed_ByteIdentical` — G2/OrionMkII unchanged.
- `Routes_OtherSingleAdc_NeverFeedback_EvenInBurst` — Hermes/HermesII excluded.
- `Routes_G2E_Production_DarkEvenInBurst` — gated capability keeps production G2E on user RX even mid-burst.
- `Compose_G2E_FeedbackBurst_ByteExact` — burst descriptor: DDC0 enable only, ADC0, 192 kHz/24-bit, byte 1363 = `0x02`.
- `Compose_G2E_AtRest_PsArmed_NoFeedbackDescriptor` — armed-but-not-keyed stays plain user RX.
- `Compose_G2E_FeedbackBurst_DoesNotPerturb_DualAdc_Default` — new parameter defaults off; dual-ADC compose unchanged (`0x05` / sync `0x02`).
- `Decode_G2E_Interleave_CouplerFirstToRx_ReferenceSecondToTx` — coupler→rx, reference→tx via the existing paired decoder.

Plus the dead-receive guard suite from the first cut (`ReservesPsFeedbackDdcs_*`, `Dispatch_*`, `Compose_*`, `ComposesPsFeedbackWire_*`) remains green. Full project run: **43/43 pass**; `Zeus.Protocol2` builds clean (0 warnings / 0 errors).

## Bench test REQUIRED (lb5va / real G2E)

This cannot merge on code review alone — Zeus has no G2E bench. Before lighting `G2ePsTimeMuxOnAir`:

1. On a real **ANAN-G2E (HermesC10)**, arm PureSignal and confirm **RX audio survives** the arm toggle (no underrun / dead receive) — with the interlock down this must already hold today.
2. With the interlock lifted (after the byte-59 safety seed lands), **key down** and confirm `ps.correcting` reaches `true` and predistortion **converges** (feedback DDC interleave decodes, `calcc` adapts), and **key up** restores user RX promptly with no stitched/partial feedback block.
3. Confirm the **ANAN-G2 still PS-corrects unchanged** — arm PS, key TX, verify the dual-ADC feedback converges exactly as before (no behavioural change expected; the dual-ADC path is byte-identical).
