### PR TITLE
fix(web): render panadapter callsigns above the frequency line

### DIFF
--- a/zeus-web/src/components/ChatRosterOverlay.tsx
+++ b/zeus-web/src/components/ChatRosterOverlay.tsx
@@ -90,7 +90,11 @@ function RosterMarker({
 
   return (
     <div
-      className="pointer-events-none absolute inset-y-0 z-[9] -translate-x-1/2"
+      // z-[16] keeps the callsign pill ABOVE the frequency-scale chrome — the
+      // ruler (z-10), band overlay (z-11), and especially the green VFO dial
+      // marker / frequency line (z-15) — so the line never draws across a
+      // callsign. Stays below the VFO readout box (z-25), which owns the corner.
+      className="pointer-events-none absolute inset-y-0 z-[16] -translate-x-1/2"
       style={{ left: `${pct}%` }}
     >
       {/* vertical tick — non-interactive so it never blocks click-to-tune */}


### PR DESCRIPTION
## Summary

The chat-roster callsign markers on the panadapter rendered at `z-[9]`, which sits **below** the panadapter's frequency-scale chrome:

- frequency-scale ruler — `z-10`
- band-plan overlay — `z-11`
- the green VFO dial marker / frequency line — `z-15`

So the frequency line drew **across** the callsign pills, partly obscuring them.

## Change

Raise the roster markers to `z-[16]` so callsigns render **on top of** the frequency line, while staying below the VFO readout box (`z-25`), which keeps the top-left corner. Same position — just on top.

One-line change in `ChatRosterOverlay.tsx` (the marker root `className`).

## Testing

Pure CSS stacking change (Tailwind `z-[9]` → `z-[16]`); no logic or type impact.