### PR TITLE
fix(web): assert friend-only gating on panadapter callsigns

### DIFF
--- a/zeus-web/src/components/ChatRosterOverlay.tsx
+++ b/zeus-web/src/components/ChatRosterOverlay.tsx
@@ -186,6 +186,8 @@ export function ChatRosterOverlay() {
   const openDm = useChatStore((s) => s.openDm);
   const freqPublic = useChatStore((s) => s.freqPublic);
   const myCallsign = useChatStore((s) => s.callsign);
+  const acceptedFriends = useChatStore((s) => s.acceptedFriends);
+  const seeAllFreq = useChatStore((s) => s.seeAllFreq);
   const show = useDisplaySettingsStore((s) => s.showChatRosterOverlay);
 
   const centerHz = useDisplayStore((s) => s.centerHz);
@@ -222,8 +224,22 @@ export function ChatRosterOverlay() {
     // pinned to your own panadapter after you've hidden. Drop it so "hidden"
     // means hidden everywhere, including your own view.
     const mine = (myCallsign ?? '').toUpperCase();
+    // Friend gate — mirror the chat roster's rule: you only see a friend's
+    // callsign on the panadapter, never a stranger's. The relay already enforces
+    // this (it strips freqHz from every non-friend before the roster leaves the
+    // server, so a stranger arrives unplaceable), but assert it here too so the
+    // intent is explicit and a future relay change can't silently leak callsigns.
+    // Yourself and the admin "see all" override are the deliberate exceptions:
+    // see-all is meant to reveal every operator on the panadapter regardless of
+    // friendship, so it bypasses the gate exactly as it does on the relay.
+    const friendSet = new Set(acceptedFriends.map((c) => c.toUpperCase()));
+    const canPlace = (op: ChatOperator) => {
+      const call = op.callsign.toUpperCase();
+      return call === mine || seeAllFreq || friendSet.has(call);
+    };
     const inView = roster
       .filter((op) => typeof op.freqHz === 'number' && Number.isFinite(op.freqHz))
+      .filter(canPlace)
       .filter((op) => freqPublic || !mine || op.callsign.toUpperCase() !== mine)
       .map((op) => ({ op, pct: ((op.freqHz! - startHz) / spanHz) * 100 }))
       .filter(({ pct }) => pct >= -2 && pct <= 102)
@@ -243,7 +259,7 @@ export function ChatRosterOverlay() {
       laneLastPct[lane] = pct;
       return { op, pct, lane };
     });
-  }, [show, enabled, connected, roster, centerHz, hzPerPixel, width, freqPublic, myCallsign]);
+  }, [show, enabled, connected, roster, centerHz, hzPerPixel, width, freqPublic, myCallsign, acceptedFriends, seeAllFreq]);
 
   if (placed.length === 0) return null;
 


### PR DESCRIPTION
## Summary

Makes the panadapter chat-roster overlay's **friend-only** rule explicit, mirroring the chat roster: you see a friend's callsign on the panadapter, never a stranger's.

Today the gating is *implicit* — the overlay only places operators that carry a `freqHz`, and the relay (`rosterFor` in `chat-room.ts`) strips `freqHz` from every non-friend before the roster leaves the server. So in practice only friends appear. This PR adds a matching client-side assertion so the intent is visible at the render site and a future relay change can't silently leak strangers' calls onto the panadapter.

## Change

In `ChatRosterOverlay.tsx`, place a callsign only when it passes:

```
call === yourself  ||  seeAllFreq (admin "see all")  ||  acceptedFriends.has(call)
```

- Reads `acceptedFriends` and `seeAllFreq` from the chat store.
- Adds a `canPlace` filter to the placement memo and the deps array.

**Deliberate exceptions preserved**, exactly as on the relay:
- **Yourself** — your own marker still shows (subject to the existing eye-toggle self-hide).
- **Admin "see all"** — the override is documented to reveal every operator "on your roster **and panadapter** regardless of friendship," so it bypasses the gate.

## Notes / trade-off

This is defense-in-depth — the relay remains the authoritative gate. The one behavioural nuance: immediately after accepting a friend, if the roster frame arrives a beat before the friends-list frame, that new friend's marker can flicker for one update until `acceptedFriends` catches up. It self-corrects on the next frame.

## Testing

Type-trivial change (existing typed store fields + already-imported `ChatOperator`). Full tsc/build via CI — the fresh worktree had no `node_modules` to run it locally.