### PR TITLE
fix(chat): self-heal stale QRZ session so chat relay stops 403-looping

### DIFF
--- a/Zeus.Server.Hosting/ChatService.cs
+++ b/Zeus.Server.Hosting/ChatService.cs
@@ -497,13 +497,35 @@ public sealed class ChatService : BackgroundService
     private async Task RunConnectionAsync(string callsign, string sessionKey, CancellationToken ct)
     {
         using var socket = new ClientWebSocket();
+        // Capture the HTTP status of a rejected upgrade so we can tell a stale
+        // QRZ session (403/401) apart from a transient transport failure.
+        socket.Options.CollectHttpResponseDetails = true;
         socket.Options.SetRequestHeader("X-QRZ-Session", sessionKey);
         socket.Options.SetRequestHeader("X-QRZ-Callsign", callsign);
         if (_relaySecret is not null)
             socket.Options.SetRequestHeader("Authorization", $"Bearer {_relaySecret}");
 
         _log.LogInformation("chat: connecting to relay {Url} as {Callsign}", _relayUrl, callsign);
-        await socket.ConnectAsync(new Uri(_relayUrl), ct);
+        try
+        {
+            await socket.ConnectAsync(new Uri(_relayUrl), ct);
+        }
+        catch (WebSocketException) when (
+            socket.HttpStatusCode is System.Net.HttpStatusCode.Forbidden
+                                  or System.Net.HttpStatusCode.Unauthorized)
+        {
+            // The relay validates our QRZ session on the upgrade and rejected it
+            // (403 = "qrz session invalid", 401 = "qrz auth required"). Our local
+            // 1-hour session cache still believes the key is live, so without
+            // evicting it the reconnect loop would replay the dead key forever.
+            // Drop it so the next attempt re-authenticates with QRZ.
+            _log.LogWarning(
+                "chat: relay rejected QRZ session ({Status}); forcing re-auth",
+                socket.HttpStatusCode);
+            await _qrz.InvalidateSessionAsync(ct);
+            throw new InvalidOperationException(
+                "QRZ session expired — re-authenticating");
+        }
 
         _socket = socket;
         _connected = true;

--- a/Zeus.Server.Hosting/QrzService.cs
+++ b/Zeus.Server.Hosting/QrzService.cs
@@ -234,6 +234,30 @@ public sealed class QrzService
         }
     }
 
+    /// <summary>
+    /// Drops the cached QRZ session key (keeping stored credentials and home
+    /// station) so the next <see cref="GetChatIdentityAsync"/> / lookup forces a
+    /// fresh login. Used when an out-of-band consumer of the session — the
+    /// ZeusChat relay validating the key on the WS upgrade — reports it invalid.
+    /// The inline "Invalid session" self-heal in <see cref="LookupInternalAsync"/>
+    /// only fires for direct lookups; a relay 401/403 has no other way to evict
+    /// the optimistically-cached key, which otherwise replays for up to an hour
+    /// and loops the chat connection on a dead session.
+    /// </summary>
+    public async Task InvalidateSessionAsync(CancellationToken ct = default)
+    {
+        await _gate.WaitAsync(ct);
+        try
+        {
+            _sessionKey = null;
+            _sessionExpiry = default;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
     public async Task LogoutAsync(CancellationToken ct = default)
     {
         _username = null;

--- a/tests/Zeus.Server.Tests/ChatServiceTests.cs
+++ b/tests/Zeus.Server.Tests/ChatServiceTests.cs
@@ -408,6 +408,40 @@ public class ChatServiceTests : IDisposable
             () => chat.AcceptFriendAsync("  ", CancellationToken.None));
     }
 
+    // ── QRZ session self-heal (relay 403/401 → drop the cached key) ──────────
+
+    // The chat path hands the relay a QRZ session key that the local cache
+    // optimistically trusts for an hour. When the relay rejects the upgrade
+    // (the key died QRZ-side before that hour elapsed), ChatService calls
+    // InvalidateSessionAsync so the *next* attempt re-authenticates instead of
+    // replaying the dead key into a 403 loop. This proves that contract.
+    [Fact]
+    public async Task InvalidateSessionAsync_forces_fresh_login_on_next_identity()
+    {
+        var handler = new StubQrzHandler();
+        var qrz = new QrzService(
+            new StubFactory(handler), NullLogger<QrzService>.Instance,
+            new CredentialStore(NullLogger<CredentialStore>.Instance, Path.Combine(_root, "creds2.db")));
+
+        var status = await qrz.LoginAsync("N9WAR", "pw", CancellationToken.None);
+        Assert.True(status.Connected);
+        Assert.Equal(1, handler.LoginCount);
+
+        // Cached: a second identity fetch must not re-hit the QRZ login endpoint.
+        var first = await qrz.GetChatIdentityAsync(CancellationToken.None);
+        Assert.NotNull(first);
+        Assert.Equal("N9WAR", first!.Value.Callsign);
+        Assert.Equal("SESSION123", first.Value.SessionKey);
+        Assert.Equal(1, handler.LoginCount);
+
+        // Relay rejected the key → evict it; the next fetch re-authenticates.
+        await qrz.InvalidateSessionAsync(CancellationToken.None);
+        var second = await qrz.GetChatIdentityAsync(CancellationToken.None);
+        Assert.NotNull(second);
+        Assert.Equal("SESSION123", second!.Value.SessionKey);
+        Assert.Equal(2, handler.LoginCount);
+    }
+
     // ── helpers ────────────────────────────────────────────────────────────
 
     private static ChatMessage Msg(int i) =>
@@ -436,5 +470,47 @@ public class ChatServiceTests : IDisposable
     private sealed class SingleClientFactory : IHttpClientFactory
     {
         public HttpClient CreateClient(string name) => new();
+    }
+
+    // Canned QRZ XML so the self-heal test can drive a real login → cache →
+    // re-login cycle without touching the network. Login requests (those with a
+    // username=) are counted; lookups return a minimal home-callsign record.
+    private sealed class StubQrzHandler : HttpMessageHandler
+    {
+        public int LoginCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var query = request.RequestUri!.Query;
+            string xml;
+            if (query.Contains("username=", StringComparison.Ordinal))
+            {
+                LoginCount++;
+                xml = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>"
+                    + "<QRZDatabase version=\"1.36\" xmlns=\"http://xmldata.qrz.com\">"
+                    + "<Session><Key>SESSION123</Key>"
+                    + "<SubExp>Wed Dec 31 23:59:59 2031</SubExp></Session></QRZDatabase>";
+            }
+            else
+            {
+                xml = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>"
+                    + "<QRZDatabase version=\"1.36\" xmlns=\"http://xmldata.qrz.com\">"
+                    + "<Session><Key>SESSION123</Key></Session>"
+                    + "<Callsign><call>N9WAR</call><fname>Test</fname></Callsign></QRZDatabase>";
+            }
+
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent(xml),
+            });
+        }
+    }
+
+    private sealed class StubFactory : IHttpClientFactory
+    {
+        private readonly HttpMessageHandler _handler;
+        public StubFactory(HttpMessageHandler handler) => _handler = handler;
+        public HttpClient CreateClient(string name) => new(_handler, disposeHandler: false);
     }
 }


### PR DESCRIPTION
## Symptom

ZeusChat fails to connect, surfacing:

> The server returned status code '403' when status code '101' was expected.

## Root cause

The Cloudflare relay validates the operator's QRZ session key on the WebSocket upgrade (`X-QRZ-Session` / `X-QRZ-Callsign`) and answers **403 "qrz session invalid or not logged in"** when QRZ reports the key dead. Confirmed against the live relay:

- `/health` → `200`
- `/chat` (no headers) → `401 qrz auth required`
- `/chat` (bad session) → **`403`** ← the reported error

The backend caches the QRZ session key for an hour (`AcquireSessionKeyAsync` sets `_sessionExpiry = +1h`) and optimistically trusts it. When QRZ invalidates the key early (logged in elsewhere, idle timeout, key rotation), `ChatService` caught the resulting `WebSocketException` generically and retried — pulling the **same cached dead key** and looping on the 403 for up to an hour.

Direct QRZ lookups already self-heal (`LookupInternalAsync` re-auths on "Invalid session"), but the chat path had no equivalent: a relay 403 never evicted the cached key.

## Fix

- New `QrzService.InvalidateSessionAsync` — drops the cached session key (keeps stored credentials + home station) so the next acquisition re-logs-in.
- `ChatService.RunConnectionAsync` sets `CollectHttpResponseDetails` and, on a `403`/`401` upgrade rejection, evicts the QRZ session before retrying. The next loop iteration re-authenticates and connects. Mirrors the self-heal that lookups already had.

If the operator is genuinely logged out of QRZ, the panel still shows "Login to QRZ" (unchanged) rather than the 403 loop.

## Verification

- `dotnet build Zeus.Server.Hosting` → clean.
- New test `InvalidateSessionAsync_forces_fresh_login_on_next_identity` drives login → cache (no re-hit) → invalidate → re-login with a canned-XML QRZ stub.
- `dotnet test --filter ChatServiceTests` → **25/25 passed**.

Scoped to a clean branch off `develop`; only 3 files changed (no relay/wire-format changes).