### PR TITLE
fix(audio-suite): incremental VST engine chain edits (no full reload per edit)

### DIFF
--- a/Zeus.Server.Hosting/AudioProcessingModeService.cs
+++ b/Zeus.Server.Hosting/AudioProcessingModeService.cs
@@ -72,6 +72,16 @@ public sealed class AudioProcessingModeService : IHostedService
     // Refreshed from every chain event, and re-applied on each load_chain so a
     // plugin's voicing survives chain edits; profiles snapshot/restore this map.
     private Dictionary<string, string> _pluginStates = new(StringComparer.Ordinal);
+    // Serializes chain pushes (full load_chain + incremental diffs) so two
+    // back-to-back operator edits can't each diff against the same stale slot map
+    // and double-apply. Control-thread only; never held across a realtime op. Lock
+    // order: _chainSyncLock THEN _editorLock, never the reverse.
+    private readonly object _chainSyncLock = new();
+    // One-shot "the next chain push must be a full reload" flag, guarded by
+    // _editorLock. Set when plugin states are replaced wholesale (profile apply /
+    // startup replay) so the new voicing reaches the engine even when the chain
+    // ORDER is unchanged — an incremental diff would be empty and push nothing.
+    private bool _forceFullReload;
 
     public AudioProcessingModeService(
         AudioProcessingModeStore store,
@@ -117,7 +127,7 @@ public sealed class AudioProcessingModeService : IHostedService
     /// </summary>
     private void OnChainOrderChanged(IReadOnlyList<string> _)
     {
-        if (_engine.IsActive) LoadChainIntoEngine();
+        if (_engine.IsActive) SyncChainToEngine();
     }
 
     /// <summary>
@@ -502,7 +512,13 @@ public sealed class AudioProcessingModeService : IHostedService
     public void SetPluginStates(IReadOnlyDictionary<string, string> states)
     {
         lock (_editorLock)
+        {
             _pluginStates = new Dictionary<string, string>(states, StringComparer.Ordinal);
+            // Wholesale state replacement (profile apply / startup replay): force the
+            // next sync to be a full load_chain so the new voicing is pushed even if
+            // the chain order didn't change (an incremental diff would be a no-op).
+            _forceFullReload = true;
+        }
     }
 
     /// <summary>
@@ -521,47 +537,83 @@ public sealed class AudioProcessingModeService : IHostedService
     /// </summary>
     private void LoadChainIntoEngine()
     {
+        lock (_chainSyncLock) LoadChainCore(BuildDesiredSlots());
+    }
+
+    /// <summary>
+    /// Build the desired engine chain: the active Audio Suite VST3 plugins in chain
+    /// order, each with its absolute path, descriptor uid ("" selects the single /
+    /// first plugin in the file), and last-known opaque state ("" loads defaults).
+    /// Non-VST (native DSP) plugins are skipped — they never reach the engine.
+    /// </summary>
+    private List<VstChainDiff.DesiredSlot> BuildDesiredSlots()
+    {
+        var byId = new Dictionary<string, ActivatedPlugin>(StringComparer.Ordinal);
+        foreach (var p in _manager.Active) byId[p.Loaded.Manifest.Id] = p;
+
+        Dictionary<string, string> savedStates;
+        lock (_editorLock) savedStates = new(_pluginStates, StringComparer.Ordinal);
+
+        var desired = new List<VstChainDiff.DesiredSlot>();
+        foreach (var id in _chainOrder.CurrentOrder) // ordered, parked excluded
+        {
+            if (!byId.TryGetValue(id, out var p)) continue;
+            var vst3 = p.Loaded.Manifest.Audio?.Vst3Path;
+            if (string.IsNullOrEmpty(vst3)) continue; // non-VST (native DSP) plugin
+
+            var abs = Path.IsPathRooted(vst3) ? vst3 : Path.Combine(p.Loaded.PluginDir, vst3);
+            var uid = p.Loaded.Manifest.Audio?.Vst3Uid ?? string.Empty;
+            var state = savedStates.GetValueOrDefault(id, string.Empty);
+            desired.Add(new VstChainDiff.DesiredSlot(id, abs, uid, state));
+        }
+        return desired;
+    }
+
+    /// <summary>
+    /// Rebuild the id→slot / file→id / uid→id maps from the desired chain's final
+    /// post-push shape under <see cref="_editorLock"/>. A full reload clears the
+    /// optimistic open-editor set (the engine closes all editors on load_chain); an
+    /// incremental push keeps editors for the plugins that survive the edit.
+    /// </summary>
+    private void RebuildEngineMaps(IReadOnlyList<VstChainDiff.DesiredSlot> desired, bool full)
+    {
+        var map = new Dictionary<string, int>(StringComparer.Ordinal);
+        var fileToId = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var uidToId = new Dictionary<string, string>(StringComparer.Ordinal);
+        for (int i = 0; i < desired.Count; i++)
+        {
+            var d = desired[i];
+            map[d.Id] = i;
+            var key = NormalizePath(d.File);
+            if (key is not null) fileToId[key] = d.Id;
+            if (d.Uid.Length > 0) uidToId[d.Uid] = d.Id;
+        }
+        lock (_editorLock)
+        {
+            _idToEngineSlot = map;
+            _fileToId = fileToId;
+            _uidToId = uidToId;
+            if (full) _openEditors.Clear();
+            else _openEditors.IntersectWith(map.Keys);
+        }
+    }
+
+    /// <summary>
+    /// Full chain (re)load: clears the engine and parallel-loads every active VST3
+    /// plugin via one <c>load_chain</c>, restoring each plugin's saved state. Used
+    /// for engine activation, supervisor reconnect, and TX-dead recovery — the
+    /// cases where the engine is (or must be treated as) empty. Assumes
+    /// <see cref="_chainSyncLock"/> is held.
+    /// </summary>
+    private void LoadChainCore(List<VstChainDiff.DesiredSlot> desired)
+    {
         try
         {
-            var byId = new Dictionary<string, ActivatedPlugin>(StringComparer.Ordinal);
-            foreach (var p in _manager.Active) byId[p.Loaded.Manifest.Id] = p;
-
-            Dictionary<string, string> savedStates;
-            lock (_editorLock) savedStates = new(_pluginStates, StringComparer.Ordinal);
-
-            var slots = new List<object>();
-            var map = new Dictionary<string, int>(StringComparer.Ordinal);
-            var fileToId = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            var uidToId = new Dictionary<string, string>(StringComparer.Ordinal);
-            foreach (var id in _chainOrder.CurrentOrder) // ordered, parked excluded
-            {
-                if (!byId.TryGetValue(id, out var p)) continue;
-                var vst3 = p.Loaded.Manifest.Audio?.Vst3Path;
-                if (string.IsNullOrEmpty(vst3)) continue; // non-VST (native DSP) plugin
-
-                var abs = Path.IsPathRooted(vst3)
-                    ? vst3
-                    : Path.Combine(p.Loaded.PluginDir, vst3);
-                // uid selects ONE plugin from a shell file; "" => engine loads the
-                // single/first plugin in the file (describeFile fallback).
-                var uid = p.Loaded.Manifest.Audio?.Vst3Uid ?? string.Empty;
-                map[id] = slots.Count; // provisional: engine slot == load_chain position
-                var key = NormalizePath(abs);
-                if (key is not null) fileToId[key] = id;
-                if (uid.Length > 0) uidToId[uid] = id;
-                // Restore the plugin's saved voicing. "" => engine loads defaults.
-                var state = savedStates.GetValueOrDefault(id, string.Empty);
-                slots.Add(new { file = abs, identifier = uid, state });
-            }
-
-            lock (_editorLock)
-            {
-                _idToEngineSlot = map;
-                _fileToId = fileToId;
-                _uidToId = uidToId;
-                _openEditors.Clear(); // the engine closes all editors on load_chain
-            }
-
+            lock (_editorLock) _forceFullReload = false;
+            RebuildEngineMaps(desired, full: true);
+            var slots = desired
+                .Select(d => (object)new { file = d.File, identifier = d.Uid, state = d.State })
+                .ToList();
             _engine.SendCommand(new { cmd = "load_chain", chain = slots });
             _log.LogInformation(
                 "VST mode: loaded {Count} VST3 plugin(s) into the engine via load_chain.",
@@ -570,6 +622,47 @@ public sealed class AudioProcessingModeService : IHostedService
         catch (Exception ex)
         {
             _log.LogWarning(ex, "VST mode chain load threw; engine runs with whatever loaded.");
+        }
+    }
+
+    /// <summary>
+    /// Reconcile the engine's loaded chain with the operator's current chain after a
+    /// LIVE edit (add / remove / reorder / park). Diffs the desired chain against the
+    /// engine's current slots and emits only the needed incremental commands, so an
+    /// edit no longer re-instantiates the whole rack — the cause of multi-second
+    /// stalls and audible glitches on every edit. Falls back to a full
+    /// <see cref="LoadChainCore"/> when there's no current chain to diff against or a
+    /// wholesale state replacement is pending (profile apply / startup replay).
+    /// </summary>
+    private void SyncChainToEngine()
+    {
+        lock (_chainSyncLock)
+        {
+            try
+            {
+                bool forceFull;
+                lock (_editorLock) forceFull = _forceFullReload;
+
+                var desired = BuildDesiredSlots();
+
+                List<string> current;
+                lock (_editorLock)
+                    current = _idToEngineSlot.OrderBy(kv => kv.Value).Select(kv => kv.Key).ToList();
+
+                var cmds = forceFull ? null : VstChainDiff.Compute(current, desired);
+                if (cmds is null) { LoadChainCore(desired); return; }
+                if (cmds.Count == 0) return; // chains already match — skip a redundant reload
+
+                RebuildEngineMaps(desired, full: false);
+                foreach (var cmd in cmds) _engine.SendCommand(cmd);
+                _log.LogInformation(
+                    "VST mode: incremental chain update — {Ops} op(s), {Count} plugin(s).",
+                    cmds.Count, desired.Count);
+            }
+            catch (Exception ex)
+            {
+                _log.LogWarning(ex, "VST mode incremental chain sync threw; engine left as-is.");
+            }
         }
     }
 }

--- a/Zeus.Server.Hosting/RxVstEngineService.cs
+++ b/Zeus.Server.Hosting/RxVstEngineService.cs
@@ -32,6 +32,10 @@ public sealed class RxVstEngineService : IHostedService, IAsyncDisposable
     private readonly HashSet<string> _openEditors = new(StringComparer.Ordinal);
     private Dictionary<string, string> _pluginStates = new(StringComparer.Ordinal);
     private int _activeVstCount;
+    // One-shot "next sync must be a full load_chain" flag, guarded by _editorLock.
+    // Set when plugin states are replaced wholesale (RX profile apply) so the new
+    // voicing reaches the engine even when the chain order is unchanged.
+    private bool _forceFullReload;
 
     public RxVstEngineService(
         PluginManager manager,
@@ -71,6 +75,10 @@ public sealed class RxVstEngineService : IHostedService, IAsyncDisposable
     private void OnEngineReconnected()
     {
         _log.LogInformation("RX VST engine reconnected (restart #{Count}); replaying chain.", _engine.RestartCount);
+        // The relaunched engine comes back EMPTY while our slot map is still stale-
+        // populated from before the crash. Force a full load_chain so the incremental
+        // diff can't see "no change" and leave the recovered engine with no plugins.
+        lock (_editorLock) _forceFullReload = true;
         _ = SyncEngineAsync(_chainOrder.CurrentOrder, CancellationToken.None);
     }
 
@@ -224,7 +232,10 @@ public sealed class RxVstEngineService : IHostedService, IAsyncDisposable
     public void SetPluginStates(IReadOnlyDictionary<string, string> states)
     {
         lock (_editorLock)
+        {
             _pluginStates = new Dictionary<string, string>(states, StringComparer.Ordinal);
+            _forceFullReload = true;
+        }
     }
 
     private async Task SyncEngineAsync(IReadOnlyList<string> activeOrder, CancellationToken ct)
@@ -240,17 +251,18 @@ public sealed class RxVstEngineService : IHostedService, IAsyncDisposable
 
         try
         {
-            var chain = BuildEngineChain(activeOrder);
-            Volatile.Write(ref _activeVstCount, chain.Slots.Count);
+            var desired = BuildDesiredSlots(activeOrder);
+            Volatile.Write(ref _activeVstCount, desired.Count);
 
-            if (chain.Slots.Count == 0)
+            if (desired.Count == 0)
             {
                 _engine.Deactivate();
                 ClearEngineMaps();
                 return;
             }
 
-            var result = _engine.IsActive
+            bool wasActive = _engine.IsActive;
+            var result = wasActive
                 ? VstEngineStartResult.Started
                 : await _engine.ActivateAsync(ReadyTimeout, ct).ConfigureAwait(false);
 
@@ -263,17 +275,41 @@ public sealed class RxVstEngineService : IHostedService, IAsyncDisposable
                 return;
             }
 
-            lock (_editorLock)
+            bool forceFull;
+            lock (_editorLock) forceFull = _forceFullReload;
+
+            // Engine already running an edit (add / remove / reorder): diff against
+            // its current slots and emit only the needed incremental commands so we
+            // don't re-instantiate the whole RX rack and glitch live receive audio.
+            if (wasActive && !forceFull)
             {
-                _idToEngineSlot = chain.IdToSlot;
-                _fileToId = chain.FileToId;
-                _uidToId = chain.UidToId;
-                _openEditors.Clear();
+                List<string> current;
+                lock (_editorLock)
+                    current = _idToEngineSlot.OrderBy(kv => kv.Value).Select(kv => kv.Key).ToList();
+
+                var cmds = VstChainDiff.Compute(current, desired);
+                if (cmds is not null)
+                {
+                    if (cmds.Count == 0) return; // already in sync — nothing to push
+                    RebuildEngineMaps(desired, full: false);
+                    foreach (var cmd in cmds) _engine.SendCommand(cmd);
+                    _log.LogInformation(
+                        "RX VST engine: incremental chain update — {Ops} op(s), {Count} plugin(s).",
+                        cmds.Count, desired.Count);
+                    return;
+                }
+                // null → no usable current state; fall through to a full load.
             }
-            _engine.SendCommand(new { cmd = "load_chain", chain = chain.Slots });
+
+            lock (_editorLock) _forceFullReload = false;
+            RebuildEngineMaps(desired, full: true);
+            var slots = desired
+                .Select(d => (object)new { file = d.File, identifier = d.Uid, state = d.State })
+                .ToList();
+            _engine.SendCommand(new { cmd = "load_chain", chain = slots });
             _log.LogInformation(
                 "RX VST engine loaded {Count} receive VST3 plugin(s).",
-                chain.Slots.Count);
+                slots.Count);
         }
         catch (Exception ex)
         {
@@ -285,7 +321,11 @@ public sealed class RxVstEngineService : IHostedService, IAsyncDisposable
         }
     }
 
-    private EngineChain BuildEngineChain(IReadOnlyList<string> activeOrder)
+    /// <summary>
+    /// Build the desired RX engine chain: active <c>rx.*</c> VST3 inserts in chain
+    /// order, each with its absolute path, descriptor uid, and last-known state.
+    /// </summary>
+    private List<VstChainDiff.DesiredSlot> BuildDesiredSlots(IReadOnlyList<string> activeOrder)
     {
         var active = new Dictionary<string, ActivatedPlugin>(StringComparer.Ordinal);
         foreach (var p in _manager.Active)
@@ -294,11 +334,7 @@ public sealed class RxVstEngineService : IHostedService, IAsyncDisposable
         Dictionary<string, string> savedStates;
         lock (_editorLock) savedStates = new(_pluginStates, StringComparer.Ordinal);
 
-        var slots = new List<object>();
-        var idToSlot = new Dictionary<string, int>(StringComparer.Ordinal);
-        var fileToId = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        var uidToId = new Dictionary<string, string>(StringComparer.Ordinal);
-
+        var desired = new List<VstChainDiff.DesiredSlot>();
         foreach (var id in activeOrder)
         {
             if (!active.TryGetValue(id, out var plugin)) continue;
@@ -314,19 +350,38 @@ public sealed class RxVstEngineService : IHostedService, IAsyncDisposable
                 ? audio.Vst3Path
                 : Path.Combine(plugin.Loaded.PluginDir, audio.Vst3Path);
             var uid = audio.Vst3Uid ?? string.Empty;
-            var key = NormalizePath(abs);
-            idToSlot[id] = slots.Count;
-            if (key is not null) fileToId[key] = id;
-            if (uid.Length > 0) uidToId[uid] = id;
-            slots.Add(new
-            {
-                file = abs,
-                identifier = uid,
-                state = savedStates.GetValueOrDefault(id, string.Empty),
-            });
+            var state = savedStates.GetValueOrDefault(id, string.Empty);
+            desired.Add(new VstChainDiff.DesiredSlot(id, abs, uid, state));
         }
+        return desired;
+    }
 
-        return new EngineChain(slots, idToSlot, fileToId, uidToId);
+    /// <summary>
+    /// Rebuild the id→slot / file→id / uid→id maps from the desired chain's final
+    /// shape. A full reload clears the optimistic open-editor set (the engine closes
+    /// all editors on load_chain); an incremental push keeps the survivors' editors.
+    /// </summary>
+    private void RebuildEngineMaps(IReadOnlyList<VstChainDiff.DesiredSlot> desired, bool full)
+    {
+        var map = new Dictionary<string, int>(StringComparer.Ordinal);
+        var fileToId = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var uidToId = new Dictionary<string, string>(StringComparer.Ordinal);
+        for (int i = 0; i < desired.Count; i++)
+        {
+            var d = desired[i];
+            map[d.Id] = i;
+            var key = NormalizePath(d.File);
+            if (key is not null) fileToId[key] = d.Id;
+            if (d.Uid.Length > 0) uidToId[d.Uid] = d.Id;
+        }
+        lock (_editorLock)
+        {
+            _idToEngineSlot = map;
+            _fileToId = fileToId;
+            _uidToId = uidToId;
+            if (full) _openEditors.Clear();
+            else _openEditors.IntersectWith(map.Keys);
+        }
     }
 
     private void OnEngineEvent(JsonElement e)
@@ -419,10 +474,4 @@ public sealed class RxVstEngineService : IHostedService, IAsyncDisposable
         if (_ownsEngine)
             await _engine.DisposeAsync().ConfigureAwait(false);
     }
-
-    private sealed record EngineChain(
-        List<object> Slots,
-        Dictionary<string, int> IdToSlot,
-        Dictionary<string, string> FileToId,
-        Dictionary<string, string> UidToId);
 }

--- a/Zeus.Server.Hosting/VstChainDiff.cs
+++ b/Zeus.Server.Hosting/VstChainDiff.cs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+namespace Zeus.Server;
+
+/// <summary>
+/// Computes the minimal sequence of incremental VST-engine control commands that
+/// transforms the engine's CURRENT loaded chain into a DESIRED chain, so a live
+/// operator edit (add / remove / reorder a single plugin) no longer tears down
+/// and re-instantiates the entire chain via <c>load_chain</c>.
+///
+/// <para><b>Why this exists:</b> <c>load_chain</c> "clears + parallel-loads" every
+/// plugin (see <c>docs/designs/vst-engine-bridge-protocol.md</c> §2.1). Sending it
+/// on every chain edit means adding one VST re-instantiates the whole rack — slow
+/// when a heavy plugin (e.g. a Waves shell) is already loaded, and it drops every
+/// running plugin's internal DSP state (compressor envelopes, reverb tails,
+/// lookahead), punching an audible gap into TX/RX audio on each edit. The engine
+/// already exposes cheap incremental ops (<c>add_plugin</c> / <c>remove_plugin</c>
+/// / <c>move_plugin</c>); this just uses them.</para>
+///
+/// <para><b>Determinism:</b> control commands are dispatched serially on the
+/// engine's message thread in send order (protocol §2), so the indices each
+/// command carries are computed against a local simulation of the chain AS THE
+/// ENGINE WILL SEE IT when that command runs — independent of when the engine's
+/// asynchronous <c>chain</c> events arrive back. A botched sequence is self-healing
+/// anyway: the next <c>chain</c> event reconciles the id→slot map.</para>
+/// </summary>
+internal static class VstChainDiff
+{
+    /// <summary>One slot in the desired chain: the Zeus plugin id, its absolute
+    /// VST3 file path, the descriptor uid (empty = single-plugin file), and the
+    /// last-known opaque base64 state ("" = load defaults).</summary>
+    internal readonly record struct DesiredSlot(string Id, string File, string Uid, string State);
+
+    /// <summary>
+    /// Build the ordered incremental commands to turn <paramref name="current"/>
+    /// (engine slot order, by Zeus id) into <paramref name="desired"/>. Each item
+    /// is an anonymous object ready for <c>VstEngineController.SendCommand</c>.
+    ///
+    /// <para>Returns <c>null</c> when an incremental diff is unsafe / pointless and
+    /// the caller should fall back to a full <c>load_chain</c> (no current chain to
+    /// diff against, or a duplicate id in either list). Returns an EMPTY list when
+    /// the chains already match — the caller should then send nothing (skipping the
+    /// redundant reload that the old code performed unconditionally).</para>
+    /// </summary>
+    internal static List<object>? Compute(
+        IReadOnlyList<string> current,
+        IReadOnlyList<DesiredSlot> desired)
+    {
+        // Nothing loaded yet → a fresh load_chain is simpler and just as cheap.
+        if (current.Count == 0) return null;
+
+        // Duplicate ids would make index math ambiguous; reload is the safe path.
+        var currentSet = new HashSet<string>(current, StringComparer.Ordinal);
+        if (currentSet.Count != current.Count) return null;
+
+        var desiredById = new Dictionary<string, DesiredSlot>(StringComparer.Ordinal);
+        foreach (var d in desired) desiredById[d.Id] = d;
+        if (desiredById.Count != desired.Count) return null;
+
+        var cmds = new List<object>();
+        // working simulates the engine's chain after each emitted command.
+        var working = new List<string>(current);
+
+        // 1. Remove plugins that are no longer wanted. Walk high→low so each
+        //    removal leaves the indices of not-yet-visited entries unchanged.
+        var wantIds = new HashSet<string>(desiredById.Keys, StringComparer.Ordinal);
+        for (int i = working.Count - 1; i >= 0; i--)
+        {
+            if (!wantIds.Contains(working[i]))
+            {
+                cmds.Add(new { cmd = "remove_plugin", index = i });
+                working.RemoveAt(i);
+            }
+        }
+
+        // 2. Positional pass: fix each target slot in ascending order. Once slot i
+        //    is correct it is never touched again, so positions [0, i) always match
+        //    desired and `working` has at least i entries when we reach i.
+        for (int i = 0; i < desired.Count; i++)
+        {
+            var d = desired[i];
+            int j = working.IndexOf(d.Id);
+            if (j == i) continue;
+
+            if (j < 0)
+            {
+                // Missing → insert at its final index, then restore its voicing.
+                cmds.Add(new { cmd = "add_plugin", file = d.File, uid = d.Uid, index = i });
+                if (d.State.Length > 0)
+                    cmds.Add(new { cmd = "set_plugin_state", index = i, state = d.State });
+                working.Insert(i, d.Id);
+            }
+            else
+            {
+                // Present but out of place (j > i, since [0, i) is already locked).
+                cmds.Add(new { cmd = "move_plugin", from = j, to = i });
+                var moved = working[j];
+                working.RemoveAt(j);
+                working.Insert(i, moved);
+            }
+        }
+
+        return cmds;
+    }
+}

--- a/tests/Zeus.Server.Tests/VstChainDiffTests.cs
+++ b/tests/Zeus.Server.Tests/VstChainDiffTests.cs
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using System.Text.Json;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="VstChainDiff"/> — the incremental VST-engine chain
+/// diff that replaced the unconditional full <c>load_chain</c> on every edit.
+/// Each emitted command is validated two ways: representative op sequences are
+/// asserted directly, and an engine-semantics simulator applies the commands to
+/// the current chain and asserts the result equals the desired order (so the
+/// generated indices are provably correct, never out of range).
+/// </summary>
+public class VstChainDiffTests
+{
+    private static VstChainDiff.DesiredSlot Slot(string id, string state = "") =>
+        // uid == id so the simulator can map add_plugin back to a Zeus id.
+        new(id, File: "f_" + id, Uid: id, State: state);
+
+    private static List<VstChainDiff.DesiredSlot> Desired(params string[] ids)
+    {
+        var list = new List<VstChainDiff.DesiredSlot>();
+        foreach (var id in ids) list.Add(Slot(id));
+        return list;
+    }
+
+    /// <summary>Apply the emitted commands to <paramref name="current"/> using the
+    /// engine's documented slot semantics, returning the resulting id order.</summary>
+    private static List<string> Apply(IReadOnlyList<string> current, IReadOnlyList<object> cmds)
+    {
+        var work = new List<string>(current);
+        foreach (var c in cmds)
+        {
+            var e = JsonSerializer.SerializeToElement(c);
+            switch (e.GetProperty("cmd").GetString())
+            {
+                case "remove_plugin":
+                    work.RemoveAt(e.GetProperty("index").GetInt32());
+                    break;
+                case "add_plugin":
+                    work.Insert(e.GetProperty("index").GetInt32(), e.GetProperty("uid").GetString()!);
+                    break;
+                case "move_plugin":
+                    var from = e.GetProperty("from").GetInt32();
+                    var to = e.GetProperty("to").GetInt32();
+                    var moved = work[from];
+                    work.RemoveAt(from);
+                    work.Insert(to, moved);
+                    break;
+                case "set_plugin_state":
+                    break; // no order effect
+                default:
+                    Assert.Fail($"unexpected cmd {e.GetProperty("cmd").GetString()}");
+                    break;
+            }
+        }
+        return work;
+    }
+
+    private static string CmdName(object c) =>
+        JsonSerializer.SerializeToElement(c).GetProperty("cmd").GetString()!;
+
+    [Fact]
+    public void EmptyCurrent_ReturnsNull_SoCallerFullLoads()
+    {
+        Assert.Null(VstChainDiff.Compute(Array.Empty<string>(), Desired("a", "b")));
+    }
+
+    [Fact]
+    public void IdenticalChains_ReturnEmpty_NoRedundantReload()
+    {
+        var cmds = VstChainDiff.Compute(new[] { "a", "b", "c" }, Desired("a", "b", "c"));
+        Assert.NotNull(cmds);
+        Assert.Empty(cmds!);
+    }
+
+    [Fact]
+    public void AppendOnePlugin_EmitsSingleAddAtEnd()
+    {
+        var current = new[] { "a", "b" };
+        var cmds = VstChainDiff.Compute(current, Desired("a", "b", "c"))!;
+        Assert.Single(cmds);
+        Assert.Equal("add_plugin", CmdName(cmds[0]));
+        var add = JsonSerializer.SerializeToElement(cmds[0]);
+        Assert.Equal(2, add.GetProperty("index").GetInt32());
+        Assert.Equal("c", add.GetProperty("uid").GetString());
+        Assert.Equal("f_c", add.GetProperty("file").GetString());
+        Assert.Equal(new[] { "a", "b", "c" }, Apply(current, cmds));
+    }
+
+    [Fact]
+    public void AddPluginWithState_EmitsAddThenSetState()
+    {
+        var current = new[] { "a" };
+        var desired = new List<VstChainDiff.DesiredSlot> { Slot("a"), Slot("b", state: "BLOB==") };
+        var cmds = VstChainDiff.Compute(current, desired)!;
+        Assert.Equal(2, cmds.Count);
+        Assert.Equal("add_plugin", CmdName(cmds[0]));
+        Assert.Equal("set_plugin_state", CmdName(cmds[1]));
+        var st = JsonSerializer.SerializeToElement(cmds[1]);
+        Assert.Equal(1, st.GetProperty("index").GetInt32());
+        Assert.Equal("BLOB==", st.GetProperty("state").GetString());
+    }
+
+    [Fact]
+    public void AddPluginWithoutState_DoesNotEmitSetState()
+    {
+        var cmds = VstChainDiff.Compute(new[] { "a" }, Desired("a", "b"))!;
+        Assert.Single(cmds);
+        Assert.Equal("add_plugin", CmdName(cmds[0]));
+    }
+
+    [Fact]
+    public void RemoveMiddlePlugin_EmitsSingleRemoveAtCorrectIndex()
+    {
+        var current = new[] { "a", "b", "c" };
+        var cmds = VstChainDiff.Compute(current, Desired("a", "c"))!;
+        Assert.Single(cmds);
+        Assert.Equal("remove_plugin", CmdName(cmds[0]));
+        Assert.Equal(1, JsonSerializer.SerializeToElement(cmds[0]).GetProperty("index").GetInt32());
+        Assert.Equal(new[] { "a", "c" }, Apply(current, cmds));
+    }
+
+    [Theory]
+    [InlineData("a,b,c", "c,b,a")]              // full reverse
+    [InlineData("a,b,c,d", "a,c,b,d")]          // adjacent swap
+    [InlineData("a,b,c", "b,c,a")]              // rotate
+    [InlineData("a,b,c,d", "d,a,b,c")]          // move last to front
+    public void Reorder_ProducesDesiredOrder(string currentCsv, string desiredCsv)
+    {
+        var current = currentCsv.Split(',');
+        var desiredIds = desiredCsv.Split(',');
+        var cmds = VstChainDiff.Compute(current, Desired(desiredIds))!;
+        // Pure reorder uses only move_plugin (no add/remove).
+        Assert.All(cmds, c => Assert.Equal("move_plugin", CmdName(c)));
+        Assert.Equal(desiredIds, Apply(current, cmds));
+    }
+
+    [Theory]
+    [InlineData("a,b,c", "a,b,c")]              // no-op
+    [InlineData("a,b,c", "x,y,z")]              // full replacement
+    [InlineData("a,b,c,d,e", "e,c,f")]          // mixed remove + add + reorder
+    [InlineData("comp,eq,gate", "gate,comp,reverb")]
+    public void MixedEdits_ApplyToDesiredOrder(string currentCsv, string desiredCsv)
+    {
+        var current = currentCsv.Split(',');
+        var desiredIds = desiredCsv.Split(',');
+        var cmds = VstChainDiff.Compute(current, Desired(desiredIds));
+        Assert.NotNull(cmds);
+        Assert.Equal(desiredIds, Apply(current, cmds!));
+    }
+
+    [Fact]
+    public void RemoveAllPlugins_EmitsRemovesAndEndsEmpty()
+    {
+        var current = new[] { "a", "b" };
+        var cmds = VstChainDiff.Compute(current, Desired())!;
+        Assert.All(cmds, c => Assert.Equal("remove_plugin", CmdName(c)));
+        Assert.Empty(Apply(current, cmds));
+    }
+}


### PR DESCRIPTION
## Problem

Two operator reports — *"adding some VSTs takes really long"* and *"something wrong with the quality"* — turned out to share one root cause.

Every chain edit (add / park / reorder a VST) called `LoadChainIntoEngine()`, which sends a single `load_chain`. Per the engine's own protocol spec (`docs/designs/vst-engine-bridge-protocol.md` §2.1) that command **"clears + parallel-loads"** the *entire* chain — so adding one plugin tore down and re-instantiated *all* of them:

- **Slow** — a heavy plugin already in the rack (e.g. a Waves shell) was reloaded on every edit → multi-second stall.
- **Quality** — every running plugin was destroyed/recreated, dropping its internal DSP state (compressor envelopes, reverb tails, lookahead) and glitching TX/RX audio on each edit.

Meanwhile the engine already exposes cheap `add_plugin` / `remove_plugin` / `move_plugin` commands that Zeus never used.

## Fix

New pure, tested **`VstChainDiff.Compute()`** turns *(current engine order → desired chain)* into the minimal incremental command sequence, with indices simulated against the engine's serial command order. Wired into both routes:

- **TX** (`AudioProcessingModeService`) — `OnChainOrderChanged` now calls `SyncChainToEngine()` (incremental); activation / supervisor reconnect / TX-dead recovery keep the full `load_chain`.
- **RX** (`RxVstEngineService`) — `SyncEngineAsync` diffs when the engine was already live; full load on first activation and on reconnect.

Existing plugins now keep running untouched across an edit, and a no-op edit pushes nothing (the old code reloaded unconditionally).

### Correctness guards
- `SetPluginStates` sets a one-shot **force-full-reload** flag so a **profile apply** (which replaces VST voicing wholesale) still pushes the new state even when chain order is unchanged — an incremental diff would otherwise be empty.
- RX **reconnect** forces a full reload: a relaunched engine is empty while the slot map is stale, so an incremental diff would see "no change" and leave the recovered engine with no plugins.

## Tests
- New `VstChainDiffTests` (15) including an engine-semantics simulator that applies the emitted commands and asserts the result equals the desired order (proves the generated indices are always valid).
- Full audio/chain/profile server suite: **99 passed, 0 failed**.

## ⚠️ Needs bench verification
This touches the **load-bearing realtime TX/RX audio path** and could not be tested against the real Windows VST engine + actual plugins. It assumes the engine applies control commands **serially on its message thread, completing each (incl. the async-load insert) before the next** — the documented JUCE/IPCBridge model (§2); a botched sequence self-heals via the next `chain` event. **Please bench-test on real hardware** (add/remove/reorder while transmitting; confirm no glitch and that plugin voicing/editors survive an edit) before merge.