### PR TITLE
fix(web): drop dead RNNoise repo link from NR3 model panel

### DIFF
--- a/zeus-web/src/components/nr/Nr3ModelPanel.test.tsx
+++ b/zeus-web/src/components/nr/Nr3ModelPanel.test.tsx
@@ -38,20 +38,21 @@ describe('Nr3ModelPanel', () => {
       .find((a) => a.getAttribute('aria-label') === label);
   }
 
-  it('links users to official RNNoise model sources', () => {
+  it('links users to the official Xiph RNNoise model directory', () => {
     renderPanel();
 
     const xiphModels = linkByLabel('Open the Xiph RNNoise model data directory');
-    const rnnoiseRepo = linkByLabel('Open the official RNNoise source repository');
 
-    if (!xiphModels || !rnnoiseRepo) throw new Error('NR3 model source links were not rendered');
+    if (!xiphModels) throw new Error('NR3 model source link was not rendered');
     expect(xiphModels.getAttribute('href')).toBe('https://media.xiph.org/rnnoise/models/');
     expect(xiphModels.getAttribute('target')).toBe('_blank');
-    expect(rnnoiseRepo.getAttribute('href')).toBe('https://gitlab.xiph.org/xiph/rnnoise');
-    expect(rnnoiseRepo.getAttribute('target')).toBe('_blank');
+
+    // The gitlab.xiph.org source repo hosts no loadable weights, so it must not
+    // be offered as a model source.
+    expect(linkByLabel('Open the official RNNoise source repository')).toBeUndefined();
   });
 
-  it('keeps model source links visible when NR3 is unavailable', () => {
+  it('keeps the model source link visible when NR3 is unavailable', () => {
     useConnectionStore.setState({
       wdspNr3RnnrAvailable: false,
       nr3ModelName: null,
@@ -60,6 +61,5 @@ describe('Nr3ModelPanel', () => {
     renderPanel();
 
     expect(linkByLabel('Open the Xiph RNNoise model data directory')).toBeDefined();
-    expect(linkByLabel('Open the official RNNoise source repository')).toBeDefined();
   });
 });

--- a/zeus-web/src/components/nr/Nr3ModelPanel.tsx
+++ b/zeus-web/src/components/nr/Nr3ModelPanel.tsx
@@ -31,7 +31,6 @@ import {
 import { useConnectionStore } from '../../state/connection-store';
 
 const RNNOISE_MODEL_DATA_URL = 'https://media.xiph.org/rnnoise/models/';
-const RNNOISE_REPO_URL = 'https://gitlab.xiph.org/xiph/rnnoise';
 
 function ModelSourceLinks() {
   return (
@@ -48,17 +47,6 @@ function ModelSourceLinks() {
         >
           <ExternalLink size={12} aria-hidden />
           Xiph models
-        </a>
-        <a
-          className="nr-settings__button"
-          href={RNNOISE_REPO_URL}
-          target="_blank"
-          rel="noreferrer"
-          title="Open the official RNNoise source repository"
-          aria-label="Open the official RNNoise source repository"
-        >
-          <ExternalLink size={12} aria-hidden />
-          RNNoise repo
         </a>
       </div>
     </div>


### PR DESCRIPTION
## What

The NR3 (RNNoise) model panel in the DSP menu showed two **Sources** links:

- **Xiph models** → `https://media.xiph.org/rnnoise/models/` — the actual directory of downloadable RNNoise model bundles.
- **RNNoise repo** → `https://gitlab.xiph.org/xiph/rnnoise` — the project source repository.

The repo link is dead weight for an operator trying to install a model: it points at C source, not at a loadable `.rnnn` weights file, so clicking it never leads to something the panel's **Upload…** / **URL → Get** controls can actually install. This PR removes it and keeps the one link that points at downloadable models.

## Changes

- `Nr3ModelPanel.tsx` — remove the `RNNOISE_REPO_URL` constant and its anchor; `ModelSourceLinks` now renders only the Xiph models link.
- `Nr3ModelPanel.test.tsx` — assert the Xiph models link still renders and the repo link is gone.

## Test

- `vitest run Nr3ModelPanel.test.tsx` — 2 passed
- `tsc --noEmit` — clean

## Note

No change to how models are loaded — operators still install via **Upload…** (local file) or **URL → Get** in the NR3 panel; the backend `Nr3ModelStore` keeps one model on disk under `…/Zeus/nr3-models/`.