### PR TITLE
fix(web): hide your own panadapter callsign when you hide your frequency

### DIFF
--- a/zeus-web/src/components/ChatRosterOverlay.tsx
+++ b/zeus-web/src/components/ChatRosterOverlay.tsx
@@ -184,6 +184,8 @@ export function ChatRosterOverlay() {
   const connected = useChatStore((s) => s.connected);
   const roster = useChatStore((s) => s.roster);
   const openDm = useChatStore((s) => s.openDm);
+  const freqPublic = useChatStore((s) => s.freqPublic);
+  const myCallsign = useChatStore((s) => s.callsign);
   const show = useDisplaySettingsStore((s) => s.showChatRosterOverlay);
 
   const centerHz = useDisplayStore((s) => s.centerHz);
@@ -213,8 +215,16 @@ export function ChatRosterOverlay() {
     }
     const spanHz = width * hzPerPixel;
     const startHz = Number(centerHz) - spanHz / 2;
+    // Respect the eye toggle for your OWN marker. The relay strips your freq
+    // from every other operator's roster the moment you hide it, so they stop
+    // seeing your callsign here — but it always sends you your own freq (so the
+    // rest of the UI can use it), which would otherwise leave your callsign
+    // pinned to your own panadapter after you've hidden. Drop it so "hidden"
+    // means hidden everywhere, including your own view.
+    const mine = (myCallsign ?? '').toUpperCase();
     const inView = roster
       .filter((op) => typeof op.freqHz === 'number' && Number.isFinite(op.freqHz))
+      .filter((op) => freqPublic || !mine || op.callsign.toUpperCase() !== mine)
       .map((op) => ({ op, pct: ((op.freqHz! - startHz) / spanHz) * 100 }))
       .filter(({ pct }) => pct >= -2 && pct <= 102)
       .sort((a, b) => a.pct - b.pct);
@@ -233,7 +243,7 @@ export function ChatRosterOverlay() {
       laneLastPct[lane] = pct;
       return { op, pct, lane };
     });
-  }, [show, enabled, connected, roster, centerHz, hzPerPixel, width]);
+  }, [show, enabled, connected, roster, centerHz, hzPerPixel, width, freqPublic, myCallsign]);
 
   if (placed.length === 0) return null;
 


### PR DESCRIPTION
## Summary

The panadapter chat-roster overlay paints connected ZeusChat operators onto the panadapter at the frequency they're tuned to. Frequency hiding (the eye toggle, `freqPublic=false`) already works correctly for **other** viewers — the relay strips a hidden operator's `freq` from everyone else's roster (`rosterFor` in `chat-room.ts`), so with no `freqHz` the overlay can't place their marker.

The gap: the relay always sends an operator their **own** frequency (the `att.callsign === viewer` clause) so the rest of the UI can use it. That left your **own** callsign pinned to your **own** panadapter even after you hid your frequency — the one spot where "hidden" visibly leaked, and exactly what you notice when testing the toggle.

## Change

`ChatRosterOverlay.tsx` now gates the viewer's own marker on `freqPublic`:

- Reads `freqPublic` and `callsign` from the chat store.
- Adds `.filter((op) => freqPublic || !mine || op.callsign.toUpperCase() !== mine)` to the placement memo.
- Updates the `useMemo` deps so toggling visibility re-renders immediately.

When sharing, your marker still appears (a confirmation that friends can see you). When hidden, "hidden" now means hidden everywhere, including your own view. Other operators are unaffected — they're governed by the relay's existing freq-stripping. An admin with **see-all** armed still sees all callsigns, as intended.

## Testing

- `npx tsc --noEmit` passes clean.
- Pure data-filter on the overlay's memo; behaviour verified by tracing the relay → backend → store → overlay path.