### PR TITLE
fix(desktop): frameless kiosk window on the native G2 front panel

### DIFF
--- a/OpenhpsdrZeus/Program.cs
+++ b/OpenhpsdrZeus/Program.cs
@@ -427,6 +427,15 @@ public partial class Program
         var initialWidth = savedGeometry.Width;
         var initialHeight = savedGeometry.Height;
 
+        // On the G2's internal Pi, Zeus runs as the radio's built-in front-panel
+        // display — an appliance, not a windowed app. Drop the title bar and frame
+        // (Photino chromeless) and fill the screen so the SPA owns the whole DSI
+        // panel with no window-manager furniture. Detection mirrors how the
+        // hardware front-panel bridge identifies "this is the G2 Pi" (the udev
+        // g2-front-* symlink); see ShouldRunChromelessKiosk. Linux-only, no-op on
+        // ordinary desktops.
+        var kioskChrome = ShouldRunChromelessKiosk();
+
         // Photino's window/dock icon is set per-OS. Windows expects .ico (Photino's
         // SetIconFile binds it to the NSWindow / HWND), Linux GTK expects PNG, and
         // macOS draws the dock icon from CFBundleIconFile in Info.plist — so during
@@ -472,6 +481,10 @@ public partial class Program
         StartupDiagnostics.Phase("desktop: creating Photino window (needs WebView2)");
         var window = new PhotinoWindow()
             .SetTitle("Zeus")
+            // Appliance mode on the G2 Pi: no titlebar, no border. Chromeless is a
+            // startup parameter, so it must be set here in the builder chain before
+            // the native window is created; toggling it later is a no-op.
+            .SetChromeless(kioskChrome)
             .SetUseOsDefaultLocation(false)
             .SetMinWidth(MinWidth)
             .SetMinHeight(MinHeight)
@@ -528,8 +541,9 @@ public partial class Program
         // Reopen maximized if that's how it was left. Setting the property before
         // WaitForClose stores it as a startup parameter (the native window doesn't
         // exist yet), so the frame opens maximized; we still seeded SetSize above
-        // so a later un-maximize restores to the saved normal size.
-        if (savedGeometry.Maximized)
+        // so a later un-maximize restores to the saved normal size. Kiosk mode
+        // always opens filled — a frameless appliance owns the whole DSI panel.
+        if (savedGeometry.Maximized || kioskChrome)
             window.Maximized = true;
 
         // Reliably apply the restored size AFTER the native window exists. The
@@ -565,7 +579,7 @@ public partial class Program
                 // when restoring maximized — so un-maximizing later lands on the
                 // visible desktop rather than wherever the saved bytes pointed.
                 PlaceWindowOnVisibleWorkArea(window, initialWidth, initialHeight);
-                if (savedGeometry.Maximized)
+                if (savedGeometry.Maximized || kioskChrome)
                     window.Maximized = true;
 
                 // A frame that comes up minimized is indistinguishable from "no
@@ -844,6 +858,44 @@ public partial class Program
             return;
         }
         try { LibcImmediateExit(0); } catch { /* fall through to a normal return */ }
+    }
+
+    // True when the desktop should run as a frameless, fullscreen appliance —
+    // the case on the G2's internal Raspberry Pi, where Zeus IS the radio's
+    // built-in front-panel display and window-manager chrome (title bar, border)
+    // is just visual noise on the fixed DSI screen.
+    //
+    // Detection reuses the same signal the hardware front-panel bridge uses to
+    // recognise "this is the G2 Pi": the udev-published g2-front-* by-id serial
+    // symlink (see G2PanelOptions.KnownSymlinks and G2FrontPanelService). That
+    // keeps the two definitions of "native G2" in lock-step and means an ordinary
+    // shack PC — which has no such symlink — keeps its normal decorated window.
+    //
+    // ZEUS_KIOSK=1/0 (or true/false) is an explicit override for benches and dev
+    // boxes that aren't a stock G2. Auto-detection is Linux-only; Windows/macOS
+    // desktops are never made chromeless on hardware presence alone.
+    private static bool ShouldRunChromelessKiosk()
+    {
+        var force = Environment.GetEnvironmentVariable("ZEUS_KIOSK");
+        if (!string.IsNullOrWhiteSpace(force))
+        {
+            if (force == "1" || string.Equals(force, "true", StringComparison.OrdinalIgnoreCase))
+                return true;
+            if (force == "0" || string.Equals(force, "false", StringComparison.OrdinalIgnoreCase))
+                return false;
+        }
+
+        if (!OperatingSystem.IsLinux())
+            return false;
+
+        foreach (var (path, _) in Zeus.Server.FrontPanel.G2PanelOptions.KnownSymlinks)
+        {
+            // File.Exists follows the symlink to the tty target, matching how
+            // G2FrontPanelService.ResolveDevice probes for the panel.
+            try { if (File.Exists(path)) return true; }
+            catch { /* probing is best-effort; a denied path just means "no panel" */ }
+        }
+        return false;
     }
 
     // Photino occasionally opens the frame off the visible desktop on


### PR DESCRIPTION
## What

On the G2's internal Raspberry Pi, Zeus is the radio's built-in front-panel display — an appliance, not a windowed app. This makes the desktop window **frameless** (no title bar, no border) and fills the screen on that host, so the SPA owns the whole DSI panel with no window-manager furniture.

## How

- New `ShouldRunChromelessKiosk()` in `OpenhpsdrZeus/Program.cs`.
- When it returns true, the Photino builder gets `.SetChromeless(true)` (a startup parameter — must be set before the native window is created) and the window opens maximized.

## Detecting "native G2"

Reuses the **same signal the hardware front-panel bridge already uses** to recognize "this is the G2 Pi": the udev-published `g2-front-*` by-id serial symlink (`G2PanelOptions.KnownSymlinks`, probed the same way as `G2FrontPanelService.ResolveDevice`). That keeps the two definitions of "native G2" in lock-step.

- **Linux-only** auto-detection. An ordinary shack PC (Windows/macOS/Linux) has no such symlink and keeps its normal decorated window — unchanged.
- `ZEUS_KIOSK=1` / `ZEUS_KIOSK=0` (also `true`/`false`) is an explicit override for benches/dev boxes that aren't a stock G2.

| Host | Result |
|------|--------|
| G2 internal Pi (Linux, `g2-front-*` present) | Frameless, fills screen |
| Ordinary desktop (no panel symlink) | Unchanged, decorated window |
| Any host with `ZEUS_KIOSK=1` | Forced frameless kiosk |
| Any host with `ZEUS_KIOSK=0` | Forced decorated window |

## Testing

- Compiles clean (`dotnet build OpenhpsdrZeus -t:Compile`).
- **Not bench-verified on real G2 hardware** — the path is gated on a symlink that only exists on the G2 Pi. To smoke-test the Linux chromeless path on a dev box, launch desktop mode with `ZEUS_KIOSK=1`. No automated tests cover Photino window chrome.

## Notes for review

- Detection triggers on **front-panel presence**, so it would also fire if a G2 USB panel were plugged into a non-G2 Linux shack PC. That matches the codebase's existing definition of "the G2 Pi"; if you'd prefer it stricter (e.g. also require Pi hardware via `/proc/device-tree/model`), easy to tighten.
- I chose **maximized** (respects any desktop panel) rather than true fullscreen. On a stock G2 with no desktop panel that's effectively fullscreen; if you want it to cover panels too, say so and I'll switch to `SetFullScreen`.

Target: `develop`
