### PR TITLE
fix(web): drop duplicate update-checker from About panel

### DIFF
--- a/zeus-web/src/components/AboutPanel.tsx
+++ b/zeus-web/src/components/AboutPanel.tsx
@@ -44,14 +44,10 @@ const RELEASE_DATE_ISO = '2026-06-20';
 
 type VersionInfo = {
   version: string;
-  latestVersion?: string;
-  updateAvailable?: boolean;
-  checkError?: string;
 };
 
 export function AboutPanel() {
   const [versionInfo, setVersionInfo] = useState<VersionInfo>({ version: 'Loading...' });
-  const [checking, setChecking] = useState(false);
   const [showUninstall, setShowUninstall] = useState(false);
 
   useEffect(() => {
@@ -66,39 +62,6 @@ export function AboutPanel() {
         setVersionInfo((prev) => ({ ...prev, version: 'Unknown' }));
       });
   }, []);
-
-  const checkForUpdates = async () => {
-    setChecking(true);
-    try {
-      const response = await fetch(
-        'https://api.github.com/repos/OpenHPSDR-Zeus-org/openhpsdr-zeus/releases/latest'
-      );
-      if (!response.ok) {
-        throw new Error(`GitHub API returned ${response.status}`);
-      }
-      const data = await response.json();
-      const latestVersion = data.tag_name?.replace(/^v/, '') || 'unknown';
-      const currentVersion = versionInfo.version.replace(/-dev$/, '');
-
-      // Simple version comparison: split by dots and compare numerically
-      const isNewer = compareVersions(latestVersion, currentVersion) > 0;
-
-      setVersionInfo((prev) => ({
-        ...prev,
-        latestVersion,
-        updateAvailable: isNewer,
-        checkError: undefined,
-      }));
-    } catch (err) {
-      console.error('Failed to check for updates:', err);
-      setVersionInfo((prev) => ({
-        ...prev,
-        checkError: err instanceof Error ? err.message : 'Network error',
-      }));
-    } finally {
-      setChecking(false);
-    }
-  };
 
   return (
     <div style={{ maxWidth: 600 }}>
@@ -137,70 +100,6 @@ export function AboutPanel() {
             })}
           </span>
         </div>
-
-        {versionInfo.latestVersion && (
-          <div style={{ marginBottom: 12 }}>
-            <span style={{ color: 'var(--fg-2)', marginRight: 8 }}>Latest Release:</span>
-            <span style={{ color: 'var(--fg-1)', fontWeight: 600 }}>{versionInfo.latestVersion}</span>
-          </div>
-        )}
-
-        {versionInfo.updateAvailable === true && (
-          <div
-            style={{
-              padding: 10,
-              marginBottom: 12,
-              borderRadius: 'var(--r-sm)',
-              background: 'rgba(255, 160, 40, 0.1)',
-              border: '1px solid rgba(255, 160, 40, 0.3)',
-              color: 'var(--accent)',
-            }}
-          >
-            🎉 A new version is available!{' '}
-            <a
-              href="https://github.com/OpenHPSDR-Zeus-org/openhpsdr-zeus/releases/latest"
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{ color: 'var(--accent)', textDecoration: 'underline' }}
-            >
-              Download here
-            </a>
-          </div>
-        )}
-
-        {versionInfo.updateAvailable === false && versionInfo.latestVersion && (
-          <div
-            style={{
-              padding: 10,
-              marginBottom: 12,
-              borderRadius: 'var(--r-sm)',
-              background: 'rgba(100, 200, 100, 0.1)',
-              border: '1px solid rgba(100, 200, 100, 0.3)',
-              color: '#6c6',
-            }}
-          >
-            ✓ You are running the latest version
-          </div>
-        )}
-
-        {versionInfo.checkError && (
-          <div
-            style={{
-              padding: 10,
-              marginBottom: 12,
-              borderRadius: 'var(--r-sm)',
-              background: 'rgba(200, 100, 100, 0.1)',
-              border: '1px solid rgba(200, 100, 100, 0.3)',
-              color: '#c66',
-            }}
-          >
-            Failed to check for updates: {versionInfo.checkError}
-          </div>
-        )}
-
-        <button type="button" className="btn sm" onClick={checkForUpdates} disabled={checking}>
-          {checking ? 'CHECKING…' : 'CHECK FOR UPDATES'}
-        </button>
       </div>
 
       <div style={{ marginBottom: 20, paddingTop: 20, borderTop: '1px solid var(--panel-border)' }}>
@@ -263,20 +162,4 @@ export function AboutPanel() {
       {showUninstall && <UninstallDialog onClose={() => setShowUninstall(false)} />}
     </div>
   );
-}
-
-// Compare semver strings (e.g., "0.1.0" vs "0.2.0")
-// Returns: -1 if a < b, 0 if equal, 1 if a > b
-function compareVersions(a: string, b: string): number {
-  const aParts = a.split('.').map((x) => parseInt(x, 10) || 0);
-  const bParts = b.split('.').map((x) => parseInt(x, 10) || 0);
-  const maxLen = Math.max(aParts.length, bParts.length);
-
-  for (let i = 0; i < maxLen; i++) {
-    const aVal = aParts[i] || 0;
-    const bVal = bParts[i] || 0;
-    if (aVal < bVal) return -1;
-    if (aVal > bVal) return 1;
-  }
-  return 0;
 }


### PR DESCRIPTION
## What

Removes the duplicate update-checking UI from the **About** panel. That
functionality already lives in the dedicated **Settings → Updates** panel
(`UpdatesPanel`), which is the fuller implementation (platform-aware
download URLs, production-channel status, "Update Now").

## Removed from `AboutPanel`
- "Latest Release" row
- update-available / up-to-date / check-error banners
- the **CHECK FOR UPDATES** button
- the now-dead `checkForUpdates` handler, `checking` state, `compareVersions`
  helper, and the `latestVersion`/`updateAvailable`/`checkError` fields

## Kept
Version, Released date, User Manual link, description, copyright/license,
and the Danger Zone (reset & uninstall).

Net: -117 lines, no behavior change beyond removing the redundant control.