### PR TITLE
fix(remote-diag): finish P3c backend↔sidecar IPC so operator presence reaches the broker

### DIFF
--- a/OpenhpsdrZeus/SupportSidecarLauncher.cs
+++ b/OpenhpsdrZeus/SupportSidecarLauncher.cs
@@ -72,7 +72,13 @@ internal static class SupportSidecarLauncher
             }
 
             Add("--supervise-pid", Environment.ProcessId.ToString(CultureInfo.InvariantCulture));
-            Add("--session", Guid.NewGuid().ToString("N"));
+            // Use the IPC bridge's session token so the sidecar listens on the SAME
+            // pipe the backend bridge connects to (remote-diag P3c). Falls back to a
+            // fresh token when no bridge is registered (non-desktop host) — the
+            // sidecar then runs without live posture updates, local crash-capture
+            // only, exactly as before P3c.
+            var bridge = services?.GetService<Zeus.Server.Hosting.Support.SupportSidecarBridge>();
+            Add("--session", bridge?.SessionToken ?? Guid.NewGuid().ToString("N"));
             Add("--app-log", PrefsDbPath.AppLogPath());
             Add("--startup-log", StartupDiagnostics.LogPath);
             Add("--crash-dir", PrefsDbPath.CrashDir());

--- a/Zeus.Server.Hosting/QrzService.cs
+++ b/Zeus.Server.Hosting/QrzService.cs
@@ -77,6 +77,21 @@ public sealed class QrzService
         _credStore = credStore;
     }
 
+    /// <summary>
+    /// Raised after a successful login or a logout — i.e. whenever the operator's
+    /// identity (callsign + session key) may have changed. The support sidecar
+    /// bridge subscribes so broker presence can come online (or drop) without a
+    /// restart. Always raised OUTSIDE the QRZ gate; handlers must be cheap and
+    /// non-throwing and must not synchronously re-enter this service.
+    /// </summary>
+    public event Action? IdentityChanged;
+
+    private void RaiseIdentityChanged()
+    {
+        try { IdentityChanged?.Invoke(); }
+        catch (Exception ex) { _log.LogDebug(ex, "QRZ IdentityChanged handler threw (ignored)"); }
+    }
+
     public async Task InitializeAsync(CancellationToken ct)
     {
         // Attempt silent re-login from stored credentials
@@ -113,6 +128,16 @@ public sealed class QrzService
         HasApiKey: !string.IsNullOrWhiteSpace(_apiKey));
 
     public async Task<QrzStatus> LoginAsync(string username, string password, CancellationToken ct)
+    {
+        // Run the gated login, then signal identity-changed OUTSIDE the gate so a
+        // subscriber (e.g. the support sidecar bridge) can re-resolve identity
+        // without deadlocking on the QRZ gate this method holds.
+        var status = await LoginCoreAsync(username, password, ct);
+        RaiseIdentityChanged();
+        return status;
+    }
+
+    private async Task<QrzStatus> LoginCoreAsync(string username, string password, CancellationToken ct)
     {
         await _gate.WaitAsync(ct);
         try
@@ -220,6 +245,10 @@ public sealed class QrzService
 
         // Delete stored credentials
         await _credStore.DeleteAsync(ServiceName, ct);
+
+        // Identity is now gone — let dependents (support sidecar bridge) drop any
+        // identity-derived state (e.g. broker presence).
+        RaiseIdentityChanged();
     }
 
     // Assumes _gate is held.

--- a/Zeus.Server.Hosting/Support/SupportSidecar.cs
+++ b/Zeus.Server.Hosting/Support/SupportSidecar.cs
@@ -46,17 +46,24 @@ public static class SupportSidecar
     }
 
     /// <summary>
-    /// Tell the out-of-process sidecar that the operator changed an opt-in
-    /// setting (the L1 "Remote Diagnostics available" master switch and/or the
-    /// crash auto-share sub-toggle). The sidecar owns the broker presence, so it
-    /// uses this to register/deregister the radio's availability and to gate
-    /// crash sharing — see <see cref="SupportStateChanged"/>.
+    /// The live backend→sidecar IPC bridge (remote-diag P3c), set by
+    /// <see cref="Hosting.Support.SupportSidecarBridge"/> when it starts. Null in
+    /// host modes that don't launch a sidecar (e.g. headless server / tests), in
+    /// which case <see cref="NotifyAvailabilityChanged"/> is a no-op.
+    /// </summary>
+    internal static Hosting.Support.SupportSidecarBridge? Bridge { get; set; }
+
+    /// <summary>
+    /// Tell the out-of-process sidecar that the operator changed an opt-in setting
+    /// (the L1 "Remote Diagnostics available" master switch and/or the crash
+    /// auto-share sub-toggle). The sidecar owns the broker presence, so it uses
+    /// this to register/deregister the radio's availability and to gate crash
+    /// sharing — see <see cref="SupportStateChanged"/>.
     ///
-    /// <para>TODO (remote-diag P3c): the backend→sidecar IPC pipe client is not
-    /// wired in-process yet (today the host only launches the sidecar detached,
-    /// see SupportSidecarLauncher). This is the minimal seam the toggle endpoint
-    /// calls; P3c finishes the sidecar receive side and the persistent pipe. The
-    /// call is best-effort and MUST never throw into the request path.</para>
+    /// <para>The bridge re-reads the authoritative posture (persisted store +
+    /// current QRZ identity) when it sends, so the arguments here are advisory for
+    /// logging only — there is no stale-snapshot risk. Best-effort and MUST never
+    /// throw into the request path.</para>
     /// </summary>
     public static void NotifyAvailabilityChanged(
         bool remoteDiagnosticsEnabled,
@@ -66,14 +73,10 @@ public static class SupportSidecar
     {
         try
         {
-            // The IPC channel is established by P3c. Until then we only record
-            // the intent locally; the next SupportHello the sidecar receives
-            // after P3c lands will carry the current persisted posture, so no
-            // state is lost — this is purely the push-on-change fast path.
-            _ = new SupportStateChanged(qrzCallsign, remoteDiagnosticsEnabled, autoShareOnCrash);
+            Bridge?.NotifyStateChanged();
             log?.LogInformation(
-                "support.sidecar availability change queued: remoteDiagnostics={Enabled} autoShareOnCrash={AutoShare}",
-                remoteDiagnosticsEnabled, autoShareOnCrash);
+                "support.sidecar availability change pushed: remoteDiagnostics={Enabled} autoShareOnCrash={AutoShare} bridge={Bridge}",
+                remoteDiagnosticsEnabled, autoShareOnCrash, Bridge is null ? "absent" : "live");
         }
         catch
         {

--- a/Zeus.Server.Hosting/Support/SupportSidecarBridge.cs
+++ b/Zeus.Server.Hosting/Support/SupportSidecarBridge.cs
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.IO.Pipes;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Zeus.Support.Contracts;
+
+namespace Zeus.Server.Hosting.Support;
+
+/// <summary>
+/// The backend's SEND side of the support IPC channel — the piece remote-diag P3c
+/// was missing. The out-of-process sidecar (Zeus.SupportAgent) runs a named-pipe
+/// SERVER and waits; this hosted service is the CLIENT that connects to it and
+/// pushes the operator's identity + opt-in posture, so the sidecar can register
+/// broker presence and gate crash auto-share against the operator's LIVE decision.
+///
+/// <para>Lifecycle: the bridge mints the per-session pipe token (handed to the
+/// sidecar by <c>SupportSidecarLauncher</c> via <c>--session</c>), then keeps a
+/// best-effort connection to the sidecar's pipe. On connect it sends a
+/// <see cref="SupportHello"/> with the current posture; thereafter it sends a
+/// <see cref="SupportStateChanged"/> whenever the operator toggles availability or
+/// signs in/out of QRZ (<see cref="NotifyStateChanged"/>), plus a periodic
+/// heartbeat. A dropped pipe (sidecar relaunch) just reconnects.</para>
+///
+/// <para>This solves the launch-time race: QRZ silent-login usually finishes a few
+/// seconds AFTER the backend starts, so the old launch-only identity capture came
+/// up empty. Here identity is resolved fresh at send time and re-pushed on the
+/// QRZ <c>IdentityChanged</c> event, so presence comes online as soon as the
+/// operator is both opted in and signed in — no restart required.</para>
+///
+/// <para>Strictly best-effort: every pipe failure is swallowed. Presence is a
+/// diagnostics convenience and must never destabilise the backend.</para>
+/// </summary>
+public sealed class SupportSidecarBridge : BackgroundService
+{
+    // Pipe liveness cadence. Independent of the sidecar→broker presence heartbeat
+    // (30s); this just keeps the local pipe active and surfaces a half-open drop.
+    private static readonly TimeSpan HeartbeatInterval = TimeSpan.FromSeconds(30);
+    // Backoff between connect attempts while the sidecar's pipe isn't up yet.
+    private static readonly TimeSpan ReconnectDelay = TimeSpan.FromSeconds(3);
+    // Bound on resolving QRZ identity at send time so a slow QRZ call never stalls
+    // the bridge loop.
+    private static readonly TimeSpan IdentityTimeout = TimeSpan.FromSeconds(4);
+
+    private readonly SupportAvailabilityStore _availability;
+    private readonly Zeus.Server.QrzService _qrz;
+    private readonly ILogger<SupportSidecarBridge> _log;
+
+    // Signalled (max count 1) when posture changes so the loop pushes a fresh
+    // SupportStateChanged without waiting out the heartbeat interval.
+    private readonly SemaphoreSlim _dirty = new(0, 1);
+
+    public SupportSidecarBridge(
+        SupportAvailabilityStore availability,
+        Zeus.Server.QrzService qrz,
+        ILogger<SupportSidecarBridge> log)
+    {
+        _availability = availability;
+        _qrz = qrz;
+        _log = log;
+
+        // The endpoint forwards the operator's availability toggle here.
+        SupportSidecar.Bridge = this;
+        // QRZ sign-in/out changes identity → re-push so presence can come online
+        // (or drop) without a restart.
+        _qrz.IdentityChanged += NotifyStateChanged;
+    }
+
+    /// <summary>
+    /// The per-session pipe token. <c>SupportSidecarLauncher</c> reads this and
+    /// passes it to the sidecar as <c>--session</c> so both ends derive the same
+    /// pipe name (and two Zeus instances never collide).
+    /// </summary>
+    public string SessionToken { get; } = Guid.NewGuid().ToString("N");
+
+    /// <summary>
+    /// Mark the operator's posture dirty so the loop pushes a fresh state frame.
+    /// Cheap and non-blocking — safe to call from a request thread or a QRZ event.
+    /// The actual identity resolution + send happen on the bridge loop.
+    /// </summary>
+    public void NotifyStateChanged()
+    {
+        // Coalesce: a single pending signal is enough; the next send reads fresh state.
+        try { _dirty.Release(); }
+        catch (SemaphoreFullException) { /* already pending */ }
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var pipeName = SupportIpc.PipeNameForSession(SessionToken);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                using var client = new NamedPipeClientStream(
+                    ".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+
+                // ConnectAsync throws TimeoutException until the sidecar's server
+                // pipe exists — caught below and retried after a short backoff.
+                await client.ConnectAsync((int)ReconnectDelay.TotalMilliseconds, stoppingToken)
+                    .ConfigureAwait(false);
+
+                _log.LogInformation("support.bridge connected to sidecar pipe");
+                await PumpAsync(client, stoppingToken).ConfigureAwait(false);
+                _log.LogInformation("support.bridge sidecar pipe closed; will reconnect");
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                // Sidecar not up yet / pipe dropped — back off and retry quietly.
+                _log.LogDebug("support.bridge connect/pump failed ({Error}); retrying", ex.GetType().Name);
+                try { await Task.Delay(ReconnectDelay, stoppingToken).ConfigureAwait(false); }
+                catch (OperationCanceledException) { break; }
+            }
+        }
+    }
+
+    // Drive one connected pipe: send the initial hello, then loop sending a fresh
+    // state frame on a dirty signal or a heartbeat on the interval. A write failure
+    // throws out to the reconnect loop.
+    private async Task PumpAsync(Stream stream, CancellationToken ct)
+    {
+        await SupportIpcFraming.WriteAsync(stream, await BuildHelloAsync(ct).ConfigureAwait(false), ct)
+            .ConfigureAwait(false);
+
+        while (!ct.IsCancellationRequested)
+        {
+            bool dirty = await _dirty.WaitAsync(HeartbeatInterval, ct).ConfigureAwait(false);
+            if (dirty)
+            {
+                await SupportIpcFraming.WriteAsync(stream, await BuildStateAsync(ct).ConfigureAwait(false), ct)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                await SupportIpcFraming.WriteAsync(
+                    stream, new SupportHeartbeat(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()), ct)
+                    .ConfigureAwait(false);
+            }
+        }
+    }
+
+    private async Task<SupportHello> BuildHelloAsync(CancellationToken ct)
+    {
+        var (callsign, sessionKey) = await ResolveIdentityAsync(ct).ConfigureAwait(false);
+        return new SupportHello(
+            ProtocolVersion: SupportIpc.ProtocolVersion,
+            BackendPid: Environment.ProcessId,
+            AppVersion: ResolveAppVersion(),
+            Platform: RuntimeInformation.OSDescription,
+            QrzCallsign: callsign,
+            RemoteDiagnosticsEnabled: _availability.IsAvailable,
+            AutoShareOnCrash: _availability.AutoShareOnCrash,
+            AppLogPath: PrefsDbPath.AppLogPath(),
+            StartupLogPath: Path.Combine(PrefsDbPath.DataDir, "zeus-startup.log"),
+            QrzSessionKey: sessionKey);
+    }
+
+    private async Task<SupportStateChanged> BuildStateAsync(CancellationToken ct)
+    {
+        var (callsign, sessionKey) = await ResolveIdentityAsync(ct).ConfigureAwait(false);
+        return new SupportStateChanged(
+            QrzCallsign: callsign,
+            RemoteDiagnosticsEnabled: _availability.IsAvailable,
+            AutoShareOnCrash: _availability.AutoShareOnCrash,
+            QrzSessionKey: sessionKey);
+    }
+
+    // Resolve the operator's QRZ identity fresh, bounded so a slow/blocked QRZ
+    // call never stalls the loop. Null identity → the sidecar stays unconfigured
+    // (no presence) until the next push.
+    private async Task<(string? Callsign, string? SessionKey)> ResolveIdentityAsync(CancellationToken ct)
+    {
+        try
+        {
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            timeout.CancelAfter(IdentityTimeout);
+            var identity = await _qrz.GetChatIdentityAsync(timeout.Token).ConfigureAwait(false);
+            return identity is { } id ? (id.Callsign, id.SessionKey) : (null, null);
+        }
+        catch
+        {
+            return (null, null);
+        }
+    }
+
+    private static string ResolveAppVersion()
+    {
+        var asm = System.Reflection.Assembly.GetEntryAssembly();
+        return asm?.GetCustomAttribute<System.Reflection.AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? asm?.GetName().Version?.ToString()
+            ?? "unknown";
+    }
+
+    public override void Dispose()
+    {
+        try { _qrz.IdentityChanged -= NotifyStateChanged; } catch { /* best effort */ }
+        if (ReferenceEquals(SupportSidecar.Bridge, this)) SupportSidecar.Bridge = null;
+        _dirty.Dispose();
+        base.Dispose();
+    }
+}

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -434,6 +434,19 @@ public static class ZeusHost
                 sp.GetService<DiagnosticLogBuffer>(),
                 sp.GetService<IHttpClientFactory>(),
                 options.HttpPort != 0 ? $"http://127.0.0.1:{options.HttpPort}" : null));
+
+        // Backend→sidecar IPC bridge (remote-diag P3c). Only the desktop host
+        // launches the out-of-process sidecar (SupportSidecarLauncher), so the
+        // bridge — the pipe CLIENT that pushes identity + opt-in posture so the
+        // sidecar can register broker presence — only runs in Desktop mode. The
+        // launcher reads its SessionToken to point the sidecar at the same pipe.
+        if (options.HostMode == ZeusHostMode.Desktop)
+        {
+            builder.Services.AddSingleton<Zeus.Server.Hosting.Support.SupportSidecarBridge>();
+            builder.Services.AddHostedService(sp =>
+                sp.GetRequiredService<Zeus.Server.Hosting.Support.SupportSidecarBridge>());
+        }
+
         // LAN Browser proxy: fetches private-LAN device web UIs on behalf of the
         // panel (esp. for remote operators whose browser can't reach the radio's
         // LAN). No auto-redirect — LanProxyService follows + re-validates each hop

--- a/Zeus.Support.Contracts/SupportIpc.cs
+++ b/Zeus.Support.Contracts/SupportIpc.cs
@@ -30,8 +30,11 @@ public static class SupportIpc
     /// <summary>
     /// Contract version. The backend stamps it into <see cref="SupportHello"/> so a
     /// mismatched sidecar can refuse to attach rather than misread later frames.
+    /// v2 adds the optional <c>QrzSessionKey</c> to the identity-bearing messages so
+    /// the sidecar can build its broker client lazily when QRZ identity arrives over
+    /// IPC, instead of depending on a launch-time env var that races QRZ login.
     /// </summary>
-    public const int ProtocolVersion = 1;
+    public const int ProtocolVersion = 2;
 
     /// <summary>
     /// Hard ceiling on a single framed message (a diagnostics snapshot is the
@@ -104,6 +107,13 @@ public abstract record SupportIpcMessage;
 /// Backend → sidecar. First message after the pipe connects, and re-sent if the
 /// backend reconnects. Carries identity + the operator's current opt-in posture
 /// and the on-disk log paths the sidecar will tail.
+///
+/// <para><see cref="QrzSessionKey"/> (v2+) is the short-lived QRZ session key the
+/// broker validates alongside the callsign. It is delivered over the same-machine,
+/// same-user IPC pipe — the same trust boundary as the launch-time env var the
+/// launcher already uses — so the sidecar can authenticate presence/crash without
+/// the env var being present (and correct) at the instant of launch. Null when the
+/// operator is signed out.</para>
 /// </summary>
 public sealed record SupportHello(
     int ProtocolVersion,
@@ -114,17 +124,23 @@ public sealed record SupportHello(
     bool RemoteDiagnosticsEnabled,
     bool AutoShareOnCrash,
     string AppLogPath,
-    string StartupLogPath) : SupportIpcMessage;
+    string StartupLogPath,
+    string? QrzSessionKey = null) : SupportIpcMessage;
 
 /// <summary>
 /// Backend → sidecar. The operator changed an opt-in setting (the L1 master
 /// switch, the crash auto-share sub-toggle) or signed in/out of QRZ. The sidecar
 /// uses this to register/deregister with the broker and to gate crash sharing.
+///
+/// <para><see cref="QrzSessionKey"/> (v2+) lets the sidecar (re)build its broker
+/// client when QRZ identity becomes available after launch — see
+/// <see cref="SupportHello.QrzSessionKey"/>. Null when signed out.</para>
 /// </summary>
 public sealed record SupportStateChanged(
     string? QrzCallsign,
     bool RemoteDiagnosticsEnabled,
-    bool AutoShareOnCrash) : SupportIpcMessage;
+    bool AutoShareOnCrash,
+    string? QrzSessionKey = null) : SupportIpcMessage;
 
 /// <summary>Either direction. Liveness ping; the peer is considered gone if these stop.</summary>
 public sealed record SupportHeartbeat(long UnixMs) : SupportIpcMessage;

--- a/Zeus.SupportAgent/HttpSupportBrokerClient.cs
+++ b/Zeus.SupportAgent/HttpSupportBrokerClient.cs
@@ -27,22 +27,40 @@ namespace Zeus.SupportAgent;
 /// the operator callsign. A blank session key disables remote calls (all methods
 /// return false) rather than sending an unauthenticated request.
 /// </summary>
-public sealed class HttpSupportBrokerClient : ISupportBrokerClient
+public sealed class HttpSupportBrokerClient : IMutableSupportBrokerClient
 {
     /// <summary>Env var the host uses to hand the QRZ session key to the sidecar (kept off the command line).</summary>
     public const string QrzSessionEnvVar = SupportIpc.SidecarQrzSessionEnvVar;
 
     private readonly HttpClient _http;
     private readonly BrokerEndpoints _endpoints;
-    private readonly string _callsign;
-    private readonly string _sessionKey;
+
+    // Identity is mutable: the host hands the sidecar a launch-time seed (often
+    // blank, because QRZ silent-login races process launch) and then refreshes it
+    // over the IPC pipe once QRZ identity is available. Each is a lone reference
+    // write, published with volatile semantics; a request that briefly observes a
+    // new callsign with the previous key just earns one retried 401, never a crash.
+    private volatile string _callsign;
+    private volatile string _sessionKey;
 
     public HttpSupportBrokerClient(HttpClient http, BrokerEndpoints endpoints, string callsign, string sessionKey)
     {
         _http = http;
         _endpoints = endpoints;
-        _callsign = callsign;
-        _sessionKey = sessionKey;
+        _callsign = callsign ?? "";
+        _sessionKey = sessionKey ?? "";
+    }
+
+    /// <summary>
+    /// Swap the operator identity used to authenticate broker calls. Called as
+    /// QRZ identity arrives/changes over IPC. Blank callsign or key leaves the
+    /// client <see cref="IsConfigured"/>=false (a no-op rather than an
+    /// unauthenticated request).
+    /// </summary>
+    public void UpdateIdentity(string? callsign, string? sessionKey)
+    {
+        _callsign = callsign ?? "";
+        _sessionKey = sessionKey ?? "";
     }
 
     /// <summary>True only when we have the identity needed to make an authenticated call.</summary>

--- a/Zeus.SupportAgent/IMutableSupportBrokerClient.cs
+++ b/Zeus.SupportAgent/IMutableSupportBrokerClient.cs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.SupportAgent;
+
+/// <summary>
+/// A broker client whose operator identity can be swapped at runtime, so the
+/// sidecar can build presence/crash auth LAZILY as QRZ identity arrives over IPC
+/// (rather than depending on a launch-time env var that races QRZ login). Drives
+/// <see cref="PresenceCoordinator"/>; the production implementation is
+/// <see cref="HttpSupportBrokerClient"/>. Abstracted so the coordinator's gating
+/// is unit/integration-testable without a live broker.
+/// </summary>
+public interface IMutableSupportBrokerClient : ISupportBrokerClient
+{
+    /// <summary>True only when the client currently holds a usable callsign + session key.</summary>
+    bool IsConfigured { get; }
+
+    /// <summary>Swap the operator identity used to authenticate broker calls. Blank parts ⇒ not configured.</summary>
+    void UpdateIdentity(string? callsign, string? sessionKey);
+}

--- a/Zeus.SupportAgent/PresenceCoordinator.cs
+++ b/Zeus.SupportAgent/PresenceCoordinator.cs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.SupportAgent;
+
+/// <summary>
+/// Applies an operator-posture snapshot learned over IPC
+/// (<see cref="SupportIpcListener.SupportState"/>) to the live broker identity and
+/// presence availability. This is the seam that lets the sidecar build its broker
+/// identity LAZILY: the broker client exists from launch with a possibly-blank
+/// identity, and each IPC update swaps in the current QRZ callsign + session key.
+/// Presence only advertises when the L1 switch is on AND the broker is configured
+/// (identity present), so a "remote diagnostics on" posture that arrives before
+/// QRZ identity simply waits — the next update (QRZ login) flips it on.
+///
+/// <para>Extracted from the sidecar's top-level flow so the gating is unit-testable
+/// without a live pipe or broker. Pure and synchronous: it only mutates the
+/// broker's identity field and the presence availability flag.</para>
+/// </summary>
+public sealed class PresenceCoordinator
+{
+    private readonly IMutableSupportBrokerClient _broker;
+    private readonly PresenceClient _presence;
+    private readonly Action<string>? _log;
+
+    /// <param name="broker">The mutable-identity broker client the presence loop drives.</param>
+    /// <param name="presence">The presence loop whose availability this gates.</param>
+    /// <param name="initialAutoShare">
+    /// The launch-time crash auto-share pre-authorisation, surfaced via
+    /// <see cref="AutoShareOnCrash"/> until an IPC update supersedes it. The post-crash
+    /// share path reads this AFTER the backend (and IPC) is gone.
+    /// </param>
+    /// <param name="log">Optional breadcrumb sink.</param>
+    public PresenceCoordinator(
+        IMutableSupportBrokerClient broker,
+        PresenceClient presence,
+        bool initialAutoShare = false,
+        Action<string>? log = null)
+    {
+        _broker = broker;
+        _presence = presence;
+        AutoShareOnCrash = initialAutoShare;
+        _log = log;
+    }
+
+    /// <summary>
+    /// The operator's current crash auto-share posture, updated by each IPC state.
+    /// Read by the post-crash share gate, which runs after the backend has died and
+    /// so cannot consult live IPC — this holds the last value the operator pushed.
+    /// </summary>
+    public bool AutoShareOnCrash { get; private set; }
+
+    /// <summary>
+    /// Apply an IPC posture update: refresh broker identity, recompute presence
+    /// availability, and record the crash auto-share posture. Availability is on
+    /// only when the L1 switch is on AND the broker now has a usable identity.
+    /// </summary>
+    public void Apply(SupportIpcListener.SupportState state)
+    {
+        _broker.UpdateIdentity(state.QrzCallsign, state.QrzSessionKey);
+        AutoShareOnCrash = state.AutoShareOnCrash;
+
+        var available = state.RemoteDiagnosticsEnabled && _broker.IsConfigured;
+        _presence.SetAvailable(available);
+
+        _log?.Invoke(
+            $"ipc: state remoteDiag={state.RemoteDiagnosticsEnabled} " +
+            $"autoShare={state.AutoShareOnCrash} " +
+            $"identity={(_broker.IsConfigured ? "set" : "-")} -> available={available}");
+    }
+}

--- a/Zeus.SupportAgent/Program.cs
+++ b/Zeus.SupportAgent/Program.cs
@@ -42,48 +42,44 @@ using var sigterm = SafeSignal(PosixSignal.SIGTERM, cts);
 Console.CancelKeyPress += (_, e) => { e.Cancel = true; cts.Cancel(); };
 
 // --- Remote presence wiring -------------------------------------------------
-// Build the broker client from the launch identity (callsign + QRZ session env)
-// and the broker URL. Null when any piece is missing → remote stays inert and the
-// sidecar behaves exactly as the Phase-1 local-only crash capturer.
+// The broker URL alone decides whether remote presence/crash is even possible;
+// the OPERATOR IDENTITY arrives lazily over the IPC pipe (callsign + QRZ session
+// key in a SupportHello/SupportStateChanged), NOT from a launch-time env var that
+// races QRZ silent-login. So the broker client is created up front with whatever
+// seed the launcher passed (often blank) and its identity is refreshed as the
+// backend pushes it; the IPC listener and presence loop ALWAYS run when a broker
+// URL is configured. Null endpoints → the Phase-1 local-only crash capturer.
 var endpoints = BrokerEndpoints.FromBrokerUrl(opts.BrokerUrl);
 var qrzSession = Environment.GetEnvironmentVariable(HttpSupportBrokerClient.QrzSessionEnvVar) ?? "";
 using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(15) };
 
 HttpSupportBrokerClient? broker = null;
-if (endpoints is not null && !string.IsNullOrWhiteSpace(opts.OperatorCallsign) && !string.IsNullOrWhiteSpace(qrzSession))
-{
-    broker = new HttpSupportBrokerClient(http, endpoints, opts.OperatorCallsign!, qrzSession);
-}
-
-// Live posture, seeded from launch args and updated by the backend over IPC. The
-// crash path reads autoShare at the end, so keep the latest value here.
-var autoShareEnabled = opts.AutoShareOnCrash;
-
-PresenceClient? presence = null;
+PresenceCoordinator? coordinator = null;
 Task presenceTask = Task.CompletedTask;
 Task ipcTask = Task.CompletedTask;
 
-if (broker is not null)
+if (endpoints is not null)
 {
-    // Presence is gated on remote diagnostics being on AND a callsign being set;
-    // the IPC listener flips availability live.
-    presence = new PresenceClient(
+    // Seed identity from the launch env (best-effort; usually blank because QRZ
+    // login hadn't settled at launch). The IPC SupportHello/SupportStateChanged
+    // refresh it the moment the operator's QRZ identity is known.
+    broker = new HttpSupportBrokerClient(http, endpoints, opts.OperatorCallsign ?? "", qrzSession);
+
+    // initiallyAvailable is false: presence only advertises once the backend
+    // confirms BOTH the L1 switch on and a usable identity over IPC.
+    var presence = new PresenceClient(
         broker,
-        initiallyAvailable: opts.RemoteDiagnosticsEnabled,
+        initiallyAvailable: false,
+        log: msg => Breadcrumb(opts, msg));
+    coordinator = new PresenceCoordinator(
+        broker, presence,
+        initialAutoShare: opts.AutoShareOnCrash,
         log: msg => Breadcrumb(opts, msg));
     presenceTask = presence.RunAsync(cts.Token);
 
     var listener = new SupportIpcListener(
         opts.SessionToken,
-        onState: state =>
-        {
-            autoShareEnabled = state.AutoShareOnCrash;
-            // Available only when the master switch is on AND a callsign is present.
-            var available = state.RemoteDiagnosticsEnabled && !string.IsNullOrWhiteSpace(state.QrzCallsign);
-            presence!.SetAvailable(available);
-            Breadcrumb(opts, $"ipc: state remoteDiag={state.RemoteDiagnosticsEnabled} " +
-                             $"autoShare={state.AutoShareOnCrash} callsign={(string.IsNullOrWhiteSpace(state.QrzCallsign) ? "-" : "set")}");
-        },
+        onState: coordinator.Apply,
         log: msg => Breadcrumb(opts, msg));
     ipcTask = listener.RunAsync(cts.Token);
 }
@@ -119,11 +115,17 @@ Breadcrumb(opts,
         : $"crash detected: pid={opts.SupervisePid} exitCode={Fmt(result.ExitCode)} -> {Path.GetFileName(written)}");
 
 // Crash auto-share: strictly gated on the operator's opt-in (default OFF). With
-// the flag off this never reads the record back or touches the broker.
+// the flag off this never reads the record back or touches the broker. The
+// authoritative posture is whatever the operator last pushed over IPC (held by
+// the coordinator), falling back to the launch-time seed if no IPC ever arrived.
+// Pass the broker only when it carries a usable identity so the outcome logging
+// distinguishes "not opted in" from "no broker identity".
 try
 {
+    var autoShareEnabled = coordinator?.AutoShareOnCrash ?? opts.AutoShareOnCrash;
+    var shareBroker = broker is { IsConfigured: true } ? broker : null;
     string? recordJson = written is not null ? TryReadAllText(written) : null;
-    var outcome = await CrashAutoShare.TryShareAsync(autoShareEnabled, recordJson, broker, CancellationToken.None)
+    var outcome = await CrashAutoShare.TryShareAsync(autoShareEnabled, recordJson, shareBroker, CancellationToken.None)
         .ConfigureAwait(false);
     Breadcrumb(opts, $"crash auto-share: {outcome}");
 }

--- a/Zeus.SupportAgent/SupportIpcListener.cs
+++ b/Zeus.SupportAgent/SupportIpcListener.cs
@@ -37,10 +37,12 @@ public sealed class SupportIpcListener
     /// <param name="QrzCallsign">Operator callsign, or null when signed out.</param>
     /// <param name="RemoteDiagnosticsEnabled">L1 master switch.</param>
     /// <param name="AutoShareOnCrash">Crash auto-share sub-toggle.</param>
+    /// <param name="QrzSessionKey">QRZ session key for broker auth (v2+), or null when signed out.</param>
     public readonly record struct SupportState(
         string? QrzCallsign,
         bool RemoteDiagnosticsEnabled,
-        bool AutoShareOnCrash);
+        bool AutoShareOnCrash,
+        string? QrzSessionKey = null);
 
     private readonly string _pipeName;
     private readonly Action<SupportState> _onState;
@@ -120,11 +122,13 @@ public sealed class SupportIpcListener
             {
                 case SupportHello hello:
                     _onState(new SupportState(
-                        hello.QrzCallsign, hello.RemoteDiagnosticsEnabled, hello.AutoShareOnCrash));
+                        hello.QrzCallsign, hello.RemoteDiagnosticsEnabled, hello.AutoShareOnCrash,
+                        hello.QrzSessionKey));
                     break;
                 case SupportStateChanged state:
                     _onState(new SupportState(
-                        state.QrzCallsign, state.RemoteDiagnosticsEnabled, state.AutoShareOnCrash));
+                        state.QrzCallsign, state.RemoteDiagnosticsEnabled, state.AutoShareOnCrash,
+                        state.QrzSessionKey));
                     break;
                 // Heartbeats and other kinds are not needed by the presence/crash
                 // subsystem; ignore them so the contract can grow without breaking us.

--- a/tests/Zeus.Server.Tests/SupportAgentTests.cs
+++ b/tests/Zeus.Server.Tests/SupportAgentTests.cs
@@ -9,6 +9,7 @@
 // statement and per-component attribution.
 
 using System.Diagnostics;
+using System.IO.Pipes;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using Zeus.Support.Contracts;
@@ -453,6 +454,241 @@ public class CrashAutoShareTests
         var outcome = await CrashAutoShare.TryShareAsync(
             autoShareEnabled: true, crashRecordJson: "{\"pid\":1}", broker, CancellationToken.None);
         Assert.Equal(CrashShareOutcome.UploadFailed, outcome);
+    }
+}
+
+public class HttpSupportBrokerClientIdentityTests
+{
+    private static BrokerEndpoints Endpoints() =>
+        BrokerEndpoints.FromBrokerUrl("wss://remote.openhpsdrzeus.com/signal?role=host")!;
+
+    [Fact]
+    public void BlankSeed_IsNotConfigured()
+    {
+        using var http = new HttpClient();
+        var broker = new HttpSupportBrokerClient(http, Endpoints(), "", "");
+        Assert.False(broker.IsConfigured);
+    }
+
+    [Fact]
+    public void UpdateIdentity_RequiresBothCallsignAndKey()
+    {
+        using var http = new HttpClient();
+        var broker = new HttpSupportBrokerClient(http, Endpoints(), "", "");
+
+        broker.UpdateIdentity("N9WAR", null);
+        Assert.False(broker.IsConfigured); // callsign without key
+
+        broker.UpdateIdentity(null, "KEY");
+        Assert.False(broker.IsConfigured); // key without callsign
+
+        broker.UpdateIdentity("N9WAR", "KEY");
+        Assert.True(broker.IsConfigured); // both present
+
+        broker.UpdateIdentity("N9WAR", "");
+        Assert.False(broker.IsConfigured); // key cleared (sign-out)
+    }
+}
+
+/// <summary>
+/// The lazy-identity gating that fixes the P3c presence bug: a "remote diagnostics
+/// on" posture must NOT advertise until a usable QRZ identity (callsign + session
+/// key) has arrived over IPC; once it has, presence comes online without a restart.
+/// </summary>
+public class PresenceCoordinatorTests
+{
+    private static (HttpSupportBrokerClient Broker, PresenceClient Presence, PresenceCoordinator Coord) Build(
+        bool initialAutoShare = false)
+    {
+        var http = new HttpClient();
+        var broker = new HttpSupportBrokerClient(
+            http, BrokerEndpoints.FromBrokerUrl("wss://remote.openhpsdrzeus.com/signal")!, "", "");
+        var presence = new PresenceClient(broker, initiallyAvailable: false);
+        var coord = new PresenceCoordinator(broker, presence, initialAutoShare);
+        return (broker, presence, coord);
+    }
+
+    private static SupportIpcListener.SupportState State(
+        bool remoteDiag, string? callsign, string? key, bool autoShare = false) =>
+        new(callsign, remoteDiag, autoShare, key);
+
+    [Fact]
+    public void RemoteDiagOn_ButNoIdentity_StaysUnavailable()
+    {
+        var (_, presence, coord) = Build();
+        coord.Apply(State(remoteDiag: true, callsign: "N9WAR", key: null)); // no session key yet
+        Assert.False(presence.IsAvailable);
+    }
+
+    [Fact]
+    public void IdentityArrivesWhileOn_BringsPresenceOnline()
+    {
+        var (_, presence, coord) = Build();
+
+        // Switch is on but QRZ identity hasn't landed → not advertising (the exact
+        // bug: operator toggled on, but presence never registered).
+        coord.Apply(State(remoteDiag: true, callsign: "N9WAR", key: null));
+        Assert.False(presence.IsAvailable);
+
+        // QRZ login completes → identity pushed over IPC → presence comes online,
+        // no restart.
+        coord.Apply(State(remoteDiag: true, callsign: "N9WAR", key: "SESSION"));
+        Assert.True(presence.IsAvailable);
+    }
+
+    [Fact]
+    public void SwitchOff_WithIdentity_StaysUnavailable()
+    {
+        var (_, presence, coord) = Build();
+        coord.Apply(State(remoteDiag: false, callsign: "N9WAR", key: "SESSION"));
+        Assert.False(presence.IsAvailable);
+    }
+
+    [Fact]
+    public void SignOut_DropsAvailability()
+    {
+        var (_, presence, coord) = Build();
+        coord.Apply(State(remoteDiag: true, callsign: "N9WAR", key: "SESSION"));
+        Assert.True(presence.IsAvailable);
+
+        // QRZ logout → identity cleared → presence drops even though the switch is on.
+        coord.Apply(State(remoteDiag: true, callsign: null, key: null));
+        Assert.False(presence.IsAvailable);
+    }
+
+    [Fact]
+    public void AutoShare_TracksLatestState_AndSeedsFromLaunch()
+    {
+        var (_, _, coord) = Build(initialAutoShare: true);
+        Assert.True(coord.AutoShareOnCrash); // launch-time seed
+
+        coord.Apply(State(remoteDiag: false, callsign: null, key: null, autoShare: false));
+        Assert.False(coord.AutoShareOnCrash);
+
+        coord.Apply(State(remoteDiag: true, callsign: "N9WAR", key: "K", autoShare: true));
+        Assert.True(coord.AutoShareOnCrash);
+    }
+}
+
+/// <summary>A mutable-identity fake broker for coordinator/pipe tests; counts calls thread-safely.</summary>
+internal sealed class FakeMutableBroker : IMutableSupportBrokerClient
+{
+    private string _callsign = "";
+    private string _sessionKey = "";
+    private int _registers;
+    private int _drops;
+
+    public int Registers => Volatile.Read(ref _registers);
+    public int Drops => Volatile.Read(ref _drops);
+
+    public bool IsConfigured =>
+        !string.IsNullOrWhiteSpace(_callsign) && !string.IsNullOrWhiteSpace(_sessionKey);
+
+    public void UpdateIdentity(string? callsign, string? sessionKey)
+    {
+        _callsign = callsign ?? "";
+        _sessionKey = sessionKey ?? "";
+    }
+
+    public Task<bool> RegisterAsync(CancellationToken ct) { Interlocked.Increment(ref _registers); return Task.FromResult(true); }
+    public Task<bool> HeartbeatAsync(CancellationToken ct) => Task.FromResult(true);
+    public Task<bool> DropAsync(CancellationToken ct) { Interlocked.Increment(ref _drops); return Task.FromResult(true); }
+    public Task<bool> UploadCrashAsync(string json, CancellationToken ct) => Task.FromResult(true);
+}
+
+/// <summary>
+/// End-to-end over a REAL OS named pipe: the backend (client) connecting to the
+/// sidecar's <see cref="SupportIpcListener"/> (server) and pushing a SupportHello
+/// must drive the <see cref="PresenceCoordinator"/> to register broker presence —
+/// the exact path that was missing before P3c. Proves the wire transport + framing
+/// + listener dispatch + lazy-identity gating + presence loop together.
+/// </summary>
+public class SupportIpcPipeHandshakeTests
+{
+    private static async Task WaitUntilAsync(Func<bool> predicate, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (predicate()) return;
+            await Task.Delay(20);
+        }
+    }
+
+    [Fact]
+    public async Task BackendHello_OnPlusIdentity_RegistersPresenceOverRealPipe()
+    {
+        var token = Guid.NewGuid().ToString("N");
+        var pipeName = SupportIpc.PipeNameForSession(token);
+        var broker = new FakeMutableBroker();
+        // Fast, non-blocking cadence so the presence loop ticks promptly after the
+        // coordinator flips availability.
+        var presence = new PresenceClient(
+            broker, initiallyAvailable: false,
+            interval: TimeSpan.FromMilliseconds(20), delay: (_, ct) => Task.Delay(10, ct));
+        var coord = new PresenceCoordinator(broker, presence);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var presenceTask = presence.RunAsync(cts.Token);
+        var listener = new SupportIpcListener(token, coord.Apply);
+        var listenerTask = listener.RunAsync(cts.Token);
+
+        // Act as the backend bridge: connect to the sidecar's pipe and push a
+        // SupportHello with the switch ON and a full QRZ identity.
+        await using (var client = new NamedPipeClientStream(
+            ".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous))
+        {
+            await client.ConnectAsync(10_000, cts.Token);
+            await SupportIpcFraming.WriteAsync(client, new SupportHello(
+                ProtocolVersion: SupportIpc.ProtocolVersion, BackendPid: 1,
+                AppVersion: "v", Platform: "p", QrzCallsign: "N9WAR",
+                RemoteDiagnosticsEnabled: true, AutoShareOnCrash: false,
+                AppLogPath: "a", StartupLogPath: "s", QrzSessionKey: "SESSION"), cts.Token);
+
+            await WaitUntilAsync(() => broker.Registers >= 1, TimeSpan.FromSeconds(10));
+        }
+
+        Assert.True(broker.Registers >= 1, "presence should register once on+identity arrives over the pipe");
+
+        cts.Cancel();
+        await Task.WhenAny(Task.WhenAll(presenceTask, listenerTask), Task.Delay(2000));
+    }
+
+    [Fact]
+    public async Task BackendHello_OnButNoIdentity_DoesNotRegister()
+    {
+        var token = Guid.NewGuid().ToString("N");
+        var pipeName = SupportIpc.PipeNameForSession(token);
+        var broker = new FakeMutableBroker();
+        var presence = new PresenceClient(
+            broker, initiallyAvailable: false,
+            interval: TimeSpan.FromMilliseconds(20), delay: (_, ct) => Task.Delay(10, ct));
+        var coord = new PresenceCoordinator(broker, presence);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var presenceTask = presence.RunAsync(cts.Token);
+        var listener = new SupportIpcListener(token, coord.Apply);
+        var listenerTask = listener.RunAsync(cts.Token);
+
+        await using (var client = new NamedPipeClientStream(
+            ".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous))
+        {
+            await client.ConnectAsync(10_000, cts.Token);
+            // Switch ON but NO session key — must stay silent (the safety property).
+            await SupportIpcFraming.WriteAsync(client, new SupportHello(
+                ProtocolVersion: SupportIpc.ProtocolVersion, BackendPid: 1,
+                AppVersion: "v", Platform: "p", QrzCallsign: "N9WAR",
+                RemoteDiagnosticsEnabled: true, AutoShareOnCrash: false,
+                AppLogPath: "a", StartupLogPath: "s", QrzSessionKey: null), cts.Token);
+
+            // Give the loop ample time to (wrongly) register if the gate were broken.
+            await Task.Delay(400);
+        }
+
+        Assert.Equal(0, broker.Registers);
+
+        cts.Cancel();
+        await Task.WhenAny(Task.WhenAll(presenceTask, listenerTask), Task.Delay(2000));
     }
 }
 

--- a/tests/Zeus.Server.Tests/SupportIpcFramingTests.cs
+++ b/tests/Zeus.Server.Tests/SupportIpcFramingTests.cs
@@ -48,6 +48,44 @@ public class SupportIpcFramingTests
     }
 
     [Fact]
+    public async Task Hello_WithQrzSessionKey_RoundTrips()
+    {
+        // v2 identity payload: the session key must survive the round-trip so the
+        // sidecar can build its broker client from IPC-delivered identity.
+        var hello = new SupportHello(
+            ProtocolVersion: SupportIpc.ProtocolVersion,
+            BackendPid: 1, AppVersion: "v", Platform: "p",
+            QrzCallsign: "N9WAR",
+            RemoteDiagnosticsEnabled: true,
+            AutoShareOnCrash: false,
+            AppLogPath: "a", StartupLogPath: "s",
+            QrzSessionKey: "sess-abc-123");
+
+        var result = Assert.IsType<SupportHello>(await RoundTripAsync(hello));
+        Assert.Equal(hello, result);
+        Assert.Equal("sess-abc-123", result.QrzSessionKey);
+    }
+
+    [Fact]
+    public async Task StateChanged_WithQrzSessionKey_RoundTrips()
+    {
+        var state = new SupportStateChanged(
+            QrzCallsign: "N9WAR",
+            RemoteDiagnosticsEnabled: true,
+            AutoShareOnCrash: true,
+            QrzSessionKey: "sess-xyz");
+
+        var result = Assert.IsType<SupportStateChanged>(await RoundTripAsync(state));
+        Assert.Equal(state, result);
+        Assert.Equal("sess-xyz", result.QrzSessionKey);
+    }
+
+    [Fact]
+    public void ProtocolVersion_IsAtLeastV2_ForIdentityOverIpc()
+        => Assert.True(SupportIpc.ProtocolVersion >= 2,
+            "v2 added QrzSessionKey to the identity messages; version must not regress.");
+
+    [Fact]
     public async Task PromptResult_PreservesEnumDecision()
     {
         var msg = new SupportPromptResult("req-1", SupportPromptDecision.Timeout);


### PR DESCRIPTION
## Problem

A consenting operator who turns on the L1 **Remote Diagnostics** switch never appears in the maintainer admin portal — for *everyone*, not a config issue. The presence path was structurally incomplete on develop. Two gaps, either one fatal:

1. **The backend never talked to the sidecar.** The sidecar runs a named-pipe *server* and waits; nothing on the backend connected as a *client*. `SupportSidecar.NotifyAvailabilityChanged` built a `SupportStateChanged` and discarded it (the standing P3c TODO). The sidecar was launched `--remote-diagnostics off` and never received an update, so it stayed silent.
2. **The launcher captured QRZ identity too early.** It resolved callsign+session in a 3s window at startup, losing the race against QRZ silent-login. The sidecar's broker client was null, so presence was gated off even with the switch on. Verified on a live box: backend reports QRZ fully connected seconds *after* the sidecar already gave up, with no retry.

## Fix — identity flows over IPC, lazily

- **New `SupportSidecarBridge`** (Desktop-mode hosted service): the backend pipe **client**. Owns the per-session token (handed to the sidecar via `--session` so both ends share the pipe), connects to the sidecar, sends `SupportHello` on connect and `SupportStateChanged` on every posture change, with heartbeat + reconnect.
- **Contract v2:** `SupportHello`/`SupportStateChanged` carry an optional `QrzSessionKey`. The sidecar builds/refreshes its broker client when identity arrives over IPC instead of depending on a launch-time env var. Same-machine/same-user pipe = same trust boundary as the env var the launcher already used.
- **`QrzService.IdentityChanged`** fires on login/logout (incl. silent re-login) so presence comes online as soon as the operator is opted in **and** signed in — no restart.
- Sidecar always runs the IPC listener + presence loop; `PresenceCoordinator` gates availability (on **and** identity present); `HttpSupportBrokerClient` identity is now mutable.

## Safety

- Presence advertises **only** when the L1 switch is on AND a usable QRZ identity is present (`PresenceCoordinator`). "On but no identity" stays silent — covered by a test.
- Bridge runs only in Desktop host mode (the only mode that launches a sidecar); headless/server/tests are unaffected.
- Best-effort throughout: every pipe failure is swallowed; presence never destabilises the backend. No change to remote-session auth (ADR-0008) — this is presence only. PureSignal untouched.

## Tests

`dotnet test` (filtered support suite) green — 63 incl. new:
- contract round-trip for the new `QrzSessionKey` field + protocol-version guard
- mutable-identity transitions on the broker client
- coordinator gating: on-but-no-identity silent; identity arrival brings presence online; sign-out drops it
- **real OS named-pipe handshake**: a backend `SupportHello` drives a presence `register` end-to-end (and the on-but-no-identity case stays silent over the real pipe)

Built clean: full solution (`dotnet build Zeus.slnx`), sidecar, hosting, host.