### PR TITLE
fix(audio): output device change no longer blocked by stale input device (#1128)

### DIFF
--- a/Zeus.Server.Hosting/NativeAudioDevicePlan.cs
+++ b/Zeus.Server.Hosting/NativeAudioDevicePlan.cs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2026 Brian Keating (EI6LF), Christian Suarez (N9WAR), and contributors.
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Decides which native audio device side(s) to (re)open in response to a
+/// device-change request, and which (if any) request a rejection.
+///
+/// <para>Background (#1128): the SPA's Audio Devices rail sends BOTH the input
+/// and the output device id on every change because the PUT contract has no
+/// "leave unchanged" sentinel — changing only the output device resends the
+/// currently-configured input id alongside the new output id. The old endpoint
+/// validated both ids against the live device list and rejected the WHOLE
+/// request if either was missing. So when an operator's previously-saved mic
+/// was unplugged (or the prefs DB was copied from another machine), every
+/// attempt to change the OUTPUT device was rejected with an input-device error
+/// and the dropdown snapped back — "Zeus will not allow me to use any of the
+/// windows sound devices for RX audio".</para>
+///
+/// <para>The fix: only validate and apply a side that is actually CHANGING
+/// relative to the current configuration. A carried-over (unchanged) id —
+/// even one that is now stale — must never block a change to the other side.
+/// As a free bonus, re-selecting the same device is a no-op rather than a
+/// needless device reopen (which would glitch audio).</para>
+/// </summary>
+internal static class NativeAudioDevicePlan
+{
+    internal readonly record struct Result(
+        bool ApplyInput,
+        bool ApplyOutput,
+        string? InputError,
+        string? OutputError);
+
+    /// <param name="hasMic">Whether a capture (mic) service is registered.</param>
+    /// <param name="currentInput">Currently-configured input device id (normalized), or null for OS default.</param>
+    /// <param name="requestedInput">Requested input device id (normalized), or null for OS default.</param>
+    /// <param name="availableInputIds">Ids present in the live capture device list.</param>
+    /// <param name="hasSink">Whether a playback (RX sink) service is registered.</param>
+    /// <param name="currentOutput">Currently-configured output device id (normalized), or null for OS default.</param>
+    /// <param name="requestedOutput">Requested output device id (normalized), or null for OS default.</param>
+    /// <param name="availableOutputIds">Ids present in the live playback device list.</param>
+    internal static Result Plan(
+        bool hasMic,
+        string? currentInput,
+        string? requestedInput,
+        IReadOnlyCollection<string> availableInputIds,
+        bool hasSink,
+        string? currentOutput,
+        string? requestedOutput,
+        IReadOnlyCollection<string> availableOutputIds)
+    {
+        var (applyInput, inputError) = PlanSide(
+            hasMic, currentInput, requestedInput, availableInputIds,
+            "inputDeviceId is not in the current native input device list");
+        var (applyOutput, outputError) = PlanSide(
+            hasSink, currentOutput, requestedOutput, availableOutputIds,
+            "outputDeviceId is not in the current native output device list");
+
+        return new Result(applyInput, applyOutput, inputError, outputError);
+    }
+
+    private static (bool Apply, string? Error) PlanSide(
+        bool hasService,
+        string? current,
+        string? requested,
+        IReadOnlyCollection<string> available,
+        string errorMessage)
+    {
+        // No service for this side (e.g. server host, or RX-only / TX-only
+        // builds): nothing to apply, and a supplied id is silently ignored
+        // rather than treated as an error.
+        if (!hasService) return (false, null);
+
+        // Unchanged relative to the current configuration → skip entirely.
+        // This is the load-bearing case: a stale-but-unchanged carried-over id
+        // must never reject the request or reopen a healthy device. (#1128)
+        if (string.Equals(requested, current, StringComparison.Ordinal))
+            return (false, null);
+
+        // Changing to OS default (null) always validates.
+        if (requested is null) return (true, null);
+
+        // Changing to a specific device: it must be in the live list.
+        foreach (var id in available)
+        {
+            if (string.Equals(id, requested, StringComparison.Ordinal))
+                return (true, null);
+        }
+        return (false, errorMessage);
+    }
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -4189,15 +4189,31 @@ public static class ZeusEndpoints
             return Results.BadRequest(new { error = $"native audio device enumeration unavailable: {ex.Message}" });
         }
 
-        if (inputDeviceId is not null && snapshot.Inputs.All(d => d.Id != inputDeviceId))
-            return Results.BadRequest(new { error = "inputDeviceId is not in the current native input device list" });
-        if (outputDeviceId is not null && snapshot.Outputs.All(d => d.Id != outputDeviceId))
-            return Results.BadRequest(new { error = "outputDeviceId is not in the current native output device list" });
+        // Only validate/apply the side that is actually changing. A carried-over
+        // (unchanged) id — even one now stale because its device was unplugged or
+        // the prefs DB came from another machine — must NOT block a change to the
+        // other side. This is the #1128 snap-back: selecting an OUTPUT device was
+        // rejected with an INPUT-device error because the previously-saved mic was
+        // gone, so RX audio could never be pointed at a real Windows device.
+        var plan = NativeAudioDevicePlan.Plan(
+            hasMic: mic is not null,
+            currentInput: mic?.ConfiguredInputDeviceId,
+            requestedInput: inputDeviceId,
+            availableInputIds: snapshot.Inputs.Select(d => d.Id).ToArray(),
+            hasSink: sink is not null,
+            currentOutput: sink?.ConfiguredOutputDeviceId,
+            requestedOutput: outputDeviceId,
+            availableOutputIds: snapshot.Outputs.Select(d => d.Id).ToArray());
 
-        if (mic is not null)
-            await mic.SetInputDeviceAsync(inputDeviceId, ct);
-        if (sink is not null)
-            await sink.SetOutputDeviceAsync(outputDeviceId, ct);
+        if (plan.InputError is not null)
+            return Results.BadRequest(new { error = plan.InputError });
+        if (plan.OutputError is not null)
+            return Results.BadRequest(new { error = plan.OutputError });
+
+        if (plan.ApplyInput)
+            await mic!.SetInputDeviceAsync(inputDeviceId, ct);
+        if (plan.ApplyOutput)
+            await sink!.SetOutputDeviceAsync(outputDeviceId, ct);
 
         return Results.Ok(BuildNativeAudioDevicesResponse(
             sink,

--- a/tests/Zeus.Server.Tests/NativeAudioDevicePlanTests.cs
+++ b/tests/Zeus.Server.Tests/NativeAudioDevicePlanTests.cs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace Zeus.Server.Tests;
+
+public sealed class NativeAudioDevicePlanTests
+{
+    private static readonly string[] Inputs = ["mic-a", "mic-b"];
+    private static readonly string[] Outputs = ["spk-a", "spk-b"];
+
+    // #1128 core case: operator changes ONLY the output while the previously
+    // configured input mic is gone. The unchanged stale input must not block
+    // the output change.
+    [Fact]
+    public void StaleUnchangedInput_DoesNotBlockOutputChange()
+    {
+        var plan = NativeAudioDevicePlan.Plan(
+            hasMic: true, currentInput: "mic-gone", requestedInput: "mic-gone", availableInputIds: Inputs,
+            hasSink: true, currentOutput: "spk-a", requestedOutput: "spk-b", availableOutputIds: Outputs);
+
+        Assert.False(plan.ApplyInput);
+        Assert.Null(plan.InputError);
+        Assert.True(plan.ApplyOutput);
+        Assert.Null(plan.OutputError);
+    }
+
+    [Fact]
+    public void ChangingInputToPresentDevice_Applies()
+    {
+        var plan = NativeAudioDevicePlan.Plan(
+            hasMic: true, currentInput: null, requestedInput: "mic-b", availableInputIds: Inputs,
+            hasSink: true, currentOutput: "spk-a", requestedOutput: "spk-a", availableOutputIds: Outputs);
+
+        Assert.True(plan.ApplyInput);
+        Assert.Null(plan.InputError);
+        Assert.False(plan.ApplyOutput);   // unchanged
+    }
+
+    [Fact]
+    public void ChangingInputToMissingDevice_Errors()
+    {
+        var plan = NativeAudioDevicePlan.Plan(
+            hasMic: true, currentInput: "mic-a", requestedInput: "mic-x", availableInputIds: Inputs,
+            hasSink: true, currentOutput: "spk-a", requestedOutput: "spk-a", availableOutputIds: Outputs);
+
+        Assert.False(plan.ApplyInput);
+        Assert.NotNull(plan.InputError);
+    }
+
+    [Fact]
+    public void ChangingToOsDefault_AlwaysApplies()
+    {
+        var plan = NativeAudioDevicePlan.Plan(
+            hasMic: true, currentInput: "mic-a", requestedInput: null, availableInputIds: Inputs,
+            hasSink: true, currentOutput: "spk-a", requestedOutput: null, availableOutputIds: Outputs);
+
+        Assert.True(plan.ApplyInput);
+        Assert.Null(plan.InputError);
+        Assert.True(plan.ApplyOutput);
+        Assert.Null(plan.OutputError);
+    }
+
+    [Fact]
+    public void NoOpRequest_AppliesNothing()
+    {
+        var plan = NativeAudioDevicePlan.Plan(
+            hasMic: true, currentInput: "mic-a", requestedInput: "mic-a", availableInputIds: Inputs,
+            hasSink: true, currentOutput: "spk-a", requestedOutput: "spk-a", availableOutputIds: Outputs);
+
+        Assert.False(plan.ApplyInput);
+        Assert.False(plan.ApplyOutput);
+        Assert.Null(plan.InputError);
+        Assert.Null(plan.OutputError);
+    }
+
+    // RX-only desktop builds (no mic service): a supplied input id is ignored
+    // rather than rejected, and the output change still goes through.
+    [Fact]
+    public void NoMicService_IgnoresInputAndAppliesOutput()
+    {
+        var plan = NativeAudioDevicePlan.Plan(
+            hasMic: false, currentInput: null, requestedInput: "mic-x", availableInputIds: [],
+            hasSink: true, currentOutput: null, requestedOutput: "spk-a", availableOutputIds: Outputs);
+
+        Assert.False(plan.ApplyInput);
+        Assert.Null(plan.InputError);
+        Assert.True(plan.ApplyOutput);
+    }
+
+    [Fact]
+    public void ChangingOutputToMissingDevice_Errors()
+    {
+        var plan = NativeAudioDevicePlan.Plan(
+            hasMic: true, currentInput: "mic-a", requestedInput: "mic-a", availableInputIds: Inputs,
+            hasSink: true, currentOutput: "spk-a", requestedOutput: "spk-x", availableOutputIds: Outputs);
+
+        Assert.False(plan.ApplyOutput);
+        Assert.NotNull(plan.OutputError);
+    }
+}


### PR DESCRIPTION
## Problem

Closes #1128 — operators report Zeus "will not allow me to use any of the Windows sound devices for RX audio." Selecting a different **output** device in the desktop **Audio Devices** rail snaps the dropdown back to its previous value and RX audio never moves to the chosen device.

## Root cause

The Audio Devices rail (`NativeAudioDevicesRail`) sends **both** the input and output device id on every change — the `PUT /api/audio/devices` contract has no "leave unchanged" sentinel, so changing only the output resends the currently-configured input mic alongside the new output.

`SetNativeAudioDevices` validated **both** ids against the live device list and returned `400` for the **whole** request if *either* was missing:

```csharp
if (inputDeviceId is not null && snapshot.Inputs.All(d => d.Id != inputDeviceId))
    return Results.BadRequest(...); // input error rejects an output-only change
```

So once the operator's saved mic was unplugged — or the prefs DB was copied from another machine (a known field scenario) — every output-device change was rejected with an *input*-device error, and the SPA reverted the dropdown to its last known-good value.

## Fix

Only validate and apply a device side that is **actually changing** relative to the current configuration. A carried-over (unchanged) id — even a stale one — can no longer block a change to the other side. Re-selecting the same device is now a no-op instead of a needless device reopen (which glitched audio).

The decision logic is extracted into a pure, unit-tested helper `NativeAudioDevicePlan.Plan(...)`.

No frontend change is required: the carried-over value now matches "unchanged" server-side and is skipped.

## Tests

- New `NativeAudioDevicePlanTests` (7 cases): stale-unchanged-input-doesn't-block-output, change-to-present/missing device, change-to-OS-default, no-op request, RX-only (no mic service). **7/7 pass.**
- `dotnet build` of `Zeus.Server.Hosting` is clean on the `develop` base.

## Scope notes

- Pure backend/persistence-wiring fix — no UX, visual, default-value, or wire-format change.
- **ASIO driver support** (the related standing ask) is intentionally **not** in this PR — it requires the non-redistributable Steinberg ASIO SDK at compile time and is Windows-only/exclusive-mode, so it needs a separate licensing/CI decision. Tracked separately.