### PR TITLE
fix(web): chat composer no longer starts as a tall multi-row box

### DIFF
--- a/zeus-web/src/layout/panels/ChatPanel.tsx
+++ b/zeus-web/src/layout/panels/ChatPanel.tsx
@@ -1823,12 +1823,17 @@ export function ChatPanel() {
     };
   }, [syncTabScroll]);
 
-  // Auto-grow textarea
+  // Auto-grow textarea. The empty field MUST stay a single row: a textarea's
+  // scrollHeight counts the (word-wrapped) placeholder, and ours wraps to two
+  // lines, so measuring scrollHeight here would inflate the empty composer to
+  // the placeholder's height — the "starts big until you click into it" bug.
+  // Clear the inline height when empty so rows=1 / minHeight govern; only grow
+  // to fit real content.
   useEffect(() => {
     const el = inputRef.current;
     if (!el) return;
     el.style.height = 'auto';
-    el.style.height = `${Math.min(el.scrollHeight, 90)}px`;
+    el.style.height = el.value ? `${Math.min(el.scrollHeight, 90)}px` : '';
   }, [draft]);
 
   // Hydrate on mount


### PR DESCRIPTION
## Problem

The chat message composer rendered as a **tall multi-row box** on open and only collapsed to a single row after the operator clicked/typed into it.

![reported state](the field shows two lines of placeholder with extra empty space)

## Root cause

The auto-grow effect in `ChatPanel.tsx` sized the textarea to `el.scrollHeight`. For an **empty** textarea, Chromium's `scrollHeight` includes the **word-wrapped placeholder** — and ours, *"Message everyone (Enter to send, Shift+Enter for newline)"*, wraps to two lines in that narrow column. So the empty field was inflated to fit the placeholder (~47px / 2 rows) instead of staying one row.

## Fix

Clear the inline height while the field is empty so `rows={1}` / `minHeight` govern the single-row baseline; only measure `scrollHeight` to grow once there's real content:

```js
el.style.height = el.value ? `${Math.min(el.scrollHeight, 90)}px` : '';
```

## Verification

Ran the exact composer markup + styles + resize logic in the live browser:

| Field state | Before | After |
|---|---|---|
| Empty (placeholder) | 47px (2 rows) ❌ | **30px (1 row)** ✅ |
| One line typed | 30px | 30px ✅ |
| Many lines | 90px (capped) | 90px (capped) ✅ |

Single row that grows with content, no click required.