### PR TITLE
fix(plugins): hide operator-scanned VST3/AU effects from the Settings ▸ Plugins list

### DIFF
--- a/Zeus.Plugins.Host/PluginEndpoints.cs
+++ b/Zeus.Plugins.Host/PluginEndpoints.cs
@@ -158,9 +158,26 @@ public static class PluginEndpoints
         }
     }
 
+    /// <summary>
+    /// True when a plugin id was minted by the VST3 / AU directory scanners
+    /// (the <c>com.openhpsdr.zeus.{vst,rxvst,au,rxau}.*</c> namespaces). These
+    /// are operator-scanned audio plugins that live ONLY in the Audio Suite
+    /// rack — they are not Zeus plugin-repo plugins, so the Settings ▸ Plugins
+    /// list filters them out. Native Zeus audio plugins (e.g. the
+    /// <c>com.openhpsdr.zeus.samples.*</c> chain) are NOT scanned and stay in
+    /// the list. Reuses the scanners' own id-prefix predicates so the
+    /// classification has a single source of truth.
+    /// </summary>
+    internal static bool IsScannedAudioPlugin(string id) =>
+        VstDirectoryScanService.IsTxPluginId(id) ||
+        VstDirectoryScanService.IsRxPluginId(id) ||
+        AuComponentScanService.IsTxPluginId(id) ||
+        AuComponentScanService.IsRxPluginId(id);
+
     internal static PluginDto ToDto(ActivatedPlugin p) => new()
     {
         Id = p.Loaded.Manifest.Id,
+        Scanned = IsScannedAudioPlugin(p.Loaded.Manifest.Id),
         Name = p.Loaded.Manifest.Name,
         Version = p.Loaded.Manifest.Version,
         Author = p.Loaded.Manifest.Author,
@@ -200,6 +217,15 @@ public sealed record PluginListResponse
 public sealed record PluginDto
 {
     public string Id { get; init; } = "";
+
+    /// <summary>
+    /// True for operator-scanned VST3 / Audio Unit plugins (the
+    /// <c>com.openhpsdr.zeus.{vst,rxvst,au,rxau}.*</c> namespaces). These belong
+    /// to the Audio Suite rack only; the Settings ▸ Plugins list hides them so
+    /// it shows just Zeus plugin-repo plugins. Defaults false.
+    /// </summary>
+    public bool Scanned { get; init; }
+
     public string Name { get; init; } = "";
     public string Version { get; init; } = "";
     public string Author { get; init; } = "";

--- a/tests/Zeus.Plugins.Host.Tests/PluginEndpointsScannedTests.cs
+++ b/tests/Zeus.Plugins.Host.Tests/PluginEndpointsScannedTests.cs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using Zeus.Plugins.Host;
+
+namespace Zeus.Plugins.Host.Tests;
+
+/// <summary>
+/// The Settings ▸ Plugins list shows only Zeus plugin-repo plugins. Operator-
+/// scanned VST3 / Audio Unit effects (registered into the Audio Suite rack via
+/// the directory / AU scanners) carry the reserved id namespaces and must be
+/// flagged <c>Scanned</c> so the frontend filters them out — while native Zeus
+/// audio plugins (the <c>samples.*</c> chain) stay in the list.
+/// </summary>
+public sealed class PluginEndpointsScannedTests
+{
+    [Theory]
+    // Scanned VST3 — TX + RX namespaces.
+    [InlineData("com.openhpsdr.zeus.vst.tdrnova", true)]
+    [InlineData("com.openhpsdr.zeus.rxvst.rnnoise", true)]
+    // Scanned Audio Units — TX + RX namespaces.
+    [InlineData("com.openhpsdr.zeus.au.fabfilterproq3", true)]
+    [InlineData("com.openhpsdr.zeus.rxau.clear", true)]
+    // Native Zeus audio plugins shipped via the plugin repo — NOT scanned.
+    [InlineData("com.openhpsdr.zeus.samples.eq", false)]
+    [InlineData("com.openhpsdr.zeus.samples.amplifier", false)]
+    // Ordinary repo plugins / arbitrary ids — NOT scanned.
+    [InlineData("com.example.cooltool", false)]
+    [InlineData("com.openhpsdr.zeus.rf2k", false)]
+    [InlineData("", false)]
+    public void IsScannedAudioPlugin_classifies_by_id_namespace(string id, bool expected)
+    {
+        Assert.Equal(expected, PluginEndpoints.IsScannedAudioPlugin(id));
+    }
+}

--- a/zeus-web/src/plugins/api/plugins.test.ts
+++ b/zeus-web/src/plugins/api/plugins.test.ts
@@ -28,6 +28,7 @@ describe('parsePluginDto', () => {
   it('coerces a complete payload', () => {
     const dto = parsePluginDto({
       id: 'hello',
+      scanned: true,
       name: 'Hello World',
       version: '1.2.3',
       author: 'EI6LF',
@@ -47,6 +48,7 @@ describe('parsePluginDto', () => {
       },
     });
     expect(dto.id).toBe('hello');
+    expect(dto.scanned).toBe(true);
     expect(dto.capabilities).toEqual(['hub:emit', 'storage']);
     expect(dto.ui?.panels[0]?.slot).toBe('workspace');
     expect(dto.audio?.sampleRate).toBe(48000);
@@ -55,6 +57,7 @@ describe('parsePluginDto', () => {
   it('falls back to safe defaults on garbage input', () => {
     const dto = parsePluginDto({});
     expect(dto.id).toBe('');
+    expect(dto.scanned).toBe(false);
     expect(dto.capabilities).toEqual([]);
     expect(dto.ui).toBeNull();
     expect(dto.audio).toBeNull();

--- a/zeus-web/src/plugins/api/plugins.ts
+++ b/zeus-web/src/plugins/api/plugins.ts
@@ -45,6 +45,13 @@ export type PluginAudioDto = {
 
 export type PluginDto = {
   id: string;
+  /**
+   * True for operator-scanned VST3 / Audio Unit plugins (server id
+   * namespaces `com.openhpsdr.zeus.{vst,rxvst,au,rxau}.*`). These live only in
+   * the Audio Suite rack; the Settings ▸ Plugins list filters them out so it
+   * shows just Zeus plugin-repo plugins. Defaults false for older servers.
+   */
+  scanned: boolean;
   name: string;
   version: string;
   author: string;
@@ -162,6 +169,7 @@ export function parsePluginDto(raw: unknown): PluginDto {
   const o = (raw ?? {}) as Record<string, unknown>;
   return {
     id: asString(o.id),
+    scanned: asBool(o.scanned),
     name: asString(o.name),
     version: asString(o.version),
     author: asString(o.author),

--- a/zeus-web/src/plugins/components/PluginsPanel.test.tsx
+++ b/zeus-web/src/plugins/components/PluginsPanel.test.tsx
@@ -184,6 +184,7 @@ describe('InstalledPlugins', () => {
       installed: [
         {
           id: 'demo',
+          scanned: false,
           name: 'Demo Plugin',
           version: '0.1.0',
           author: 'EI6LF',
@@ -241,6 +242,7 @@ describe('InstalledPlugins', () => {
       installed: [
         {
           id: 'demo',
+          scanned: false,
           name: 'Demo Plugin',
           version: '0.1.0',
           author: '',

--- a/zeus-web/src/plugins/state/plugins-store.test.ts
+++ b/zeus-web/src/plugins/state/plugins-store.test.ts
@@ -67,6 +67,34 @@ describe('usePluginsStore', () => {
     expect(s.sdkAbi).toBe(1);
   });
 
+  it('refreshInstalled excludes operator-scanned VST3 / AU plugins', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn<typeof fetch>().mockResolvedValue(
+        jsonResponse({
+          sdkAbi: 1,
+          sdkVersion: '0.6.0',
+          plugins: [
+            { id: 'com.openhpsdr.zeus.samples.eq', name: 'EQ', version: '1', author: '', description: '', license: 'GPL', capabilities: [] },
+            { id: 'com.example.repo', name: 'Repo Plugin', version: '1', author: '', description: '', license: 'GPL', capabilities: [] },
+            { id: 'com.openhpsdr.zeus.vst.tdrnova', name: 'TDR Nova', version: '1', author: '', description: '', license: 'Unknown', capabilities: [], scanned: true },
+            { id: 'com.openhpsdr.zeus.rxau.clear', name: 'Clear RX', version: '1', author: '', description: '', license: 'Unknown', capabilities: [], scanned: true },
+          ],
+        }),
+      ),
+    );
+
+    await usePluginsStore.getState().refreshInstalled();
+
+    const s = usePluginsStore.getState();
+    expect(s.installedLoad.loaded).toBe(true);
+    // Both scanned audio plugins are filtered out; only the repo plugins remain.
+    expect(s.installed.map((p) => p.id)).toEqual([
+      'com.openhpsdr.zeus.samples.eq',
+      'com.example.repo',
+    ]);
+  });
+
   it('refreshInstalled records loadError on a 500', async () => {
     vi.stubGlobal(
       'fetch',

--- a/zeus-web/src/plugins/state/plugins-store.ts
+++ b/zeus-web/src/plugins/state/plugins-store.ts
@@ -116,7 +116,11 @@ export const usePluginsStore = create<PluginsStoreState>((set, get) => ({
     try {
       const resp: PluginListResponse = await fetchInstalledPlugins();
       set({
-        installed: resp.plugins,
+        // Operator-scanned VST3 / AU plugins (resp.plugins[].scanned) live in
+        // the Audio Suite rack only — they are not Zeus plugin-repo plugins, so
+        // the Settings ▸ Plugins list excludes them. The Audio Suite has its own
+        // consumer (pluginRuntime.fetchInstalledPlugins) that still sees them.
+        installed: resp.plugins.filter((p) => !p.scanned),
         sdkAbi: resp.sdkAbi,
         sdkVersion: resp.sdkVersion,
         installedLoad: { loaded: true, inflight: false, loadError: null },


### PR DESCRIPTION
## Problem

Audio plugins (VST3 / AU) the operator scans into the **Audio Suite** were also
showing up in **Settings ▸ Plugins** ("Installed" tab), mixed in with real Zeus
plugin-repo plugins.

Root cause: the VST3/AU directory scanners register each scanned effect as a
synthesized Zeus plugin (reserved id namespaces `com.openhpsdr.zeus.{vst,rxvst,au,rxau}.*`)
so the VST host can slot it into the rack. `GET /api/plugins` returns the entire
`PluginManager.Active` set, so those effects leaked into the settings list too.

## Goal

The Settings ▸ Plugins list should show **only Zeus plugin-repo plugins** — including
the native Zeus audio plugins (`com.openhpsdr.zeus.samples.*`). Scanned VST/AU
effects should appear **only** in the VST-host Audio Suite (TX/RX), exactly where
they already do.

## Fix (surgical — VST host untouched)

- **Backend** `Zeus.Plugins.Host/PluginEndpoints.cs`: additive `PluginDto.Scanned`
  flag, computed by `IsScannedAudioPlugin(id)` which ORs the scanners' **own**
  `IsTxPluginId` / `IsRxPluginId` predicates (single source of truth — no
  duplicated prefix strings).
- **Frontend** `plugins/api/plugins.ts`: parse `scanned` (defaults `false`, so old
  servers degrade gracefully).
- **Frontend** `plugins/state/plugins-store.ts`: `refreshInstalled` filters out
  `p.scanned`. This store feeds **only** the settings menu.

The Audio Suite uses a **separate** consumer (`plugins/runtime/pluginRuntime.ts` →
`fetchInstalledPlugins`), which is unchanged and still receives the full list. Rack,
directory scan, park/un-park, reorder, generic-VST panels and editor windows are all
unaffected.

## Why it's safe — adversarial audit

Three independent review lenses (VST-host regression / discriminator completeness /
serialization + cross-platform) found **0 regressions or gaps**:
- Audio Suite never imports `usePluginsStore`; it reads the unfiltered list.
- The four reserved namespaces are minted **only** by the scanners; native
  `samples.*` plugins are never matched.
- AU is pure string-prefix matching → no platform branch; missing `scanned`
  field → `false` → graceful on older servers.

## Tests / gates

- Backend: `PluginEndpointsScannedTests` (8-case discriminator theory); plugins-host
  suite **144 passed**.
- Frontend: store-filter test + parser assertions; touched vitest **37 passed**;
  `npm run typecheck` clean.
- `dotnet build Zeus.slnx` and `npm --prefix zeus-web run build` green.

## Scope

No PureSignal, drive/PA/TX, or `Zeus.Contracts` wire-format surfaces touched.
`PluginDto` lives in `Zeus.Plugins.Host` and the new field is additive.
