### PR TITLE
fix(audio-suite): reserve TX VST plugins for the out-of-process engine

### DIFF
--- a/Zeus.Server.Hosting/AudioPluginBridge.cs
+++ b/Zeus.Server.Hosting/AudioPluginBridge.cs
@@ -1484,6 +1484,28 @@ public sealed class AudioPluginBridge : IHostedService, IAsyncDisposable
             if (_txInitializedIds.Contains(id)) return true;
         }
 
+        // VST mode (out-of-process engine selected): the external engine hosts the
+        // VST3 plugins, so DON'T load them in the in-process VST bridge — mirror the
+        // receive path's EnsureRxPluginInitialized reservation. This is essential for
+        // plugins the in-process host can't load (e.g. Waves shells, which fail with
+        // VST3 load status=5): without it InitializeAudioAsync throws here and the
+        // caller DETACHES the plugin, so it can never be added to the chain even
+        // though the engine could host it. Gated on State (not IsActive) so it also
+        // covers the startup window before the engine finishes its handshake, plus a
+        // crash-looping / backoff engine — all cases where VST is the chosen route.
+        // Native mode leaves the controller Inactive, so the in-process load below
+        // still runs unchanged.
+        if (audioPlugin is VstHostAudioPlugin
+            && _vstEngine is not null
+            && _vstEngine.State != VstEngineState.Inactive)
+        {
+            lock (_lock) _txInitializedIds.Add(id);
+            _log.LogInformation(
+                "TX VST plugin {Id} reserved for the out-of-process VST engine; in-process VST bridge not loaded",
+                id);
+            return true;
+        }
+
         try
         {
             audioPlugin.InitializeAudioAsync(

--- a/tests/Zeus.Server.Tests/AudioPluginBridgeVstReserveTests.cs
+++ b/tests/Zeus.Server.Tests/AudioPluginBridgeVstReserveTests.cs
@@ -1,0 +1,130 @@
+using System.Reflection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Plugins.Contracts;
+using Zeus.Plugins.Contracts.Audio;
+using Zeus.Plugins.Contracts.Extensions;
+using Zeus.Plugins.Host.Audio;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Regression coverage: in out-of-process VST mode, a TX VST plugin must be
+/// RESERVED for the external engine and NOT loaded in the in-process VST bridge —
+/// mirroring the receive path's <c>EnsureRxPluginInitialized</c>. Before the fix
+/// the TX init path always tried the in-process load, so a plugin the in-process
+/// host can't load (e.g. a Waves shell, VST3 load status=5) threw during attach
+/// and got DETACHED, making it impossible to add to the chain even though the
+/// active engine could host it. The gate is the engine <see cref="VstEngineState"/>
+/// (not IsActive) so it also holds during the startup window before the engine
+/// finishes its handshake; Native mode (Inactive) still loads in-process.
+/// </summary>
+public sealed class AudioPluginBridgeVstReserveTests
+{
+    [Theory]
+    [InlineData(VstEngineState.Active)]      // engine live
+    [InlineData(VstEngineState.Activating)]  // startup window — engine not up yet
+    [InlineData(VstEngineState.Backoff)]     // crash-loop: still VST mode, don't fall back
+    [InlineData(VstEngineState.Faulted)]
+    public void VstMode_ReservesTxPluginForEngine_WithoutInProcessLoad(VstEngineState state)
+    {
+        var bridge = NewBridge();
+        var engine = NewEngineInState(state);
+        SetPrivateField(bridge, "_vstEngine", engine);
+
+        var native = new FailingVstBridge();
+        var plugin = NewVstPlugin(native);
+        const string id = "com.openhpsdr.zeus.vst.waveshellsub";
+
+        var ok = EnsureTxPluginInitialized(bridge, id, plugin);
+
+        Assert.True(ok);                                        // reserved → success
+        Assert.Equal(0, native.LoadCount);                     // in-process load NEVER attempted
+        Assert.Contains(id, TxInitializedSet(bridge));         // marked reserved
+    }
+
+    // Native mode (engine Inactive) is intentionally not asserted here: the in-
+    // process load path it falls through to is env-gated (ZEUS_ENABLE_VST_LOAD) and
+    // unchanged by this fix — the new early-return is scoped strictly to a
+    // non-Inactive engine, so Native behaviour is identical to before.
+
+    // -- harness ---------------------------------------------------------
+
+    private static AudioPluginBridge NewBridge() =>
+        new(
+            isMoxOn: () => false,
+            isMonitorOn: () => false,
+            log: NullLogger<AudioPluginBridge>.Instance);
+
+    private static VstHostAudioPlugin NewVstPlugin(IVstBridgeNative native) =>
+        new(
+            native,
+            new AudioBlock { Vst3Path = "Fake.vst3", Slot = "tx.post-leveler" },
+            Path.GetTempPath(),
+            "Fake VST");
+
+    private static VstEngineController NewEngineInState(VstEngineState state)
+    {
+        var engine = new VstEngineController(maxFrames: 512, rate: 48000, channels: 1);
+        var field = typeof(VstEngineController).GetField(
+            "_state", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        field!.SetValue(engine, state);
+        return engine;
+    }
+
+    private static bool EnsureTxPluginInitialized(
+        AudioPluginBridge bridge, string id, IAudioPlugin plugin)
+    {
+        var method = typeof(AudioPluginBridge).GetMethod(
+            "EnsureTxPluginInitialized", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return (bool)method!.Invoke(bridge, [id, plugin, "tx.post-leveler"])!;
+    }
+
+    private static HashSet<string> TxInitializedSet(AudioPluginBridge b)
+    {
+        var field = typeof(AudioPluginBridge).GetField(
+            "_txInitializedIds", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        return (HashSet<string>)field!.GetValue(b)!;
+    }
+
+    private static void SetPrivateField(object target, string name, object? value)
+    {
+        var field = target.GetType().GetField(
+            name, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        field!.SetValue(target, value);
+    }
+
+    /// <summary>A native bridge whose VST3 load always fails (like a Waves shell
+    /// returning status=5 in-process), counting attempts so a reservation that
+    /// SKIPS the in-process load is observable.</summary>
+    private sealed class FailingVstBridge : IVstBridgeNative
+    {
+        public int LoadCount { get; private set; }
+
+        public int Init(int abi) => VstBridgeStatus.Ok;
+
+        public int LoadVst3(string path, int channels, int sampleRate, int blockSize, out nint handle)
+        {
+            LoadCount++;
+            handle = 0;
+            return 5; // zvst_status_t load failure (matches the observed WaveShell status)
+        }
+
+        public int Process(nint handle, ReadOnlySpan<float> input, Span<float> output, int frames)
+        {
+            input.CopyTo(output);
+            return VstBridgeStatus.Ok;
+        }
+
+        public int SetParameter(nint handle, uint paramId, double normalized) => VstBridgeStatus.Ok;
+        public int Unload(nint handle) => VstBridgeStatus.Ok;
+        public int Shutdown() => VstBridgeStatus.Ok;
+        public int EditorOpen(nint handle, string title) => VstBridgeStatus.Ok;
+        public int EditorClose(nint handle) => VstBridgeStatus.Ok;
+        public bool EditorIsOpen(nint handle) => false;
+    }
+}


### PR DESCRIPTION
## Problem

In out-of-process **VST mode**, adding many scanned VSTs to the **TX** chain silently does nothing — clicking **+** in the Audio Suite has no effect. Reproduced live against a running desktop build:

```
PUT /api/tx-audio-suite/plugins/com.openhpsdr.zeus.vst.c1gatestereo/chain-membership {"active":true}
→ HTTP 400 {"error":"cannot park / un-park '...c1gatestereo': it is not an attached audio plugin."}
```

The frontend only `console.warn`s that rejection, so the plugin never appears in the chain and there's no visible error. The affected plugins (Britpressor, C1, F6, L3 UltraMaximizer, MannyM…) are all **Waves shell** plugins sharing `WaveShell1-VST3 16.7_x64.vst3`.

## Root cause

The TX init path (`EnsureTxPluginInitialized`) always tries to load the VST3 in the **in-process** bridge — even when the operator is in out-of-process VST mode. The desktop log shows the failure at attach time:

```
PluginLoader  Loaded plugin com.openhpsdr.zeus.vst.c1gatestereo
AudioPluginBridge  com.openhpsdr.zeus.vst.c1gatestereo InitializeAudioAsync threw; leaving it inactive
   PluginLoadException: VST3 load failed for ...WaveShell1-VST3 16.7_x64.vst3 (status=5)
```

When the in-process load throws, `OnPluginActivated` **detaches** the plugin. It stays *registered* (shows in Available/Favorites) but *unattached*, so the un-park (add) endpoint rejects it. There's also a **startup race**: the engine became active ~30s *after* these plugins attached, so even in-process-capable timing falls into the failing path and detaches for the whole session.

The receive path already handles this correctly — `EnsureRxPluginInitialized` *reserves* VST plugins for the out-of-process engine and skips the in-process load. TX was missing the symmetric guard.

## Fix

Mirror the RX reservation in `EnsureTxPluginInitialized`: when the plugin is a `VstHostAudioPlugin` and the engine is selected (`VstEngineController.State != Inactive`), reserve it for the external engine and **skip the in-process load**. The external engine hosts it (via the chain-load path).

Gated on `State` (not `IsActive`) so it also covers:
- the **startup window** before the engine finishes its `ready` handshake (`Activating`), and
- a **crash-looping / backoff** engine (`Backoff`/`Faulted`) — still VST mode, so we must not fall back to a failing in-process load.

**Native mode** leaves the controller `Inactive`, so the in-process load path is byte-for-byte unchanged.

## Tests
- New `AudioPluginBridgeVstReserveTests`: a VST plugin whose in-process load would fail (`status=5`) is reserved with **no in-process load attempted** and stays attached, across `Active` / `Activating` / `Backoff` / `Faulted` engine states.
- All `AudioPluginBridge` tests green (29).

## ⚠️ Needs bench verification
Touches the load-bearing TX audio attach path; verify on real hardware that scanned/Waves TX VSTs add to the chain in VST mode and that Native-mode in-process VST hosting is unaffected. Operators with already-detached plugins from a prior session will pick this up after the next restart (attach no longer detaches them).