### PR TITLE
fix(audio-suite): don't detach TX VSTs on in-process load failure when the engine is installed

### DIFF
--- a/Zeus.Server.Hosting/AudioPluginBridge.cs
+++ b/Zeus.Server.Hosting/AudioPluginBridge.cs
@@ -1515,6 +1515,28 @@ public sealed class AudioPluginBridge : IHostedService, IAsyncDisposable
         }
         catch (Exception ex)
         {
+            // The in-process load failed. If this is a VST and the out-of-process
+            // engine is INSTALLED, the engine can still host it — so reserve it
+            // rather than failing (a false return makes the caller DETACH it, which
+            // removes it from ChainOrderService and leaves it permanently
+            // un-addable). This is the boot-time race for plugins the in-process
+            // host can't load (Waves shells, status=5): they attach while the engine
+            // is still handshaking (State == Inactive, so the reservation above
+            // didn't fire), the in-process load throws here, and without this they'd
+            // be detached for the whole session. Keeping them reserved leaves them in
+            // the operator's chain — in-process Process passes through harmlessly
+            // (handle 0) until the engine comes up and LoadChainIntoEngine hosts them.
+            if (audioPlugin is VstHostAudioPlugin
+                && _vstEngine is not null
+                && VstEngineController.FindEngineExe() is not null)
+            {
+                _log.LogWarning(ex,
+                    "TX VST plugin {Id} failed the in-process load; reserving it for the "
+                    + "out-of-process VST engine instead of detaching", id);
+                lock (_lock) _txInitializedIds.Add(id);
+                return true;
+            }
+
             _log.LogError(ex,
                 "Audio plugin {Id} InitializeAudioAsync threw; leaving it inactive", id);
             return false;


### PR DESCRIPTION
## Problem (follow-up to #1157)

Even after #1157, some Waves TX plugins still can't be added — the **+** button does nothing and the endpoint returns `400 "not an attached audio plugin"`. Re-probed live:

- Engine became active at **22:42:05**.
- `c1gatestereo` / `f6stereo` / `l3ultramaximizerstereo` failed their **in-process** WaveShell load (`status=5`) at **22:41:39–46** — ~24s *before* the engine was up — and were **detached**.
- `britpressor` / `rare` attached *after* 22:42 and reserved correctly (you can see them now in the live chain order).

#1157's reservation is gated on the engine controller `State`, but `_state = Activating` is set **after** awaits inside `TryLaunchAndArmAsync`, so during the boot window it's still `Inactive`. A VST that is **active in the saved chain** attaches in that window → reservation doesn't fire → in-process load runs → throws → the plugin is detached for the whole session → un-addable.

## Fix

In `EnsureTxPluginInitialized`'s failure path: if the plugin is a `VstHostAudioPlugin` and the out-of-process engine is **installed** (`FindEngineExe() != null`), **reserve it instead of returning false**. Returning false makes the caller detach it; reserving keeps it attached and in the operator's chain. The uninitialized in-process plugin passes through harmlessly (handle 0) until the engine finishes starting, at which point `LoadChainIntoEngine` hosts it from the active chain.

Result: a chain VST that can only load out-of-process **survives every boot with no re-add**, and stays addable.

- Only the **failure** path changes — an in-process-capable VST still loads in-process exactly as before.
- With **no engine installed**, the old detach behaviour is unchanged (the plugin genuinely can't run anywhere).

## Tests
All `AudioPluginBridge` / `ChainOrder` / `VstChainDiff` tests green (65). A dedicated test for this catch-path is intentionally omitted: triggering it requires the engine binary installed **and** native load enabled **and** a real in-process load failure simultaneously, which is environment-dependent and would be flaky in CI. The change is a strict leniency on the failure path, covered by the existing #1157 reservation tests plus the no-regression run.

## ⚠️ Needs bench verification
Load-bearing TX attach path. Verify on real hardware: a Waves/shell VST left active in the saved chain comes back hosted after a restart (no re-add needed), and Native-mode in-process VSTs are unaffected.