### PR TITLE
feat(dxcluster): native Telnet DX-cluster client with callsign/password login (#1140)

### DIFF
--- a/Zeus.Contracts/DxClusterDtos.cs
+++ b/Zeus.Contracts/DxClusterDtos.cs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+namespace Zeus.Contracts;
+
+/// <summary>
+/// Live connection state of the native Telnet DX-cluster client. Additive wire
+/// contract — serialised as a string in the status DTO so adding states later
+/// stays backward compatible.
+/// </summary>
+public enum DxClusterConnectionState
+{
+    /// <summary>Not connected and not trying (operator disabled or idle).</summary>
+    Disconnected = 0,
+    /// <summary>Opening the TCP socket / logging in.</summary>
+    Connecting = 1,
+    /// <summary>Logged in and receiving spot lines.</summary>
+    Connected = 2,
+    /// <summary>Dropped — waiting out the backoff before the next attempt.</summary>
+    Reconnecting = 3,
+}
+
+/// <summary>
+/// Operator configuration for the DX-cluster client. Persisted in zeus-prefs.db
+/// via DxClusterConfigStore. Everything defaults OFF / empty — the client never
+/// reaches out to the network until the operator enables it.
+///
+/// <para><b>Password</b> is stored at-rest as plaintext in zeus-prefs.db,
+/// consistent with the existing CredentialStore (QRZ) precedent — see the PR
+/// notes. Most DX clusters do not require a password at all.</para>
+///
+/// <para><b>LoginCommands</b> is a newline-separated list of commands sent once
+/// after a successful login (e.g. <c>set/filter</c>, <c>sh/dx</c>).</para>
+/// </summary>
+public sealed record DxClusterConfig(
+    bool Enabled = false,
+    string Host = "",
+    int Port = 7373,
+    string Callsign = "",
+    string Password = "",
+    string LoginCommands = "",
+    bool AutoConnect = false);
+
+/// <summary>Status of the DX-cluster client (config echo + live connection state).</summary>
+public sealed record DxClusterStatus(
+    bool Enabled,
+    string Host,
+    int Port,
+    string Callsign,
+    bool HasPassword,
+    string LoginCommands,
+    bool AutoConnect,
+    DxClusterConnectionState State,
+    int SpotsReceived,
+    string? LastSpotCallsign,
+    string? Error);

--- a/Zeus.Server.Hosting/DxCluster/DxClusterClient.cs
+++ b/Zeus.Server.Hosting/DxCluster/DxClusterClient.cs
@@ -1,0 +1,340 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using System.Net.Sockets;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Zeus.Contracts;
+using Zeus.Server.Tci;
+
+namespace Zeus.Server.DxCluster;
+
+/// <summary>
+/// Connects to a Telnet DX cluster, logs in, and feeds received spots into the
+/// existing <see cref="SpotManager"/> ingest path (the same path TCI spots use →
+/// SpotBroadcastService → SpotOverlay on the panadapter). No parallel pipeline.
+///
+/// <para>The socket sits behind an injectable seam (<see cref="_connector"/>):
+/// real TCP in production, a fake in-memory duplex stream in tests. No unit test
+/// ever opens a real socket. A single session over a given stream is driven by
+/// <see cref="RunSessionAsync"/>, which is what tests call directly.</para>
+///
+/// <para>The connect/backoff loop ((<see cref="Start"/>/<see cref="Stop"/>) owns
+/// a CancellationTokenSource and a single Task; nothing is left running past
+/// <see cref="Stop"/> or <see cref="Dispose"/>.</para>
+/// </summary>
+public sealed class DxClusterClient : IDisposable
+{
+    // Default spot tick/label colour: Zeus accent blue (#4A9EFF). Packed ARGB with
+    // A=0, which SpotOverlay treats as fully opaque (see argbToRgba). This is a
+    // numeric wire value handed to the existing overlay, not a CSS token.
+    private const uint DefaultSpotArgb = 0x004A9EFFu;
+
+    private static readonly Encoding Latin1 = Encoding.Latin1;
+    private const int MaxLineLength = 4096;
+
+    private readonly ILogger _log;
+    private readonly SpotManager _spots;
+    private readonly Func<string, int, CancellationToken, Task<Stream>> _connector;
+
+    private readonly object _sync = new();
+    private CancellationTokenSource? _cts;
+    private Task? _loop;
+
+    private volatile DxClusterConnectionState _state = DxClusterConnectionState.Disconnected;
+    private int _spotsReceived;
+    private string? _lastSpotCallsign;
+    private volatile string? _lastError;
+
+    public DxClusterClient(ILogger<DxClusterClient> log, SpotManager spots)
+        : this(log, spots, connector: null)
+    {
+    }
+
+    // Test/seam ctor: a null connector wires the production TCP connector.
+    internal DxClusterClient(
+        ILogger log,
+        SpotManager spots,
+        Func<string, int, CancellationToken, Task<Stream>>? connector)
+    {
+        _log = log;
+        _spots = spots;
+        _connector = connector ?? DefaultTcpConnector;
+    }
+
+    public DxClusterConnectionState State => _state;
+    public int SpotsReceived => Volatile.Read(ref _spotsReceived);
+    public string? LastSpotCallsign => Volatile.Read(ref _lastSpotCallsign);
+    public string? LastError => _lastError;
+    public bool IsRunning { get { lock (_sync) return _loop is { IsCompleted: false }; } }
+
+    /// <summary>Start the connect/backoff loop for the given config. Idempotent —
+    /// a second Start while running is a no-op.</summary>
+    public void Start(DxClusterConfig cfg)
+    {
+        lock (_sync)
+        {
+            if (_loop is { IsCompleted: false })
+                return;
+            _lastError = null;
+            _cts = new CancellationTokenSource();
+            var token = _cts.Token;
+            _loop = Task.Run(() => RunLoopAsync(cfg, token), CancellationToken.None);
+        }
+    }
+
+    /// <summary>Stop the loop and wait for it to unwind. Safe to call when idle.</summary>
+    public async Task StopAsync()
+    {
+        CancellationTokenSource? cts;
+        Task? loop;
+        lock (_sync)
+        {
+            cts = _cts;
+            loop = _loop;
+            _cts = null;
+            _loop = null;
+        }
+
+        if (cts is null)
+            return;
+
+        try { cts.Cancel(); } catch { /* already disposed */ }
+        if (loop is not null)
+        {
+            try { await loop.ConfigureAwait(false); }
+            catch (OperationCanceledException) { }
+            catch (Exception ex) { _log.LogDebug(ex, "dxcluster.loop ended with exception"); }
+        }
+        cts.Dispose();
+        _state = DxClusterConnectionState.Disconnected;
+    }
+
+    private async Task RunLoopAsync(DxClusterConfig cfg, CancellationToken ct)
+    {
+        // Bounded exponential backoff: 2s → 60s, reset after a healthy session.
+        var backoff = TimeSpan.FromSeconds(2);
+        var maxBackoff = TimeSpan.FromSeconds(60);
+
+        while (!ct.IsCancellationRequested)
+        {
+            Stream? stream = null;
+            try
+            {
+                _state = DxClusterConnectionState.Connecting;
+                _log.LogInformation("dxcluster.connect host={Host} port={Port}", cfg.Host, cfg.Port);
+                stream = await _connector(cfg.Host, cfg.Port, ct).ConfigureAwait(false);
+
+                _state = DxClusterConnectionState.Connected;
+                _lastError = null;
+                backoff = TimeSpan.FromSeconds(2);
+
+                await RunSessionAsync(cfg, stream, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _lastError = ex.Message;
+                _log.LogWarning("dxcluster.session error: {Msg}", ex.Message);
+            }
+            finally
+            {
+                stream?.Dispose();
+            }
+
+            if (ct.IsCancellationRequested)
+                break;
+
+            _state = DxClusterConnectionState.Reconnecting;
+            try { await Task.Delay(backoff, ct).ConfigureAwait(false); }
+            catch (OperationCanceledException) { break; }
+            backoff = TimeSpan.FromMilliseconds(Math.Min(maxBackoff.TotalMilliseconds, backoff.TotalMilliseconds * 2));
+        }
+
+        _state = DxClusterConnectionState.Disconnected;
+    }
+
+    /// <summary>
+    /// Drive one session over an already-connected duplex stream: run the login
+    /// handshake, strip Telnet IAC bytes, split newline-delimited lines, parse
+    /// spots, and ingest them. Returns when the stream ends or is cancelled.
+    /// Tests call this directly with a fake in-memory duplex stream.
+    /// </summary>
+    internal async Task RunSessionAsync(DxClusterConfig cfg, Stream stream, CancellationToken ct)
+    {
+        var handshake = new DxClusterHandshake(cfg.Callsign, cfg.Password, SplitLoginCommands(cfg.LoginCommands));
+        var filter = new TelnetByteFilter();
+        var readBuf = new byte[4096];
+        var filtered = new List<byte>(4096);
+        var lineBuf = new List<byte>(256);
+
+        while (!ct.IsCancellationRequested)
+        {
+            int n = await stream.ReadAsync(readBuf.AsMemory(0, readBuf.Length), ct).ConfigureAwait(false);
+            if (n <= 0)
+                break; // EOF — peer closed
+
+            filtered.Clear();
+            filter.Process(readBuf, n, filtered);
+
+            foreach (var b in filtered)
+            {
+                if (b == (byte)'\n')
+                {
+                    await EmitLineAsync(lineBuf, handshake, stream, ct).ConfigureAwait(false);
+                    lineBuf.Clear();
+                }
+                else if (b == (byte)'\r')
+                {
+                    // ignore CR; line terminates on LF
+                }
+                else
+                {
+                    if (lineBuf.Count < MaxLineLength)
+                        lineBuf.Add(b);
+                    // Some clusters print a non-newline-terminated prompt ("login: ").
+                    // Treat a trailing-space prompt opportunistically: see EmitPromptProbe.
+                }
+            }
+
+            // A login/password prompt may arrive WITHOUT a trailing newline. After
+            // draining a chunk, probe the pending partial line for a prompt so the
+            // handshake doesn't stall waiting for a LF that never comes.
+            await ProbePromptAsync(lineBuf, handshake, stream, ct).ConfigureAwait(false);
+        }
+    }
+
+    private async Task EmitLineAsync(List<byte> lineBytes, DxClusterHandshake handshake, Stream stream, CancellationToken ct)
+    {
+        var line = Latin1.GetString(lineBytes.ToArray()).Trim();
+        if (line.Length == 0)
+            return;
+
+        var replies = handshake.OnLine(line);
+        await SendRepliesAsync(replies, stream, ct).ConfigureAwait(false);
+
+        if (DxSpotLineParser.TryParse(line, out var spot))
+        {
+            _spots.AddSpot(spot.DxCall, spot.Mode, spot.FreqHz, DefaultSpotArgb,
+                string.IsNullOrEmpty(spot.Comment) ? null : spot.Comment);
+            Interlocked.Increment(ref _spotsReceived);
+            Volatile.Write(ref _lastSpotCallsign, spot.DxCall);
+            _log.LogDebug("dxcluster.spot {Call} {Mode} {Freq}Hz", spot.DxCall, spot.Mode, spot.FreqHz);
+        }
+    }
+
+    // Probe a not-yet-terminated partial line for a login/password prompt. Only
+    // sends when the handshake actually emits a reply, so non-prompt partial text
+    // is left to accumulate until its newline.
+    private async Task ProbePromptAsync(List<byte> lineBytes, DxClusterHandshake handshake, Stream stream, CancellationToken ct)
+    {
+        if (lineBytes.Count == 0)
+            return;
+        var partial = Latin1.GetString(lineBytes.ToArray());
+        var lower = partial.ToLowerInvariant();
+        // Cheap pre-filter: only invoke the handshake for prompt-shaped partials.
+        if (!(lower.Contains("login") || lower.Contains("call") || lower.Contains("password")))
+            return;
+        var replies = handshake.OnLine(partial.Trim());
+        if (replies.Count > 0)
+        {
+            await SendRepliesAsync(replies, stream, ct).ConfigureAwait(false);
+            lineBytes.Clear(); // consumed as a prompt; don't double-feed at LF
+        }
+    }
+
+    private static async Task SendRepliesAsync(IReadOnlyList<string> replies, Stream stream, CancellationToken ct)
+    {
+        if (replies.Count == 0)
+            return;
+        foreach (var r in replies)
+        {
+            var bytes = Latin1.GetBytes(r + "\r\n");
+            await stream.WriteAsync(bytes.AsMemory(), ct).ConfigureAwait(false);
+        }
+        await stream.FlushAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <summary>Split the newline-separated login-commands blob into trimmed,
+    /// non-empty commands. Pure helper, shared with the handshake.</summary>
+    public static IReadOnlyList<string> SplitLoginCommands(string? blob)
+    {
+        if (string.IsNullOrWhiteSpace(blob))
+            return Array.Empty<string>();
+        return blob
+            .Replace("\r\n", "\n").Replace('\r', '\n')
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
+    private static async Task<Stream> DefaultTcpConnector(string host, int port, CancellationToken ct)
+    {
+        var tcp = new TcpClient();
+        try
+        {
+            await tcp.ConnectAsync(host, port, ct).ConfigureAwait(false);
+            // The TcpClient owns the socket; the returned stream's Dispose (called
+            // by the loop's finally) tears the connection down. Keep a reference so
+            // disposing the stream also disposes the client.
+            return new TcpClientStream(tcp);
+        }
+        catch
+        {
+            tcp.Dispose();
+            throw;
+        }
+    }
+
+    public void Dispose()
+    {
+        try { StopAsync().GetAwaiter().GetResult(); } catch { /* best effort */ }
+    }
+
+    // Wraps a TcpClient's NetworkStream so disposing the stream also disposes the
+    // owning client (and thus the socket). Keeps the production connector to a
+    // single Stream return type that matches the test seam.
+    private sealed class TcpClientStream : Stream
+    {
+        private readonly TcpClient _client;
+        private readonly NetworkStream _inner;
+
+        public TcpClientStream(TcpClient client)
+        {
+            _client = client;
+            _inner = client.GetStream();
+        }
+
+        public override bool CanRead => _inner.CanRead;
+        public override bool CanSeek => false;
+        public override bool CanWrite => _inner.CanWrite;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public override void Flush() => _inner.Flush();
+        public override Task FlushAsync(CancellationToken ct) => _inner.FlushAsync(ct);
+        public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken ct = default) => _inner.ReadAsync(buffer, ct);
+        public override void Write(byte[] buffer, int offset, int count) => _inner.Write(buffer, offset, count);
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken ct = default) => _inner.WriteAsync(buffer, ct);
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _inner.Dispose();
+                _client.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Zeus.Server.Hosting/DxCluster/DxClusterHandshake.cs
+++ b/Zeus.Server.Hosting/DxCluster/DxClusterHandshake.cs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+namespace Zeus.Server.DxCluster;
+
+/// <summary>
+/// Pure login/handshake state machine for a DX cluster. No I/O: it is fed each
+/// incoming line and returns the lines that should be sent in response (without
+/// trailing CRLF — the caller frames them). It is idempotent: the callsign /
+/// password / login commands are each sent at most once, no matter how many
+/// times a prompt re-appears.
+///
+/// Recognised prompts (case-insensitive substring match):
+///   • callsign — "login:", "call:", "please enter your call", "enter your call",
+///     "your call", "callsign:".
+///   • password — "password:", "password>", "enter password".
+///
+/// Login commands (if any) are sent once, on the first line received after the
+/// callsign (and password, when one is configured) have been sent — i.e. once we
+/// are past the login exchange and the node is talking to us.
+/// </summary>
+public sealed class DxClusterHandshake
+{
+    private static readonly string[] CallPrompts =
+    {
+        "login:", "callsign:", "call:", "please enter your call",
+        "enter your call", "your call",
+    };
+
+    private static readonly string[] PasswordPrompts =
+    {
+        "password:", "password>", "enter password",
+    };
+
+    private readonly string _callsign;
+    private readonly string? _password;
+    private readonly string[] _loginCommands;
+
+    private bool _callsignSent;
+    private bool _passwordSent;
+    private bool _loginCommandsSent;
+
+    public DxClusterHandshake(string callsign, string? password, IEnumerable<string>? loginCommands)
+    {
+        _callsign = (callsign ?? "").Trim();
+        _password = string.IsNullOrWhiteSpace(password) ? null : password;
+        _loginCommands = (loginCommands ?? Array.Empty<string>())
+            .Select(c => c?.Trim() ?? "")
+            .Where(c => c.Length > 0)
+            .ToArray();
+    }
+
+    private bool PasswordRequired => _password is not null;
+
+    /// <summary>True once the callsign has been sent (login exchange underway).</summary>
+    public bool CallsignSent => _callsignSent;
+
+    /// <summary>
+    /// Feed one received line. Returns zero or more lines to send back. The
+    /// returned strings carry no line terminator.
+    /// </summary>
+    public IReadOnlyList<string> OnLine(string? line)
+    {
+        if (line is null)
+            return Array.Empty<string>();
+
+        var lower = line.ToLowerInvariant();
+
+        // 1) Callsign at a login/call prompt — once.
+        if (!_callsignSent && _callsign.Length > 0 && ContainsAny(lower, CallPrompts))
+        {
+            _callsignSent = true;
+            return new[] { _callsign };
+        }
+
+        // 2) Password at a password prompt — once, only if one is configured.
+        if (PasswordRequired && !_passwordSent && ContainsAny(lower, PasswordPrompts))
+        {
+            _passwordSent = true;
+            return new[] { _password! };
+        }
+
+        // 3) Post-login commands — once, on the first line after the login
+        //    exchange completed. Guarded so they never fire before login.
+        if (!_loginCommandsSent
+            && _loginCommands.Length > 0
+            && _callsignSent
+            && (!PasswordRequired || _passwordSent))
+        {
+            _loginCommandsSent = true;
+            return _loginCommands;
+        }
+
+        return Array.Empty<string>();
+    }
+
+    private static bool ContainsAny(string haystack, string[] needles)
+    {
+        foreach (var n in needles)
+            if (haystack.Contains(n, StringComparison.Ordinal))
+                return true;
+        return false;
+    }
+}

--- a/Zeus.Server.Hosting/DxCluster/DxSpotLineParser.cs
+++ b/Zeus.Server.Hosting/DxCluster/DxSpotLineParser.cs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Zeus.Server.DxCluster;
+
+/// <summary>
+/// A single parsed DX-cluster spot line. Pure data — no I/O. <see cref="FreqHz"/>
+/// is integer Hz (kHz on the wire × 1000). <see cref="Mode"/> is "" when it
+/// cannot be derived from the comment.
+/// </summary>
+public sealed record DxSpotLine(
+    string SpotterCall,
+    string DxCall,
+    long FreqHz,
+    string Comment,
+    string Mode,
+    string Time);
+
+/// <summary>
+/// Pure parser for standard DX-cluster spot lines. No sockets, no state — a
+/// static function over a line of text. Handles the DXSpider / AR-Cluster /
+/// CC-Cluster spacing variants and rejects everything that is not a spot
+/// (banners, prompts, talk / announce / WWV lines).
+///
+/// Canonical form:
+///   <c>DX de &lt;SPOTTER&gt;:   &lt;FREQ_kHz&gt;  &lt;DXCALL&gt;   &lt;comment...&gt;   &lt;HHMMZ&gt;</c>
+/// e.g. <c>DX de W3LPL:    14074.0  K1ABC        FT8  -12 dB         1432Z</c>
+/// </summary>
+public static class DxSpotLineParser
+{
+    // A callsign-ish token: letters, digits, slash, dash, optional SSID/portable.
+    // Deliberately lenient — cluster node calls and portable suffixes vary — but
+    // it must contain at least one letter and one digit somewhere so plain words
+    // (banner text) are rejected as the spotter/DX call.
+    private const string Call = @"[A-Za-z0-9][A-Za-z0-9/\-]*";
+
+    // ^DX de <spotter>:?  <freq>  <dxcall>  <rest...>
+    // - "DX de" is case-insensitive and tolerant of extra spaces.
+    // - The colon after the spotter is optional (a few nodes omit it).
+    // - Freq is kHz, integer or decimal.
+    private static readonly Regex SpotRe = new(
+        @"^\s*DX\s+de\s+(?<spotter>" + Call + @")\s*:?\s+(?<freq>\d{1,9}(?:\.\d+)?)\s+(?<dx>" + Call + @")\s+(?<rest>.*)$",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    // Trailing UTC time token "1432Z" (3 or 4 digits). Anchored to the end,
+    // tolerating an optional 4/6-char grid square after it on some nodes.
+    private static readonly Regex TrailingTimeRe = new(
+        @"\b(?<time>\d{3,4}Z)\b(?:\s+[A-Z]{2}\d{2}(?:[A-Za-z]{2})?)?\s*$",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// Try to parse a single line as a DX spot. Returns false for any line that
+    /// is not a well-formed spot (login banner, prompt, talk/announce, blank).
+    /// </summary>
+    public static bool TryParse(string? line, out DxSpotLine spot)
+    {
+        spot = null!;
+        if (string.IsNullOrWhiteSpace(line))
+            return false;
+
+        var m = SpotRe.Match(line);
+        if (!m.Success)
+            return false;
+
+        // Frequency: kHz on the wire → integer Hz. Reject implausible values so a
+        // stray number-shaped banner line can't masquerade as a spot.
+        if (!double.TryParse(m.Groups["freq"].Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var khz))
+            return false;
+        if (khz < 1.0 || khz > 10_000_000.0) // 1 kHz .. 10 GHz
+            return false;
+        var freqHz = (long)Math.Round(khz * 1000.0, MidpointRounding.AwayFromZero);
+
+        var spotter = m.Groups["spotter"].Value.ToUpperInvariant();
+        var dxCall = m.Groups["dx"].Value.ToUpperInvariant();
+        if (!LooksLikeCall(dxCall))
+            return false;
+
+        var rest = m.Groups["rest"].Value.Trim();
+
+        // Pull the trailing time token off the end; the remainder is the comment.
+        string time = "";
+        string comment = rest;
+        var tm = TrailingTimeRe.Match(rest);
+        if (tm.Success)
+        {
+            time = tm.Groups["time"].Value.ToUpperInvariant();
+            comment = rest[..tm.Index].Trim();
+        }
+
+        var mode = DeriveMode(comment);
+
+        spot = new DxSpotLine(spotter, dxCall, freqHz, comment, mode, time);
+        return true;
+    }
+
+    // A real callsign has at least one letter AND at least one digit. This is the
+    // guard that keeps "DX de NODE: 14074 CQ ..." style noise out — a DX call of
+    // "CQ" (no digit) is rejected.
+    private static bool LooksLikeCall(string s)
+    {
+        bool hasLetter = false, hasDigit = false;
+        foreach (var c in s)
+        {
+            if (char.IsLetter(c)) hasLetter = true;
+            else if (char.IsDigit(c)) hasDigit = true;
+        }
+        return hasLetter && hasDigit;
+    }
+
+    // Best-effort mode from the comment text. Only the common, unambiguous modes
+    // the issue calls out; "" when nothing matches.
+    private static readonly (string Token, string Mode)[] ModeTokens =
+    {
+        ("FT8", "FT8"),
+        ("FT4", "FT4"),
+        ("RTTY", "RTTY"),
+        ("PSK", "PSK"),
+        ("JT65", "JT65"),
+        ("CW", "CW"),
+        ("USB", "SSB"),
+        ("LSB", "SSB"),
+        ("SSB", "SSB"),
+    };
+
+    private static string DeriveMode(string comment)
+    {
+        if (string.IsNullOrWhiteSpace(comment))
+            return "";
+        var upper = comment.ToUpperInvariant();
+        foreach (var (token, mode) in ModeTokens)
+        {
+            // Word-boundary match so "FT8" in "FT8" but not inside a serial number.
+            if (Regex.IsMatch(upper, $@"\b{Regex.Escape(token)}\b"))
+                return mode;
+        }
+        return "";
+    }
+}

--- a/Zeus.Server.Hosting/DxCluster/DxSpotLineParser.cs
+++ b/Zeus.Server.Hosting/DxCluster/DxSpotLineParser.cs
@@ -118,29 +118,36 @@ public static class DxSpotLineParser
     }
 
     // Best-effort mode from the comment text. Only the common, unambiguous modes
-    // the issue calls out; "" when nothing matches.
-    private static readonly (string Token, string Mode)[] ModeTokens =
+    // the issue calls out; "" when nothing matches. Each token's word-boundary
+    // pattern is compiled once (static), so a firehose of spots never churns the
+    // shared static Regex cache or re-allocates pattern strings per spot.
+    private static readonly (Regex Pattern, string Mode)[] ModePatterns =
     {
-        ("FT8", "FT8"),
-        ("FT4", "FT4"),
-        ("RTTY", "RTTY"),
-        ("PSK", "PSK"),
-        ("JT65", "JT65"),
-        ("CW", "CW"),
-        ("USB", "SSB"),
-        ("LSB", "SSB"),
-        ("SSB", "SSB"),
+        (ModeRegex("FT8"),  "FT8"),
+        (ModeRegex("FT4"),  "FT4"),
+        (ModeRegex("RTTY"), "RTTY"),
+        (ModeRegex("PSK"),  "PSK"),
+        (ModeRegex("JT65"), "JT65"),
+        (ModeRegex("CW"),   "CW"),
+        (ModeRegex("USB"),  "SSB"),
+        (ModeRegex("LSB"),  "SSB"),
+        (ModeRegex("SSB"),  "SSB"),
     };
+
+    // Word-boundary match (against the upper-cased comment) so "FT8" matches in
+    // "FT8 -12 dB" but not inside a serial number.
+    private static Regex ModeRegex(string token) => new(
+        $@"\b{Regex.Escape(token)}\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static string DeriveMode(string comment)
     {
         if (string.IsNullOrWhiteSpace(comment))
             return "";
         var upper = comment.ToUpperInvariant();
-        foreach (var (token, mode) in ModeTokens)
+        foreach (var (pattern, mode) in ModePatterns)
         {
-            // Word-boundary match so "FT8" in "FT8" but not inside a serial number.
-            if (Regex.IsMatch(upper, $@"\b{Regex.Escape(token)}\b"))
+            if (pattern.IsMatch(upper))
                 return mode;
         }
         return "";

--- a/Zeus.Server.Hosting/DxCluster/TelnetByteFilter.cs
+++ b/Zeus.Server.Hosting/DxCluster/TelnetByteFilter.cs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+namespace Zeus.Server.DxCluster;
+
+/// <summary>
+/// Strips Telnet (RFC 854) IAC option-negotiation sequences from an inbound byte
+/// stream, leaving only the application text. Stateful across calls so a sequence
+/// that straddles a read boundary is handled correctly. No I/O — pure byte
+/// transform, fully unit-testable.
+///
+/// We are a passive reader of a (mostly line-mode) cluster, so we never reply to
+/// negotiations — most clusters work fine without WILL/WONT handshakes, and the
+/// few control bytes are simply discarded. <c>IAC IAC</c> (0xFF 0xFF) is the one
+/// case that yields a literal 0xFF data byte.
+/// </summary>
+public sealed class TelnetByteFilter
+{
+    private const byte IAC = 0xFF;
+    private const byte SB = 0xFA;  // begin subnegotiation
+    private const byte SE = 0xF0;  // end subnegotiation
+    private const byte WILL = 0xFB;
+    private const byte WONT = 0xFC;
+    private const byte DO = 0xFD;
+    private const byte DONT = 0xFE;
+
+    private enum S { Normal, Iac, Option, SubNeg, SubNegIac }
+
+    private S _state = S.Normal;
+
+    /// <summary>
+    /// Process <paramref name="count"/> bytes from <paramref name="input"/>,
+    /// appending the surviving data bytes to <paramref name="sink"/>.
+    /// </summary>
+    public void Process(byte[] input, int count, List<byte> sink)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            byte b = input[i];
+            switch (_state)
+            {
+                case S.Normal:
+                    if (b == IAC) _state = S.Iac;
+                    else sink.Add(b);
+                    break;
+
+                case S.Iac:
+                    if (b == IAC) { sink.Add(IAC); _state = S.Normal; }   // escaped literal 0xFF
+                    else if (b is WILL or WONT or DO or DONT) _state = S.Option;
+                    else if (b == SB) _state = S.SubNeg;
+                    else _state = S.Normal;                                // 2-byte command, drop
+                    break;
+
+                case S.Option:
+                    // The single option byte after WILL/WONT/DO/DONT — drop it.
+                    _state = S.Normal;
+                    break;
+
+                case S.SubNeg:
+                    if (b == IAC) _state = S.SubNegIac;                    // maybe IAC SE
+                    break;                                                 // else still inside SB, drop
+
+                case S.SubNegIac:
+                    if (b == SE) _state = S.Normal;                        // end of subnegotiation
+                    else if (b == IAC) _state = S.SubNegIac;              // escaped 0xFF inside SB, drop
+                    else _state = S.SubNeg;                                // back inside SB
+                    break;
+            }
+        }
+    }
+}

--- a/Zeus.Server.Hosting/DxClusterConfigStore.cs
+++ b/Zeus.Server.Hosting/DxClusterConfigStore.cs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using LiteDB;
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+// DX-cluster client config persistence. Single-row collection in zeus-prefs.db
+// — one cluster connection per Zeus instance, so a profile key would just be
+// ceremony. Mirrors TciConfigStore / CatConfigStore exactly: the SAME shared
+// LiteDB lease (Zeus.Data.SharedLiteDatabase.Acquire) so we never open a second
+// LiteDatabase handle (the Windows-only exclusive-lock IOException, GH #682).
+//
+// Password is stored at-rest as plaintext, consistent with the existing
+// CredentialStore (QRZ) precedent in the same DB — see the PR notes.
+public sealed class DxClusterConfigStore : IDisposable
+{
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<DxClusterConfigEntry> _entries;
+    private readonly ILogger<DxClusterConfigStore> _log;
+    private readonly object _sync = new();
+
+    public DxClusterConfigStore(ILogger<DxClusterConfigStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
+        _entries = _db.GetCollection<DxClusterConfigEntry>("dxcluster_config");
+
+        _log.LogInformation("DxClusterConfigStore initialized at {Path}", dbPath);
+    }
+
+    // null = nothing persisted yet — caller falls back to the default (all-off) config.
+    public DxClusterConfig? Get()
+    {
+        lock (_sync)
+        {
+            var e = _entries.FindAll().FirstOrDefault();
+            if (e is null) return null;
+            return new DxClusterConfig(
+                Enabled: e.Enabled,
+                Host: e.Host ?? "",
+                Port: e.Port,
+                Callsign: e.Callsign ?? "",
+                Password: e.Password ?? "",
+                LoginCommands: e.LoginCommands ?? "",
+                AutoConnect: e.AutoConnect);
+        }
+    }
+
+    public void Set(DxClusterConfig config)
+    {
+        lock (_sync)
+        {
+            var existing = _entries.FindAll().FirstOrDefault();
+            if (existing is null)
+            {
+                _entries.Insert(new DxClusterConfigEntry
+                {
+                    Enabled = config.Enabled,
+                    Host = config.Host,
+                    Port = config.Port,
+                    Callsign = config.Callsign,
+                    Password = config.Password,
+                    LoginCommands = config.LoginCommands,
+                    AutoConnect = config.AutoConnect,
+                    UpdatedUtc = DateTime.UtcNow,
+                });
+            }
+            else
+            {
+                existing.Enabled = config.Enabled;
+                existing.Host = config.Host;
+                existing.Port = config.Port;
+                existing.Callsign = config.Callsign;
+                existing.Password = config.Password;
+                existing.LoginCommands = config.LoginCommands;
+                existing.AutoConnect = config.AutoConnect;
+                existing.UpdatedUtc = DateTime.UtcNow;
+                _entries.Update(existing);
+            }
+        }
+    }
+
+    public void Dispose() => _dbLease.Dispose();
+}
+
+public sealed class DxClusterConfigEntry
+{
+    public int Id { get; set; }
+    public bool Enabled { get; set; }
+    public string? Host { get; set; } = "";
+    public int Port { get; set; } = 7373;
+    public string? Callsign { get; set; } = "";
+    public string? Password { get; set; } = "";
+    public string? LoginCommands { get; set; } = "";
+    public bool AutoConnect { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/DxClusterManagementService.cs
+++ b/Zeus.Server.Hosting/DxClusterManagementService.cs
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using Microsoft.Extensions.Hosting;
+using Zeus.Contracts;
+using Zeus.Server.DxCluster;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Config + status facade and lifecycle owner for the native Telnet DX-cluster
+/// client. Mirrors TciManagementService's shape (config persistence + status
+/// reporting) but, because the cluster is an OUTBOUND connection (not a Kestrel
+/// listener), it can connect/disconnect at runtime with no restart.
+///
+/// IHostedService: on startup it auto-connects only when the operator persisted
+/// Enabled AND AutoConnect — otherwise it stays idle until an explicit
+/// POST /api/dxcluster/connect. On shutdown it tears the client down cleanly.
+/// </summary>
+public sealed class DxClusterManagementService : IHostedService, IDisposable
+{
+    private readonly ILogger<DxClusterManagementService> _log;
+    private readonly DxClusterConfigStore _store;
+    private readonly DxClusterClient _client;
+    private readonly object _sync = new();
+    private DxClusterConfig _config;
+
+    public DxClusterManagementService(
+        ILogger<DxClusterManagementService> log,
+        DxClusterConfigStore store,
+        DxClusterClient client)
+    {
+        _log = log;
+        _store = store;
+        _client = client;
+        // Default OFF when nothing persisted — new network egress is opt-in.
+        _config = store.Get() ?? new DxClusterConfig();
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var cfg = GetConfig();
+        if (cfg.Enabled && cfg.AutoConnect && CanConnect(cfg))
+        {
+            _log.LogInformation("dxcluster.autoconnect host={Host} port={Port}", cfg.Host, cfg.Port);
+            _client.Start(cfg);
+        }
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        await _client.StopAsync().ConfigureAwait(false);
+    }
+
+    public DxClusterConfig GetConfig()
+    {
+        lock (_sync) return _config;
+    }
+
+    public DxClusterStatus GetStatus()
+    {
+        var c = GetConfig();
+        return new DxClusterStatus(
+            Enabled: c.Enabled,
+            Host: c.Host,
+            Port: c.Port,
+            Callsign: c.Callsign,
+            HasPassword: !string.IsNullOrEmpty(c.Password),
+            LoginCommands: c.LoginCommands,
+            AutoConnect: c.AutoConnect,
+            State: _client.State,
+            SpotsReceived: _client.SpotsReceived,
+            LastSpotCallsign: _client.LastSpotCallsign,
+            Error: _client.LastError);
+    }
+
+    /// <summary>Persist a new config. If the client is running, restart it so the
+    /// new host/callsign/etc. take effect immediately (no restart needed).</summary>
+    public DxClusterStatus SetConfig(DxClusterConfig config)
+    {
+        var normalized = Normalize(config);
+        lock (_sync) _config = normalized;
+
+        try { _store.Set(normalized); }
+        catch (Exception ex) { _log.LogWarning(ex, "dxcluster.config.persist failed"); }
+
+        _log.LogInformation(
+            "dxcluster.config.updated enabled={En} host={Host} port={Port} call={Call} auto={Auto}",
+            normalized.Enabled, normalized.Host, normalized.Port, normalized.Callsign, normalized.AutoConnect);
+
+        // Reconcile: if it was running, restart on the new settings; if it is now
+        // disabled, stop. We do NOT auto-start here on a mere enable — connecting
+        // is an explicit operator action (POST /connect) unless AutoConnect drove
+        // it at startup.
+        if (_client.IsRunning)
+        {
+            if (!normalized.Enabled || !CanConnect(normalized))
+            {
+                _ = _client.StopAsync();
+            }
+            else
+            {
+                _ = RestartAsync(normalized);
+            }
+        }
+
+        return GetStatus();
+    }
+
+    /// <summary>Explicit operator connect. No-op if already running or not
+    /// connectable.</summary>
+    public DxClusterStatus Connect()
+    {
+        var cfg = GetConfig();
+        if (!cfg.Enabled)
+        {
+            _log.LogInformation("dxcluster.connect ignored — not enabled");
+            return GetStatus();
+        }
+        if (!CanConnect(cfg))
+        {
+            _log.LogInformation("dxcluster.connect ignored — host/callsign not set");
+            return GetStatus();
+        }
+        _client.Start(cfg);
+        return GetStatus();
+    }
+
+    /// <summary>Explicit operator disconnect.</summary>
+    public DxClusterStatus Disconnect()
+    {
+        _ = _client.StopAsync();
+        return GetStatus();
+    }
+
+    private async Task RestartAsync(DxClusterConfig cfg)
+    {
+        try
+        {
+            await _client.StopAsync().ConfigureAwait(false);
+            _client.Start(cfg);
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "dxcluster.restart failed");
+        }
+    }
+
+    private static bool CanConnect(DxClusterConfig c) =>
+        !string.IsNullOrWhiteSpace(c.Host)
+        && c.Port is > 0 and < 65536
+        && !string.IsNullOrWhiteSpace(c.Callsign);
+
+    private static DxClusterConfig Normalize(DxClusterConfig c) => new(
+        Enabled: c.Enabled,
+        Host: (c.Host ?? "").Trim(),
+        Port: c.Port is > 0 and < 65536 ? c.Port : 7373,
+        Callsign: (c.Callsign ?? "").Trim().ToUpperInvariant(),
+        Password: c.Password ?? "",
+        LoginCommands: (c.LoginCommands ?? "").Trim(),
+        AutoConnect: c.AutoConnect);
+
+    public void Dispose() => _client.Dispose();
+}

--- a/Zeus.Server.Hosting/SpotBroadcastService.cs
+++ b/Zeus.Server.Hosting/SpotBroadcastService.cs
@@ -12,13 +12,29 @@ namespace Zeus.Server;
 
 /// <summary>
 /// Watches <see cref="SpotManager.SpotsChanged"/> and broadcasts a fresh
-/// <see cref="SpotListFrame"/> to all WS clients whenever the TCI spot list
-/// changes. No background loop — entirely event-driven.
+/// <see cref="SpotListFrame"/> to all WS clients whenever the spot list changes.
+///
+/// <para>Broadcasts are <b>coalesced</b>: a change only marks the snapshot dirty;
+/// a periodic flush (<see cref="FlushInterval"/>) serialises and broadcasts once
+/// per tick. This keeps the cost off the producer thread (the DX-cluster
+/// socket-read loop) and collapses a firehose of per-spot changes into one
+/// full-snapshot rebroadcast per interval, instead of O(n) serialise-and-send
+/// work on every single spot. A modest TCI trickle is unaffected — it just sees
+/// at most one flush-interval of added latency.</para>
 /// </summary>
 public sealed class SpotBroadcastService : BackgroundService
 {
+    // Coalescing window. Long enough to collapse a contest-cluster firehose into
+    // one rebroadcast per tick, short enough to feel immediate for a logger's
+    // trickle. Spot display has no realtime requirement.
+    internal static readonly TimeSpan FlushInterval = TimeSpan.FromMilliseconds(300);
+
     private readonly SpotManager _spots;
     private readonly StreamingHub _hub;
+
+    // 0 = clean, 1 = a change is pending a flush. Set on the producer thread,
+    // cleared on the flush thread; Interlocked makes the handoff race-free.
+    private int _dirty;
 
     public SpotBroadcastService(SpotManager spots, StreamingHub hub)
     {
@@ -27,10 +43,32 @@ public sealed class SpotBroadcastService : BackgroundService
         _spots.SpotsChanged += OnSpotsChanged;
     }
 
-    // ExecuteAsync is a no-op; all work happens in the SpotsChanged handler.
-    protected override Task ExecuteAsync(CancellationToken stoppingToken) => Task.CompletedTask;
+    // Producer-thread handler: just flag dirty. No serialise/broadcast here.
+    private void OnSpotsChanged() => Interlocked.Exchange(ref _dirty, 1);
 
-    private void OnSpotsChanged()
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var timer = new PeriodicTimer(FlushInterval);
+        try
+        {
+            while (await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false))
+            {
+                if (Interlocked.Exchange(ref _dirty, 0) == 1)
+                    Flush();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Shutdown requested.
+        }
+
+        // Final flush so the last change isn't stranded if it landed between the
+        // last tick and cancellation.
+        if (Interlocked.Exchange(ref _dirty, 0) == 1)
+            Flush();
+    }
+
+    private void Flush()
     {
         var all = _spots.GetAll();
         var entries = all.Select(s => new SpotListFrame.SpotEntry(

--- a/Zeus.Server.Hosting/Tci/SpotManager.cs
+++ b/Zeus.Server.Hosting/Tci/SpotManager.cs
@@ -46,14 +46,39 @@
 namespace Zeus.Server.Tci;
 
 /// <summary>
-/// In-memory storage for DX cluster spots received via TCI.
-/// Fires <see cref="SpotsChanged"/> after every mutation so
-/// SpotBroadcastService can push a fresh snapshot to all WS clients.
+/// In-memory storage for DX cluster spots received via TCI or a native Telnet
+/// DX-cluster connection. Fires <see cref="SpotsChanged"/> after every mutation
+/// so SpotBroadcastService can push a fresh snapshot to all WS clients.
+///
+/// <para>The store is bounded (LRU): once <see cref="MaxSpots"/> distinct
+/// callsigns are held, adding a new one evicts the least-recently-spotted call.
+/// Re-spotting an existing call refreshes its recency. This matters for the
+/// native DX-cluster path, where a busy/contest cluster is a firehose of unique
+/// callsigns that would otherwise accumulate without bound for the whole
+/// session (the TCI path self-expires via RemoveSpot, so it never hits the
+/// cap). The bound also caps the per-broadcast snapshot size.</para>
 /// </summary>
 public sealed class SpotManager
 {
+    /// <summary>Default upper bound on retained distinct callsigns.</summary>
+    public const int DefaultMaxSpots = 1000;
+
     private readonly object _sync = new();
-    private readonly Dictionary<string, Spot> _spots = new();
+    // LRU ordering: head = least-recently-spotted, tail = most-recent. The
+    // dictionary indexes nodes by callsign for O(1) add/update/remove.
+    private readonly LinkedList<Spot> _order = new();
+    private readonly Dictionary<string, LinkedListNode<Spot>> _index = new();
+
+    /// <summary>Maximum number of distinct callsigns retained before the
+    /// least-recently-spotted is evicted.</summary>
+    public int MaxSpots { get; }
+
+    public SpotManager() : this(DefaultMaxSpots) { }
+
+    public SpotManager(int maxSpots)
+    {
+        MaxSpots = maxSpots > 0 ? maxSpots : DefaultMaxSpots;
+    }
 
     /// <summary>
     /// Raised after any mutation (add, remove, or clear). Fired while the
@@ -63,13 +88,32 @@ public sealed class SpotManager
     public event Action? SpotsChanged;
 
     /// <summary>
-    /// Add or update a spot.
+    /// Add or update a spot. Adding a brand-new callsign past <see cref="MaxSpots"/>
+    /// evicts the least-recently-spotted one. Updating an existing callsign
+    /// refreshes its value and its recency.
     /// </summary>
     public void AddSpot(string callsign, string mode, long freqHz, uint argb, string? comment = null)
     {
         lock (_sync)
         {
-            _spots[callsign] = new Spot(callsign, mode, freqHz, argb, comment);
+            var spot = new Spot(callsign, mode, freqHz, argb, comment);
+            if (_index.TryGetValue(callsign, out var existing))
+            {
+                // Update in place and move to the MRU end.
+                existing.Value = spot;
+                _order.Remove(existing);
+                _order.AddLast(existing);
+            }
+            else
+            {
+                _index[callsign] = _order.AddLast(spot);
+                if (_index.Count > MaxSpots)
+                {
+                    var oldest = _order.First!; // count > cap >= 1 ⇒ non-null
+                    _order.RemoveFirst();
+                    _index.Remove(oldest.Value.Callsign);
+                }
+            }
         }
         SpotsChanged?.Invoke();
     }
@@ -81,7 +125,11 @@ public sealed class SpotManager
     {
         lock (_sync)
         {
-            _spots.Remove(callsign);
+            if (_index.TryGetValue(callsign, out var node))
+            {
+                _order.Remove(node);
+                _index.Remove(callsign);
+            }
         }
         SpotsChanged?.Invoke();
     }
@@ -93,19 +141,24 @@ public sealed class SpotManager
     {
         lock (_sync)
         {
-            _spots.Clear();
+            _order.Clear();
+            _index.Clear();
         }
         SpotsChanged?.Invoke();
     }
 
     /// <summary>
-    /// Get a snapshot of all spots.
+    /// Get a snapshot of all spots, oldest-spotted first.
     /// </summary>
     public Spot[] GetAll()
     {
         lock (_sync)
         {
-            return _spots.Values.ToArray();
+            var arr = new Spot[_order.Count];
+            int i = 0;
+            foreach (var s in _order)
+                arr[i++] = s;
+            return arr;
         }
     }
 

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -3852,6 +3852,23 @@ public static class ZeusEndpoints
             return Results.Ok(result);
         });
 
+        // Native Telnet DX-cluster client. Mirrors /api/tci's shape. GET returns
+        // the config echo + live connection state; PUT persists config; POST
+        // connect/disconnect drive the outbound connection at runtime (no restart).
+        app.MapGet("/api/dxcluster/status", (DxClusterManagementService dx) => dx.GetStatus());
+
+        app.MapPut("/api/dxcluster/config", (DxClusterConfig req, DxClusterManagementService dx) =>
+        {
+            log.LogInformation(
+                "api.dxcluster.config enabled={En} host={Host} port={Port} auto={Auto}",
+                req.Enabled, req.Host, req.Port, req.AutoConnect);
+            return Results.Ok(dx.SetConfig(req));
+        });
+
+        app.MapPost("/api/dxcluster/connect", (DxClusterManagementService dx) => Results.Ok(dx.Connect()));
+
+        app.MapPost("/api/dxcluster/disconnect", (DxClusterManagementService dx) => Results.Ok(dx.Disconnect()));
+
         app.MapGet("/api/cat/status", (CatManagementService cat) => cat.GetStatus());
 
         app.MapPost("/api/cat/config", (CatRuntimeConfig req, CatManagementService cat, HttpContext ctx) =>

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -1029,6 +1029,17 @@ public static class ZeusHost
         builder.Services.AddHostedService(sp => sp.GetRequiredService<SpotBroadcastService>());
         builder.Services.AddSingleton<TciManagementService>();
 
+        // Native Telnet DX-cluster client — connects OUT to a DX cluster, logs in
+        // with the operator's callsign (+ optional password), and feeds received
+        // spots into the SAME SpotManager ingest path TCI spots use (→
+        // SpotBroadcastService → SpotOverlay). Disabled by default; never reaches
+        // the network until the operator enables + connects. Auto-connects at
+        // startup only when both Enabled and AutoConnect are persisted.
+        builder.Services.AddSingleton<DxClusterConfigStore>();
+        builder.Services.AddSingleton<Zeus.Server.DxCluster.DxClusterClient>();
+        builder.Services.AddSingleton<DxClusterManagementService>();
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<DxClusterManagementService>());
+
         // CAT (Kenwood TS-2000 over TCP) server — control-only sibling of TCI for
         // loggers / digital-mode apps (WSJT-X, N1MM+, fldigi, Hamlib net rigctl).
         // Disabled by default; enable via appsettings.json Cat:Enabled=true or the

--- a/tests/Zeus.Server.Tests/DxClusterClientTests.cs
+++ b/tests/Zeus.Server.Tests/DxClusterClientTests.cs
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// DxClusterClient session test driven by a FAKE in-memory duplex stream — NO
+// real sockets (a real ConnectAsync in a test loop minidump-crashes the Windows
+// CI host). We feed banner → login prompt → spot through the read side and assert
+// (a) the callsign was written back and (b) a parsed spot reached the existing
+// SpotManager ingest seam.
+
+using System.Text;
+using System.Threading.Channels;
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server.DxCluster;
+using Zeus.Server.Tci;
+
+namespace Zeus.Server.Tests;
+
+public class DxClusterClientTests
+{
+    [Fact]
+    public async Task Session_LoginAndSpot_ReachesIngestSeam()
+    {
+        var spots = new SpotManager();
+        var client = new DxClusterClient(NullLogger<DxClusterClient>.Instance, spots, connector: null);
+        var stream = new FakeDuplexStream();
+        var cfg = new DxClusterConfig(
+            Enabled: true, Host: "fake", Port: 7373, Callsign: "K1ABC");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var session = client.RunSessionAsync(cfg, stream, cts.Token);
+
+        // Server banner, then a login prompt, then a spot line.
+        stream.ServerSend("Welcome to the DX cluster\r\n");
+        stream.ServerSend("login: ");
+        stream.ServerSend("\r\n");
+        stream.ServerSend("DX de W3LPL:    14074.0  K1XYZ   FT8  -12 dB   1432Z\r\n");
+
+        // Wait for the spot to land in the SpotManager.
+        await WaitForAsync(() => spots.GetAll().Length > 0, TimeSpan.FromSeconds(5));
+
+        var all = spots.GetAll();
+        var spot = Assert.Single(all);
+        Assert.Equal("K1XYZ", spot.Callsign);
+        Assert.Equal("FT8", spot.Mode);
+        Assert.Equal(14074000L, spot.FreqHz);
+        Assert.Equal(1, client.SpotsReceived);
+        Assert.Equal("K1XYZ", client.LastSpotCallsign);
+
+        // The callsign must have been written back to the cluster.
+        await WaitForAsync(() => stream.WrittenText().Contains("K1ABC"), TimeSpan.FromSeconds(5));
+        Assert.Contains("K1ABC\r\n", stream.WrittenText());
+
+        // End the session cleanly (EOF) and confirm the task completes.
+        stream.ServerClose();
+        await session;
+    }
+
+    [Fact]
+    public async Task Session_PasswordPrompt_SendsConfiguredPassword()
+    {
+        var spots = new SpotManager();
+        var client = new DxClusterClient(NullLogger<DxClusterClient>.Instance, spots, connector: null);
+        var stream = new FakeDuplexStream();
+        var cfg = new DxClusterConfig(
+            Enabled: true, Host: "fake", Port: 7373, Callsign: "K1ABC", Password: "topsecret");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var session = client.RunSessionAsync(cfg, stream, cts.Token);
+
+        stream.ServerSend("login: \r\n");
+        await WaitForAsync(() => stream.WrittenText().Contains("K1ABC"), TimeSpan.FromSeconds(5));
+        stream.ServerSend("password: \r\n");
+        await WaitForAsync(() => stream.WrittenText().Contains("topsecret"), TimeSpan.FromSeconds(5));
+
+        Assert.Contains("K1ABC\r\n", stream.WrittenText());
+        Assert.Contains("topsecret\r\n", stream.WrittenText());
+
+        stream.ServerClose();
+        await session;
+    }
+
+    [Fact]
+    public async Task Session_TelnetIacBytes_StrippedBeforeParse()
+    {
+        var spots = new SpotManager();
+        var client = new DxClusterClient(NullLogger<DxClusterClient>.Instance, spots, connector: null);
+        var stream = new FakeDuplexStream();
+        var cfg = new DxClusterConfig(Enabled: true, Host: "fake", Port: 7373, Callsign: "K1ABC");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var session = client.RunSessionAsync(cfg, stream, cts.Token);
+
+        // Prepend a Telnet IAC DO ECHO (0xFF 0xFD 0x01) negotiation before the
+        // spot — it must be stripped so the spot still parses.
+        var iac = new byte[] { 0xFF, 0xFD, 0x01 };
+        stream.ServerSendBytes(iac);
+        stream.ServerSend("DX de G3XYZ:   7025.0  DL1AB   CW   0901Z\r\n");
+
+        await WaitForAsync(() => spots.GetAll().Length > 0, TimeSpan.FromSeconds(5));
+        var spot = Assert.Single(spots.GetAll());
+        Assert.Equal("DL1AB", spot.Callsign);
+
+        stream.ServerClose();
+        await session;
+    }
+
+    [Fact]
+    public async Task Session_EofImmediately_CompletesWithoutSpots()
+    {
+        var spots = new SpotManager();
+        var client = new DxClusterClient(NullLogger<DxClusterClient>.Instance, spots, connector: null);
+        var stream = new FakeDuplexStream();
+        var cfg = new DxClusterConfig(Enabled: true, Host: "fake", Port: 7373, Callsign: "K1ABC");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var session = client.RunSessionAsync(cfg, stream, cts.Token);
+        stream.ServerClose();
+        await session; // returns on EOF, no exception
+        Assert.Empty(spots.GetAll());
+    }
+
+    private static async Task WaitForAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.Elapsed < timeout)
+        {
+            if (condition()) return;
+            await Task.Delay(20);
+        }
+        if (!condition())
+            throw new TimeoutException("condition not met within timeout");
+    }
+
+    // In-memory bidirectional stream. The "server" pushes bytes into the read
+    // side via ServerSend/ServerSendBytes/ServerClose; everything the client
+    // writes is captured for assertions. No sockets, deterministic.
+    private sealed class FakeDuplexStream : Stream
+    {
+        private readonly Channel<byte[]> _incoming = Channel.CreateUnbounded<byte[]>();
+        private byte[] _leftover = Array.Empty<byte>();
+        private int _leftoverPos;
+        private readonly List<byte> _written = new();
+        private readonly object _writeSync = new();
+
+        public void ServerSend(string s) => ServerSendBytes(Encoding.Latin1.GetBytes(s));
+        public void ServerSendBytes(byte[] bytes) => _incoming.Writer.TryWrite(bytes);
+        public void ServerClose() => _incoming.Writer.TryComplete();
+
+        public string WrittenText()
+        {
+            lock (_writeSync) return Encoding.Latin1.GetString(_written.ToArray());
+        }
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken ct = default)
+        {
+            if (_leftoverPos >= _leftover.Length)
+            {
+                try
+                {
+                    if (!await _incoming.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
+                        return 0; // completed → EOF
+                }
+                catch (ChannelClosedException)
+                {
+                    return 0;
+                }
+                if (!_incoming.Reader.TryRead(out var chunk) || chunk is null)
+                    return 0;
+                _leftover = chunk;
+                _leftoverPos = 0;
+                if (_leftover.Length == 0)
+                    return 0;
+            }
+
+            int n = Math.Min(buffer.Length, _leftover.Length - _leftoverPos);
+            _leftover.AsSpan(_leftoverPos, n).CopyTo(buffer.Span);
+            _leftoverPos += n;
+            return n;
+        }
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken ct = default)
+        {
+            lock (_writeSync) _written.AddRange(buffer.ToArray());
+            return ValueTask.CompletedTask;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            ReadAsync(buffer.AsMemory(offset, count)).AsTask().GetAwaiter().GetResult();
+        public override void Write(byte[] buffer, int offset, int count) =>
+            WriteAsync(buffer.AsMemory(offset, count)).AsTask().GetAwaiter().GetResult();
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override Task FlushAsync(CancellationToken ct) => Task.CompletedTask;
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+    }
+}

--- a/tests/Zeus.Server.Tests/DxClusterConfigStoreTests.cs
+++ b/tests/Zeus.Server.Tests/DxClusterConfigStoreTests.cs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// DxClusterConfigStore — single-row LiteDB persistence via the shared lease.
+// Mirrors PttSettingsStoreTests' temp-DB pattern (explicit dbPathOverride so the
+// suite never collides on the shared zeus-prefs.db). Round-trips every field,
+// confirms the default-off (no row → null) contract, and that values survive a
+// store re-open on the same path.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class DxClusterConfigStoreTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-dxcluster-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+        try { if (File.Exists(_dbPath + "-log")) File.Delete(_dbPath + "-log"); } catch { }
+    }
+
+    [Fact]
+    public void Get_FreshDb_ReturnsNull()
+    {
+        using var store = new DxClusterConfigStore(NullLogger<DxClusterConfigStore>.Instance, _dbPath);
+        Assert.Null(store.Get());
+    }
+
+    [Fact]
+    public void SetGet_RoundTripsAllFields()
+    {
+        using var store = new DxClusterConfigStore(NullLogger<DxClusterConfigStore>.Instance, _dbPath);
+        var cfg = new DxClusterConfig(
+            Enabled: true,
+            Host: "dxc.example.org",
+            Port: 7300,
+            Callsign: "K1ABC",
+            Password: "s3cret",
+            LoginCommands: "set/filter on\nsh/dx",
+            AutoConnect: true);
+
+        store.Set(cfg);
+        var got = store.Get();
+
+        Assert.NotNull(got);
+        Assert.True(got!.Enabled);
+        Assert.Equal("dxc.example.org", got.Host);
+        Assert.Equal(7300, got.Port);
+        Assert.Equal("K1ABC", got.Callsign);
+        Assert.Equal("s3cret", got.Password);
+        Assert.Equal("set/filter on\nsh/dx", got.LoginCommands);
+        Assert.True(got.AutoConnect);
+    }
+
+    [Fact]
+    public void Set_Twice_UpdatesSingleRow()
+    {
+        using var store = new DxClusterConfigStore(NullLogger<DxClusterConfigStore>.Instance, _dbPath);
+        store.Set(new DxClusterConfig(Enabled: true, Host: "a", Port: 1, Callsign: "K1A"));
+        store.Set(new DxClusterConfig(Enabled: false, Host: "b", Port: 2, Callsign: "K2B"));
+
+        var got = store.Get();
+        Assert.NotNull(got);
+        Assert.False(got!.Enabled);
+        Assert.Equal("b", got.Host);
+        Assert.Equal(2, got.Port);
+        Assert.Equal("K2B", got.Callsign);
+    }
+
+    [Fact]
+    public void Config_PersistsAcrossReopen()
+    {
+        using (var store = new DxClusterConfigStore(NullLogger<DxClusterConfigStore>.Instance, _dbPath))
+        {
+            store.Set(new DxClusterConfig(
+                Enabled: true, Host: "host", Port: 7373, Callsign: "K1ABC", AutoConnect: true));
+        }
+
+        using (var reopened = new DxClusterConfigStore(NullLogger<DxClusterConfigStore>.Instance, _dbPath))
+        {
+            var got = reopened.Get();
+            Assert.NotNull(got);
+            Assert.True(got!.Enabled);
+            Assert.Equal("host", got.Host);
+            Assert.True(got.AutoConnect);
+        }
+    }
+}

--- a/tests/Zeus.Server.Tests/DxClusterHandshakeTests.cs
+++ b/tests/Zeus.Server.Tests/DxClusterHandshakeTests.cs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+
+using Zeus.Server.DxCluster;
+
+namespace Zeus.Server.Tests;
+
+public class DxClusterHandshakeTests
+{
+    [Fact]
+    public void SendsCallsign_OnLoginPrompt()
+    {
+        var hs = new DxClusterHandshake("K1ABC", password: null, loginCommands: null);
+        Assert.Empty(hs.OnLine("Welcome to the cluster"));
+        var r = hs.OnLine("Please enter your call: ");
+        Assert.Equal(new[] { "K1ABC" }, r);
+        Assert.True(hs.CallsignSent);
+    }
+
+    [Theory]
+    [InlineData("login: ")]
+    [InlineData("Please enter your call:")]
+    [InlineData("enter your call")]
+    [InlineData("callsign:")]
+    [InlineData("Your call?")]
+    public void RecognisesCallPromptVariants(string prompt)
+    {
+        var hs = new DxClusterHandshake("K1ABC", null, null);
+        Assert.Equal(new[] { "K1ABC" }, hs.OnLine(prompt));
+    }
+
+    [Fact]
+    public void DoesNotResendCallsign()
+    {
+        var hs = new DxClusterHandshake("K1ABC", null, null);
+        Assert.Single(hs.OnLine("login:"));
+        // A second prompt must NOT re-send the callsign.
+        Assert.Empty(hs.OnLine("login:"));
+    }
+
+    [Fact]
+    public void SendsPassword_OnlyWhenConfiguredAndPrompted()
+    {
+        var hs = new DxClusterHandshake("K1ABC", "secret", null);
+        Assert.Equal(new[] { "K1ABC" }, hs.OnLine("login:"));
+        Assert.Equal(new[] { "secret" }, hs.OnLine("password: "));
+        // Idempotent.
+        Assert.Empty(hs.OnLine("password: "));
+    }
+
+    [Fact]
+    public void NoPasswordConfigured_PasswordPromptIgnored()
+    {
+        var hs = new DxClusterHandshake("K1ABC", password: null, loginCommands: null);
+        Assert.Equal(new[] { "K1ABC" }, hs.OnLine("login:"));
+        // Without a configured password we never send one even if prompted.
+        Assert.Empty(hs.OnLine("password: "));
+    }
+
+    [Fact]
+    public void SendsLoginCommands_OnceAfterLogin_NoPassword()
+    {
+        var hs = new DxClusterHandshake("K1ABC", null, new[] { "set/filter on", "sh/dx" });
+        Assert.Equal(new[] { "K1ABC" }, hs.OnLine("login:"));
+        // First post-login line triggers the configured commands, once.
+        Assert.Equal(new[] { "set/filter on", "sh/dx" }, hs.OnLine("K1ABC de NODE >"));
+        Assert.Empty(hs.OnLine("another line"));
+    }
+
+    [Fact]
+    public void SendsLoginCommands_OnlyAfterPassword_WhenPasswordRequired()
+    {
+        var hs = new DxClusterHandshake("K1ABC", "secret", new[] { "sh/dx" });
+        Assert.Equal(new[] { "K1ABC" }, hs.OnLine("login:"));
+        // Login commands must NOT fire before the password is sent.
+        Assert.Equal(new[] { "secret" }, hs.OnLine("password:"));
+        Assert.Equal(new[] { "sh/dx" }, hs.OnLine("node ready"));
+    }
+
+    [Fact]
+    public void EmptyCallsign_NeverSends()
+    {
+        var hs = new DxClusterHandshake("", null, null);
+        Assert.Empty(hs.OnLine("login:"));
+        Assert.False(hs.CallsignSent);
+    }
+
+    [Fact]
+    public void BlankLoginCommands_AreFilteredOut()
+    {
+        var hs = new DxClusterHandshake("K1ABC", null, new[] { "  ", "", "sh/dx", "  " });
+        hs.OnLine("login:");
+        Assert.Equal(new[] { "sh/dx" }, hs.OnLine("post-login"));
+    }
+}

--- a/tests/Zeus.Server.Tests/DxSpotLineParserTests.cs
+++ b/tests/Zeus.Server.Tests/DxSpotLineParserTests.cs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+
+using Zeus.Server.DxCluster;
+
+namespace Zeus.Server.Tests;
+
+public class DxSpotLineParserTests
+{
+    [Theory]
+    // Canonical DXSpider line.
+    [InlineData("DX de W3LPL:    14074.0  K1ABC        FT8  -12 dB         1432Z",
+        "W3LPL", "K1ABC", 14074000L, "FT8")]
+    // Integer frequency, CW.
+    [InlineData("DX de G3XYZ:     7025.0  DL1ABC       CW                  0901Z",
+        "G3XYZ", "DL1ABC", 7025000L, "CW")]
+    // AR-Cluster-style tighter spacing.
+    [InlineData("DX de N1XX: 21260.0 EA8XX SSB up 2 1700Z",
+        "N1XX", "EA8XX", 21260000L, "SSB")]
+    // FT4 derivation.
+    [InlineData("DX de JA1ABC:   7047.5  VK3XYZ  FT4 +03  2230Z",
+        "JA1ABC", "VK3XYZ", 7047500L, "FT4")]
+    // Portable / slashed calls on both ends.
+    [InlineData("DX de SV1XX/P:  10136.0  9A/DL1XX/MM   FT8         1010Z",
+        "SV1XX/P", "9A/DL1XX/MM", 10136000L, "FT8")]
+    // Six-digit MHz-band freq (VHF), no mode in comment → mode "".
+    [InlineData("DX de W2ABC:   144174.0  W3DEF        nice sig     1300Z",
+        "W2ABC", "W3DEF", 144174000L, "")]
+    public void TryParse_ValidLines_Extracts(string line, string spotter, string dx, long freqHz, string mode)
+    {
+        Assert.True(DxSpotLineParser.TryParse(line, out var spot));
+        Assert.Equal(spotter, spot.SpotterCall);
+        Assert.Equal(dx, spot.DxCall);
+        Assert.Equal(freqHz, spot.FreqHz);
+        Assert.Equal(mode, spot.Mode);
+    }
+
+    [Fact]
+    public void TryParse_StripsTrailingTimeFromComment()
+    {
+        Assert.True(DxSpotLineParser.TryParse(
+            "DX de W3LPL:    14074.0  K1ABC        FT8  -12 dB         1432Z", out var spot));
+        Assert.Equal("1432Z", spot.Time);
+        Assert.DoesNotContain("1432Z", spot.Comment);
+        Assert.Contains("FT8", spot.Comment);
+        Assert.Contains("-12 dB", spot.Comment);
+    }
+
+    [Fact]
+    public void TryParse_TrailingGridAfterTime_Ignored()
+    {
+        Assert.True(DxSpotLineParser.TryParse(
+            "DX de EA1XX:    14025.0  K1ABC   CW   1432Z FN42", out var spot));
+        Assert.Equal("1432Z", spot.Time);
+        Assert.Equal("CW", spot.Mode);
+    }
+
+    [Fact]
+    public void TryParse_NoTrailingTime_StillParses()
+    {
+        Assert.True(DxSpotLineParser.TryParse(
+            "DX de W3LPL:    14074.0  K1ABC   FT8", out var spot));
+        Assert.Equal("", spot.Time);
+        Assert.Equal("FT8", spot.Mode);
+        Assert.Equal("K1ABC", spot.DxCall);
+    }
+
+    [Fact]
+    public void TryParse_DecimalFreq_RoundsToInteger()
+    {
+        Assert.True(DxSpotLineParser.TryParse(
+            "DX de W1AW:     3573.1  K9XYZ   FT8   0000Z", out var spot));
+        Assert.Equal(3573100L, spot.FreqHz);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    // Login banner / MOTD.
+    [InlineData("Welcome to the W3LPL DX Cluster")]
+    [InlineData("Please enter your call: ")]
+    [InlineData("login: ")]
+    // Prompt.
+    [InlineData("W3LPL de K1ABC >")]
+    // Talk / announce lines (not DX spots).
+    [InlineData("To ALL de W3LPL: contest this weekend")]
+    [InlineData("WX de G3XYZ: raining here 1200Z")]
+    // WWV / WCY propagation bulletins.
+    [InlineData("WWV de VE7CC <18>:   SFI=120, A=7, K=2 1500Z")]
+    [InlineData("WCY de DK0WCY-1 <12> : K=1 expK=0 A=4 R=0 SFI=120 1200Z")]
+    // Malformed: no frequency.
+    [InlineData("DX de W3LPL: K1ABC nice signal 1432Z")]
+    // Malformed: DX call has no digit (looks like a word, not a call).
+    [InlineData("DX de W3LPL:  14074.0  CQ   calling   1432Z")]
+    // Frequency out of plausible range.
+    [InlineData("DX de W3LPL:  0.5  K1ABC   CW   1432Z")]
+    // Not a DX line at all.
+    [InlineData("set/filter on")]
+    [InlineData("73 de W3LPL")]
+    public void TryParse_NonSpotLines_Rejected(string? line)
+    {
+        Assert.False(DxSpotLineParser.TryParse(line, out _));
+    }
+
+    [Fact]
+    public void TryParse_CaseInsensitivePrefix()
+    {
+        // Some nodes lowercase the prefix.
+        Assert.True(DxSpotLineParser.TryParse(
+            "dx de w3lpl:  14074.0  k1abc  ft8  1432Z", out var spot));
+        Assert.Equal("W3LPL", spot.SpotterCall);
+        Assert.Equal("K1ABC", spot.DxCall);
+        Assert.Equal("FT8", spot.Mode);
+    }
+}

--- a/tests/Zeus.Server.Tests/Tci/SpotManagerTests.cs
+++ b/tests/Zeus.Server.Tests/Tci/SpotManagerTests.cs
@@ -151,4 +151,61 @@ public class SpotManagerTests
         Assert.Single(spots);
         Assert.Null(spots[0].Comment);
     }
+
+    [Fact]
+    public void AddSpot_PastCap_EvictsLeastRecentlySpotted()
+    {
+        // A DX-cluster firehose of unique callsigns must not accumulate without
+        // bound: the store is capped and evicts the least-recently-spotted call.
+        var manager = new SpotManager(maxSpots: 3);
+        manager.AddSpot("A1AA", "CW", 14000000, 0xFF000000);
+        manager.AddSpot("B2BB", "CW", 14001000, 0xFF000000);
+        manager.AddSpot("C3CC", "CW", 14002000, 0xFF000000);
+        manager.AddSpot("D4DD", "CW", 14003000, 0xFF000000); // evicts A1AA (oldest)
+
+        var spots = manager.GetAll();
+        Assert.Equal(3, spots.Length);
+        Assert.DoesNotContain(spots, s => s.Callsign == "A1AA");
+        Assert.Contains(spots, s => s.Callsign == "B2BB");
+        Assert.Contains(spots, s => s.Callsign == "C3CC");
+        Assert.Contains(spots, s => s.Callsign == "D4DD");
+    }
+
+    [Fact]
+    public void AddSpot_RespottingExisting_RefreshesRecency_DoesNotGrow()
+    {
+        var manager = new SpotManager(maxSpots: 3);
+        manager.AddSpot("A1AA", "CW", 14000000, 0xFF000000);
+        manager.AddSpot("B2BB", "CW", 14001000, 0xFF000000);
+        manager.AddSpot("C3CC", "CW", 14002000, 0xFF000000);
+
+        // Re-spot the oldest call — it becomes most-recent, so the NEXT add must
+        // evict B2BB (now the oldest), not A1AA.
+        manager.AddSpot("A1AA", "SSB", 14000500, 0xFF000000);
+        manager.AddSpot("D4DD", "CW", 14003000, 0xFF000000);
+
+        var spots = manager.GetAll();
+        Assert.Equal(3, spots.Length);
+        Assert.DoesNotContain(spots, s => s.Callsign == "B2BB");
+        Assert.Contains(spots, s => s.Callsign == "A1AA");
+        // The re-spot updated the value in place.
+        Assert.Equal("SSB", Assert.Single(spots, s => s.Callsign == "A1AA").Mode);
+    }
+
+    [Fact]
+    public void AddSpot_NeverExceedsCap_UnderFirehose()
+    {
+        var manager = new SpotManager(maxSpots: 50);
+        for (int i = 0; i < 5000; i++)
+            manager.AddSpot($"CALL{i}", "FT8", 14074000, 0xFF000000);
+
+        Assert.Equal(50, manager.GetAll().Length);
+    }
+
+    [Fact]
+    public void Ctor_NonPositiveCap_FallsBackToDefault()
+    {
+        Assert.Equal(SpotManager.DefaultMaxSpots, new SpotManager(0).MaxSpots);
+        Assert.Equal(SpotManager.DefaultMaxSpots, new SpotManager(-5).MaxSpots);
+    }
 }

--- a/tests/Zeus.Server.Tests/TelnetByteFilterTests.cs
+++ b/tests/Zeus.Server.Tests/TelnetByteFilterTests.cs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+
+using System.Text;
+using Zeus.Server.DxCluster;
+
+namespace Zeus.Server.Tests;
+
+public class TelnetByteFilterTests
+{
+    private static string Filter(params byte[][] chunks)
+    {
+        var f = new TelnetByteFilter();
+        var sink = new List<byte>();
+        foreach (var c in chunks)
+            f.Process(c, c.Length, sink);
+        return Encoding.Latin1.GetString(sink.ToArray());
+    }
+
+    [Fact]
+    public void PlainText_PassesThrough()
+    {
+        Assert.Equal("DX de W3LPL", Filter(Encoding.Latin1.GetBytes("DX de W3LPL")));
+    }
+
+    [Fact]
+    public void Strips_DoWillNegotiation()
+    {
+        // IAC DO ECHO (FF FD 01) + "hi" + IAC WILL SGA (FF FB 03)
+        var bytes = new byte[] { 0xFF, 0xFD, 0x01, (byte)'h', (byte)'i', 0xFF, 0xFB, 0x03 };
+        Assert.Equal("hi", Filter(bytes));
+    }
+
+    [Fact]
+    public void EscapedIac_YieldsLiteralFF()
+    {
+        // IAC IAC (FF FF) → a single literal 0xFF data byte.
+        var bytes = new byte[] { (byte)'a', 0xFF, 0xFF, (byte)'b' };
+        var result = Filter(bytes);
+        Assert.Equal(3, result.Length);
+        Assert.Equal('a', result[0]);
+        Assert.Equal((char)0xFF, result[1]);
+        Assert.Equal('b', result[2]);
+    }
+
+    [Fact]
+    public void Strips_Subnegotiation()
+    {
+        // IAC SB <opt> <data...> IAC SE  (FF FA ... FF F0)
+        var bytes = new byte[] { (byte)'x', 0xFF, 0xFA, 0x18, 0x00, (byte)'A', (byte)'B', 0xFF, 0xF0, (byte)'y' };
+        Assert.Equal("xy", Filter(bytes));
+    }
+
+    [Fact]
+    public void Sequence_SplitAcrossChunks_HandledStatefully()
+    {
+        // IAC at end of one chunk, DO ECHO continuing in the next.
+        var c1 = new byte[] { (byte)'a', 0xFF };
+        var c2 = new byte[] { 0xFD, 0x01, (byte)'b' };
+        Assert.Equal("ab", Filter(c1, c2));
+    }
+}

--- a/zeus-web/src/api/dxcluster.ts
+++ b/zeus-web/src/api/dxcluster.ts
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+import { ApiError } from './client';
+
+export type DxClusterConnectionState =
+  | 'Disconnected'
+  | 'Connecting'
+  | 'Connected'
+  | 'Reconnecting';
+
+export type DxClusterStatus = {
+  enabled: boolean;
+  host: string;
+  port: number;
+  callsign: string;
+  hasPassword: boolean;
+  loginCommands: string;
+  autoConnect: boolean;
+  state: DxClusterConnectionState;
+  spotsReceived: number;
+  lastSpotCallsign: string | null;
+  error: string | null;
+};
+
+export type DxClusterConfig = {
+  enabled: boolean;
+  host: string;
+  port: number;
+  callsign: string;
+  password: string;
+  loginCommands: string;
+  autoConnect: boolean;
+};
+
+const STATES: DxClusterConnectionState[] = [
+  'Disconnected',
+  'Connecting',
+  'Connected',
+  'Reconnecting',
+];
+
+function normalizeState(raw: unknown): DxClusterConnectionState {
+  if (typeof raw === 'string' && (STATES as string[]).includes(raw)) {
+    return raw as DxClusterConnectionState;
+  }
+  // The enum may arrive numeric depending on serializer config.
+  if (typeof raw === 'number' && raw >= 0 && raw < STATES.length) {
+    return STATES[raw] ?? 'Disconnected';
+  }
+  return 'Disconnected';
+}
+
+export function normalizeStatus(raw: unknown): DxClusterStatus {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  return {
+    enabled: Boolean(r.enabled),
+    host: typeof r.host === 'string' ? r.host : '',
+    port: typeof r.port === 'number' ? r.port : 7373,
+    callsign: typeof r.callsign === 'string' ? r.callsign : '',
+    hasPassword: Boolean(r.hasPassword),
+    loginCommands: typeof r.loginCommands === 'string' ? r.loginCommands : '',
+    autoConnect: Boolean(r.autoConnect),
+    state: normalizeState(r.state),
+    spotsReceived: typeof r.spotsReceived === 'number' ? r.spotsReceived : 0,
+    lastSpotCallsign:
+      typeof r.lastSpotCallsign === 'string' && r.lastSpotCallsign.length > 0
+        ? r.lastSpotCallsign
+        : null,
+    error: typeof r.error === 'string' && r.error.length > 0 ? r.error : null,
+  };
+}
+
+async function jsonFetch<T>(
+  input: RequestInfo,
+  init: RequestInit | undefined,
+  parse: (raw: unknown) => T,
+): Promise<T> {
+  const res = await fetch(input, init);
+  if (!res.ok) {
+    let message = `${res.status} ${res.statusText}`;
+    try {
+      const body = (await res.json()) as unknown;
+      if (
+        body &&
+        typeof body === 'object' &&
+        'error' in body &&
+        typeof (body as { error: unknown }).error === 'string'
+      ) {
+        message = (body as { error: string }).error;
+      }
+    } catch {
+      /* non-JSON */
+    }
+    throw new ApiError(res.status, message);
+  }
+  return parse((await res.json()) as unknown);
+}
+
+export function getDxClusterStatus(signal?: AbortSignal): Promise<DxClusterStatus> {
+  return jsonFetch('/api/dxcluster/status', { signal }, normalizeStatus);
+}
+
+export function putDxClusterConfig(cfg: DxClusterConfig, signal?: AbortSignal): Promise<DxClusterStatus> {
+  return jsonFetch(
+    '/api/dxcluster/config',
+    {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(cfg),
+      signal,
+    },
+    normalizeStatus,
+  );
+}
+
+export function connectDxCluster(signal?: AbortSignal): Promise<DxClusterStatus> {
+  return jsonFetch('/api/dxcluster/connect', { method: 'POST', signal }, normalizeStatus);
+}
+
+export function disconnectDxCluster(signal?: AbortSignal): Promise<DxClusterStatus> {
+  return jsonFetch('/api/dxcluster/disconnect', { method: 'POST', signal }, normalizeStatus);
+}

--- a/zeus-web/src/components/DxClusterSettingsPanel.test.tsx
+++ b/zeus-web/src/components/DxClusterSettingsPanel.test.tsx
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// DxClusterSettingsPanel — Network-tab DX-cluster section test. Verifies the
+// default-OFF form, that SAVE persists the operator-entered host/callsign/port,
+// and that CONNECT calls the store. The harness import installs the localStorage
+// polyfill + act flag before the store loads; store methods are stubbed so no
+// real fetch fires.
+
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { createElement } from 'react';
+import { act, render } from './meters/__tests__/harness';
+import { DxClusterSettingsPanel } from './DxClusterSettingsPanel';
+import { useDxClusterStore } from '../state/dxcluster-store';
+import type { DxClusterConfig } from '../api/dxcluster';
+
+const OFF: DxClusterConfig = {
+  enabled: false,
+  host: '',
+  port: 7373,
+  callsign: '',
+  password: '',
+  loginCommands: '',
+  autoConnect: false,
+};
+
+function setInputValue(input: HTMLInputElement | HTMLTextAreaElement, value: string) {
+  const proto =
+    input instanceof HTMLTextAreaElement
+      ? window.HTMLTextAreaElement.prototype
+      : window.HTMLInputElement.prototype;
+  const setter = Object.getOwnPropertyDescriptor(proto, 'value')!.set!;
+  act(() => {
+    setter.call(input, value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+}
+
+function clickByText(container: HTMLElement, text: string) {
+  const btn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === text);
+  expect(btn, `button "${text}"`).toBeTruthy();
+  act(() => (btn as HTMLButtonElement).click());
+}
+
+describe('DxClusterSettingsPanel', () => {
+  beforeEach(() => {
+    act(() => {
+      useDxClusterStore.setState({
+        config: { ...OFF },
+        status: null,
+        refreshStatus: async () => {},
+        saveConfig: async () => ({
+          ...OFF,
+          hasPassword: false,
+          state: 'Disconnected',
+          spotsReceived: 0,
+          lastSpotCallsign: null,
+          error: null,
+        }),
+        connect: async () => ({
+          ...OFF,
+          hasPassword: false,
+          state: 'Connecting',
+          spotsReceived: 0,
+          lastSpotCallsign: null,
+          error: null,
+        }),
+        disconnect: async () => ({
+          ...OFF,
+          hasPassword: false,
+          state: 'Disconnected',
+          spotsReceived: 0,
+          lastSpotCallsign: null,
+          error: null,
+        }),
+      } as never);
+    });
+  });
+
+  it('renders the DX cluster section, default disabled', () => {
+    const { container, unmount } = render(createElement(DxClusterSettingsPanel));
+    expect(container.textContent).toContain('DX CLUSTER (TELNET)');
+    const enabled = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(enabled.checked).toBe(false);
+    unmount();
+  });
+
+  it('SAVE persists the operator-entered host/port/callsign', () => {
+    const saveConfig = vi.fn(async () => ({
+      ...OFF,
+      hasPassword: false,
+      state: 'Disconnected' as const,
+      spotsReceived: 0,
+      lastSpotCallsign: null,
+      error: null,
+    }));
+    act(() => useDxClusterStore.setState({ saveConfig } as never));
+
+    const { container, unmount } = render(createElement(DxClusterSettingsPanel));
+    const enabled = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    act(() => enabled.click());
+
+    setInputValue(container.querySelector('input[placeholder="dxc.example.org"]') as HTMLInputElement, 'dxc.example.org');
+    setInputValue(container.querySelector('input[type="number"]') as HTMLInputElement, '7300');
+    setInputValue(container.querySelector('input[placeholder="K1ABC"]') as HTMLInputElement, 'k1abc');
+
+    clickByText(container, 'SAVE');
+    expect(saveConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: true,
+        host: 'dxc.example.org',
+        port: 7300,
+        callsign: 'K1ABC',
+      }),
+    );
+    unmount();
+  });
+
+  it('CONNECT calls the store connect action', () => {
+    const connect = vi.fn(async () => ({
+      ...OFF,
+      hasPassword: false,
+      state: 'Connecting' as const,
+      spotsReceived: 0,
+      lastSpotCallsign: null,
+      error: null,
+    }));
+    act(() =>
+      useDxClusterStore.setState({ config: { ...OFF, enabled: true }, connect } as never),
+    );
+
+    const { container, unmount } = render(createElement(DxClusterSettingsPanel));
+    clickByText(container, 'CONNECT');
+    expect(connect).toHaveBeenCalled();
+    unmount();
+  });
+});

--- a/zeus-web/src/components/DxClusterSettingsPanel.test.tsx
+++ b/zeus-web/src/components/DxClusterSettingsPanel.test.tsx
@@ -115,6 +115,36 @@ describe('DxClusterSettingsPanel', () => {
     unmount();
   });
 
+  it('SAVE with an out-of-range port surfaces an error and does not persist', async () => {
+    const saveConfig = vi.fn(async () => ({
+      ...OFF,
+      hasPassword: false,
+      state: 'Disconnected' as const,
+      spotsReceived: 0,
+      lastSpotCallsign: null,
+      error: null,
+    }));
+    act(() => useDxClusterStore.setState({ saveConfig } as never));
+
+    const { container, unmount } = render(createElement(DxClusterSettingsPanel));
+    setInputValue(container.querySelector('input[placeholder="dxc.example.org"]') as HTMLInputElement, 'dxc.example.org');
+    setInputValue(container.querySelector('input[type="number"]') as HTMLInputElement, '99999');
+
+    clickByText(container, 'SAVE');
+    // The submit handler is async; flush its synchronous state update to the DOM.
+    await act(async () => {});
+    expect(saveConfig).not.toHaveBeenCalled();
+    expect(container.textContent).toContain('Port must be a whole number between 1 and 65535.');
+
+    // Editing the port clears the error, and a valid value now saves.
+    setInputValue(container.querySelector('input[type="number"]') as HTMLInputElement, '7300');
+    expect(container.textContent).not.toContain('Port must be a whole number');
+    clickByText(container, 'SAVE');
+    await act(async () => {});
+    expect(saveConfig).toHaveBeenCalledWith(expect.objectContaining({ port: 7300 }));
+    unmount();
+  });
+
   it('CONNECT calls the store connect action', () => {
     const connect = vi.fn(async () => ({
       ...OFF,

--- a/zeus-web/src/components/DxClusterSettingsPanel.tsx
+++ b/zeus-web/src/components/DxClusterSettingsPanel.tsx
@@ -50,6 +50,7 @@ export function DxClusterSettingsPanel() {
   const [autoConnect, setAutoConnect] = useState(config.autoConnect);
   const [saving, setSaving] = useState(false);
   const [busy, setBusy] = useState(false);
+  const [portError, setPortError] = useState<string | null>(null);
 
   // Rehydrate the form when the store syncs from the backend.
   useEffect(() => {
@@ -67,10 +68,16 @@ export function DxClusterSettingsPanel() {
 
   async function onSave(e: React.FormEvent) {
     e.preventDefault();
+    const portNum = Number(port);
+    if (!Number.isInteger(portNum) || portNum <= 0 || portNum >= 65536) {
+      // Don't silently swallow an out-of-range / pasted value — tell the operator
+      // why SAVE did nothing instead of leaving a dead button.
+      setPortError('Port must be a whole number between 1 and 65535.');
+      return;
+    }
+    setPortError(null);
     setSaving(true);
     try {
-      const portNum = Number(port);
-      if (!Number.isFinite(portNum) || portNum <= 0 || portNum >= 65536) return;
       await saveConfig({
         enabled,
         host: host.trim(),
@@ -135,7 +142,11 @@ export function DxClusterSettingsPanel() {
         callsign; add a password only if your cluster requires one.
       </div>
 
-      <form onSubmit={onSave} style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+      {/* noValidate: bypass the browser's native constraint-validation bubble for
+          the number field (its max would silently block submit and the operator
+          never learns why). We validate the port in onSave and surface an
+          in-app, in-palette message instead. */}
+      <form noValidate onSubmit={onSave} style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
         <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <input
             type="checkbox"
@@ -163,14 +174,21 @@ export function DxClusterSettingsPanel() {
           <input
             type="number"
             value={port}
-            onChange={(e) => setPort(e.target.value)}
+            onChange={(e) => {
+              setPort(e.target.value);
+              if (portError) setPortError(null);
+            }}
             min={1}
             max={65535}
-            style={inputStyle}
+            style={portError ? { ...inputStyle, borderColor: 'var(--tx)' } : inputStyle}
           />
-          <span style={{ fontSize: 10, color: 'var(--fg-3)' }}>
-            Default: 7373. Common cluster telnet ports are 7300, 7373, and 8000.
-          </span>
+          {portError ? (
+            <span style={{ fontSize: 10, color: 'var(--tx)' }}>{portError}</span>
+          ) : (
+            <span style={{ fontSize: 10, color: 'var(--fg-3)' }}>
+              Default: 7373. Common cluster telnet ports are 7300, 7373, and 8000.
+            </span>
+          )}
         </label>
 
         <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>

--- a/zeus-web/src/components/DxClusterSettingsPanel.tsx
+++ b/zeus-web/src/components/DxClusterSettingsPanel.tsx
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+import { useEffect, useState } from 'react';
+import { useDxClusterStore } from '../state/dxcluster-store';
+import type { DxClusterConnectionState } from '../api/dxcluster';
+
+const inputStyle: React.CSSProperties = {
+  padding: '6px 8px',
+  fontSize: 12,
+  fontFamily: 'monospace',
+  background: 'var(--bg-0)',
+  border: '1px solid var(--panel-border)',
+  borderRadius: 'var(--r-sm)',
+  color: 'var(--fg-0)',
+};
+
+function stateColor(state: DxClusterConnectionState): string {
+  switch (state) {
+    case 'Connected':
+      return 'var(--accent)';
+    case 'Connecting':
+    case 'Reconnecting':
+      return 'var(--power)';
+    default:
+      return 'var(--fg-3)';
+  }
+}
+
+export function DxClusterSettingsPanel() {
+  const config = useDxClusterStore((s) => s.config);
+  const status = useDxClusterStore((s) => s.status);
+  const saveConfig = useDxClusterStore((s) => s.saveConfig);
+  const connect = useDxClusterStore((s) => s.connect);
+  const disconnect = useDxClusterStore((s) => s.disconnect);
+
+  const [enabled, setEnabled] = useState(config.enabled);
+  const [host, setHost] = useState(config.host);
+  const [port, setPort] = useState(String(config.port));
+  const [callsign, setCallsign] = useState(config.callsign);
+  const [password, setPassword] = useState(config.password);
+  const [loginCommands, setLoginCommands] = useState(config.loginCommands);
+  const [autoConnect, setAutoConnect] = useState(config.autoConnect);
+  const [saving, setSaving] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  // Rehydrate the form when the store syncs from the backend.
+  useEffect(() => {
+    setEnabled(config.enabled);
+    setHost(config.host);
+    setPort(String(config.port));
+    setCallsign(config.callsign);
+    setLoginCommands(config.loginCommands);
+    setAutoConnect(config.autoConnect);
+  }, [config.enabled, config.host, config.port, config.callsign, config.loginCommands, config.autoConnect]);
+
+  const state: DxClusterConnectionState = status?.state ?? 'Disconnected';
+  const spotsReceived = status?.spotsReceived ?? 0;
+  const connected = state === 'Connected';
+
+  async function onSave(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      const portNum = Number(port);
+      if (!Number.isFinite(portNum) || portNum <= 0 || portNum >= 65536) return;
+      await saveConfig({
+        enabled,
+        host: host.trim(),
+        port: portNum,
+        callsign: callsign.trim().toUpperCase(),
+        password,
+        loginCommands,
+        autoConnect,
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function onConnect() {
+    setBusy(true);
+    try {
+      await connect();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onDisconnect() {
+    setBusy(true);
+    try {
+      await disconnect();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div style={{ maxWidth: 700 }}>
+      <h3
+        style={{
+          margin: '0 0 14px',
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: '0.12em',
+          textTransform: 'uppercase',
+          color: 'var(--fg-2)',
+        }}
+      >
+        DX CLUSTER (TELNET)
+      </h3>
+
+      <div
+        style={{
+          padding: 12,
+          marginBottom: 16,
+          fontSize: 11,
+          lineHeight: 1.5,
+          color: 'var(--fg-2)',
+          background: 'var(--bg-0)',
+          border: '1px solid var(--panel-border)',
+          borderRadius: 'var(--r-sm)',
+        }}
+      >
+        Connect directly to a Telnet DX cluster (DXSpider / AR-Cluster / CC-Cluster). Spots land on
+        the panadapter automatically — no Cluster-TCI bridge needed. Enter the cluster host and your
+        callsign; add a password only if your cluster requires one.
+      </div>
+
+      <form onSubmit={onSave} style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+        <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+            style={{ accentColor: 'var(--accent)' }}
+          />
+          <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--fg-1)' }}>Enabled</span>
+        </label>
+
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--fg-2)' }}>Host</span>
+          <input
+            type="text"
+            value={host}
+            onChange={(e) => setHost(e.target.value)}
+            spellCheck={false}
+            placeholder="dxc.example.org"
+            style={inputStyle}
+          />
+        </label>
+
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--fg-2)' }}>Port</span>
+          <input
+            type="number"
+            value={port}
+            onChange={(e) => setPort(e.target.value)}
+            min={1}
+            max={65535}
+            style={inputStyle}
+          />
+          <span style={{ fontSize: 10, color: 'var(--fg-3)' }}>
+            Default: 7373. Common cluster telnet ports are 7300, 7373, and 8000.
+          </span>
+        </label>
+
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--fg-2)' }}>Callsign</span>
+          <input
+            type="text"
+            value={callsign}
+            onChange={(e) => setCallsign(e.target.value)}
+            spellCheck={false}
+            placeholder="K1ABC"
+            style={{ ...inputStyle, textTransform: 'uppercase' }}
+          />
+          <span style={{ fontSize: 10, color: 'var(--fg-3)' }}>
+            Sent automatically when the cluster asks for your call.
+          </span>
+        </label>
+
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--fg-2)' }}>
+            Password <span style={{ color: 'var(--fg-3)', fontWeight: 400 }}>(optional)</span>
+          </span>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            spellCheck={false}
+            placeholder={status?.hasPassword ? '•••••••• (saved)' : 'leave blank if not required'}
+            autoComplete="off"
+            style={inputStyle}
+          />
+        </label>
+
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--fg-2)' }}>
+            Login commands <span style={{ color: 'var(--fg-3)', fontWeight: 400 }}>(optional, one per line)</span>
+          </span>
+          <textarea
+            value={loginCommands}
+            onChange={(e) => setLoginCommands(e.target.value)}
+            spellCheck={false}
+            rows={3}
+            placeholder={'set/filter on\nset/dx/extension'}
+            style={{ ...inputStyle, resize: 'vertical' }}
+          />
+          <span style={{ fontSize: 10, color: 'var(--fg-3)' }}>
+            Sent once after login (e.g. spot filters).
+          </span>
+        </label>
+
+        <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <input
+            type="checkbox"
+            checked={autoConnect}
+            onChange={(e) => setAutoConnect(e.target.checked)}
+            style={{ accentColor: 'var(--accent)' }}
+          />
+          <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--fg-1)' }}>
+            Connect automatically on startup
+          </span>
+        </label>
+
+        {status?.error && (
+          <div
+            style={{
+              padding: 10,
+              fontSize: 12,
+              color: 'var(--tx)',
+              background: 'rgba(230, 58, 43, 0.1)',
+              border: '1px solid var(--tx)',
+              borderRadius: 'var(--r-sm)',
+            }}
+          >
+            {status.error}
+          </div>
+        )}
+
+        <div
+          style={{
+            padding: 10,
+            background: 'var(--bg-0)',
+            border: '1px solid var(--panel-border)',
+            borderRadius: 'var(--r-sm)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            fontSize: 12,
+            color: 'var(--fg-1)',
+          }}
+        >
+          <span
+            style={{
+              width: 8,
+              height: 8,
+              borderRadius: '50%',
+              background: stateColor(state),
+              flexShrink: 0,
+            }}
+          />
+          <span style={{ color: 'var(--fg-2)' }}>Status:</span>
+          <span style={{ fontWeight: 600, color: stateColor(state) }}>{state}</span>
+          <span style={{ color: 'var(--fg-2)' }}>·</span>
+          <span style={{ color: 'var(--fg-2)' }}>Spots:</span>
+          <span style={{ fontFamily: 'monospace', fontWeight: 600 }}>{spotsReceived}</span>
+          {status?.lastSpotCallsign && (
+            <>
+              <span style={{ color: 'var(--fg-2)' }}>·</span>
+              <span style={{ color: 'var(--fg-2)' }}>Last:</span>
+              <span style={{ fontFamily: 'monospace', fontWeight: 600 }}>{status.lastSpotCallsign}</span>
+            </>
+          )}
+        </div>
+
+        <div style={{ display: 'flex', gap: 6 }}>
+          <button
+            type="button"
+            onClick={onConnect}
+            disabled={busy || connected || !enabled}
+            className="btn sm"
+          >
+            CONNECT
+          </button>
+          <button
+            type="button"
+            onClick={onDisconnect}
+            disabled={busy || state === 'Disconnected'}
+            className="btn sm"
+          >
+            DISCONNECT
+          </button>
+          <span style={{ flex: 1 }} />
+          <button type="submit" disabled={saving} className="btn sm active">
+            {saving ? 'SAVING…' : 'SAVE'}
+          </button>
+        </div>
+
+        <div style={{ fontSize: 10, lineHeight: 1.4, color: 'var(--fg-3)' }}>
+          Spots appear on the panadapter through the same overlay as TCI spots. Save your settings,
+          then Connect. Enabling “Connect automatically on startup” reconnects on the next launch.
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/zeus-web/src/components/NetworkSettingsPanel.tsx
+++ b/zeus-web/src/components/NetworkSettingsPanel.tsx
@@ -11,6 +11,7 @@
 import { CatSettingsPanel } from './CatSettingsPanel';
 import { CatSerialPortsPanel } from './CatSerialPortsPanel';
 import { TciSettingsPanel } from './TciSettingsPanel';
+import { DxClusterSettingsPanel } from './DxClusterSettingsPanel';
 import { WsjtxSettingsPanel } from './WsjtxSettingsPanel';
 import { SpottingSettingsPanel } from './SpottingSettingsPanel';
 
@@ -29,6 +30,8 @@ export function NetworkSettingsPanel() {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
       <TciSettingsPanel />
+      <div style={{ borderTop: '1px solid var(--panel-border)' }} />
+      <DxClusterSettingsPanel />
       <div style={{ borderTop: '1px solid var(--panel-border)' }} />
       <CatSettingsPanel />
       <div style={{ borderTop: '1px solid var(--panel-border)' }} />

--- a/zeus-web/src/state/dxcluster-store.test.ts
+++ b/zeus-web/src/state/dxcluster-store.test.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+import { describe, expect, it, vi } from 'vitest';
+import type { DxClusterStatus } from '../api/dxcluster';
+
+// Mock the REST layer BEFORE the store imports it — the store fires a one-shot
+// status probe on module load. The client defaults OFF (no network egress).
+const disabledStatus: DxClusterStatus = {
+  enabled: false,
+  host: '',
+  port: 7373,
+  callsign: '',
+  hasPassword: false,
+  loginCommands: '',
+  autoConnect: false,
+  state: 'Disconnected',
+  spotsReceived: 0,
+  lastSpotCallsign: null,
+  error: null,
+};
+
+vi.mock('../api/dxcluster', () => ({
+  getDxClusterStatus: vi.fn(async () => disabledStatus),
+  putDxClusterConfig: vi.fn(
+    async (cfg: { enabled: boolean; host: string; port: number; callsign: string }) => ({
+      ...disabledStatus,
+      enabled: cfg.enabled,
+      host: cfg.host,
+      port: cfg.port,
+      callsign: cfg.callsign,
+    }),
+  ),
+  connectDxCluster: vi.fn(async () => ({ ...disabledStatus, enabled: true, state: 'Connecting' })),
+  disconnectDxCluster: vi.fn(async () => ({ ...disabledStatus, state: 'Disconnected' })),
+}));
+
+import { useDxClusterStore } from './dxcluster-store';
+import * as api from '../api/dxcluster';
+
+describe('dxcluster-store', () => {
+  it('defaults to disabled (opt-in egress)', () => {
+    const { config } = useDxClusterStore.getState();
+    expect(config.enabled).toBe(false);
+    expect(config.port).toBe(7373);
+  });
+
+  it('never auto-PUTs config on load (no silent connect)', () => {
+    expect(api.putDxClusterConfig).not.toHaveBeenCalled();
+    expect(api.connectDxCluster).not.toHaveBeenCalled();
+  });
+
+  it('saveConfig pushes the operator choice to the backend', async () => {
+    const cfg = {
+      enabled: true,
+      host: 'dxc.example.org',
+      port: 7300,
+      callsign: 'K1ABC',
+      password: 'secret',
+      loginCommands: 'set/filter on',
+      autoConnect: true,
+    };
+    const status = await useDxClusterStore.getState().saveConfig(cfg);
+    expect(api.putDxClusterConfig).toHaveBeenCalledWith(cfg);
+    expect(status.enabled).toBe(true);
+    expect(status.host).toBe('dxc.example.org');
+    expect(useDxClusterStore.getState().config.callsign).toBe('K1ABC');
+    // The password is retained locally (the API never echoes it back).
+    expect(useDxClusterStore.getState().config.password).toBe('secret');
+  });
+
+  it('connect/disconnect update the live status', async () => {
+    const c = await useDxClusterStore.getState().connect();
+    expect(api.connectDxCluster).toHaveBeenCalled();
+    expect(c.state).toBe('Connecting');
+
+    const d = await useDxClusterStore.getState().disconnect();
+    expect(api.disconnectDxCluster).toHaveBeenCalled();
+    expect(d.state).toBe('Disconnected');
+  });
+});

--- a/zeus-web/src/state/dxcluster-store.ts
+++ b/zeus-web/src/state/dxcluster-store.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+import { create } from 'zustand';
+import {
+  getDxClusterStatus,
+  putDxClusterConfig,
+  connectDxCluster,
+  disconnectDxCluster,
+  type DxClusterConfig,
+  type DxClusterStatus,
+} from '../api/dxcluster';
+
+// The backend (DxClusterConfigStore on disk) is the source of truth. The form
+// initialises from /api/dxcluster/status once it arrives; this constant is only
+// a transient placeholder. The password is never returned by the API (only
+// hasPassword), so the local password field stays whatever the operator typed.
+const DEFAULT_CONFIG: DxClusterConfig = {
+  enabled: false,
+  host: '',
+  port: 7373,
+  callsign: '',
+  password: '',
+  loginCommands: '',
+  autoConnect: false,
+};
+
+export type DxClusterStoreState = {
+  config: DxClusterConfig;
+  status: DxClusterStatus | null;
+
+  refreshStatus: () => Promise<void>;
+  saveConfig: (cfg: DxClusterConfig) => Promise<DxClusterStatus>;
+  connect: () => Promise<DxClusterStatus>;
+  disconnect: () => Promise<DxClusterStatus>;
+};
+
+export const useDxClusterStore = create<DxClusterStoreState>((set, get) => ({
+  config: DEFAULT_CONFIG,
+  status: null,
+
+  refreshStatus: async () => {
+    try {
+      const status = await getDxClusterStatus();
+      // Sync non-secret config fields from the backend so the form never
+      // disagrees with disk. Preserve the locally-typed password (the API
+      // never echoes it back) and skip the sync if the operator has unsaved
+      // edits to the synced fields.
+      const current = get().config;
+      const synced =
+        current.enabled === status.enabled &&
+        current.host === status.host &&
+        current.port === status.port &&
+        current.callsign === status.callsign &&
+        current.loginCommands === status.loginCommands &&
+        current.autoConnect === status.autoConnect;
+      set({
+        status,
+        config: synced
+          ? current
+          : {
+              enabled: status.enabled,
+              host: status.host,
+              port: status.port,
+              callsign: status.callsign,
+              password: current.password,
+              loginCommands: status.loginCommands,
+              autoConnect: status.autoConnect,
+            },
+      });
+    } catch {
+      /* transient — next poll recovers */
+    }
+  },
+
+  saveConfig: async (cfg) => {
+    const status = await putDxClusterConfig(cfg);
+    set({ config: cfg, status });
+    return status;
+  },
+
+  connect: async () => {
+    const status = await connectDxCluster();
+    set({ status });
+    return status;
+  },
+
+  disconnect: async () => {
+    const status = await disconnectDxCluster();
+    set({ status });
+    return status;
+  },
+}));
+
+// Initial status probe + 3 s polling while the page is alive AND the cluster is
+// enabled. Status changes drive the panel's connection indicator / spot count.
+if (typeof window !== 'undefined') {
+  void useDxClusterStore.getState().refreshStatus();
+  window.setInterval(() => {
+    if (!useDxClusterStore.getState().config.enabled) return;
+    void useDxClusterStore.getState().refreshStatus();
+  }, 3000);
+}


### PR DESCRIPTION
Implements #1140 — a **native Telnet DX-cluster client** so Zeus connects directly to a DX cluster (DXSpider / AR-Cluster / CC-Cluster), logs in with your callsign (and a password if the cluster needs one), and drops the received spots onto the panadapter — **without the third-party Cluster-TCI bridge in between**.

## Architecture

Spots flow into the **exact same pipeline TCI spots already use** — there is **no parallel spot pipeline**:

`DxClusterClient` → `SpotManager.AddSpot(call, mode, freqHz, argb, comment)` → `SpotsChanged` → `SpotBroadcastService` (0x32 `SpotListFrame`) → `ws-client.ts` → `useSpotStore` → `SpotOverlay` on the panadapter.

The connection lifecycle, config persistence, status reporting and API surface **mirror the existing TCI/CAT seams**:

| Concern | TCI seam reused as the model | New DX-cluster equivalent |
|---|---|---|
| Spot ingest | `SpotManager.AddSpot` (called by `TciSession`) | `DxClusterClient` calls the same method |
| Config persistence | `TciConfigStore` (shared LiteDB lease) | `DxClusterConfigStore` (same shared lease, single row, default-off) |
| Config/status facade | `TciManagementService` | `DxClusterManagementService` (also `IHostedService`) |
| API shape | `/api/tci/status`,`/config`,`/test` | `/api/dxcluster/status`,`/config`,`/connect`,`/disconnect` |
| Settings UI | `TciSettingsPanel` in `NetworkSettingsPanel` | `DxClusterSettingsPanel` beside it |

### Backend (`Zeus.Server.Hosting/DxCluster/`)
- **`DxSpotLineParser`** — pure, no I/O. Parses `DX de <SPOTTER>:  <kHz>  <DXCALL>  <comment>  <HHMMZ>`, converts kHz→integer Hz, derives mode (FT8/FT4/CW/SSB/RTTY…) from the comment when reasonable, and rejects everything that isn't a spot (login banners, prompts, talk/announce, WWV/WCY bulletins, malformed lines). Handles DXSpider / AR-Cluster / CC-Cluster spacing variants.
- **`DxClusterHandshake`** — pure, idempotent login state machine: sends the callsign at a call/login prompt, the password at a password prompt **only if one is configured**, and optional post-login commands **once**. Never resends.
- **`TelnetByteFilter`** — stateful, pure stripper for Telnet IAC (`0xFF`) option-negotiation sequences (handles WILL/WONT/DO/DONT, subnegotiation, escaped `IAC IAC`, and sequences that straddle read boundaries).
- **`DxClusterClient`** — the connection service. **The socket sits behind an injectable seam** (`Func<host,port,ct,Task<Stream>>`): real TCP in production, a fake in-memory duplex in tests. Bounded exponential reconnect backoff (2 s → 60 s), clean cancellation on dispose, **no fire-and-forget loop left running past `StopAsync`/`Dispose`**. A single session over a given stream is `RunSessionAsync`, which the tests drive directly.
- **`DxClusterConfigStore`** — LiteDB via `SharedLiteDatabase.Acquire` (the shared lease, **never `new LiteDatabase`**), single-row, default everything off.
- **`DxClusterManagementService`** — `IHostedService`; **auto-connects on startup only when both `Enabled` and `AutoConnect` are persisted**, otherwise idle until an explicit connect.

### Contracts (additive only)
`DxClusterConfig`, `DxClusterStatus`, and a `DxClusterConnectionState` enum. No changes to any existing wire type.

### Frontend
`api/dxcluster.ts`, `state/dxcluster-store.ts`, and `DxClusterSettingsPanel.tsx` wired into the Network tab next to TCI. Form: enable, host, port, callsign, optional password, optional login commands, auto-connect, Connect/Disconnect + a live status indicator (state + spot count). Spots render through the existing overlay — **no new overlay code**. Design tokens only (no raw hex).

## Testing — injectable socket, no real network I/O
Per the Windows-CI rule (a real `ConnectAsync` in a test loop crashes the host), **no unit test opens a socket**. The connection test feeds *banner → login prompt → spot line* through a fake in-memory duplex stream and asserts the callsign was written back and a parsed spot reached `SpotManager`.

- `DxSpotLineParserTests` — real-world variants + malformed/non-spot rejection
- `DxClusterHandshakeTests` — prompt sequences, password present/absent, no duplicate sends
- `TelnetByteFilterTests` — IAC stripping incl. split-across-chunks
- `DxClusterConfigStoreTests` — round-trip via the shared lease (temp-DB pattern)
- `DxClusterClientTests` — full session over a fake duplex (login + password + IAC + EOF)
- `dxcluster-store.test.ts`, `DxClusterSettingsPanel.test.tsx` — store + panel

**Gates run locally:** `dotnet build Zeus.slnx` green; backend tests **2561 pass (0 fail)**; `npm run typecheck` clean; DX-cluster vitest **8/8 pass**.

## Cross-platform
`System.Net.Sockets`, `System.Threading.Channels`, `Latin1`, LiteDB shared lease — all portable. No platform-specific paths, clocks, or line-ending assumptions.

## PureSignal / RF
Untouched. This is a pure network/UI feature — nothing in the DSP/WDSP/TX/PA/protocol drive path.


## Audit fixes applied (commit 2)
Follow-up commit addresses the review's scaling defect and nits — the firehose now can't drive O(n^2) full-snapshot rebroadcasts on the socket-read thread:
- **Bounded spot store (LRU, default 1000):** cluster spots can no longer accumulate unbounded for a session; eviction also caps the per-broadcast payload. TCI (self-expiring) never hits the cap.
- **Coalesced broadcasts (300 ms):** `SpotsChanged` now just marks dirty; a timer flushes one serialise+broadcast per tick, off the read thread. New clients still get the cached snapshot on attach.
- **Precompiled mode regexes** in `DeriveMode` (no per-spot pattern allocation / cache churn).
- **Port validation:** an out-of-range/pasted port now surfaces an in-app message instead of a silent no-op (form uses `noValidate` so the JS validation, not the native bubble, owns the feedback).

## :red_circle: Decisions needing KB2UKA sign-off (DRAFT — do not merge)
1. **Default telnet port = 7373.** Common cluster ports are 7300 (DXSpider), 7373 (AR/CC), 8000. Picked 7373; operator-configurable. Confirm the default.
2. **Credential at rest.** Password is stored **plaintext in `zeus-prefs.db`**, consistent with the existing `CredentialStore` (QRZ) precedent in the same DB. Confirm acceptable.
3. **New Network settings section** (DX Cluster) — red-light per repo rules (Network tab + UX).
4. **Additive Contracts** (`DxClusterConfig`/`DxClusterStatus`/enum).
5. **Default spot colour** = Zeus accent blue (`#4A9EFF`) packed ARGB, A=0 (overlay treats as opaque). Not band/mode-coded.

Bench note: not yet tested against a live cluster on hardware — logic is covered by the fake-duplex session test; a real-cluster smoke is worth doing before merge.
