### PR TITLE
Release v0.10.6 — Windows audio-device hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@ see the corresponding GitHub Release page.
 
 ---
 
+## [0.10.6] — 2026-06-29
+
+> **🔧 Hotfix on 0.10.5.** The headline is an audio-device fix for Windows: operators who couldn't select a Windows sound device for receive audio can now switch output devices freely again. This release also folds in every fix — and the one new feature — that landed since 0.10.5: a built-in **DX-cluster client**, HamClock link handling, audio-suite / VST robustness, and a round of web-UI polish.
+
+### 🔊 Audio
+
+- **Windows sound devices are selectable again.** Changing your **output** device no longer fails when the saved **input** (microphone) device is missing or stale — a carried-over device id can no longer block a change to the other side, and re-selecting the same device is now a no-op instead of a glitchy reopen. This fixes the "Zeus won't let me use any of the Windows sound devices for RX audio" reports. *(#1128)*
+- **Smoother radio-speaker audio (Protocol 2).** The radio-speaker UDP send is decoupled from the DSP tick, so speaker output no longer rides on DSP timing. *(#1148)*
+
+### 🛰️ New — DX Cluster (direct Telnet)
+
+- **Connect straight to a DX cluster.** A native Telnet DX-cluster client logs in to a DXSpider / AR-Cluster / CC-Cluster node with your callsign (and a password if the node needs one), runs any post-login commands you set, and drops the received spots straight onto the panadapter — no third-party bridge in between. Configure it under **Settings → Network**, beside TCI, with a live connection status and spot count. *(#1140)*
+
+### 🗺️ HamClock
+
+- External links and rig-bridge downloads inside the HamClock panel now hand off to your OS web browser instead of dead-ending in the embedded webview. *(#1112)*
+- The bundled map now states plainly that it cannot receive live DX auto-pins. *(#1110)*
+
+### 🎚️ Audio suite & VST
+
+- Editing the VST engine chain is now incremental — adding or removing one effect no longer reloads the entire chain. *(#1153)*
+- TX VST plugins are reserved for the out-of-process engine, and a TX VST that fails to load in-process is no longer detached when the engine is installed. *(#1157, #1159)*
+
+### 💬 Chat & 🖥️ Web UI
+
+- The chat relay self-heals a stale QRZ session instead of looping on 403s, and the chat composer no longer starts as a tall multi-row box. *(#1149, #1152)*
+- Panadapter callsigns render above the frequency line, honor friend-only gating, and hide together with your own frequency when you choose to hide it. *(#1151, #1155, #1158)*
+- Workspace column pitch re-latches if an early width was a transient; the Meter Group tile size survives a Settings round-trip; **Settings → Zeus Digital** now matches the house settings style; and operator-scanned VST3 / AU effects are hidden from the **Settings ▸ Plugins** list. *(#1146, #1160, #1166, #1168)*
+
+**Credits.** The Windows audio-device fix, the audio-suite / VST robustness work, the chat/QRZ self-heal, and the panadapter-callsign handling are by **Christian Suarez (N9WAR)**. The DX-cluster client, the HamClock link/download fixes, the Protocol-2 radio-speaker decoupling, the Zeus Digital settings styling, and the workspace / meter-layout fixes are by **Douglas Cerrato (KB2UKA)**.
+
+---
+
 ## [0.10.5] — 2026-06-28
 
 > **🎙️ The digital-modes release.** More than 200 pull requests land here, and the headline is that Zeus now does the digital modes natively: **FreeDV digital voice** (including the new neural **RADE** codec) as a first-class transmit/receive mode, and a built-in **FT8 / FT4** suite — decode, click-to-tune, armed auto-sequencing, an integrated logbook, and spotting — with no external software. Alongside the digital work this cycle brings **up to eight independent hardware receivers**, **full remote operation over the internet**, a **KiwiSDR** slice receiver, a real-time **Lightning Map**, serial **CAT** control, and the **return of external accessory-port switching** that was temporarily out in 0.10.0. The WAV recorder is now an installable plugin rather than core.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,8 +8,8 @@
     <!-- Version Management -->
     <!-- When building from a tag (e.g., v0.1.0), GITHUB_REF_NAME will be set -->
     <!-- Otherwise, fall back to the in-development VersionPrefix below.    -->
-    <!-- Bump this when a release branch opens — current target: v0.10.5.   -->
-    <VersionPrefix Condition="'$(VersionPrefix)' == ''">0.10.5</VersionPrefix>
+    <!-- Bump this when a release branch opens — current target: v0.10.6.   -->
+    <VersionPrefix Condition="'$(VersionPrefix)' == ''">0.10.6</VersionPrefix>
     <VersionSuffix Condition="'$(VersionSuffix)' == '' AND '$(GITHUB_REF_TYPE)' != 'tag'">dev</VersionSuffix>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>

--- a/Zeus.Contracts/DxClusterDtos.cs
+++ b/Zeus.Contracts/DxClusterDtos.cs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+namespace Zeus.Contracts;
+
+/// <summary>
+/// Live connection state of the native Telnet DX-cluster client. Additive wire
+/// contract — serialised as a string in the status DTO so adding states later
+/// stays backward compatible.
+/// </summary>
+public enum DxClusterConnectionState
+{
+    /// <summary>Not connected and not trying (operator disabled or idle).</summary>
+    Disconnected = 0,
+    /// <summary>Opening the TCP socket / logging in.</summary>
+    Connecting = 1,
+    /// <summary>Logged in and receiving spot lines.</summary>
+    Connected = 2,
+    /// <summary>Dropped — waiting out the backoff before the next attempt.</summary>
+    Reconnecting = 3,
+}
+
+/// <summary>
+/// Operator configuration for the DX-cluster client. Persisted in zeus-prefs.db
+/// via DxClusterConfigStore. Everything defaults OFF / empty — the client never
+/// reaches out to the network until the operator enables it.
+///
+/// <para><b>Password</b> is stored at-rest as plaintext in zeus-prefs.db,
+/// consistent with the existing CredentialStore (QRZ) precedent — see the PR
+/// notes. Most DX clusters do not require a password at all.</para>
+///
+/// <para><b>LoginCommands</b> is a newline-separated list of commands sent once
+/// after a successful login (e.g. <c>set/filter</c>, <c>sh/dx</c>).</para>
+/// </summary>
+public sealed record DxClusterConfig(
+    bool Enabled = false,
+    string Host = "",
+    int Port = 7373,
+    string Callsign = "",
+    string Password = "",
+    string LoginCommands = "",
+    bool AutoConnect = false);
+
+/// <summary>Status of the DX-cluster client (config echo + live connection state).</summary>
+public sealed record DxClusterStatus(
+    bool Enabled,
+    string Host,
+    int Port,
+    string Callsign,
+    bool HasPassword,
+    string LoginCommands,
+    bool AutoConnect,
+    DxClusterConnectionState State,
+    int SpotsReceived,
+    string? LastSpotCallsign,
+    string? Error);

--- a/Zeus.Plugins.Host/PluginEndpoints.cs
+++ b/Zeus.Plugins.Host/PluginEndpoints.cs
@@ -158,9 +158,26 @@ public static class PluginEndpoints
         }
     }
 
+    /// <summary>
+    /// True when a plugin id was minted by the VST3 / AU directory scanners
+    /// (the <c>com.openhpsdr.zeus.{vst,rxvst,au,rxau}.*</c> namespaces). These
+    /// are operator-scanned audio plugins that live ONLY in the Audio Suite
+    /// rack — they are not Zeus plugin-repo plugins, so the Settings ▸ Plugins
+    /// list filters them out. Native Zeus audio plugins (e.g. the
+    /// <c>com.openhpsdr.zeus.samples.*</c> chain) are NOT scanned and stay in
+    /// the list. Reuses the scanners' own id-prefix predicates so the
+    /// classification has a single source of truth.
+    /// </summary>
+    internal static bool IsScannedAudioPlugin(string id) =>
+        VstDirectoryScanService.IsTxPluginId(id) ||
+        VstDirectoryScanService.IsRxPluginId(id) ||
+        AuComponentScanService.IsTxPluginId(id) ||
+        AuComponentScanService.IsRxPluginId(id);
+
     internal static PluginDto ToDto(ActivatedPlugin p) => new()
     {
         Id = p.Loaded.Manifest.Id,
+        Scanned = IsScannedAudioPlugin(p.Loaded.Manifest.Id),
         Name = p.Loaded.Manifest.Name,
         Version = p.Loaded.Manifest.Version,
         Author = p.Loaded.Manifest.Author,
@@ -200,6 +217,15 @@ public sealed record PluginListResponse
 public sealed record PluginDto
 {
     public string Id { get; init; } = "";
+
+    /// <summary>
+    /// True for operator-scanned VST3 / Audio Unit plugins (the
+    /// <c>com.openhpsdr.zeus.{vst,rxvst,au,rxau}.*</c> namespaces). These belong
+    /// to the Audio Suite rack only; the Settings ▸ Plugins list hides them so
+    /// it shows just Zeus plugin-repo plugins. Defaults false.
+    /// </summary>
+    public bool Scanned { get; init; }
+
     public string Name { get; init; } = "";
     public string Version { get; init; } = "";
     public string Author { get; init; } = "";

--- a/Zeus.Server.Hosting/AudioPluginBridge.cs
+++ b/Zeus.Server.Hosting/AudioPluginBridge.cs
@@ -1515,6 +1515,28 @@ public sealed class AudioPluginBridge : IHostedService, IAsyncDisposable
         }
         catch (Exception ex)
         {
+            // The in-process load failed. If this is a VST and the out-of-process
+            // engine is INSTALLED, the engine can still host it — so reserve it
+            // rather than failing (a false return makes the caller DETACH it, which
+            // removes it from ChainOrderService and leaves it permanently
+            // un-addable). This is the boot-time race for plugins the in-process
+            // host can't load (Waves shells, status=5): they attach while the engine
+            // is still handshaking (State == Inactive, so the reservation above
+            // didn't fire), the in-process load throws here, and without this they'd
+            // be detached for the whole session. Keeping them reserved leaves them in
+            // the operator's chain — in-process Process passes through harmlessly
+            // (handle 0) until the engine comes up and LoadChainIntoEngine hosts them.
+            if (audioPlugin is VstHostAudioPlugin
+                && _vstEngine is not null
+                && VstEngineController.FindEngineExe() is not null)
+            {
+                _log.LogWarning(ex,
+                    "TX VST plugin {Id} failed the in-process load; reserving it for the "
+                    + "out-of-process VST engine instead of detaching", id);
+                lock (_lock) _txInitializedIds.Add(id);
+                return true;
+            }
+
             _log.LogError(ex,
                 "Audio plugin {Id} InitializeAudioAsync threw; leaving it inactive", id);
             return false;

--- a/Zeus.Server.Hosting/AudioPluginBridge.cs
+++ b/Zeus.Server.Hosting/AudioPluginBridge.cs
@@ -1484,6 +1484,28 @@ public sealed class AudioPluginBridge : IHostedService, IAsyncDisposable
             if (_txInitializedIds.Contains(id)) return true;
         }
 
+        // VST mode (out-of-process engine selected): the external engine hosts the
+        // VST3 plugins, so DON'T load them in the in-process VST bridge — mirror the
+        // receive path's EnsureRxPluginInitialized reservation. This is essential for
+        // plugins the in-process host can't load (e.g. Waves shells, which fail with
+        // VST3 load status=5): without it InitializeAudioAsync throws here and the
+        // caller DETACHES the plugin, so it can never be added to the chain even
+        // though the engine could host it. Gated on State (not IsActive) so it also
+        // covers the startup window before the engine finishes its handshake, plus a
+        // crash-looping / backoff engine — all cases where VST is the chosen route.
+        // Native mode leaves the controller Inactive, so the in-process load below
+        // still runs unchanged.
+        if (audioPlugin is VstHostAudioPlugin
+            && _vstEngine is not null
+            && _vstEngine.State != VstEngineState.Inactive)
+        {
+            lock (_lock) _txInitializedIds.Add(id);
+            _log.LogInformation(
+                "TX VST plugin {Id} reserved for the out-of-process VST engine; in-process VST bridge not loaded",
+                id);
+            return true;
+        }
+
         try
         {
             audioPlugin.InitializeAudioAsync(

--- a/Zeus.Server.Hosting/AudioProcessingModeService.cs
+++ b/Zeus.Server.Hosting/AudioProcessingModeService.cs
@@ -72,6 +72,16 @@ public sealed class AudioProcessingModeService : IHostedService
     // Refreshed from every chain event, and re-applied on each load_chain so a
     // plugin's voicing survives chain edits; profiles snapshot/restore this map.
     private Dictionary<string, string> _pluginStates = new(StringComparer.Ordinal);
+    // Serializes chain pushes (full load_chain + incremental diffs) so two
+    // back-to-back operator edits can't each diff against the same stale slot map
+    // and double-apply. Control-thread only; never held across a realtime op. Lock
+    // order: _chainSyncLock THEN _editorLock, never the reverse.
+    private readonly object _chainSyncLock = new();
+    // One-shot "the next chain push must be a full reload" flag, guarded by
+    // _editorLock. Set when plugin states are replaced wholesale (profile apply /
+    // startup replay) so the new voicing reaches the engine even when the chain
+    // ORDER is unchanged — an incremental diff would be empty and push nothing.
+    private bool _forceFullReload;
 
     public AudioProcessingModeService(
         AudioProcessingModeStore store,
@@ -117,7 +127,7 @@ public sealed class AudioProcessingModeService : IHostedService
     /// </summary>
     private void OnChainOrderChanged(IReadOnlyList<string> _)
     {
-        if (_engine.IsActive) LoadChainIntoEngine();
+        if (_engine.IsActive) SyncChainToEngine();
     }
 
     /// <summary>
@@ -502,7 +512,13 @@ public sealed class AudioProcessingModeService : IHostedService
     public void SetPluginStates(IReadOnlyDictionary<string, string> states)
     {
         lock (_editorLock)
+        {
             _pluginStates = new Dictionary<string, string>(states, StringComparer.Ordinal);
+            // Wholesale state replacement (profile apply / startup replay): force the
+            // next sync to be a full load_chain so the new voicing is pushed even if
+            // the chain order didn't change (an incremental diff would be a no-op).
+            _forceFullReload = true;
+        }
     }
 
     /// <summary>
@@ -521,47 +537,83 @@ public sealed class AudioProcessingModeService : IHostedService
     /// </summary>
     private void LoadChainIntoEngine()
     {
+        lock (_chainSyncLock) LoadChainCore(BuildDesiredSlots());
+    }
+
+    /// <summary>
+    /// Build the desired engine chain: the active Audio Suite VST3 plugins in chain
+    /// order, each with its absolute path, descriptor uid ("" selects the single /
+    /// first plugin in the file), and last-known opaque state ("" loads defaults).
+    /// Non-VST (native DSP) plugins are skipped — they never reach the engine.
+    /// </summary>
+    private List<VstChainDiff.DesiredSlot> BuildDesiredSlots()
+    {
+        var byId = new Dictionary<string, ActivatedPlugin>(StringComparer.Ordinal);
+        foreach (var p in _manager.Active) byId[p.Loaded.Manifest.Id] = p;
+
+        Dictionary<string, string> savedStates;
+        lock (_editorLock) savedStates = new(_pluginStates, StringComparer.Ordinal);
+
+        var desired = new List<VstChainDiff.DesiredSlot>();
+        foreach (var id in _chainOrder.CurrentOrder) // ordered, parked excluded
+        {
+            if (!byId.TryGetValue(id, out var p)) continue;
+            var vst3 = p.Loaded.Manifest.Audio?.Vst3Path;
+            if (string.IsNullOrEmpty(vst3)) continue; // non-VST (native DSP) plugin
+
+            var abs = Path.IsPathRooted(vst3) ? vst3 : Path.Combine(p.Loaded.PluginDir, vst3);
+            var uid = p.Loaded.Manifest.Audio?.Vst3Uid ?? string.Empty;
+            var state = savedStates.GetValueOrDefault(id, string.Empty);
+            desired.Add(new VstChainDiff.DesiredSlot(id, abs, uid, state));
+        }
+        return desired;
+    }
+
+    /// <summary>
+    /// Rebuild the id→slot / file→id / uid→id maps from the desired chain's final
+    /// post-push shape under <see cref="_editorLock"/>. A full reload clears the
+    /// optimistic open-editor set (the engine closes all editors on load_chain); an
+    /// incremental push keeps editors for the plugins that survive the edit.
+    /// </summary>
+    private void RebuildEngineMaps(IReadOnlyList<VstChainDiff.DesiredSlot> desired, bool full)
+    {
+        var map = new Dictionary<string, int>(StringComparer.Ordinal);
+        var fileToId = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var uidToId = new Dictionary<string, string>(StringComparer.Ordinal);
+        for (int i = 0; i < desired.Count; i++)
+        {
+            var d = desired[i];
+            map[d.Id] = i;
+            var key = NormalizePath(d.File);
+            if (key is not null) fileToId[key] = d.Id;
+            if (d.Uid.Length > 0) uidToId[d.Uid] = d.Id;
+        }
+        lock (_editorLock)
+        {
+            _idToEngineSlot = map;
+            _fileToId = fileToId;
+            _uidToId = uidToId;
+            if (full) _openEditors.Clear();
+            else _openEditors.IntersectWith(map.Keys);
+        }
+    }
+
+    /// <summary>
+    /// Full chain (re)load: clears the engine and parallel-loads every active VST3
+    /// plugin via one <c>load_chain</c>, restoring each plugin's saved state. Used
+    /// for engine activation, supervisor reconnect, and TX-dead recovery — the
+    /// cases where the engine is (or must be treated as) empty. Assumes
+    /// <see cref="_chainSyncLock"/> is held.
+    /// </summary>
+    private void LoadChainCore(List<VstChainDiff.DesiredSlot> desired)
+    {
         try
         {
-            var byId = new Dictionary<string, ActivatedPlugin>(StringComparer.Ordinal);
-            foreach (var p in _manager.Active) byId[p.Loaded.Manifest.Id] = p;
-
-            Dictionary<string, string> savedStates;
-            lock (_editorLock) savedStates = new(_pluginStates, StringComparer.Ordinal);
-
-            var slots = new List<object>();
-            var map = new Dictionary<string, int>(StringComparer.Ordinal);
-            var fileToId = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            var uidToId = new Dictionary<string, string>(StringComparer.Ordinal);
-            foreach (var id in _chainOrder.CurrentOrder) // ordered, parked excluded
-            {
-                if (!byId.TryGetValue(id, out var p)) continue;
-                var vst3 = p.Loaded.Manifest.Audio?.Vst3Path;
-                if (string.IsNullOrEmpty(vst3)) continue; // non-VST (native DSP) plugin
-
-                var abs = Path.IsPathRooted(vst3)
-                    ? vst3
-                    : Path.Combine(p.Loaded.PluginDir, vst3);
-                // uid selects ONE plugin from a shell file; "" => engine loads the
-                // single/first plugin in the file (describeFile fallback).
-                var uid = p.Loaded.Manifest.Audio?.Vst3Uid ?? string.Empty;
-                map[id] = slots.Count; // provisional: engine slot == load_chain position
-                var key = NormalizePath(abs);
-                if (key is not null) fileToId[key] = id;
-                if (uid.Length > 0) uidToId[uid] = id;
-                // Restore the plugin's saved voicing. "" => engine loads defaults.
-                var state = savedStates.GetValueOrDefault(id, string.Empty);
-                slots.Add(new { file = abs, identifier = uid, state });
-            }
-
-            lock (_editorLock)
-            {
-                _idToEngineSlot = map;
-                _fileToId = fileToId;
-                _uidToId = uidToId;
-                _openEditors.Clear(); // the engine closes all editors on load_chain
-            }
-
+            lock (_editorLock) _forceFullReload = false;
+            RebuildEngineMaps(desired, full: true);
+            var slots = desired
+                .Select(d => (object)new { file = d.File, identifier = d.Uid, state = d.State })
+                .ToList();
             _engine.SendCommand(new { cmd = "load_chain", chain = slots });
             _log.LogInformation(
                 "VST mode: loaded {Count} VST3 plugin(s) into the engine via load_chain.",
@@ -570,6 +622,47 @@ public sealed class AudioProcessingModeService : IHostedService
         catch (Exception ex)
         {
             _log.LogWarning(ex, "VST mode chain load threw; engine runs with whatever loaded.");
+        }
+    }
+
+    /// <summary>
+    /// Reconcile the engine's loaded chain with the operator's current chain after a
+    /// LIVE edit (add / remove / reorder / park). Diffs the desired chain against the
+    /// engine's current slots and emits only the needed incremental commands, so an
+    /// edit no longer re-instantiates the whole rack — the cause of multi-second
+    /// stalls and audible glitches on every edit. Falls back to a full
+    /// <see cref="LoadChainCore"/> when there's no current chain to diff against or a
+    /// wholesale state replacement is pending (profile apply / startup replay).
+    /// </summary>
+    private void SyncChainToEngine()
+    {
+        lock (_chainSyncLock)
+        {
+            try
+            {
+                bool forceFull;
+                lock (_editorLock) forceFull = _forceFullReload;
+
+                var desired = BuildDesiredSlots();
+
+                List<string> current;
+                lock (_editorLock)
+                    current = _idToEngineSlot.OrderBy(kv => kv.Value).Select(kv => kv.Key).ToList();
+
+                var cmds = forceFull ? null : VstChainDiff.Compute(current, desired);
+                if (cmds is null) { LoadChainCore(desired); return; }
+                if (cmds.Count == 0) return; // chains already match — skip a redundant reload
+
+                RebuildEngineMaps(desired, full: false);
+                foreach (var cmd in cmds) _engine.SendCommand(cmd);
+                _log.LogInformation(
+                    "VST mode: incremental chain update — {Ops} op(s), {Count} plugin(s).",
+                    cmds.Count, desired.Count);
+            }
+            catch (Exception ex)
+            {
+                _log.LogWarning(ex, "VST mode incremental chain sync threw; engine left as-is.");
+            }
         }
     }
 }

--- a/Zeus.Server.Hosting/ChatService.cs
+++ b/Zeus.Server.Hosting/ChatService.cs
@@ -497,13 +497,35 @@ public sealed class ChatService : BackgroundService
     private async Task RunConnectionAsync(string callsign, string sessionKey, CancellationToken ct)
     {
         using var socket = new ClientWebSocket();
+        // Capture the HTTP status of a rejected upgrade so we can tell a stale
+        // QRZ session (403/401) apart from a transient transport failure.
+        socket.Options.CollectHttpResponseDetails = true;
         socket.Options.SetRequestHeader("X-QRZ-Session", sessionKey);
         socket.Options.SetRequestHeader("X-QRZ-Callsign", callsign);
         if (_relaySecret is not null)
             socket.Options.SetRequestHeader("Authorization", $"Bearer {_relaySecret}");
 
         _log.LogInformation("chat: connecting to relay {Url} as {Callsign}", _relayUrl, callsign);
-        await socket.ConnectAsync(new Uri(_relayUrl), ct);
+        try
+        {
+            await socket.ConnectAsync(new Uri(_relayUrl), ct);
+        }
+        catch (WebSocketException) when (
+            socket.HttpStatusCode is System.Net.HttpStatusCode.Forbidden
+                                  or System.Net.HttpStatusCode.Unauthorized)
+        {
+            // The relay validates our QRZ session on the upgrade and rejected it
+            // (403 = "qrz session invalid", 401 = "qrz auth required"). Our local
+            // 1-hour session cache still believes the key is live, so without
+            // evicting it the reconnect loop would replay the dead key forever.
+            // Drop it so the next attempt re-authenticates with QRZ.
+            _log.LogWarning(
+                "chat: relay rejected QRZ session ({Status}); forcing re-auth",
+                socket.HttpStatusCode);
+            await _qrz.InvalidateSessionAsync(ct);
+            throw new InvalidOperationException(
+                "QRZ session expired — re-authenticating");
+        }
 
         _socket = socket;
         _connected = true;

--- a/Zeus.Server.Hosting/DxCluster/DxClusterClient.cs
+++ b/Zeus.Server.Hosting/DxCluster/DxClusterClient.cs
@@ -1,0 +1,340 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using System.Net.Sockets;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Zeus.Contracts;
+using Zeus.Server.Tci;
+
+namespace Zeus.Server.DxCluster;
+
+/// <summary>
+/// Connects to a Telnet DX cluster, logs in, and feeds received spots into the
+/// existing <see cref="SpotManager"/> ingest path (the same path TCI spots use →
+/// SpotBroadcastService → SpotOverlay on the panadapter). No parallel pipeline.
+///
+/// <para>The socket sits behind an injectable seam (<see cref="_connector"/>):
+/// real TCP in production, a fake in-memory duplex stream in tests. No unit test
+/// ever opens a real socket. A single session over a given stream is driven by
+/// <see cref="RunSessionAsync"/>, which is what tests call directly.</para>
+///
+/// <para>The connect/backoff loop ((<see cref="Start"/>/<see cref="Stop"/>) owns
+/// a CancellationTokenSource and a single Task; nothing is left running past
+/// <see cref="Stop"/> or <see cref="Dispose"/>.</para>
+/// </summary>
+public sealed class DxClusterClient : IDisposable
+{
+    // Default spot tick/label colour: Zeus accent blue (#4A9EFF). Packed ARGB with
+    // A=0, which SpotOverlay treats as fully opaque (see argbToRgba). This is a
+    // numeric wire value handed to the existing overlay, not a CSS token.
+    private const uint DefaultSpotArgb = 0x004A9EFFu;
+
+    private static readonly Encoding Latin1 = Encoding.Latin1;
+    private const int MaxLineLength = 4096;
+
+    private readonly ILogger _log;
+    private readonly SpotManager _spots;
+    private readonly Func<string, int, CancellationToken, Task<Stream>> _connector;
+
+    private readonly object _sync = new();
+    private CancellationTokenSource? _cts;
+    private Task? _loop;
+
+    private volatile DxClusterConnectionState _state = DxClusterConnectionState.Disconnected;
+    private int _spotsReceived;
+    private string? _lastSpotCallsign;
+    private volatile string? _lastError;
+
+    public DxClusterClient(ILogger<DxClusterClient> log, SpotManager spots)
+        : this(log, spots, connector: null)
+    {
+    }
+
+    // Test/seam ctor: a null connector wires the production TCP connector.
+    internal DxClusterClient(
+        ILogger log,
+        SpotManager spots,
+        Func<string, int, CancellationToken, Task<Stream>>? connector)
+    {
+        _log = log;
+        _spots = spots;
+        _connector = connector ?? DefaultTcpConnector;
+    }
+
+    public DxClusterConnectionState State => _state;
+    public int SpotsReceived => Volatile.Read(ref _spotsReceived);
+    public string? LastSpotCallsign => Volatile.Read(ref _lastSpotCallsign);
+    public string? LastError => _lastError;
+    public bool IsRunning { get { lock (_sync) return _loop is { IsCompleted: false }; } }
+
+    /// <summary>Start the connect/backoff loop for the given config. Idempotent —
+    /// a second Start while running is a no-op.</summary>
+    public void Start(DxClusterConfig cfg)
+    {
+        lock (_sync)
+        {
+            if (_loop is { IsCompleted: false })
+                return;
+            _lastError = null;
+            _cts = new CancellationTokenSource();
+            var token = _cts.Token;
+            _loop = Task.Run(() => RunLoopAsync(cfg, token), CancellationToken.None);
+        }
+    }
+
+    /// <summary>Stop the loop and wait for it to unwind. Safe to call when idle.</summary>
+    public async Task StopAsync()
+    {
+        CancellationTokenSource? cts;
+        Task? loop;
+        lock (_sync)
+        {
+            cts = _cts;
+            loop = _loop;
+            _cts = null;
+            _loop = null;
+        }
+
+        if (cts is null)
+            return;
+
+        try { cts.Cancel(); } catch { /* already disposed */ }
+        if (loop is not null)
+        {
+            try { await loop.ConfigureAwait(false); }
+            catch (OperationCanceledException) { }
+            catch (Exception ex) { _log.LogDebug(ex, "dxcluster.loop ended with exception"); }
+        }
+        cts.Dispose();
+        _state = DxClusterConnectionState.Disconnected;
+    }
+
+    private async Task RunLoopAsync(DxClusterConfig cfg, CancellationToken ct)
+    {
+        // Bounded exponential backoff: 2s → 60s, reset after a healthy session.
+        var backoff = TimeSpan.FromSeconds(2);
+        var maxBackoff = TimeSpan.FromSeconds(60);
+
+        while (!ct.IsCancellationRequested)
+        {
+            Stream? stream = null;
+            try
+            {
+                _state = DxClusterConnectionState.Connecting;
+                _log.LogInformation("dxcluster.connect host={Host} port={Port}", cfg.Host, cfg.Port);
+                stream = await _connector(cfg.Host, cfg.Port, ct).ConfigureAwait(false);
+
+                _state = DxClusterConnectionState.Connected;
+                _lastError = null;
+                backoff = TimeSpan.FromSeconds(2);
+
+                await RunSessionAsync(cfg, stream, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _lastError = ex.Message;
+                _log.LogWarning("dxcluster.session error: {Msg}", ex.Message);
+            }
+            finally
+            {
+                stream?.Dispose();
+            }
+
+            if (ct.IsCancellationRequested)
+                break;
+
+            _state = DxClusterConnectionState.Reconnecting;
+            try { await Task.Delay(backoff, ct).ConfigureAwait(false); }
+            catch (OperationCanceledException) { break; }
+            backoff = TimeSpan.FromMilliseconds(Math.Min(maxBackoff.TotalMilliseconds, backoff.TotalMilliseconds * 2));
+        }
+
+        _state = DxClusterConnectionState.Disconnected;
+    }
+
+    /// <summary>
+    /// Drive one session over an already-connected duplex stream: run the login
+    /// handshake, strip Telnet IAC bytes, split newline-delimited lines, parse
+    /// spots, and ingest them. Returns when the stream ends or is cancelled.
+    /// Tests call this directly with a fake in-memory duplex stream.
+    /// </summary>
+    internal async Task RunSessionAsync(DxClusterConfig cfg, Stream stream, CancellationToken ct)
+    {
+        var handshake = new DxClusterHandshake(cfg.Callsign, cfg.Password, SplitLoginCommands(cfg.LoginCommands));
+        var filter = new TelnetByteFilter();
+        var readBuf = new byte[4096];
+        var filtered = new List<byte>(4096);
+        var lineBuf = new List<byte>(256);
+
+        while (!ct.IsCancellationRequested)
+        {
+            int n = await stream.ReadAsync(readBuf.AsMemory(0, readBuf.Length), ct).ConfigureAwait(false);
+            if (n <= 0)
+                break; // EOF — peer closed
+
+            filtered.Clear();
+            filter.Process(readBuf, n, filtered);
+
+            foreach (var b in filtered)
+            {
+                if (b == (byte)'\n')
+                {
+                    await EmitLineAsync(lineBuf, handshake, stream, ct).ConfigureAwait(false);
+                    lineBuf.Clear();
+                }
+                else if (b == (byte)'\r')
+                {
+                    // ignore CR; line terminates on LF
+                }
+                else
+                {
+                    if (lineBuf.Count < MaxLineLength)
+                        lineBuf.Add(b);
+                    // Some clusters print a non-newline-terminated prompt ("login: ").
+                    // Treat a trailing-space prompt opportunistically: see EmitPromptProbe.
+                }
+            }
+
+            // A login/password prompt may arrive WITHOUT a trailing newline. After
+            // draining a chunk, probe the pending partial line for a prompt so the
+            // handshake doesn't stall waiting for a LF that never comes.
+            await ProbePromptAsync(lineBuf, handshake, stream, ct).ConfigureAwait(false);
+        }
+    }
+
+    private async Task EmitLineAsync(List<byte> lineBytes, DxClusterHandshake handshake, Stream stream, CancellationToken ct)
+    {
+        var line = Latin1.GetString(lineBytes.ToArray()).Trim();
+        if (line.Length == 0)
+            return;
+
+        var replies = handshake.OnLine(line);
+        await SendRepliesAsync(replies, stream, ct).ConfigureAwait(false);
+
+        if (DxSpotLineParser.TryParse(line, out var spot))
+        {
+            _spots.AddSpot(spot.DxCall, spot.Mode, spot.FreqHz, DefaultSpotArgb,
+                string.IsNullOrEmpty(spot.Comment) ? null : spot.Comment);
+            Interlocked.Increment(ref _spotsReceived);
+            Volatile.Write(ref _lastSpotCallsign, spot.DxCall);
+            _log.LogDebug("dxcluster.spot {Call} {Mode} {Freq}Hz", spot.DxCall, spot.Mode, spot.FreqHz);
+        }
+    }
+
+    // Probe a not-yet-terminated partial line for a login/password prompt. Only
+    // sends when the handshake actually emits a reply, so non-prompt partial text
+    // is left to accumulate until its newline.
+    private async Task ProbePromptAsync(List<byte> lineBytes, DxClusterHandshake handshake, Stream stream, CancellationToken ct)
+    {
+        if (lineBytes.Count == 0)
+            return;
+        var partial = Latin1.GetString(lineBytes.ToArray());
+        var lower = partial.ToLowerInvariant();
+        // Cheap pre-filter: only invoke the handshake for prompt-shaped partials.
+        if (!(lower.Contains("login") || lower.Contains("call") || lower.Contains("password")))
+            return;
+        var replies = handshake.OnLine(partial.Trim());
+        if (replies.Count > 0)
+        {
+            await SendRepliesAsync(replies, stream, ct).ConfigureAwait(false);
+            lineBytes.Clear(); // consumed as a prompt; don't double-feed at LF
+        }
+    }
+
+    private static async Task SendRepliesAsync(IReadOnlyList<string> replies, Stream stream, CancellationToken ct)
+    {
+        if (replies.Count == 0)
+            return;
+        foreach (var r in replies)
+        {
+            var bytes = Latin1.GetBytes(r + "\r\n");
+            await stream.WriteAsync(bytes.AsMemory(), ct).ConfigureAwait(false);
+        }
+        await stream.FlushAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <summary>Split the newline-separated login-commands blob into trimmed,
+    /// non-empty commands. Pure helper, shared with the handshake.</summary>
+    public static IReadOnlyList<string> SplitLoginCommands(string? blob)
+    {
+        if (string.IsNullOrWhiteSpace(blob))
+            return Array.Empty<string>();
+        return blob
+            .Replace("\r\n", "\n").Replace('\r', '\n')
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
+    private static async Task<Stream> DefaultTcpConnector(string host, int port, CancellationToken ct)
+    {
+        var tcp = new TcpClient();
+        try
+        {
+            await tcp.ConnectAsync(host, port, ct).ConfigureAwait(false);
+            // The TcpClient owns the socket; the returned stream's Dispose (called
+            // by the loop's finally) tears the connection down. Keep a reference so
+            // disposing the stream also disposes the client.
+            return new TcpClientStream(tcp);
+        }
+        catch
+        {
+            tcp.Dispose();
+            throw;
+        }
+    }
+
+    public void Dispose()
+    {
+        try { StopAsync().GetAwaiter().GetResult(); } catch { /* best effort */ }
+    }
+
+    // Wraps a TcpClient's NetworkStream so disposing the stream also disposes the
+    // owning client (and thus the socket). Keeps the production connector to a
+    // single Stream return type that matches the test seam.
+    private sealed class TcpClientStream : Stream
+    {
+        private readonly TcpClient _client;
+        private readonly NetworkStream _inner;
+
+        public TcpClientStream(TcpClient client)
+        {
+            _client = client;
+            _inner = client.GetStream();
+        }
+
+        public override bool CanRead => _inner.CanRead;
+        public override bool CanSeek => false;
+        public override bool CanWrite => _inner.CanWrite;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public override void Flush() => _inner.Flush();
+        public override Task FlushAsync(CancellationToken ct) => _inner.FlushAsync(ct);
+        public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken ct = default) => _inner.ReadAsync(buffer, ct);
+        public override void Write(byte[] buffer, int offset, int count) => _inner.Write(buffer, offset, count);
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken ct = default) => _inner.WriteAsync(buffer, ct);
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _inner.Dispose();
+                _client.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Zeus.Server.Hosting/DxCluster/DxClusterHandshake.cs
+++ b/Zeus.Server.Hosting/DxCluster/DxClusterHandshake.cs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+namespace Zeus.Server.DxCluster;
+
+/// <summary>
+/// Pure login/handshake state machine for a DX cluster. No I/O: it is fed each
+/// incoming line and returns the lines that should be sent in response (without
+/// trailing CRLF — the caller frames them). It is idempotent: the callsign /
+/// password / login commands are each sent at most once, no matter how many
+/// times a prompt re-appears.
+///
+/// Recognised prompts (case-insensitive substring match):
+///   • callsign — "login:", "call:", "please enter your call", "enter your call",
+///     "your call", "callsign:".
+///   • password — "password:", "password>", "enter password".
+///
+/// Login commands (if any) are sent once, on the first line received after the
+/// callsign (and password, when one is configured) have been sent — i.e. once we
+/// are past the login exchange and the node is talking to us.
+/// </summary>
+public sealed class DxClusterHandshake
+{
+    private static readonly string[] CallPrompts =
+    {
+        "login:", "callsign:", "call:", "please enter your call",
+        "enter your call", "your call",
+    };
+
+    private static readonly string[] PasswordPrompts =
+    {
+        "password:", "password>", "enter password",
+    };
+
+    private readonly string _callsign;
+    private readonly string? _password;
+    private readonly string[] _loginCommands;
+
+    private bool _callsignSent;
+    private bool _passwordSent;
+    private bool _loginCommandsSent;
+
+    public DxClusterHandshake(string callsign, string? password, IEnumerable<string>? loginCommands)
+    {
+        _callsign = (callsign ?? "").Trim();
+        _password = string.IsNullOrWhiteSpace(password) ? null : password;
+        _loginCommands = (loginCommands ?? Array.Empty<string>())
+            .Select(c => c?.Trim() ?? "")
+            .Where(c => c.Length > 0)
+            .ToArray();
+    }
+
+    private bool PasswordRequired => _password is not null;
+
+    /// <summary>True once the callsign has been sent (login exchange underway).</summary>
+    public bool CallsignSent => _callsignSent;
+
+    /// <summary>
+    /// Feed one received line. Returns zero or more lines to send back. The
+    /// returned strings carry no line terminator.
+    /// </summary>
+    public IReadOnlyList<string> OnLine(string? line)
+    {
+        if (line is null)
+            return Array.Empty<string>();
+
+        var lower = line.ToLowerInvariant();
+
+        // 1) Callsign at a login/call prompt — once.
+        if (!_callsignSent && _callsign.Length > 0 && ContainsAny(lower, CallPrompts))
+        {
+            _callsignSent = true;
+            return new[] { _callsign };
+        }
+
+        // 2) Password at a password prompt — once, only if one is configured.
+        if (PasswordRequired && !_passwordSent && ContainsAny(lower, PasswordPrompts))
+        {
+            _passwordSent = true;
+            return new[] { _password! };
+        }
+
+        // 3) Post-login commands — once, on the first line after the login
+        //    exchange completed. Guarded so they never fire before login.
+        if (!_loginCommandsSent
+            && _loginCommands.Length > 0
+            && _callsignSent
+            && (!PasswordRequired || _passwordSent))
+        {
+            _loginCommandsSent = true;
+            return _loginCommands;
+        }
+
+        return Array.Empty<string>();
+    }
+
+    private static bool ContainsAny(string haystack, string[] needles)
+    {
+        foreach (var n in needles)
+            if (haystack.Contains(n, StringComparison.Ordinal))
+                return true;
+        return false;
+    }
+}

--- a/Zeus.Server.Hosting/DxCluster/DxSpotLineParser.cs
+++ b/Zeus.Server.Hosting/DxCluster/DxSpotLineParser.cs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Zeus.Server.DxCluster;
+
+/// <summary>
+/// A single parsed DX-cluster spot line. Pure data — no I/O. <see cref="FreqHz"/>
+/// is integer Hz (kHz on the wire × 1000). <see cref="Mode"/> is "" when it
+/// cannot be derived from the comment.
+/// </summary>
+public sealed record DxSpotLine(
+    string SpotterCall,
+    string DxCall,
+    long FreqHz,
+    string Comment,
+    string Mode,
+    string Time);
+
+/// <summary>
+/// Pure parser for standard DX-cluster spot lines. No sockets, no state — a
+/// static function over a line of text. Handles the DXSpider / AR-Cluster /
+/// CC-Cluster spacing variants and rejects everything that is not a spot
+/// (banners, prompts, talk / announce / WWV lines).
+///
+/// Canonical form:
+///   <c>DX de &lt;SPOTTER&gt;:   &lt;FREQ_kHz&gt;  &lt;DXCALL&gt;   &lt;comment...&gt;   &lt;HHMMZ&gt;</c>
+/// e.g. <c>DX de W3LPL:    14074.0  K1ABC        FT8  -12 dB         1432Z</c>
+/// </summary>
+public static class DxSpotLineParser
+{
+    // A callsign-ish token: letters, digits, slash, dash, optional SSID/portable.
+    // Deliberately lenient — cluster node calls and portable suffixes vary — but
+    // it must contain at least one letter and one digit somewhere so plain words
+    // (banner text) are rejected as the spotter/DX call.
+    private const string Call = @"[A-Za-z0-9][A-Za-z0-9/\-]*";
+
+    // ^DX de <spotter>:?  <freq>  <dxcall>  <rest...>
+    // - "DX de" is case-insensitive and tolerant of extra spaces.
+    // - The colon after the spotter is optional (a few nodes omit it).
+    // - Freq is kHz, integer or decimal.
+    private static readonly Regex SpotRe = new(
+        @"^\s*DX\s+de\s+(?<spotter>" + Call + @")\s*:?\s+(?<freq>\d{1,9}(?:\.\d+)?)\s+(?<dx>" + Call + @")\s+(?<rest>.*)$",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    // Trailing UTC time token "1432Z" (3 or 4 digits). Anchored to the end,
+    // tolerating an optional 4/6-char grid square after it on some nodes.
+    private static readonly Regex TrailingTimeRe = new(
+        @"\b(?<time>\d{3,4}Z)\b(?:\s+[A-Z]{2}\d{2}(?:[A-Za-z]{2})?)?\s*$",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// Try to parse a single line as a DX spot. Returns false for any line that
+    /// is not a well-formed spot (login banner, prompt, talk/announce, blank).
+    /// </summary>
+    public static bool TryParse(string? line, out DxSpotLine spot)
+    {
+        spot = null!;
+        if (string.IsNullOrWhiteSpace(line))
+            return false;
+
+        var m = SpotRe.Match(line);
+        if (!m.Success)
+            return false;
+
+        // Frequency: kHz on the wire → integer Hz. Reject implausible values so a
+        // stray number-shaped banner line can't masquerade as a spot.
+        if (!double.TryParse(m.Groups["freq"].Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var khz))
+            return false;
+        if (khz < 1.0 || khz > 10_000_000.0) // 1 kHz .. 10 GHz
+            return false;
+        var freqHz = (long)Math.Round(khz * 1000.0, MidpointRounding.AwayFromZero);
+
+        var spotter = m.Groups["spotter"].Value.ToUpperInvariant();
+        var dxCall = m.Groups["dx"].Value.ToUpperInvariant();
+        if (!LooksLikeCall(dxCall))
+            return false;
+
+        var rest = m.Groups["rest"].Value.Trim();
+
+        // Pull the trailing time token off the end; the remainder is the comment.
+        string time = "";
+        string comment = rest;
+        var tm = TrailingTimeRe.Match(rest);
+        if (tm.Success)
+        {
+            time = tm.Groups["time"].Value.ToUpperInvariant();
+            comment = rest[..tm.Index].Trim();
+        }
+
+        var mode = DeriveMode(comment);
+
+        spot = new DxSpotLine(spotter, dxCall, freqHz, comment, mode, time);
+        return true;
+    }
+
+    // A real callsign has at least one letter AND at least one digit. This is the
+    // guard that keeps "DX de NODE: 14074 CQ ..." style noise out — a DX call of
+    // "CQ" (no digit) is rejected.
+    private static bool LooksLikeCall(string s)
+    {
+        bool hasLetter = false, hasDigit = false;
+        foreach (var c in s)
+        {
+            if (char.IsLetter(c)) hasLetter = true;
+            else if (char.IsDigit(c)) hasDigit = true;
+        }
+        return hasLetter && hasDigit;
+    }
+
+    // Best-effort mode from the comment text. Only the common, unambiguous modes
+    // the issue calls out; "" when nothing matches. Each token's word-boundary
+    // pattern is compiled once (static), so a firehose of spots never churns the
+    // shared static Regex cache or re-allocates pattern strings per spot.
+    private static readonly (Regex Pattern, string Mode)[] ModePatterns =
+    {
+        (ModeRegex("FT8"),  "FT8"),
+        (ModeRegex("FT4"),  "FT4"),
+        (ModeRegex("RTTY"), "RTTY"),
+        (ModeRegex("PSK"),  "PSK"),
+        (ModeRegex("JT65"), "JT65"),
+        (ModeRegex("CW"),   "CW"),
+        (ModeRegex("USB"),  "SSB"),
+        (ModeRegex("LSB"),  "SSB"),
+        (ModeRegex("SSB"),  "SSB"),
+    };
+
+    // Word-boundary match (against the upper-cased comment) so "FT8" matches in
+    // "FT8 -12 dB" but not inside a serial number.
+    private static Regex ModeRegex(string token) => new(
+        $@"\b{Regex.Escape(token)}\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static string DeriveMode(string comment)
+    {
+        if (string.IsNullOrWhiteSpace(comment))
+            return "";
+        var upper = comment.ToUpperInvariant();
+        foreach (var (pattern, mode) in ModePatterns)
+        {
+            if (pattern.IsMatch(upper))
+                return mode;
+        }
+        return "";
+    }
+}

--- a/Zeus.Server.Hosting/DxCluster/TelnetByteFilter.cs
+++ b/Zeus.Server.Hosting/DxCluster/TelnetByteFilter.cs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+namespace Zeus.Server.DxCluster;
+
+/// <summary>
+/// Strips Telnet (RFC 854) IAC option-negotiation sequences from an inbound byte
+/// stream, leaving only the application text. Stateful across calls so a sequence
+/// that straddles a read boundary is handled correctly. No I/O — pure byte
+/// transform, fully unit-testable.
+///
+/// We are a passive reader of a (mostly line-mode) cluster, so we never reply to
+/// negotiations — most clusters work fine without WILL/WONT handshakes, and the
+/// few control bytes are simply discarded. <c>IAC IAC</c> (0xFF 0xFF) is the one
+/// case that yields a literal 0xFF data byte.
+/// </summary>
+public sealed class TelnetByteFilter
+{
+    private const byte IAC = 0xFF;
+    private const byte SB = 0xFA;  // begin subnegotiation
+    private const byte SE = 0xF0;  // end subnegotiation
+    private const byte WILL = 0xFB;
+    private const byte WONT = 0xFC;
+    private const byte DO = 0xFD;
+    private const byte DONT = 0xFE;
+
+    private enum S { Normal, Iac, Option, SubNeg, SubNegIac }
+
+    private S _state = S.Normal;
+
+    /// <summary>
+    /// Process <paramref name="count"/> bytes from <paramref name="input"/>,
+    /// appending the surviving data bytes to <paramref name="sink"/>.
+    /// </summary>
+    public void Process(byte[] input, int count, List<byte> sink)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            byte b = input[i];
+            switch (_state)
+            {
+                case S.Normal:
+                    if (b == IAC) _state = S.Iac;
+                    else sink.Add(b);
+                    break;
+
+                case S.Iac:
+                    if (b == IAC) { sink.Add(IAC); _state = S.Normal; }   // escaped literal 0xFF
+                    else if (b is WILL or WONT or DO or DONT) _state = S.Option;
+                    else if (b == SB) _state = S.SubNeg;
+                    else _state = S.Normal;                                // 2-byte command, drop
+                    break;
+
+                case S.Option:
+                    // The single option byte after WILL/WONT/DO/DONT — drop it.
+                    _state = S.Normal;
+                    break;
+
+                case S.SubNeg:
+                    if (b == IAC) _state = S.SubNegIac;                    // maybe IAC SE
+                    break;                                                 // else still inside SB, drop
+
+                case S.SubNegIac:
+                    if (b == SE) _state = S.Normal;                        // end of subnegotiation
+                    else if (b == IAC) _state = S.SubNegIac;              // escaped 0xFF inside SB, drop
+                    else _state = S.SubNeg;                                // back inside SB
+                    break;
+            }
+        }
+    }
+}

--- a/Zeus.Server.Hosting/DxClusterConfigStore.cs
+++ b/Zeus.Server.Hosting/DxClusterConfigStore.cs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using LiteDB;
+using Zeus.Contracts;
+
+namespace Zeus.Server;
+
+// DX-cluster client config persistence. Single-row collection in zeus-prefs.db
+// — one cluster connection per Zeus instance, so a profile key would just be
+// ceremony. Mirrors TciConfigStore / CatConfigStore exactly: the SAME shared
+// LiteDB lease (Zeus.Data.SharedLiteDatabase.Acquire) so we never open a second
+// LiteDatabase handle (the Windows-only exclusive-lock IOException, GH #682).
+//
+// Password is stored at-rest as plaintext, consistent with the existing
+// CredentialStore (QRZ) precedent in the same DB — see the PR notes.
+public sealed class DxClusterConfigStore : IDisposable
+{
+    private readonly Zeus.Data.SharedLiteDatabase.Lease _dbLease;
+    private readonly LiteDatabase _db;
+    private readonly ILiteCollection<DxClusterConfigEntry> _entries;
+    private readonly ILogger<DxClusterConfigStore> _log;
+    private readonly object _sync = new();
+
+    public DxClusterConfigStore(ILogger<DxClusterConfigStore> log, string? dbPathOverride = null)
+    {
+        _log = log;
+        var dbPath = dbPathOverride ?? PrefsDbPath.Get();
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        _dbLease = Zeus.Data.SharedLiteDatabase.Acquire(dbPath);
+        _db = _dbLease.Database;
+        _entries = _db.GetCollection<DxClusterConfigEntry>("dxcluster_config");
+
+        _log.LogInformation("DxClusterConfigStore initialized at {Path}", dbPath);
+    }
+
+    // null = nothing persisted yet — caller falls back to the default (all-off) config.
+    public DxClusterConfig? Get()
+    {
+        lock (_sync)
+        {
+            var e = _entries.FindAll().FirstOrDefault();
+            if (e is null) return null;
+            return new DxClusterConfig(
+                Enabled: e.Enabled,
+                Host: e.Host ?? "",
+                Port: e.Port,
+                Callsign: e.Callsign ?? "",
+                Password: e.Password ?? "",
+                LoginCommands: e.LoginCommands ?? "",
+                AutoConnect: e.AutoConnect);
+        }
+    }
+
+    public void Set(DxClusterConfig config)
+    {
+        lock (_sync)
+        {
+            var existing = _entries.FindAll().FirstOrDefault();
+            if (existing is null)
+            {
+                _entries.Insert(new DxClusterConfigEntry
+                {
+                    Enabled = config.Enabled,
+                    Host = config.Host,
+                    Port = config.Port,
+                    Callsign = config.Callsign,
+                    Password = config.Password,
+                    LoginCommands = config.LoginCommands,
+                    AutoConnect = config.AutoConnect,
+                    UpdatedUtc = DateTime.UtcNow,
+                });
+            }
+            else
+            {
+                existing.Enabled = config.Enabled;
+                existing.Host = config.Host;
+                existing.Port = config.Port;
+                existing.Callsign = config.Callsign;
+                existing.Password = config.Password;
+                existing.LoginCommands = config.LoginCommands;
+                existing.AutoConnect = config.AutoConnect;
+                existing.UpdatedUtc = DateTime.UtcNow;
+                _entries.Update(existing);
+            }
+        }
+    }
+
+    public void Dispose() => _dbLease.Dispose();
+}
+
+public sealed class DxClusterConfigEntry
+{
+    public int Id { get; set; }
+    public bool Enabled { get; set; }
+    public string? Host { get; set; } = "";
+    public int Port { get; set; } = 7373;
+    public string? Callsign { get; set; } = "";
+    public string? Password { get; set; } = "";
+    public string? LoginCommands { get; set; } = "";
+    public bool AutoConnect { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/Zeus.Server.Hosting/DxClusterManagementService.cs
+++ b/Zeus.Server.Hosting/DxClusterManagementService.cs
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+using Microsoft.Extensions.Hosting;
+using Zeus.Contracts;
+using Zeus.Server.DxCluster;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Config + status facade and lifecycle owner for the native Telnet DX-cluster
+/// client. Mirrors TciManagementService's shape (config persistence + status
+/// reporting) but, because the cluster is an OUTBOUND connection (not a Kestrel
+/// listener), it can connect/disconnect at runtime with no restart.
+///
+/// IHostedService: on startup it auto-connects only when the operator persisted
+/// Enabled AND AutoConnect — otherwise it stays idle until an explicit
+/// POST /api/dxcluster/connect. On shutdown it tears the client down cleanly.
+/// </summary>
+public sealed class DxClusterManagementService : IHostedService, IDisposable
+{
+    private readonly ILogger<DxClusterManagementService> _log;
+    private readonly DxClusterConfigStore _store;
+    private readonly DxClusterClient _client;
+    private readonly object _sync = new();
+    private DxClusterConfig _config;
+
+    public DxClusterManagementService(
+        ILogger<DxClusterManagementService> log,
+        DxClusterConfigStore store,
+        DxClusterClient client)
+    {
+        _log = log;
+        _store = store;
+        _client = client;
+        // Default OFF when nothing persisted — new network egress is opt-in.
+        _config = store.Get() ?? new DxClusterConfig();
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var cfg = GetConfig();
+        if (cfg.Enabled && cfg.AutoConnect && CanConnect(cfg))
+        {
+            _log.LogInformation("dxcluster.autoconnect host={Host} port={Port}", cfg.Host, cfg.Port);
+            _client.Start(cfg);
+        }
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        await _client.StopAsync().ConfigureAwait(false);
+    }
+
+    public DxClusterConfig GetConfig()
+    {
+        lock (_sync) return _config;
+    }
+
+    public DxClusterStatus GetStatus()
+    {
+        var c = GetConfig();
+        return new DxClusterStatus(
+            Enabled: c.Enabled,
+            Host: c.Host,
+            Port: c.Port,
+            Callsign: c.Callsign,
+            HasPassword: !string.IsNullOrEmpty(c.Password),
+            LoginCommands: c.LoginCommands,
+            AutoConnect: c.AutoConnect,
+            State: _client.State,
+            SpotsReceived: _client.SpotsReceived,
+            LastSpotCallsign: _client.LastSpotCallsign,
+            Error: _client.LastError);
+    }
+
+    /// <summary>Persist a new config. If the client is running, restart it so the
+    /// new host/callsign/etc. take effect immediately (no restart needed).</summary>
+    public DxClusterStatus SetConfig(DxClusterConfig config)
+    {
+        var normalized = Normalize(config);
+        lock (_sync) _config = normalized;
+
+        try { _store.Set(normalized); }
+        catch (Exception ex) { _log.LogWarning(ex, "dxcluster.config.persist failed"); }
+
+        _log.LogInformation(
+            "dxcluster.config.updated enabled={En} host={Host} port={Port} call={Call} auto={Auto}",
+            normalized.Enabled, normalized.Host, normalized.Port, normalized.Callsign, normalized.AutoConnect);
+
+        // Reconcile: if it was running, restart on the new settings; if it is now
+        // disabled, stop. We do NOT auto-start here on a mere enable — connecting
+        // is an explicit operator action (POST /connect) unless AutoConnect drove
+        // it at startup.
+        if (_client.IsRunning)
+        {
+            if (!normalized.Enabled || !CanConnect(normalized))
+            {
+                _ = _client.StopAsync();
+            }
+            else
+            {
+                _ = RestartAsync(normalized);
+            }
+        }
+
+        return GetStatus();
+    }
+
+    /// <summary>Explicit operator connect. No-op if already running or not
+    /// connectable.</summary>
+    public DxClusterStatus Connect()
+    {
+        var cfg = GetConfig();
+        if (!cfg.Enabled)
+        {
+            _log.LogInformation("dxcluster.connect ignored — not enabled");
+            return GetStatus();
+        }
+        if (!CanConnect(cfg))
+        {
+            _log.LogInformation("dxcluster.connect ignored — host/callsign not set");
+            return GetStatus();
+        }
+        _client.Start(cfg);
+        return GetStatus();
+    }
+
+    /// <summary>Explicit operator disconnect.</summary>
+    public DxClusterStatus Disconnect()
+    {
+        _ = _client.StopAsync();
+        return GetStatus();
+    }
+
+    private async Task RestartAsync(DxClusterConfig cfg)
+    {
+        try
+        {
+            await _client.StopAsync().ConfigureAwait(false);
+            _client.Start(cfg);
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "dxcluster.restart failed");
+        }
+    }
+
+    private static bool CanConnect(DxClusterConfig c) =>
+        !string.IsNullOrWhiteSpace(c.Host)
+        && c.Port is > 0 and < 65536
+        && !string.IsNullOrWhiteSpace(c.Callsign);
+
+    private static DxClusterConfig Normalize(DxClusterConfig c) => new(
+        Enabled: c.Enabled,
+        Host: (c.Host ?? "").Trim(),
+        Port: c.Port is > 0 and < 65536 ? c.Port : 7373,
+        Callsign: (c.Callsign ?? "").Trim().ToUpperInvariant(),
+        Password: c.Password ?? "",
+        LoginCommands: (c.LoginCommands ?? "").Trim(),
+        AutoConnect: c.AutoConnect);
+
+    public void Dispose() => _client.Dispose();
+}

--- a/Zeus.Server.Hosting/HamClockService.cs
+++ b/Zeus.Server.Hosting/HamClockService.cs
@@ -396,6 +396,7 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
             // We own this local copy, so disable frameguard.
             PatchHelmetFrameguard();
             PatchZeusCatBridge();
+            PatchZeusExternalLinks();
 
             lock (_gate) { _phase = HamClockPhase.Installed; _busy = false; }
             Append("HamClock installed. Click Start to launch the panel.");
@@ -451,6 +452,8 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
             PatchHelmetFrameguard();
             // Covers installs that predate the Zeus CAT bridge (idempotent).
             PatchZeusCatBridge();
+            // Covers installs that predate the external-links bridge (idempotent).
+            PatchZeusExternalLinks();
 
             var psi = MakePsi("node", "server.js", InstallDir);
             // Belt-and-suspenders env (overridden by .env, but harmless).
@@ -1122,11 +1125,83 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
         """;
 
     internal static string InjectZeusCatBridgeTag(string html)
+        => InjectScriptTag(html, ZeusCatBridgeScriptName);
+
+    // -- Zeus external-links bridge --------------------------------------
+
+    internal const string ZeusExternalLinksScriptName = "zeus-external-links.js";
+
+    // Injected into HamClock's dist/. The HamClock iframe is cross-origin to the
+    // Zeus SPA, and the Photino desktop webview swallows window.open / target=_blank
+    // and has no download handler — so the Rig Bridge download buttons and the
+    // "Readme on GitHub" link do nothing when clicked in the desktop app. This
+    // capture-phase listener catches those anchor clicks before HamClock's own
+    // handlers run, and forwards the absolute URL up to the Zeus host
+    // (HamClockPanel), which opens it in the OS browser via the existing
+    // zeus.openExternal bridge. Two cases are forwarded:
+    //   - external links (origin != HamClock's own) — e.g. the GitHub readme,
+    //     and any target=_blank the webview would otherwise drop;
+    //   - same-origin downloads — any anchor carrying a `download` attribute, OR
+    //     a sidecar URL under /api/rig/download/. The `download`-attribute gate is
+    //     the robust one: it forwards whatever path OpenHamClock's Rig Bridge
+    //     buttons actually use without hinging on one literal prefix. The explicit
+    //     /api/rig/download/ prefix is kept as a belt-and-braces fallback for
+    //     download links that omit the attribute. Either way the URL resolves to
+    //     the sidecar's absolute http URL (host:port), which the OS browser
+    //     fetches and saves natively (the webview cannot).
+    //
+    // Plain left-clicks only: modifier/middle clicks and already-handled events
+    // are left alone so the script never hijacks a click the page meant to keep.
+    internal const string ZeusExternalLinksScript = """
+        (() => {
+          if (window.__zeusHamClockExternalLinksInstalled) return;
+          window.__zeusHamClockExternalLinksInstalled = true;
+
+          document.addEventListener('click', (event) => {
+            if (event.defaultPrevented) return;
+            if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+
+            const anchor = event.target?.closest?.('a[href]');
+            if (!anchor) return;
+
+            const href = anchor.getAttribute('href');
+            if (!href) return;
+
+            let url;
+            try {
+              url = new URL(href, document.baseURI);
+            } catch {
+              return;
+            }
+
+            if (url.protocol !== 'http:' && url.protocol !== 'https:') return;
+
+            const isExternal = url.origin !== location.origin;
+            const isSidecarDownload = url.pathname.startsWith('/api/rig/download/');
+            const hasDownloadAttr = anchor.hasAttribute('download');
+            if (!isExternal && !isSidecarDownload && !hasDownloadAttr) return;
+
+            event.preventDefault();
+            event.stopPropagation();
+            window.parent?.postMessage({ type: 'zeus.openExternal', url: url.href }, '*');
+          }, true);
+        })();
+        """;
+
+    internal static string InjectZeusExternalLinksTag(string html)
+        => InjectScriptTag(html, ZeusExternalLinksScriptName);
+
+    /// <summary>
+    /// Insert a <c>&lt;script src="/&lt;name&gt;" defer&gt;</c> tag just before
+    /// <c>&lt;/head&gt;</c> (or append it if there is no head), once. Idempotent:
+    /// returns the input unchanged when the script is already referenced.
+    /// </summary>
+    private static string InjectScriptTag(string html, string scriptName)
     {
-        if (html.Contains(ZeusCatBridgeScriptName, StringComparison.Ordinal))
+        if (html.Contains(scriptName, StringComparison.Ordinal))
             return html;
 
-        var tag = $"<script src=\"/{ZeusCatBridgeScriptName}\" defer></script>";
+        var tag = $"<script src=\"/{scriptName}\" defer></script>";
         var headEnd = html.IndexOf("</head>", StringComparison.OrdinalIgnoreCase);
         if (headEnd >= 0)
             return html.Insert(headEnd, $"  {tag}\n  ");
@@ -1173,6 +1248,40 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
     /// This avoids depending on OpenHamClock's standalone rig-bridge settings.
     /// </summary>
     private void PatchZeusCatBridge()
+        => PatchInjectedScript(
+            ZeusCatBridgeScriptName,
+            ZeusCatBridgeScript,
+            InjectZeusCatBridgeTag,
+            "Patched HamClock DX spots to notify Zeus click-to-tune.",
+            "Zeus CAT bridge");
+
+    /// <summary>
+    /// Inject a tiny client script into HamClock's built frontend that forwards
+    /// external-link / Rig-Bridge-download anchor clicks up to the Zeus host so
+    /// they open in the OS browser (the Photino webview swallows window.open and
+    /// has no download handler). Idempotent. See <see cref="ZeusExternalLinksScript"/>.
+    /// </summary>
+    private void PatchZeusExternalLinks()
+        => PatchInjectedScript(
+            ZeusExternalLinksScriptName,
+            ZeusExternalLinksScript,
+            InjectZeusExternalLinksTag,
+            "Patched HamClock external links to open in the OS browser.",
+            "Zeus external-links");
+
+    /// <summary>
+    /// Write <paramref name="scriptBody"/> into HamClock's <c>dist/</c> as
+    /// <paramref name="scriptName"/> and inject its <c>&lt;script&gt;</c> tag into
+    /// <c>dist/index.html</c> via <paramref name="injectTag"/>. Idempotent: the
+    /// script file is rewritten each call (harmless), and the tag is inserted at
+    /// most once. No-op until the build has produced <c>index.html</c>.
+    /// </summary>
+    private void PatchInjectedScript(
+        string scriptName,
+        string scriptBody,
+        Func<string, string> injectTag,
+        string successNote,
+        string label)
     {
         try
         {
@@ -1181,19 +1290,19 @@ public sealed class HamClockService : IHostedService, IAsyncDisposable
             if (!File.Exists(index)) return;
 
             Directory.CreateDirectory(dist);
-            File.WriteAllText(Path.Combine(dist, ZeusCatBridgeScriptName), ZeusCatBridgeScript);
+            File.WriteAllText(Path.Combine(dist, scriptName), scriptBody);
 
             var html = File.ReadAllText(index);
-            var updated = InjectZeusCatBridgeTag(html);
-            if (!ReferenceEquals(updated, html) && updated != html)
+            var updated = injectTag(html);
+            if (updated != html)
             {
                 File.WriteAllText(index, updated);
-                Append("Patched HamClock DX spots to notify Zeus click-to-tune.");
+                Append(successNote);
             }
         }
         catch (Exception ex)
         {
-            Append($"  (Zeus CAT bridge patch skipped: {ex.Message})");
+            Append($"  ({label} patch skipped: {ex.Message})");
         }
     }
 

--- a/Zeus.Server.Hosting/NativeAudioDevicePlan.cs
+++ b/Zeus.Server.Hosting/NativeAudioDevicePlan.cs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2026 Brian Keating (EI6LF), Christian Suarez (N9WAR), and contributors.
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Decides which native audio device side(s) to (re)open in response to a
+/// device-change request, and which (if any) request a rejection.
+///
+/// <para>Background (#1128): the SPA's Audio Devices rail sends BOTH the input
+/// and the output device id on every change because the PUT contract has no
+/// "leave unchanged" sentinel — changing only the output device resends the
+/// currently-configured input id alongside the new output id. The old endpoint
+/// validated both ids against the live device list and rejected the WHOLE
+/// request if either was missing. So when an operator's previously-saved mic
+/// was unplugged (or the prefs DB was copied from another machine), every
+/// attempt to change the OUTPUT device was rejected with an input-device error
+/// and the dropdown snapped back — "Zeus will not allow me to use any of the
+/// windows sound devices for RX audio".</para>
+///
+/// <para>The fix: only validate and apply a side that is actually CHANGING
+/// relative to the current configuration. A carried-over (unchanged) id —
+/// even one that is now stale — must never block a change to the other side.
+/// As a free bonus, re-selecting the same device is a no-op rather than a
+/// needless device reopen (which would glitch audio).</para>
+/// </summary>
+internal static class NativeAudioDevicePlan
+{
+    internal readonly record struct Result(
+        bool ApplyInput,
+        bool ApplyOutput,
+        string? InputError,
+        string? OutputError);
+
+    /// <param name="hasMic">Whether a capture (mic) service is registered.</param>
+    /// <param name="currentInput">Currently-configured input device id (normalized), or null for OS default.</param>
+    /// <param name="requestedInput">Requested input device id (normalized), or null for OS default.</param>
+    /// <param name="availableInputIds">Ids present in the live capture device list.</param>
+    /// <param name="hasSink">Whether a playback (RX sink) service is registered.</param>
+    /// <param name="currentOutput">Currently-configured output device id (normalized), or null for OS default.</param>
+    /// <param name="requestedOutput">Requested output device id (normalized), or null for OS default.</param>
+    /// <param name="availableOutputIds">Ids present in the live playback device list.</param>
+    internal static Result Plan(
+        bool hasMic,
+        string? currentInput,
+        string? requestedInput,
+        IReadOnlyCollection<string> availableInputIds,
+        bool hasSink,
+        string? currentOutput,
+        string? requestedOutput,
+        IReadOnlyCollection<string> availableOutputIds)
+    {
+        var (applyInput, inputError) = PlanSide(
+            hasMic, currentInput, requestedInput, availableInputIds,
+            "inputDeviceId is not in the current native input device list");
+        var (applyOutput, outputError) = PlanSide(
+            hasSink, currentOutput, requestedOutput, availableOutputIds,
+            "outputDeviceId is not in the current native output device list");
+
+        return new Result(applyInput, applyOutput, inputError, outputError);
+    }
+
+    private static (bool Apply, string? Error) PlanSide(
+        bool hasService,
+        string? current,
+        string? requested,
+        IReadOnlyCollection<string> available,
+        string errorMessage)
+    {
+        // No service for this side (e.g. server host, or RX-only / TX-only
+        // builds): nothing to apply, and a supplied id is silently ignored
+        // rather than treated as an error.
+        if (!hasService) return (false, null);
+
+        // Unchanged relative to the current configuration → skip entirely.
+        // This is the load-bearing case: a stale-but-unchanged carried-over id
+        // must never reject the request or reopen a healthy device. (#1128)
+        if (string.Equals(requested, current, StringComparison.Ordinal))
+            return (false, null);
+
+        // Changing to OS default (null) always validates.
+        if (requested is null) return (true, null);
+
+        // Changing to a specific device: it must be in the live list.
+        foreach (var id in available)
+        {
+            if (string.Equals(id, requested, StringComparison.Ordinal))
+                return (true, null);
+        }
+        return (false, errorMessage);
+    }
+}

--- a/Zeus.Server.Hosting/QrzService.cs
+++ b/Zeus.Server.Hosting/QrzService.cs
@@ -234,6 +234,30 @@ public sealed class QrzService
         }
     }
 
+    /// <summary>
+    /// Drops the cached QRZ session key (keeping stored credentials and home
+    /// station) so the next <see cref="GetChatIdentityAsync"/> / lookup forces a
+    /// fresh login. Used when an out-of-band consumer of the session — the
+    /// ZeusChat relay validating the key on the WS upgrade — reports it invalid.
+    /// The inline "Invalid session" self-heal in <see cref="LookupInternalAsync"/>
+    /// only fires for direct lookups; a relay 401/403 has no other way to evict
+    /// the optimistically-cached key, which otherwise replays for up to an hour
+    /// and loops the chat connection on a dead session.
+    /// </summary>
+    public async Task InvalidateSessionAsync(CancellationToken ct = default)
+    {
+        await _gate.WaitAsync(ct);
+        try
+        {
+            _sessionKey = null;
+            _sessionExpiry = default;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
     public async Task LogoutAsync(CancellationToken ct = default)
     {
         _username = null;

--- a/Zeus.Server.Hosting/RxVstEngineService.cs
+++ b/Zeus.Server.Hosting/RxVstEngineService.cs
@@ -32,6 +32,10 @@ public sealed class RxVstEngineService : IHostedService, IAsyncDisposable
     private readonly HashSet<string> _openEditors = new(StringComparer.Ordinal);
     private Dictionary<string, string> _pluginStates = new(StringComparer.Ordinal);
     private int _activeVstCount;
+    // One-shot "next sync must be a full load_chain" flag, guarded by _editorLock.
+    // Set when plugin states are replaced wholesale (RX profile apply) so the new
+    // voicing reaches the engine even when the chain order is unchanged.
+    private bool _forceFullReload;
 
     public RxVstEngineService(
         PluginManager manager,
@@ -71,6 +75,10 @@ public sealed class RxVstEngineService : IHostedService, IAsyncDisposable
     private void OnEngineReconnected()
     {
         _log.LogInformation("RX VST engine reconnected (restart #{Count}); replaying chain.", _engine.RestartCount);
+        // The relaunched engine comes back EMPTY while our slot map is still stale-
+        // populated from before the crash. Force a full load_chain so the incremental
+        // diff can't see "no change" and leave the recovered engine with no plugins.
+        lock (_editorLock) _forceFullReload = true;
         _ = SyncEngineAsync(_chainOrder.CurrentOrder, CancellationToken.None);
     }
 
@@ -224,7 +232,10 @@ public sealed class RxVstEngineService : IHostedService, IAsyncDisposable
     public void SetPluginStates(IReadOnlyDictionary<string, string> states)
     {
         lock (_editorLock)
+        {
             _pluginStates = new Dictionary<string, string>(states, StringComparer.Ordinal);
+            _forceFullReload = true;
+        }
     }
 
     private async Task SyncEngineAsync(IReadOnlyList<string> activeOrder, CancellationToken ct)
@@ -240,17 +251,18 @@ public sealed class RxVstEngineService : IHostedService, IAsyncDisposable
 
         try
         {
-            var chain = BuildEngineChain(activeOrder);
-            Volatile.Write(ref _activeVstCount, chain.Slots.Count);
+            var desired = BuildDesiredSlots(activeOrder);
+            Volatile.Write(ref _activeVstCount, desired.Count);
 
-            if (chain.Slots.Count == 0)
+            if (desired.Count == 0)
             {
                 _engine.Deactivate();
                 ClearEngineMaps();
                 return;
             }
 
-            var result = _engine.IsActive
+            bool wasActive = _engine.IsActive;
+            var result = wasActive
                 ? VstEngineStartResult.Started
                 : await _engine.ActivateAsync(ReadyTimeout, ct).ConfigureAwait(false);
 
@@ -263,17 +275,41 @@ public sealed class RxVstEngineService : IHostedService, IAsyncDisposable
                 return;
             }
 
-            lock (_editorLock)
+            bool forceFull;
+            lock (_editorLock) forceFull = _forceFullReload;
+
+            // Engine already running an edit (add / remove / reorder): diff against
+            // its current slots and emit only the needed incremental commands so we
+            // don't re-instantiate the whole RX rack and glitch live receive audio.
+            if (wasActive && !forceFull)
             {
-                _idToEngineSlot = chain.IdToSlot;
-                _fileToId = chain.FileToId;
-                _uidToId = chain.UidToId;
-                _openEditors.Clear();
+                List<string> current;
+                lock (_editorLock)
+                    current = _idToEngineSlot.OrderBy(kv => kv.Value).Select(kv => kv.Key).ToList();
+
+                var cmds = VstChainDiff.Compute(current, desired);
+                if (cmds is not null)
+                {
+                    if (cmds.Count == 0) return; // already in sync — nothing to push
+                    RebuildEngineMaps(desired, full: false);
+                    foreach (var cmd in cmds) _engine.SendCommand(cmd);
+                    _log.LogInformation(
+                        "RX VST engine: incremental chain update — {Ops} op(s), {Count} plugin(s).",
+                        cmds.Count, desired.Count);
+                    return;
+                }
+                // null → no usable current state; fall through to a full load.
             }
-            _engine.SendCommand(new { cmd = "load_chain", chain = chain.Slots });
+
+            lock (_editorLock) _forceFullReload = false;
+            RebuildEngineMaps(desired, full: true);
+            var slots = desired
+                .Select(d => (object)new { file = d.File, identifier = d.Uid, state = d.State })
+                .ToList();
+            _engine.SendCommand(new { cmd = "load_chain", chain = slots });
             _log.LogInformation(
                 "RX VST engine loaded {Count} receive VST3 plugin(s).",
-                chain.Slots.Count);
+                slots.Count);
         }
         catch (Exception ex)
         {
@@ -285,7 +321,11 @@ public sealed class RxVstEngineService : IHostedService, IAsyncDisposable
         }
     }
 
-    private EngineChain BuildEngineChain(IReadOnlyList<string> activeOrder)
+    /// <summary>
+    /// Build the desired RX engine chain: active <c>rx.*</c> VST3 inserts in chain
+    /// order, each with its absolute path, descriptor uid, and last-known state.
+    /// </summary>
+    private List<VstChainDiff.DesiredSlot> BuildDesiredSlots(IReadOnlyList<string> activeOrder)
     {
         var active = new Dictionary<string, ActivatedPlugin>(StringComparer.Ordinal);
         foreach (var p in _manager.Active)
@@ -294,11 +334,7 @@ public sealed class RxVstEngineService : IHostedService, IAsyncDisposable
         Dictionary<string, string> savedStates;
         lock (_editorLock) savedStates = new(_pluginStates, StringComparer.Ordinal);
 
-        var slots = new List<object>();
-        var idToSlot = new Dictionary<string, int>(StringComparer.Ordinal);
-        var fileToId = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        var uidToId = new Dictionary<string, string>(StringComparer.Ordinal);
-
+        var desired = new List<VstChainDiff.DesiredSlot>();
         foreach (var id in activeOrder)
         {
             if (!active.TryGetValue(id, out var plugin)) continue;
@@ -314,19 +350,38 @@ public sealed class RxVstEngineService : IHostedService, IAsyncDisposable
                 ? audio.Vst3Path
                 : Path.Combine(plugin.Loaded.PluginDir, audio.Vst3Path);
             var uid = audio.Vst3Uid ?? string.Empty;
-            var key = NormalizePath(abs);
-            idToSlot[id] = slots.Count;
-            if (key is not null) fileToId[key] = id;
-            if (uid.Length > 0) uidToId[uid] = id;
-            slots.Add(new
-            {
-                file = abs,
-                identifier = uid,
-                state = savedStates.GetValueOrDefault(id, string.Empty),
-            });
+            var state = savedStates.GetValueOrDefault(id, string.Empty);
+            desired.Add(new VstChainDiff.DesiredSlot(id, abs, uid, state));
         }
+        return desired;
+    }
 
-        return new EngineChain(slots, idToSlot, fileToId, uidToId);
+    /// <summary>
+    /// Rebuild the id→slot / file→id / uid→id maps from the desired chain's final
+    /// shape. A full reload clears the optimistic open-editor set (the engine closes
+    /// all editors on load_chain); an incremental push keeps the survivors' editors.
+    /// </summary>
+    private void RebuildEngineMaps(IReadOnlyList<VstChainDiff.DesiredSlot> desired, bool full)
+    {
+        var map = new Dictionary<string, int>(StringComparer.Ordinal);
+        var fileToId = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var uidToId = new Dictionary<string, string>(StringComparer.Ordinal);
+        for (int i = 0; i < desired.Count; i++)
+        {
+            var d = desired[i];
+            map[d.Id] = i;
+            var key = NormalizePath(d.File);
+            if (key is not null) fileToId[key] = d.Id;
+            if (d.Uid.Length > 0) uidToId[d.Uid] = d.Id;
+        }
+        lock (_editorLock)
+        {
+            _idToEngineSlot = map;
+            _fileToId = fileToId;
+            _uidToId = uidToId;
+            if (full) _openEditors.Clear();
+            else _openEditors.IntersectWith(map.Keys);
+        }
     }
 
     private void OnEngineEvent(JsonElement e)
@@ -419,10 +474,4 @@ public sealed class RxVstEngineService : IHostedService, IAsyncDisposable
         if (_ownsEngine)
             await _engine.DisposeAsync().ConfigureAwait(false);
     }
-
-    private sealed record EngineChain(
-        List<object> Slots,
-        Dictionary<string, int> IdToSlot,
-        Dictionary<string, string> FileToId,
-        Dictionary<string, string> UidToId);
 }

--- a/Zeus.Server.Hosting/SaturnSpeakerAudioSink.cs
+++ b/Zeus.Server.Hosting/SaturnSpeakerAudioSink.cs
@@ -27,6 +27,17 @@ namespace Zeus.Server;
 /// <see cref="RadioSpeakerAudioSink"/> (writes into the EP2 frame's L/R slots
 /// instead of opening a separate UDP socket); the two are mutually exclusive at
 /// runtime because they self-gate on which protocol is currently active.
+///
+/// <para>Threading: <see cref="Publish"/> is called on the DSP RX tick thread
+/// (the same thread that feeds <see cref="NativeAudioSink"/>'s playback ring).
+/// It writes mono float samples into an in-process SPSC ring and signals a
+/// dedicated sender thread that drains the ring, packs PCM packets, and runs
+/// the 16 UDP syscalls per audio frame. This keeps the DSP tick off the
+/// network hot path so the host soundcard's playback ring is filled on time
+/// (issue #1148). All socket lifecycle (open / refresh on state change /
+/// close on disable) also runs on the sender thread; cross-thread events from
+/// <see cref="RadioService"/> and <see cref="RadioSpeakerSettingsStore"/> are
+/// reduced to volatile flag flips + a wake on the worker.</para>
 /// </summary>
 internal sealed class SaturnSpeakerAudioSink : IRxAudioSink, IHostedService, IDisposable
 {
@@ -36,21 +47,54 @@ internal sealed class SaturnSpeakerAudioSink : IRxAudioSink, IHostedService, IDi
     private const int PacketBytes = 4 + PacketFrames * 2 * sizeof(short);
     private const int TargetRefreshMs = 1_000;
 
+    // ~170 ms @ 48 kHz mono = 8192 samples. Power of two for the FloatSpscRing
+    // mask wrap. The sender drains ~750 packets/sec (one packet per 64 samples
+    // ≈ 1.33 ms), so even worst-case scheduler latency between a DSP burst and
+    // the sender waking fits in a fraction of this. Sized for jitter slack, not
+    // capacity — keep small so a stalled sender doesn't accumulate seconds of
+    // stale audio queued for the radio's speaker jack.
+    private const int RingCapacity = 8_192;
+
+    // Sender wake timeout — covers the (rare) case where a wake signal was
+    // missed across a flag toggle (settings/state change racing the wait). At
+    // 100 ms it's well below human-perceptible latency; the common path is
+    // wake-on-publish (~46 Hz) and never hits the timer.
+    private static readonly TimeSpan WorkerWakeTimeout = TimeSpan.FromMilliseconds(100);
+
     private readonly RadioService _radio;
     private readonly RadioSpeakerSettingsStore _settings;
     private readonly ILogger<SaturnSpeakerAudioSink> _log;
-    private readonly object _sync = new();
+    private readonly FloatSpscRing _ring = new(RingCapacity);
+    private readonly ManualResetEventSlim _wake = new(false);
+    private readonly ManualResetEventSlim _idle = new(true);
+    private readonly CancellationTokenSource _cts = new();
     private readonly byte[] _packet = new byte[PacketBytes];
 
+    // Sender-thread state (single owner — only WorkerLoop reads/writes these
+    // after StartAsync completes). The reflection-based test helpers read
+    // _socket and _sequence after waiting for the worker to go idle.
     private Socket? _socket;
     private IPEndPoint? _target;
     private int _packetFrames;
     private uint _sequence;
     private long _nextRefreshMs;
     private long _droppedPackets;
+    private long _droppedSamples;
     private bool _wasEligible;
     private ConnectionStatus _lastStatus = ConnectionStatus.Disconnected;
     private string? _lastEndpoint;
+
+    // Cross-thread signals. Volatile reads/writes are sufficient — these are
+    // single-bit flags, not data values; the worker re-snapshots radio/settings
+    // state when it acts on them so there's nothing to atomicise.
+    private volatile bool _refreshRequested;
+    private volatile bool _drainRequested;
+
+    // Set first thing in Dispose so the cross-thread signallers stop touching
+    // _wake before it is disposed. See SignalWake.
+    private volatile bool _disposed;
+
+    private Thread? _worker;
 
     public SaturnSpeakerAudioSink(
         RadioService radio,
@@ -66,10 +110,13 @@ internal sealed class SaturnSpeakerAudioSink : IRxAudioSink, IHostedService, IDi
     {
         _radio.StateChanged += OnRadioStateChanged;
         _settings.Changed += OnSettingsChanged;
-        lock (_sync)
+        _refreshRequested = true;
+        _worker = new Thread(WorkerLoop)
         {
-            RefreshTargetLocked(_radio.Snapshot(), force: true);
-        }
+            IsBackground = true,
+            Name = "zeus-p2-speaker-tx",
+        };
+        _worker.Start();
         return Task.CompletedTask;
     }
 
@@ -77,10 +124,10 @@ internal sealed class SaturnSpeakerAudioSink : IRxAudioSink, IHostedService, IDi
     {
         _radio.StateChanged -= OnRadioStateChanged;
         _settings.Changed -= OnSettingsChanged;
-        lock (_sync)
-        {
-            CloseSocketLocked();
-        }
+        _cts.Cancel();
+        _wake.Set();
+        try { _worker?.Join(TimeSpan.FromSeconds(2)); }
+        catch { /* best-effort */ }
         return Task.CompletedTask;
     }
 
@@ -96,75 +143,142 @@ internal sealed class SaturnSpeakerAudioSink : IRxAudioSink, IHostedService, IDi
         // socket re-flap. RadioSpeakerAudioSink owns P1 via IsProtocol1Active.
         if (!_radio.IsProtocol2Active) return;
 
-        lock (_sync)
+        // Mirror the P1 sink's MOX mute: while transmitting, don't carry the
+        // operator's TX-monitor / CW sidetone out to the radio's speaker jack.
+        // Ask the worker to drop the buffered tail (and the partial packet) so
+        // RX resumes clean on unkey instead of replaying the pre-key tail.
+        if (_radio.IsMox)
         {
-            // Mirror the P1 sink's MOX mute: while transmitting, don't carry the
-            // operator's TX-monitor / CW sidetone out to the radio's speaker jack.
-            // Drop the buffered partial packet so RX resumes clean on unkey.
-            if (_radio.IsMox)
-            {
-                _packetFrames = 0;
-                return;
-            }
-            if (_socket is null) RefreshTargetIfDueLocked();
-            if (_socket is null) return;
-
-            foreach (float sample in frame.Samples.Span)
-            {
-                int offset = 4 + _packetFrames * 2 * sizeof(short);
-                short pcm = FloatToPcm16(sample);
-                BinaryPrimitives.WriteInt16BigEndian(_packet.AsSpan(offset, sizeof(short)), pcm);
-                BinaryPrimitives.WriteInt16BigEndian(_packet.AsSpan(offset + sizeof(short), sizeof(short)), pcm);
-
-                _packetFrames++;
-                if (_packetFrames == PacketFrames)
-                {
-                    SendPacketLocked();
-                }
-            }
+            _drainRequested = true;
+            SignalWake();
+            return;
         }
+
+        var src = frame.Samples.Span;
+        int written = _ring.Write(src);
+        if (written < src.Length)
+        {
+            Interlocked.Add(ref _droppedSamples, src.Length - written);
+        }
+        SignalWake();
+    }
+
+    // Wake the sender, tolerating a late call that races Dispose. Publish (on
+    // the DSP tick thread) and the RadioService / settings event handlers can
+    // all fire after the sink is disposed during host shutdown — the sink stays
+    // registered as an IRxAudioSink, so PublishAudio can still fan a frame to
+    // us, and a state/settings event can still arrive in the unsubscribe window.
+    // Setting a disposed ManualResetEventSlim would throw ObjectDisposedException
+    // on the real-time audio thread and take it down; swallow that one race.
+    private void SignalWake()
+    {
+        if (_disposed) return;
+        try { _wake.Set(); }
+        catch (ObjectDisposedException) { /* raced Dispose — nothing to wake */ }
     }
 
     private void OnRadioStateChanged(StateDto state)
     {
-        lock (_sync)
-        {
-            RefreshTargetLocked(state, force: false);
-        }
+        _refreshRequested = true;
+        SignalWake();
     }
 
     private void OnSettingsChanged()
     {
-        lock (_sync)
+        // Disable also asks the worker to drop the buffered tail so a later
+        // re-enable starts clean rather than replaying stale samples that
+        // pre-date the operator's last toggle. Worker re-reads _settings.Enabled
+        // inside RefreshTarget so a flip-on path is covered by the same refresh.
+        if (!_settings.Enabled) _drainRequested = true;
+        _refreshRequested = true;
+        SignalWake();
+    }
+
+    private void WorkerLoop()
+    {
+        var ct = _cts.Token;
+        Span<float> scratch = stackalloc float[PacketFrames];
+
+        while (!ct.IsCancellationRequested)
         {
-            if (_settings.Enabled)
+            _idle.Set();
+            try { _wake.Wait(WorkerWakeTimeout, ct); }
+            catch (OperationCanceledException) { break; }
+            _wake.Reset();
+            _idle.Reset();
+
+            if (ct.IsCancellationRequested) break;
+
+            if (_refreshRequested)
             {
-                // Operator just opted in — re-evaluate the target so audio starts
-                // flowing on the next published frame rather than waiting up to a
-                // second for the lazy refresh path inside Publish.
-                RefreshTargetLocked(_radio.Snapshot(), force: true);
+                _refreshRequested = false;
+                RefreshTarget(_radio.Snapshot(), force: true);
             }
-            else
+
+            if (_drainRequested)
             {
-                // Drop the buffered tail and close the socket so a later re-enable
-                // starts clean rather than replaying stale samples or sequence
-                // numbers that pre-date the operator's last toggle.
+                _drainRequested = false;
+                _ring.Clear();
                 _packetFrames = 0;
-                CloseSocketLocked();
+            }
+
+            if (_socket is null)
+            {
+                RefreshTargetIfDue();
+                if (_socket is null)
+                {
+                    // No target yet — discard anything the producer wrote
+                    // before the gate evaluated (or while the socket was
+                    // being re-opened) so we don't carry stale audio across
+                    // a connection flap.
+                    _ring.Clear();
+                    _packetFrames = 0;
+                    continue;
+                }
+            }
+
+            DrainAndSend(scratch);
+        }
+
+        _idle.Set();
+        CloseSocket();
+    }
+
+    private void DrainAndSend(Span<float> scratch)
+    {
+        while (true)
+        {
+            int need = PacketFrames - _packetFrames;
+            int read = _ring.Read(scratch[..need]);
+            if (read == 0) return;
+
+            for (int i = 0; i < read; i++)
+            {
+                int offset = 4 + _packetFrames * 2 * sizeof(short);
+                short pcm = FloatToPcm16(scratch[i]);
+                BinaryPrimitives.WriteInt16BigEndian(_packet.AsSpan(offset, sizeof(short)), pcm);
+                BinaryPrimitives.WriteInt16BigEndian(_packet.AsSpan(offset + sizeof(short), sizeof(short)), pcm);
+                _packetFrames++;
+            }
+
+            if (_packetFrames == PacketFrames)
+            {
+                SendPacket();
+                if (_socket is null) return;
             }
         }
     }
 
-    private void RefreshTargetIfDueLocked()
+    private void RefreshTargetIfDue()
     {
         long now = Environment.TickCount64;
         if (now < _nextRefreshMs) return;
         _nextRefreshMs = now + TargetRefreshMs;
 
-        RefreshTargetLocked(_radio.Snapshot(), force: true);
+        RefreshTarget(_radio.Snapshot(), force: true);
     }
 
-    private void RefreshTargetLocked(StateDto state, bool force)
+    private void RefreshTarget(StateDto state, bool force)
     {
         if (!force
             && _lastStatus == state.Status
@@ -200,7 +314,7 @@ internal sealed class SaturnSpeakerAudioSink : IRxAudioSink, IHostedService, IDi
                 _log.LogInformation("audio.radio.speaker.p2 disabled");
             }
             _wasEligible = false;
-            CloseSocketLocked();
+            CloseSocket();
             return;
         }
 
@@ -210,7 +324,7 @@ internal sealed class SaturnSpeakerAudioSink : IRxAudioSink, IHostedService, IDi
             return;
         }
 
-        CloseSocketLocked();
+        CloseSocket();
 
         try
         {
@@ -232,12 +346,12 @@ internal sealed class SaturnSpeakerAudioSink : IRxAudioSink, IHostedService, IDi
         }
         catch (Exception ex) when (ex is SocketException or ObjectDisposedException)
         {
-            CloseSocketLocked();
+            CloseSocket();
             _log.LogWarning(ex, "audio.radio.speaker.p2 open failed target={Target}", target);
         }
     }
 
-    private void SendPacketLocked()
+    private void SendPacket()
     {
         var socket = _socket;
         if (socket is null) return;
@@ -259,7 +373,7 @@ internal sealed class SaturnSpeakerAudioSink : IRxAudioSink, IHostedService, IDi
         catch (Exception ex) when (ex is SocketException or ObjectDisposedException)
         {
             var dropped = Interlocked.Read(ref _droppedPackets);
-            CloseSocketLocked();
+            CloseSocket();
             _wasEligible = false;
             _log.LogWarning(ex, "audio.radio.speaker.p2 send failed dropped={DroppedPackets}", dropped);
         }
@@ -269,7 +383,7 @@ internal sealed class SaturnSpeakerAudioSink : IRxAudioSink, IHostedService, IDi
         }
     }
 
-    private void CloseSocketLocked()
+    private void CloseSocket()
     {
         if (_socket is not null)
         {
@@ -291,14 +405,44 @@ internal sealed class SaturnSpeakerAudioSink : IRxAudioSink, IHostedService, IDi
         return (short)MathF.Round(sample * scale);
     }
 
+    /// <summary>Test-only: block until the worker has processed every signal
+    /// posted before this call and is parked back in its wake-wait. Lets tests
+    /// that mutate <see cref="RadioSpeakerSettingsStore"/> /
+    /// <see cref="RadioService"/> state assert against socket / sequence
+    /// snapshots without sleep-flake races against the worker thread.</summary>
+    internal bool WaitForIdleForTest(TimeSpan timeout)
+    {
+        long deadlineTicks = Environment.TickCount64 + (long)timeout.TotalMilliseconds;
+        while (true)
+        {
+            long remainingMs = deadlineTicks - Environment.TickCount64;
+            if (remainingMs <= 0) return false;
+            _wake.Set();
+            if (!_idle.Wait(TimeSpan.FromMilliseconds(Math.Min(20, remainingMs)))) continue;
+            // Worker may have just set _idle right before reading the next
+            // wake; loop until it actually settles with no pending work.
+            if (!_refreshRequested && !_drainRequested && _ring.Count == 0) return true;
+        }
+    }
+
     public void Dispose()
     {
+        // Stop the cross-thread signallers before tearing _wake down.
+        _disposed = true;
         _radio.StateChanged -= OnRadioStateChanged;
         _settings.Changed -= OnSettingsChanged;
 
-        lock (_sync)
+        if (!_cts.IsCancellationRequested)
         {
-            CloseSocketLocked();
+            _cts.Cancel();
+            _wake.Set();
+            try { _worker?.Join(TimeSpan.FromSeconds(2)); }
+            catch { /* best-effort */ }
         }
+
+        _wake.Dispose();
+        _idle.Dispose();
+        _cts.Dispose();
+        CloseSocket();
     }
 }

--- a/Zeus.Server.Hosting/SpotBroadcastService.cs
+++ b/Zeus.Server.Hosting/SpotBroadcastService.cs
@@ -12,13 +12,29 @@ namespace Zeus.Server;
 
 /// <summary>
 /// Watches <see cref="SpotManager.SpotsChanged"/> and broadcasts a fresh
-/// <see cref="SpotListFrame"/> to all WS clients whenever the TCI spot list
-/// changes. No background loop — entirely event-driven.
+/// <see cref="SpotListFrame"/> to all WS clients whenever the spot list changes.
+///
+/// <para>Broadcasts are <b>coalesced</b>: a change only marks the snapshot dirty;
+/// a periodic flush (<see cref="FlushInterval"/>) serialises and broadcasts once
+/// per tick. This keeps the cost off the producer thread (the DX-cluster
+/// socket-read loop) and collapses a firehose of per-spot changes into one
+/// full-snapshot rebroadcast per interval, instead of O(n) serialise-and-send
+/// work on every single spot. A modest TCI trickle is unaffected — it just sees
+/// at most one flush-interval of added latency.</para>
 /// </summary>
 public sealed class SpotBroadcastService : BackgroundService
 {
+    // Coalescing window. Long enough to collapse a contest-cluster firehose into
+    // one rebroadcast per tick, short enough to feel immediate for a logger's
+    // trickle. Spot display has no realtime requirement.
+    internal static readonly TimeSpan FlushInterval = TimeSpan.FromMilliseconds(300);
+
     private readonly SpotManager _spots;
     private readonly StreamingHub _hub;
+
+    // 0 = clean, 1 = a change is pending a flush. Set on the producer thread,
+    // cleared on the flush thread; Interlocked makes the handoff race-free.
+    private int _dirty;
 
     public SpotBroadcastService(SpotManager spots, StreamingHub hub)
     {
@@ -27,10 +43,32 @@ public sealed class SpotBroadcastService : BackgroundService
         _spots.SpotsChanged += OnSpotsChanged;
     }
 
-    // ExecuteAsync is a no-op; all work happens in the SpotsChanged handler.
-    protected override Task ExecuteAsync(CancellationToken stoppingToken) => Task.CompletedTask;
+    // Producer-thread handler: just flag dirty. No serialise/broadcast here.
+    private void OnSpotsChanged() => Interlocked.Exchange(ref _dirty, 1);
 
-    private void OnSpotsChanged()
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var timer = new PeriodicTimer(FlushInterval);
+        try
+        {
+            while (await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false))
+            {
+                if (Interlocked.Exchange(ref _dirty, 0) == 1)
+                    Flush();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Shutdown requested.
+        }
+
+        // Final flush so the last change isn't stranded if it landed between the
+        // last tick and cancellation.
+        if (Interlocked.Exchange(ref _dirty, 0) == 1)
+            Flush();
+    }
+
+    private void Flush()
     {
         var all = _spots.GetAll();
         var entries = all.Select(s => new SpotListFrame.SpotEntry(

--- a/Zeus.Server.Hosting/Tci/SpotManager.cs
+++ b/Zeus.Server.Hosting/Tci/SpotManager.cs
@@ -46,14 +46,39 @@
 namespace Zeus.Server.Tci;
 
 /// <summary>
-/// In-memory storage for DX cluster spots received via TCI.
-/// Fires <see cref="SpotsChanged"/> after every mutation so
-/// SpotBroadcastService can push a fresh snapshot to all WS clients.
+/// In-memory storage for DX cluster spots received via TCI or a native Telnet
+/// DX-cluster connection. Fires <see cref="SpotsChanged"/> after every mutation
+/// so SpotBroadcastService can push a fresh snapshot to all WS clients.
+///
+/// <para>The store is bounded (LRU): once <see cref="MaxSpots"/> distinct
+/// callsigns are held, adding a new one evicts the least-recently-spotted call.
+/// Re-spotting an existing call refreshes its recency. This matters for the
+/// native DX-cluster path, where a busy/contest cluster is a firehose of unique
+/// callsigns that would otherwise accumulate without bound for the whole
+/// session (the TCI path self-expires via RemoveSpot, so it never hits the
+/// cap). The bound also caps the per-broadcast snapshot size.</para>
 /// </summary>
 public sealed class SpotManager
 {
+    /// <summary>Default upper bound on retained distinct callsigns.</summary>
+    public const int DefaultMaxSpots = 1000;
+
     private readonly object _sync = new();
-    private readonly Dictionary<string, Spot> _spots = new();
+    // LRU ordering: head = least-recently-spotted, tail = most-recent. The
+    // dictionary indexes nodes by callsign for O(1) add/update/remove.
+    private readonly LinkedList<Spot> _order = new();
+    private readonly Dictionary<string, LinkedListNode<Spot>> _index = new();
+
+    /// <summary>Maximum number of distinct callsigns retained before the
+    /// least-recently-spotted is evicted.</summary>
+    public int MaxSpots { get; }
+
+    public SpotManager() : this(DefaultMaxSpots) { }
+
+    public SpotManager(int maxSpots)
+    {
+        MaxSpots = maxSpots > 0 ? maxSpots : DefaultMaxSpots;
+    }
 
     /// <summary>
     /// Raised after any mutation (add, remove, or clear). Fired while the
@@ -63,13 +88,32 @@ public sealed class SpotManager
     public event Action? SpotsChanged;
 
     /// <summary>
-    /// Add or update a spot.
+    /// Add or update a spot. Adding a brand-new callsign past <see cref="MaxSpots"/>
+    /// evicts the least-recently-spotted one. Updating an existing callsign
+    /// refreshes its value and its recency.
     /// </summary>
     public void AddSpot(string callsign, string mode, long freqHz, uint argb, string? comment = null)
     {
         lock (_sync)
         {
-            _spots[callsign] = new Spot(callsign, mode, freqHz, argb, comment);
+            var spot = new Spot(callsign, mode, freqHz, argb, comment);
+            if (_index.TryGetValue(callsign, out var existing))
+            {
+                // Update in place and move to the MRU end.
+                existing.Value = spot;
+                _order.Remove(existing);
+                _order.AddLast(existing);
+            }
+            else
+            {
+                _index[callsign] = _order.AddLast(spot);
+                if (_index.Count > MaxSpots)
+                {
+                    var oldest = _order.First!; // count > cap >= 1 ⇒ non-null
+                    _order.RemoveFirst();
+                    _index.Remove(oldest.Value.Callsign);
+                }
+            }
         }
         SpotsChanged?.Invoke();
     }
@@ -81,7 +125,11 @@ public sealed class SpotManager
     {
         lock (_sync)
         {
-            _spots.Remove(callsign);
+            if (_index.TryGetValue(callsign, out var node))
+            {
+                _order.Remove(node);
+                _index.Remove(callsign);
+            }
         }
         SpotsChanged?.Invoke();
     }
@@ -93,19 +141,24 @@ public sealed class SpotManager
     {
         lock (_sync)
         {
-            _spots.Clear();
+            _order.Clear();
+            _index.Clear();
         }
         SpotsChanged?.Invoke();
     }
 
     /// <summary>
-    /// Get a snapshot of all spots.
+    /// Get a snapshot of all spots, oldest-spotted first.
     /// </summary>
     public Spot[] GetAll()
     {
         lock (_sync)
         {
-            return _spots.Values.ToArray();
+            var arr = new Spot[_order.Count];
+            int i = 0;
+            foreach (var s in _order)
+                arr[i++] = s;
+            return arr;
         }
     }
 

--- a/Zeus.Server.Hosting/VstChainDiff.cs
+++ b/Zeus.Server.Hosting/VstChainDiff.cs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+namespace Zeus.Server;
+
+/// <summary>
+/// Computes the minimal sequence of incremental VST-engine control commands that
+/// transforms the engine's CURRENT loaded chain into a DESIRED chain, so a live
+/// operator edit (add / remove / reorder a single plugin) no longer tears down
+/// and re-instantiates the entire chain via <c>load_chain</c>.
+///
+/// <para><b>Why this exists:</b> <c>load_chain</c> "clears + parallel-loads" every
+/// plugin (see <c>docs/designs/vst-engine-bridge-protocol.md</c> §2.1). Sending it
+/// on every chain edit means adding one VST re-instantiates the whole rack — slow
+/// when a heavy plugin (e.g. a Waves shell) is already loaded, and it drops every
+/// running plugin's internal DSP state (compressor envelopes, reverb tails,
+/// lookahead), punching an audible gap into TX/RX audio on each edit. The engine
+/// already exposes cheap incremental ops (<c>add_plugin</c> / <c>remove_plugin</c>
+/// / <c>move_plugin</c>); this just uses them.</para>
+///
+/// <para><b>Determinism:</b> control commands are dispatched serially on the
+/// engine's message thread in send order (protocol §2), so the indices each
+/// command carries are computed against a local simulation of the chain AS THE
+/// ENGINE WILL SEE IT when that command runs — independent of when the engine's
+/// asynchronous <c>chain</c> events arrive back. A botched sequence is self-healing
+/// anyway: the next <c>chain</c> event reconciles the id→slot map.</para>
+/// </summary>
+internal static class VstChainDiff
+{
+    /// <summary>One slot in the desired chain: the Zeus plugin id, its absolute
+    /// VST3 file path, the descriptor uid (empty = single-plugin file), and the
+    /// last-known opaque base64 state ("" = load defaults).</summary>
+    internal readonly record struct DesiredSlot(string Id, string File, string Uid, string State);
+
+    /// <summary>
+    /// Build the ordered incremental commands to turn <paramref name="current"/>
+    /// (engine slot order, by Zeus id) into <paramref name="desired"/>. Each item
+    /// is an anonymous object ready for <c>VstEngineController.SendCommand</c>.
+    ///
+    /// <para>Returns <c>null</c> when an incremental diff is unsafe / pointless and
+    /// the caller should fall back to a full <c>load_chain</c> (no current chain to
+    /// diff against, or a duplicate id in either list). Returns an EMPTY list when
+    /// the chains already match — the caller should then send nothing (skipping the
+    /// redundant reload that the old code performed unconditionally).</para>
+    /// </summary>
+    internal static List<object>? Compute(
+        IReadOnlyList<string> current,
+        IReadOnlyList<DesiredSlot> desired)
+    {
+        // Nothing loaded yet → a fresh load_chain is simpler and just as cheap.
+        if (current.Count == 0) return null;
+
+        // Duplicate ids would make index math ambiguous; reload is the safe path.
+        var currentSet = new HashSet<string>(current, StringComparer.Ordinal);
+        if (currentSet.Count != current.Count) return null;
+
+        var desiredById = new Dictionary<string, DesiredSlot>(StringComparer.Ordinal);
+        foreach (var d in desired) desiredById[d.Id] = d;
+        if (desiredById.Count != desired.Count) return null;
+
+        var cmds = new List<object>();
+        // working simulates the engine's chain after each emitted command.
+        var working = new List<string>(current);
+
+        // 1. Remove plugins that are no longer wanted. Walk high→low so each
+        //    removal leaves the indices of not-yet-visited entries unchanged.
+        var wantIds = new HashSet<string>(desiredById.Keys, StringComparer.Ordinal);
+        for (int i = working.Count - 1; i >= 0; i--)
+        {
+            if (!wantIds.Contains(working[i]))
+            {
+                cmds.Add(new { cmd = "remove_plugin", index = i });
+                working.RemoveAt(i);
+            }
+        }
+
+        // 2. Positional pass: fix each target slot in ascending order. Once slot i
+        //    is correct it is never touched again, so positions [0, i) always match
+        //    desired and `working` has at least i entries when we reach i.
+        for (int i = 0; i < desired.Count; i++)
+        {
+            var d = desired[i];
+            int j = working.IndexOf(d.Id);
+            if (j == i) continue;
+
+            if (j < 0)
+            {
+                // Missing → insert at its final index, then restore its voicing.
+                cmds.Add(new { cmd = "add_plugin", file = d.File, uid = d.Uid, index = i });
+                if (d.State.Length > 0)
+                    cmds.Add(new { cmd = "set_plugin_state", index = i, state = d.State });
+                working.Insert(i, d.Id);
+            }
+            else
+            {
+                // Present but out of place (j > i, since [0, i) is already locked).
+                cmds.Add(new { cmd = "move_plugin", from = j, to = i });
+                var moved = working[j];
+                working.RemoveAt(j);
+                working.Insert(i, moved);
+            }
+        }
+
+        return cmds;
+    }
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -4189,15 +4189,31 @@ public static class ZeusEndpoints
             return Results.BadRequest(new { error = $"native audio device enumeration unavailable: {ex.Message}" });
         }
 
-        if (inputDeviceId is not null && snapshot.Inputs.All(d => d.Id != inputDeviceId))
-            return Results.BadRequest(new { error = "inputDeviceId is not in the current native input device list" });
-        if (outputDeviceId is not null && snapshot.Outputs.All(d => d.Id != outputDeviceId))
-            return Results.BadRequest(new { error = "outputDeviceId is not in the current native output device list" });
+        // Only validate/apply the side that is actually changing. A carried-over
+        // (unchanged) id — even one now stale because its device was unplugged or
+        // the prefs DB came from another machine — must NOT block a change to the
+        // other side. This is the #1128 snap-back: selecting an OUTPUT device was
+        // rejected with an INPUT-device error because the previously-saved mic was
+        // gone, so RX audio could never be pointed at a real Windows device.
+        var plan = NativeAudioDevicePlan.Plan(
+            hasMic: mic is not null,
+            currentInput: mic?.ConfiguredInputDeviceId,
+            requestedInput: inputDeviceId,
+            availableInputIds: snapshot.Inputs.Select(d => d.Id).ToArray(),
+            hasSink: sink is not null,
+            currentOutput: sink?.ConfiguredOutputDeviceId,
+            requestedOutput: outputDeviceId,
+            availableOutputIds: snapshot.Outputs.Select(d => d.Id).ToArray());
 
-        if (mic is not null)
-            await mic.SetInputDeviceAsync(inputDeviceId, ct);
-        if (sink is not null)
-            await sink.SetOutputDeviceAsync(outputDeviceId, ct);
+        if (plan.InputError is not null)
+            return Results.BadRequest(new { error = plan.InputError });
+        if (plan.OutputError is not null)
+            return Results.BadRequest(new { error = plan.OutputError });
+
+        if (plan.ApplyInput)
+            await mic!.SetInputDeviceAsync(inputDeviceId, ct);
+        if (plan.ApplyOutput)
+            await sink!.SetOutputDeviceAsync(outputDeviceId, ct);
 
         return Results.Ok(BuildNativeAudioDevicesResponse(
             sink,

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -3852,6 +3852,23 @@ public static class ZeusEndpoints
             return Results.Ok(result);
         });
 
+        // Native Telnet DX-cluster client. Mirrors /api/tci's shape. GET returns
+        // the config echo + live connection state; PUT persists config; POST
+        // connect/disconnect drive the outbound connection at runtime (no restart).
+        app.MapGet("/api/dxcluster/status", (DxClusterManagementService dx) => dx.GetStatus());
+
+        app.MapPut("/api/dxcluster/config", (DxClusterConfig req, DxClusterManagementService dx) =>
+        {
+            log.LogInformation(
+                "api.dxcluster.config enabled={En} host={Host} port={Port} auto={Auto}",
+                req.Enabled, req.Host, req.Port, req.AutoConnect);
+            return Results.Ok(dx.SetConfig(req));
+        });
+
+        app.MapPost("/api/dxcluster/connect", (DxClusterManagementService dx) => Results.Ok(dx.Connect()));
+
+        app.MapPost("/api/dxcluster/disconnect", (DxClusterManagementService dx) => Results.Ok(dx.Disconnect()));
+
         app.MapGet("/api/cat/status", (CatManagementService cat) => cat.GetStatus());
 
         app.MapPost("/api/cat/config", (CatRuntimeConfig req, CatManagementService cat, HttpContext ctx) =>

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -1029,6 +1029,17 @@ public static class ZeusHost
         builder.Services.AddHostedService(sp => sp.GetRequiredService<SpotBroadcastService>());
         builder.Services.AddSingleton<TciManagementService>();
 
+        // Native Telnet DX-cluster client — connects OUT to a DX cluster, logs in
+        // with the operator's callsign (+ optional password), and feeds received
+        // spots into the SAME SpotManager ingest path TCI spots use (→
+        // SpotBroadcastService → SpotOverlay). Disabled by default; never reaches
+        // the network until the operator enables + connects. Auto-connects at
+        // startup only when both Enabled and AutoConnect are persisted.
+        builder.Services.AddSingleton<DxClusterConfigStore>();
+        builder.Services.AddSingleton<Zeus.Server.DxCluster.DxClusterClient>();
+        builder.Services.AddSingleton<DxClusterManagementService>();
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<DxClusterManagementService>());
+
         // CAT (Kenwood TS-2000 over TCP) server — control-only sibling of TCI for
         // loggers / digital-mode apps (WSJT-X, N1MM+, fldigi, Hamlib net rigctl).
         // Disabled by default; enable via appsettings.json Cat:Enabled=true or the

--- a/docs/manual/assemble.mjs
+++ b/docs/manual/assemble.mjs
@@ -11,8 +11,8 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const SRC = join(HERE, 'chapters');
 const BUILD = join(HERE, 'build');
 const OUT = join(BUILD, 'Zeus-Operator-Manual.html');
-const EDITION = process.env.MANUAL_EDITION || 'v0.10.5 — June 2026';
-const COVERS = process.env.MANUAL_COVERS || 'Covers the Zeus 0.10.5 release';
+const EDITION = process.env.MANUAL_EDITION || 'v0.10.6 — June 2026';
+const COVERS = process.env.MANUAL_COVERS || 'Covers the Zeus 0.10.6 release';
 
 // Cover logo, inlined as a data URI so the print engine never depends on a
 // relative file path (headless Chrome prints from build/, the asset lives in

--- a/docs/manual/chapters/14-accessories.md
+++ b/docs/manual/chapters/14-accessories.md
@@ -95,6 +95,26 @@ Everything is configured under **Settings → Spots**:
   blocked when no radio is connected, CW sideband, and small dial offsets
   for CW and digital so you can land slightly off the published frequency.
 
+### DX Cluster (direct Telnet)
+
+Separately from the aggregated **Spots** feed above, Zeus can connect
+**directly** to a DX cluster node over Telnet — a DXSpider, AR-Cluster, or
+CC-Cluster server — and drop its spots straight onto the panadapter, with no
+third-party bridge (such as Cluster-TCI) in between. The spots arrive on the
+same overlay as every other source, so click-to-tune and the rest work
+exactly as before.
+
+You set it up under **Settings → Network**, beside TCI: enter the cluster's
+**host** and **port** (clusters commonly use 7300, 7373, or 8000), your
+**callsign**, an optional **password** if the node requires one, and any
+**login commands** you want sent once after you're logged in (for example a
+filter that limits which bands or spotters you receive). Tick **Auto-connect**
+to have Zeus log in automatically at startup, or use the **Connect** /
+**Disconnect** button to do it by hand. A live status indicator shows the
+connection state and how many spots have come in. If the link drops, Zeus
+reconnects on its own with a backing-off retry so a brief network hiccup
+doesn't leave you spot-blind.
+
 ### Space Weather & Propagation
 
 The **Solar · Space Weather** panel is a propagation dashboard fed by the

--- a/docs/manual/chapters/15-settings-diag.md
+++ b/docs/manual/chapters/15-settings-diag.md
@@ -19,7 +19,7 @@ A note on one tab in particular: **PA Settings** is the only tab with an explici
 | **Band Plan** | The frequency/mode band plan editor. |
 | **QRZ** | Sign in to QRZ.com for callsign lookups and your home grid. |
 | **Rotator** | Connect to a Hamlib `rotctld` antenna rotator. |
-| **Network** | Expose Zeus to external software two ways: **TCI** (ExpertSDR3 Transceiver Control Interface) and **CAT** (Kenwood TS-2000 emulation), for logging, contest, and digital-mode programs. |
+| **Network** | Expose Zeus to external software two ways: **TCI** (ExpertSDR3 Transceiver Control Interface) and **CAT** (Kenwood TS-2000 emulation), for logging, contest, and digital-mode programs. Also home to the direct **DX-cluster** (Telnet) client. |
 | **Display** | Theme, panadapter background, trace color, spectrum scale, waterfall colormap. |
 | **Plugins** | Install and manage backend/UI/audio plugins from the registry or by URL. |
 | **HamClock** | Install and embed the OpenHamClock dashboard as a workspace panel. |

--- a/tests/Zeus.Plugins.Host.Tests/PluginEndpointsScannedTests.cs
+++ b/tests/Zeus.Plugins.Host.Tests/PluginEndpointsScannedTests.cs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using Zeus.Plugins.Host;
+
+namespace Zeus.Plugins.Host.Tests;
+
+/// <summary>
+/// The Settings ▸ Plugins list shows only Zeus plugin-repo plugins. Operator-
+/// scanned VST3 / Audio Unit effects (registered into the Audio Suite rack via
+/// the directory / AU scanners) carry the reserved id namespaces and must be
+/// flagged <c>Scanned</c> so the frontend filters them out — while native Zeus
+/// audio plugins (the <c>samples.*</c> chain) stay in the list.
+/// </summary>
+public sealed class PluginEndpointsScannedTests
+{
+    [Theory]
+    // Scanned VST3 — TX + RX namespaces.
+    [InlineData("com.openhpsdr.zeus.vst.tdrnova", true)]
+    [InlineData("com.openhpsdr.zeus.rxvst.rnnoise", true)]
+    // Scanned Audio Units — TX + RX namespaces.
+    [InlineData("com.openhpsdr.zeus.au.fabfilterproq3", true)]
+    [InlineData("com.openhpsdr.zeus.rxau.clear", true)]
+    // Native Zeus audio plugins shipped via the plugin repo — NOT scanned.
+    [InlineData("com.openhpsdr.zeus.samples.eq", false)]
+    [InlineData("com.openhpsdr.zeus.samples.amplifier", false)]
+    // Ordinary repo plugins / arbitrary ids — NOT scanned.
+    [InlineData("com.example.cooltool", false)]
+    [InlineData("com.openhpsdr.zeus.rf2k", false)]
+    [InlineData("", false)]
+    public void IsScannedAudioPlugin_classifies_by_id_namespace(string id, bool expected)
+    {
+        Assert.Equal(expected, PluginEndpoints.IsScannedAudioPlugin(id));
+    }
+}

--- a/tests/Zeus.Server.Tests/AudioPluginBridgeVstReserveTests.cs
+++ b/tests/Zeus.Server.Tests/AudioPluginBridgeVstReserveTests.cs
@@ -1,0 +1,130 @@
+using System.Reflection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Plugins.Contracts;
+using Zeus.Plugins.Contracts.Audio;
+using Zeus.Plugins.Contracts.Extensions;
+using Zeus.Plugins.Host.Audio;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Regression coverage: in out-of-process VST mode, a TX VST plugin must be
+/// RESERVED for the external engine and NOT loaded in the in-process VST bridge —
+/// mirroring the receive path's <c>EnsureRxPluginInitialized</c>. Before the fix
+/// the TX init path always tried the in-process load, so a plugin the in-process
+/// host can't load (e.g. a Waves shell, VST3 load status=5) threw during attach
+/// and got DETACHED, making it impossible to add to the chain even though the
+/// active engine could host it. The gate is the engine <see cref="VstEngineState"/>
+/// (not IsActive) so it also holds during the startup window before the engine
+/// finishes its handshake; Native mode (Inactive) still loads in-process.
+/// </summary>
+public sealed class AudioPluginBridgeVstReserveTests
+{
+    [Theory]
+    [InlineData(VstEngineState.Active)]      // engine live
+    [InlineData(VstEngineState.Activating)]  // startup window — engine not up yet
+    [InlineData(VstEngineState.Backoff)]     // crash-loop: still VST mode, don't fall back
+    [InlineData(VstEngineState.Faulted)]
+    public void VstMode_ReservesTxPluginForEngine_WithoutInProcessLoad(VstEngineState state)
+    {
+        var bridge = NewBridge();
+        var engine = NewEngineInState(state);
+        SetPrivateField(bridge, "_vstEngine", engine);
+
+        var native = new FailingVstBridge();
+        var plugin = NewVstPlugin(native);
+        const string id = "com.openhpsdr.zeus.vst.waveshellsub";
+
+        var ok = EnsureTxPluginInitialized(bridge, id, plugin);
+
+        Assert.True(ok);                                        // reserved → success
+        Assert.Equal(0, native.LoadCount);                     // in-process load NEVER attempted
+        Assert.Contains(id, TxInitializedSet(bridge));         // marked reserved
+    }
+
+    // Native mode (engine Inactive) is intentionally not asserted here: the in-
+    // process load path it falls through to is env-gated (ZEUS_ENABLE_VST_LOAD) and
+    // unchanged by this fix — the new early-return is scoped strictly to a
+    // non-Inactive engine, so Native behaviour is identical to before.
+
+    // -- harness ---------------------------------------------------------
+
+    private static AudioPluginBridge NewBridge() =>
+        new(
+            isMoxOn: () => false,
+            isMonitorOn: () => false,
+            log: NullLogger<AudioPluginBridge>.Instance);
+
+    private static VstHostAudioPlugin NewVstPlugin(IVstBridgeNative native) =>
+        new(
+            native,
+            new AudioBlock { Vst3Path = "Fake.vst3", Slot = "tx.post-leveler" },
+            Path.GetTempPath(),
+            "Fake VST");
+
+    private static VstEngineController NewEngineInState(VstEngineState state)
+    {
+        var engine = new VstEngineController(maxFrames: 512, rate: 48000, channels: 1);
+        var field = typeof(VstEngineController).GetField(
+            "_state", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        field!.SetValue(engine, state);
+        return engine;
+    }
+
+    private static bool EnsureTxPluginInitialized(
+        AudioPluginBridge bridge, string id, IAudioPlugin plugin)
+    {
+        var method = typeof(AudioPluginBridge).GetMethod(
+            "EnsureTxPluginInitialized", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return (bool)method!.Invoke(bridge, [id, plugin, "tx.post-leveler"])!;
+    }
+
+    private static HashSet<string> TxInitializedSet(AudioPluginBridge b)
+    {
+        var field = typeof(AudioPluginBridge).GetField(
+            "_txInitializedIds", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        return (HashSet<string>)field!.GetValue(b)!;
+    }
+
+    private static void SetPrivateField(object target, string name, object? value)
+    {
+        var field = target.GetType().GetField(
+            name, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        field!.SetValue(target, value);
+    }
+
+    /// <summary>A native bridge whose VST3 load always fails (like a Waves shell
+    /// returning status=5 in-process), counting attempts so a reservation that
+    /// SKIPS the in-process load is observable.</summary>
+    private sealed class FailingVstBridge : IVstBridgeNative
+    {
+        public int LoadCount { get; private set; }
+
+        public int Init(int abi) => VstBridgeStatus.Ok;
+
+        public int LoadVst3(string path, int channels, int sampleRate, int blockSize, out nint handle)
+        {
+            LoadCount++;
+            handle = 0;
+            return 5; // zvst_status_t load failure (matches the observed WaveShell status)
+        }
+
+        public int Process(nint handle, ReadOnlySpan<float> input, Span<float> output, int frames)
+        {
+            input.CopyTo(output);
+            return VstBridgeStatus.Ok;
+        }
+
+        public int SetParameter(nint handle, uint paramId, double normalized) => VstBridgeStatus.Ok;
+        public int Unload(nint handle) => VstBridgeStatus.Ok;
+        public int Shutdown() => VstBridgeStatus.Ok;
+        public int EditorOpen(nint handle, string title) => VstBridgeStatus.Ok;
+        public int EditorClose(nint handle) => VstBridgeStatus.Ok;
+        public bool EditorIsOpen(nint handle) => false;
+    }
+}

--- a/tests/Zeus.Server.Tests/ChatServiceTests.cs
+++ b/tests/Zeus.Server.Tests/ChatServiceTests.cs
@@ -408,6 +408,40 @@ public class ChatServiceTests : IDisposable
             () => chat.AcceptFriendAsync("  ", CancellationToken.None));
     }
 
+    // ── QRZ session self-heal (relay 403/401 → drop the cached key) ──────────
+
+    // The chat path hands the relay a QRZ session key that the local cache
+    // optimistically trusts for an hour. When the relay rejects the upgrade
+    // (the key died QRZ-side before that hour elapsed), ChatService calls
+    // InvalidateSessionAsync so the *next* attempt re-authenticates instead of
+    // replaying the dead key into a 403 loop. This proves that contract.
+    [Fact]
+    public async Task InvalidateSessionAsync_forces_fresh_login_on_next_identity()
+    {
+        var handler = new StubQrzHandler();
+        var qrz = new QrzService(
+            new StubFactory(handler), NullLogger<QrzService>.Instance,
+            new CredentialStore(NullLogger<CredentialStore>.Instance, Path.Combine(_root, "creds2.db")));
+
+        var status = await qrz.LoginAsync("N9WAR", "pw", CancellationToken.None);
+        Assert.True(status.Connected);
+        Assert.Equal(1, handler.LoginCount);
+
+        // Cached: a second identity fetch must not re-hit the QRZ login endpoint.
+        var first = await qrz.GetChatIdentityAsync(CancellationToken.None);
+        Assert.NotNull(first);
+        Assert.Equal("N9WAR", first!.Value.Callsign);
+        Assert.Equal("SESSION123", first.Value.SessionKey);
+        Assert.Equal(1, handler.LoginCount);
+
+        // Relay rejected the key → evict it; the next fetch re-authenticates.
+        await qrz.InvalidateSessionAsync(CancellationToken.None);
+        var second = await qrz.GetChatIdentityAsync(CancellationToken.None);
+        Assert.NotNull(second);
+        Assert.Equal("SESSION123", second!.Value.SessionKey);
+        Assert.Equal(2, handler.LoginCount);
+    }
+
     // ── helpers ────────────────────────────────────────────────────────────
 
     private static ChatMessage Msg(int i) =>
@@ -436,5 +470,47 @@ public class ChatServiceTests : IDisposable
     private sealed class SingleClientFactory : IHttpClientFactory
     {
         public HttpClient CreateClient(string name) => new();
+    }
+
+    // Canned QRZ XML so the self-heal test can drive a real login → cache →
+    // re-login cycle without touching the network. Login requests (those with a
+    // username=) are counted; lookups return a minimal home-callsign record.
+    private sealed class StubQrzHandler : HttpMessageHandler
+    {
+        public int LoginCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var query = request.RequestUri!.Query;
+            string xml;
+            if (query.Contains("username=", StringComparison.Ordinal))
+            {
+                LoginCount++;
+                xml = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>"
+                    + "<QRZDatabase version=\"1.36\" xmlns=\"http://xmldata.qrz.com\">"
+                    + "<Session><Key>SESSION123</Key>"
+                    + "<SubExp>Wed Dec 31 23:59:59 2031</SubExp></Session></QRZDatabase>";
+            }
+            else
+            {
+                xml = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>"
+                    + "<QRZDatabase version=\"1.36\" xmlns=\"http://xmldata.qrz.com\">"
+                    + "<Session><Key>SESSION123</Key></Session>"
+                    + "<Callsign><call>N9WAR</call><fname>Test</fname></Callsign></QRZDatabase>";
+            }
+
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent(xml),
+            });
+        }
+    }
+
+    private sealed class StubFactory : IHttpClientFactory
+    {
+        private readonly HttpMessageHandler _handler;
+        public StubFactory(HttpMessageHandler handler) => _handler = handler;
+        public HttpClient CreateClient(string name) => new(_handler, disposeHandler: false);
     }
 }

--- a/tests/Zeus.Server.Tests/DxClusterClientTests.cs
+++ b/tests/Zeus.Server.Tests/DxClusterClientTests.cs
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// DxClusterClient session test driven by a FAKE in-memory duplex stream — NO
+// real sockets (a real ConnectAsync in a test loop minidump-crashes the Windows
+// CI host). We feed banner → login prompt → spot through the read side and assert
+// (a) the callsign was written back and (b) a parsed spot reached the existing
+// SpotManager ingest seam.
+
+using System.Text;
+using System.Threading.Channels;
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server.DxCluster;
+using Zeus.Server.Tci;
+
+namespace Zeus.Server.Tests;
+
+public class DxClusterClientTests
+{
+    [Fact]
+    public async Task Session_LoginAndSpot_ReachesIngestSeam()
+    {
+        var spots = new SpotManager();
+        var client = new DxClusterClient(NullLogger<DxClusterClient>.Instance, spots, connector: null);
+        var stream = new FakeDuplexStream();
+        var cfg = new DxClusterConfig(
+            Enabled: true, Host: "fake", Port: 7373, Callsign: "K1ABC");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var session = client.RunSessionAsync(cfg, stream, cts.Token);
+
+        // Server banner, then a login prompt, then a spot line.
+        stream.ServerSend("Welcome to the DX cluster\r\n");
+        stream.ServerSend("login: ");
+        stream.ServerSend("\r\n");
+        stream.ServerSend("DX de W3LPL:    14074.0  K1XYZ   FT8  -12 dB   1432Z\r\n");
+
+        // Wait for the spot to land in the SpotManager.
+        await WaitForAsync(() => spots.GetAll().Length > 0, TimeSpan.FromSeconds(5));
+
+        var all = spots.GetAll();
+        var spot = Assert.Single(all);
+        Assert.Equal("K1XYZ", spot.Callsign);
+        Assert.Equal("FT8", spot.Mode);
+        Assert.Equal(14074000L, spot.FreqHz);
+        Assert.Equal(1, client.SpotsReceived);
+        Assert.Equal("K1XYZ", client.LastSpotCallsign);
+
+        // The callsign must have been written back to the cluster.
+        await WaitForAsync(() => stream.WrittenText().Contains("K1ABC"), TimeSpan.FromSeconds(5));
+        Assert.Contains("K1ABC\r\n", stream.WrittenText());
+
+        // End the session cleanly (EOF) and confirm the task completes.
+        stream.ServerClose();
+        await session;
+    }
+
+    [Fact]
+    public async Task Session_PasswordPrompt_SendsConfiguredPassword()
+    {
+        var spots = new SpotManager();
+        var client = new DxClusterClient(NullLogger<DxClusterClient>.Instance, spots, connector: null);
+        var stream = new FakeDuplexStream();
+        var cfg = new DxClusterConfig(
+            Enabled: true, Host: "fake", Port: 7373, Callsign: "K1ABC", Password: "topsecret");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var session = client.RunSessionAsync(cfg, stream, cts.Token);
+
+        stream.ServerSend("login: \r\n");
+        await WaitForAsync(() => stream.WrittenText().Contains("K1ABC"), TimeSpan.FromSeconds(5));
+        stream.ServerSend("password: \r\n");
+        await WaitForAsync(() => stream.WrittenText().Contains("topsecret"), TimeSpan.FromSeconds(5));
+
+        Assert.Contains("K1ABC\r\n", stream.WrittenText());
+        Assert.Contains("topsecret\r\n", stream.WrittenText());
+
+        stream.ServerClose();
+        await session;
+    }
+
+    [Fact]
+    public async Task Session_TelnetIacBytes_StrippedBeforeParse()
+    {
+        var spots = new SpotManager();
+        var client = new DxClusterClient(NullLogger<DxClusterClient>.Instance, spots, connector: null);
+        var stream = new FakeDuplexStream();
+        var cfg = new DxClusterConfig(Enabled: true, Host: "fake", Port: 7373, Callsign: "K1ABC");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var session = client.RunSessionAsync(cfg, stream, cts.Token);
+
+        // Prepend a Telnet IAC DO ECHO (0xFF 0xFD 0x01) negotiation before the
+        // spot — it must be stripped so the spot still parses.
+        var iac = new byte[] { 0xFF, 0xFD, 0x01 };
+        stream.ServerSendBytes(iac);
+        stream.ServerSend("DX de G3XYZ:   7025.0  DL1AB   CW   0901Z\r\n");
+
+        await WaitForAsync(() => spots.GetAll().Length > 0, TimeSpan.FromSeconds(5));
+        var spot = Assert.Single(spots.GetAll());
+        Assert.Equal("DL1AB", spot.Callsign);
+
+        stream.ServerClose();
+        await session;
+    }
+
+    [Fact]
+    public async Task Session_EofImmediately_CompletesWithoutSpots()
+    {
+        var spots = new SpotManager();
+        var client = new DxClusterClient(NullLogger<DxClusterClient>.Instance, spots, connector: null);
+        var stream = new FakeDuplexStream();
+        var cfg = new DxClusterConfig(Enabled: true, Host: "fake", Port: 7373, Callsign: "K1ABC");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var session = client.RunSessionAsync(cfg, stream, cts.Token);
+        stream.ServerClose();
+        await session; // returns on EOF, no exception
+        Assert.Empty(spots.GetAll());
+    }
+
+    private static async Task WaitForAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.Elapsed < timeout)
+        {
+            if (condition()) return;
+            await Task.Delay(20);
+        }
+        if (!condition())
+            throw new TimeoutException("condition not met within timeout");
+    }
+
+    // In-memory bidirectional stream. The "server" pushes bytes into the read
+    // side via ServerSend/ServerSendBytes/ServerClose; everything the client
+    // writes is captured for assertions. No sockets, deterministic.
+    private sealed class FakeDuplexStream : Stream
+    {
+        private readonly Channel<byte[]> _incoming = Channel.CreateUnbounded<byte[]>();
+        private byte[] _leftover = Array.Empty<byte>();
+        private int _leftoverPos;
+        private readonly List<byte> _written = new();
+        private readonly object _writeSync = new();
+
+        public void ServerSend(string s) => ServerSendBytes(Encoding.Latin1.GetBytes(s));
+        public void ServerSendBytes(byte[] bytes) => _incoming.Writer.TryWrite(bytes);
+        public void ServerClose() => _incoming.Writer.TryComplete();
+
+        public string WrittenText()
+        {
+            lock (_writeSync) return Encoding.Latin1.GetString(_written.ToArray());
+        }
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken ct = default)
+        {
+            if (_leftoverPos >= _leftover.Length)
+            {
+                try
+                {
+                    if (!await _incoming.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
+                        return 0; // completed → EOF
+                }
+                catch (ChannelClosedException)
+                {
+                    return 0;
+                }
+                if (!_incoming.Reader.TryRead(out var chunk) || chunk is null)
+                    return 0;
+                _leftover = chunk;
+                _leftoverPos = 0;
+                if (_leftover.Length == 0)
+                    return 0;
+            }
+
+            int n = Math.Min(buffer.Length, _leftover.Length - _leftoverPos);
+            _leftover.AsSpan(_leftoverPos, n).CopyTo(buffer.Span);
+            _leftoverPos += n;
+            return n;
+        }
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken ct = default)
+        {
+            lock (_writeSync) _written.AddRange(buffer.ToArray());
+            return ValueTask.CompletedTask;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            ReadAsync(buffer.AsMemory(offset, count)).AsTask().GetAwaiter().GetResult();
+        public override void Write(byte[] buffer, int offset, int count) =>
+            WriteAsync(buffer.AsMemory(offset, count)).AsTask().GetAwaiter().GetResult();
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override Task FlushAsync(CancellationToken ct) => Task.CompletedTask;
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+    }
+}

--- a/tests/Zeus.Server.Tests/DxClusterConfigStoreTests.cs
+++ b/tests/Zeus.Server.Tests/DxClusterConfigStoreTests.cs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+//
+// DxClusterConfigStore — single-row LiteDB persistence via the shared lease.
+// Mirrors PttSettingsStoreTests' temp-DB pattern (explicit dbPathOverride so the
+// suite never collides on the shared zeus-prefs.db). Round-trips every field,
+// confirms the default-off (no row → null) contract, and that values survive a
+// store re-open on the same path.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public class DxClusterConfigStoreTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-prefs-dxcluster-{Guid.NewGuid():N}.db");
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+        try { if (File.Exists(_dbPath + "-log")) File.Delete(_dbPath + "-log"); } catch { }
+    }
+
+    [Fact]
+    public void Get_FreshDb_ReturnsNull()
+    {
+        using var store = new DxClusterConfigStore(NullLogger<DxClusterConfigStore>.Instance, _dbPath);
+        Assert.Null(store.Get());
+    }
+
+    [Fact]
+    public void SetGet_RoundTripsAllFields()
+    {
+        using var store = new DxClusterConfigStore(NullLogger<DxClusterConfigStore>.Instance, _dbPath);
+        var cfg = new DxClusterConfig(
+            Enabled: true,
+            Host: "dxc.example.org",
+            Port: 7300,
+            Callsign: "K1ABC",
+            Password: "s3cret",
+            LoginCommands: "set/filter on\nsh/dx",
+            AutoConnect: true);
+
+        store.Set(cfg);
+        var got = store.Get();
+
+        Assert.NotNull(got);
+        Assert.True(got!.Enabled);
+        Assert.Equal("dxc.example.org", got.Host);
+        Assert.Equal(7300, got.Port);
+        Assert.Equal("K1ABC", got.Callsign);
+        Assert.Equal("s3cret", got.Password);
+        Assert.Equal("set/filter on\nsh/dx", got.LoginCommands);
+        Assert.True(got.AutoConnect);
+    }
+
+    [Fact]
+    public void Set_Twice_UpdatesSingleRow()
+    {
+        using var store = new DxClusterConfigStore(NullLogger<DxClusterConfigStore>.Instance, _dbPath);
+        store.Set(new DxClusterConfig(Enabled: true, Host: "a", Port: 1, Callsign: "K1A"));
+        store.Set(new DxClusterConfig(Enabled: false, Host: "b", Port: 2, Callsign: "K2B"));
+
+        var got = store.Get();
+        Assert.NotNull(got);
+        Assert.False(got!.Enabled);
+        Assert.Equal("b", got.Host);
+        Assert.Equal(2, got.Port);
+        Assert.Equal("K2B", got.Callsign);
+    }
+
+    [Fact]
+    public void Config_PersistsAcrossReopen()
+    {
+        using (var store = new DxClusterConfigStore(NullLogger<DxClusterConfigStore>.Instance, _dbPath))
+        {
+            store.Set(new DxClusterConfig(
+                Enabled: true, Host: "host", Port: 7373, Callsign: "K1ABC", AutoConnect: true));
+        }
+
+        using (var reopened = new DxClusterConfigStore(NullLogger<DxClusterConfigStore>.Instance, _dbPath))
+        {
+            var got = reopened.Get();
+            Assert.NotNull(got);
+            Assert.True(got!.Enabled);
+            Assert.Equal("host", got.Host);
+            Assert.True(got.AutoConnect);
+        }
+    }
+}

--- a/tests/Zeus.Server.Tests/DxClusterHandshakeTests.cs
+++ b/tests/Zeus.Server.Tests/DxClusterHandshakeTests.cs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+
+using Zeus.Server.DxCluster;
+
+namespace Zeus.Server.Tests;
+
+public class DxClusterHandshakeTests
+{
+    [Fact]
+    public void SendsCallsign_OnLoginPrompt()
+    {
+        var hs = new DxClusterHandshake("K1ABC", password: null, loginCommands: null);
+        Assert.Empty(hs.OnLine("Welcome to the cluster"));
+        var r = hs.OnLine("Please enter your call: ");
+        Assert.Equal(new[] { "K1ABC" }, r);
+        Assert.True(hs.CallsignSent);
+    }
+
+    [Theory]
+    [InlineData("login: ")]
+    [InlineData("Please enter your call:")]
+    [InlineData("enter your call")]
+    [InlineData("callsign:")]
+    [InlineData("Your call?")]
+    public void RecognisesCallPromptVariants(string prompt)
+    {
+        var hs = new DxClusterHandshake("K1ABC", null, null);
+        Assert.Equal(new[] { "K1ABC" }, hs.OnLine(prompt));
+    }
+
+    [Fact]
+    public void DoesNotResendCallsign()
+    {
+        var hs = new DxClusterHandshake("K1ABC", null, null);
+        Assert.Single(hs.OnLine("login:"));
+        // A second prompt must NOT re-send the callsign.
+        Assert.Empty(hs.OnLine("login:"));
+    }
+
+    [Fact]
+    public void SendsPassword_OnlyWhenConfiguredAndPrompted()
+    {
+        var hs = new DxClusterHandshake("K1ABC", "secret", null);
+        Assert.Equal(new[] { "K1ABC" }, hs.OnLine("login:"));
+        Assert.Equal(new[] { "secret" }, hs.OnLine("password: "));
+        // Idempotent.
+        Assert.Empty(hs.OnLine("password: "));
+    }
+
+    [Fact]
+    public void NoPasswordConfigured_PasswordPromptIgnored()
+    {
+        var hs = new DxClusterHandshake("K1ABC", password: null, loginCommands: null);
+        Assert.Equal(new[] { "K1ABC" }, hs.OnLine("login:"));
+        // Without a configured password we never send one even if prompted.
+        Assert.Empty(hs.OnLine("password: "));
+    }
+
+    [Fact]
+    public void SendsLoginCommands_OnceAfterLogin_NoPassword()
+    {
+        var hs = new DxClusterHandshake("K1ABC", null, new[] { "set/filter on", "sh/dx" });
+        Assert.Equal(new[] { "K1ABC" }, hs.OnLine("login:"));
+        // First post-login line triggers the configured commands, once.
+        Assert.Equal(new[] { "set/filter on", "sh/dx" }, hs.OnLine("K1ABC de NODE >"));
+        Assert.Empty(hs.OnLine("another line"));
+    }
+
+    [Fact]
+    public void SendsLoginCommands_OnlyAfterPassword_WhenPasswordRequired()
+    {
+        var hs = new DxClusterHandshake("K1ABC", "secret", new[] { "sh/dx" });
+        Assert.Equal(new[] { "K1ABC" }, hs.OnLine("login:"));
+        // Login commands must NOT fire before the password is sent.
+        Assert.Equal(new[] { "secret" }, hs.OnLine("password:"));
+        Assert.Equal(new[] { "sh/dx" }, hs.OnLine("node ready"));
+    }
+
+    [Fact]
+    public void EmptyCallsign_NeverSends()
+    {
+        var hs = new DxClusterHandshake("", null, null);
+        Assert.Empty(hs.OnLine("login:"));
+        Assert.False(hs.CallsignSent);
+    }
+
+    [Fact]
+    public void BlankLoginCommands_AreFilteredOut()
+    {
+        var hs = new DxClusterHandshake("K1ABC", null, new[] { "  ", "", "sh/dx", "  " });
+        hs.OnLine("login:");
+        Assert.Equal(new[] { "sh/dx" }, hs.OnLine("post-login"));
+    }
+}

--- a/tests/Zeus.Server.Tests/DxSpotLineParserTests.cs
+++ b/tests/Zeus.Server.Tests/DxSpotLineParserTests.cs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+
+using Zeus.Server.DxCluster;
+
+namespace Zeus.Server.Tests;
+
+public class DxSpotLineParserTests
+{
+    [Theory]
+    // Canonical DXSpider line.
+    [InlineData("DX de W3LPL:    14074.0  K1ABC        FT8  -12 dB         1432Z",
+        "W3LPL", "K1ABC", 14074000L, "FT8")]
+    // Integer frequency, CW.
+    [InlineData("DX de G3XYZ:     7025.0  DL1ABC       CW                  0901Z",
+        "G3XYZ", "DL1ABC", 7025000L, "CW")]
+    // AR-Cluster-style tighter spacing.
+    [InlineData("DX de N1XX: 21260.0 EA8XX SSB up 2 1700Z",
+        "N1XX", "EA8XX", 21260000L, "SSB")]
+    // FT4 derivation.
+    [InlineData("DX de JA1ABC:   7047.5  VK3XYZ  FT4 +03  2230Z",
+        "JA1ABC", "VK3XYZ", 7047500L, "FT4")]
+    // Portable / slashed calls on both ends.
+    [InlineData("DX de SV1XX/P:  10136.0  9A/DL1XX/MM   FT8         1010Z",
+        "SV1XX/P", "9A/DL1XX/MM", 10136000L, "FT8")]
+    // Six-digit MHz-band freq (VHF), no mode in comment → mode "".
+    [InlineData("DX de W2ABC:   144174.0  W3DEF        nice sig     1300Z",
+        "W2ABC", "W3DEF", 144174000L, "")]
+    public void TryParse_ValidLines_Extracts(string line, string spotter, string dx, long freqHz, string mode)
+    {
+        Assert.True(DxSpotLineParser.TryParse(line, out var spot));
+        Assert.Equal(spotter, spot.SpotterCall);
+        Assert.Equal(dx, spot.DxCall);
+        Assert.Equal(freqHz, spot.FreqHz);
+        Assert.Equal(mode, spot.Mode);
+    }
+
+    [Fact]
+    public void TryParse_StripsTrailingTimeFromComment()
+    {
+        Assert.True(DxSpotLineParser.TryParse(
+            "DX de W3LPL:    14074.0  K1ABC        FT8  -12 dB         1432Z", out var spot));
+        Assert.Equal("1432Z", spot.Time);
+        Assert.DoesNotContain("1432Z", spot.Comment);
+        Assert.Contains("FT8", spot.Comment);
+        Assert.Contains("-12 dB", spot.Comment);
+    }
+
+    [Fact]
+    public void TryParse_TrailingGridAfterTime_Ignored()
+    {
+        Assert.True(DxSpotLineParser.TryParse(
+            "DX de EA1XX:    14025.0  K1ABC   CW   1432Z FN42", out var spot));
+        Assert.Equal("1432Z", spot.Time);
+        Assert.Equal("CW", spot.Mode);
+    }
+
+    [Fact]
+    public void TryParse_NoTrailingTime_StillParses()
+    {
+        Assert.True(DxSpotLineParser.TryParse(
+            "DX de W3LPL:    14074.0  K1ABC   FT8", out var spot));
+        Assert.Equal("", spot.Time);
+        Assert.Equal("FT8", spot.Mode);
+        Assert.Equal("K1ABC", spot.DxCall);
+    }
+
+    [Fact]
+    public void TryParse_DecimalFreq_RoundsToInteger()
+    {
+        Assert.True(DxSpotLineParser.TryParse(
+            "DX de W1AW:     3573.1  K9XYZ   FT8   0000Z", out var spot));
+        Assert.Equal(3573100L, spot.FreqHz);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    // Login banner / MOTD.
+    [InlineData("Welcome to the W3LPL DX Cluster")]
+    [InlineData("Please enter your call: ")]
+    [InlineData("login: ")]
+    // Prompt.
+    [InlineData("W3LPL de K1ABC >")]
+    // Talk / announce lines (not DX spots).
+    [InlineData("To ALL de W3LPL: contest this weekend")]
+    [InlineData("WX de G3XYZ: raining here 1200Z")]
+    // WWV / WCY propagation bulletins.
+    [InlineData("WWV de VE7CC <18>:   SFI=120, A=7, K=2 1500Z")]
+    [InlineData("WCY de DK0WCY-1 <12> : K=1 expK=0 A=4 R=0 SFI=120 1200Z")]
+    // Malformed: no frequency.
+    [InlineData("DX de W3LPL: K1ABC nice signal 1432Z")]
+    // Malformed: DX call has no digit (looks like a word, not a call).
+    [InlineData("DX de W3LPL:  14074.0  CQ   calling   1432Z")]
+    // Frequency out of plausible range.
+    [InlineData("DX de W3LPL:  0.5  K1ABC   CW   1432Z")]
+    // Not a DX line at all.
+    [InlineData("set/filter on")]
+    [InlineData("73 de W3LPL")]
+    public void TryParse_NonSpotLines_Rejected(string? line)
+    {
+        Assert.False(DxSpotLineParser.TryParse(line, out _));
+    }
+
+    [Fact]
+    public void TryParse_CaseInsensitivePrefix()
+    {
+        // Some nodes lowercase the prefix.
+        Assert.True(DxSpotLineParser.TryParse(
+            "dx de w3lpl:  14074.0  k1abc  ft8  1432Z", out var spot));
+        Assert.Equal("W3LPL", spot.SpotterCall);
+        Assert.Equal("K1ABC", spot.DxCall);
+        Assert.Equal("FT8", spot.Mode);
+    }
+}

--- a/tests/Zeus.Server.Tests/HamClockServiceTests.cs
+++ b/tests/Zeus.Server.Tests/HamClockServiceTests.cs
@@ -198,4 +198,71 @@ public sealed class HamClockServiceTests
         Assert.True(updated.IndexOf(HamClockService.ZeusCatBridgeScriptName, StringComparison.Ordinal) < updated.IndexOf("</head>", StringComparison.OrdinalIgnoreCase));
         Assert.Equal(updated, second);
     }
+
+    [Fact]
+    public void InjectZeusExternalLinksTag_AddsBridgeOnceBeforeHeadClose()
+    {
+        const string html = """
+            <!doctype html>
+            <html>
+              <head>
+                <title>HamClock</title>
+              </head>
+              <body></body>
+            </html>
+            """;
+
+        var updated = HamClockService.InjectZeusExternalLinksTag(html);
+        var second = HamClockService.InjectZeusExternalLinksTag(updated);
+
+        Assert.Contains(
+            $"<script src=\"/{HamClockService.ZeusExternalLinksScriptName}\" defer></script>",
+            updated);
+        Assert.True(
+            updated.IndexOf(HamClockService.ZeusExternalLinksScriptName, StringComparison.Ordinal)
+            < updated.IndexOf("</head>", StringComparison.OrdinalIgnoreCase));
+        // Idempotent — injecting twice does not duplicate the tag.
+        Assert.Equal(updated, second);
+        var first = updated.IndexOf(HamClockService.ZeusExternalLinksScriptName, StringComparison.Ordinal);
+        Assert.Equal(
+            first,
+            updated.LastIndexOf(HamClockService.ZeusExternalLinksScriptName, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void InjectZeusExternalLinksTag_AppendsWhenNoHead()
+    {
+        const string html = "<div>no head here</div>";
+
+        var updated = HamClockService.InjectZeusExternalLinksTag(html);
+
+        Assert.Contains(
+            $"<script src=\"/{HamClockService.ZeusExternalLinksScriptName}\" defer></script>",
+            updated);
+    }
+
+    [Fact]
+    public void ZeusExternalLinksScript_ForwardsExternalAndRigDownloadClicks()
+    {
+        // The injected client script is the actual fix surface — assert it carries
+        // the forwarding handler, the once-guard, the capture-phase listener, the
+        // http/https + cross-origin gate, and the same-origin sidecar-download path.
+        var script = HamClockService.ZeusExternalLinksScript;
+
+        Assert.Contains("__zeusHamClockExternalLinksInstalled", script);
+        Assert.Contains("addEventListener('click'", script);
+        Assert.Contains("a[href]", script);
+        Assert.Contains("/api/rig/download/", script);
+        // The robust download gate: any same-origin anchor carrying a download
+        // attribute is forwarded, so the fix doesn't hinge on one literal prefix.
+        Assert.Contains("hasAttribute('download')", script);
+        Assert.Contains("url.origin !== location.origin", script);
+        Assert.Contains("'zeus.openExternal'", script);
+        Assert.Contains("window.parent?.postMessage", script);
+        // Plain left-clicks only: modifier/middle/already-handled clicks are skipped.
+        Assert.Contains("event.defaultPrevented", script);
+        Assert.Contains("event.button !== 0", script);
+        // Capture phase (true) so it beats HamClock's own handlers.
+        Assert.Contains(", true)", script);
+    }
 }

--- a/tests/Zeus.Server.Tests/NativeAudioDevicePlanTests.cs
+++ b/tests/Zeus.Server.Tests/NativeAudioDevicePlanTests.cs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace Zeus.Server.Tests;
+
+public sealed class NativeAudioDevicePlanTests
+{
+    private static readonly string[] Inputs = ["mic-a", "mic-b"];
+    private static readonly string[] Outputs = ["spk-a", "spk-b"];
+
+    // #1128 core case: operator changes ONLY the output while the previously
+    // configured input mic is gone. The unchanged stale input must not block
+    // the output change.
+    [Fact]
+    public void StaleUnchangedInput_DoesNotBlockOutputChange()
+    {
+        var plan = NativeAudioDevicePlan.Plan(
+            hasMic: true, currentInput: "mic-gone", requestedInput: "mic-gone", availableInputIds: Inputs,
+            hasSink: true, currentOutput: "spk-a", requestedOutput: "spk-b", availableOutputIds: Outputs);
+
+        Assert.False(plan.ApplyInput);
+        Assert.Null(plan.InputError);
+        Assert.True(plan.ApplyOutput);
+        Assert.Null(plan.OutputError);
+    }
+
+    [Fact]
+    public void ChangingInputToPresentDevice_Applies()
+    {
+        var plan = NativeAudioDevicePlan.Plan(
+            hasMic: true, currentInput: null, requestedInput: "mic-b", availableInputIds: Inputs,
+            hasSink: true, currentOutput: "spk-a", requestedOutput: "spk-a", availableOutputIds: Outputs);
+
+        Assert.True(plan.ApplyInput);
+        Assert.Null(plan.InputError);
+        Assert.False(plan.ApplyOutput);   // unchanged
+    }
+
+    [Fact]
+    public void ChangingInputToMissingDevice_Errors()
+    {
+        var plan = NativeAudioDevicePlan.Plan(
+            hasMic: true, currentInput: "mic-a", requestedInput: "mic-x", availableInputIds: Inputs,
+            hasSink: true, currentOutput: "spk-a", requestedOutput: "spk-a", availableOutputIds: Outputs);
+
+        Assert.False(plan.ApplyInput);
+        Assert.NotNull(plan.InputError);
+    }
+
+    [Fact]
+    public void ChangingToOsDefault_AlwaysApplies()
+    {
+        var plan = NativeAudioDevicePlan.Plan(
+            hasMic: true, currentInput: "mic-a", requestedInput: null, availableInputIds: Inputs,
+            hasSink: true, currentOutput: "spk-a", requestedOutput: null, availableOutputIds: Outputs);
+
+        Assert.True(plan.ApplyInput);
+        Assert.Null(plan.InputError);
+        Assert.True(plan.ApplyOutput);
+        Assert.Null(plan.OutputError);
+    }
+
+    [Fact]
+    public void NoOpRequest_AppliesNothing()
+    {
+        var plan = NativeAudioDevicePlan.Plan(
+            hasMic: true, currentInput: "mic-a", requestedInput: "mic-a", availableInputIds: Inputs,
+            hasSink: true, currentOutput: "spk-a", requestedOutput: "spk-a", availableOutputIds: Outputs);
+
+        Assert.False(plan.ApplyInput);
+        Assert.False(plan.ApplyOutput);
+        Assert.Null(plan.InputError);
+        Assert.Null(plan.OutputError);
+    }
+
+    // RX-only desktop builds (no mic service): a supplied input id is ignored
+    // rather than rejected, and the output change still goes through.
+    [Fact]
+    public void NoMicService_IgnoresInputAndAppliesOutput()
+    {
+        var plan = NativeAudioDevicePlan.Plan(
+            hasMic: false, currentInput: null, requestedInput: "mic-x", availableInputIds: [],
+            hasSink: true, currentOutput: null, requestedOutput: "spk-a", availableOutputIds: Outputs);
+
+        Assert.False(plan.ApplyInput);
+        Assert.Null(plan.InputError);
+        Assert.True(plan.ApplyOutput);
+    }
+
+    [Fact]
+    public void ChangingOutputToMissingDevice_Errors()
+    {
+        var plan = NativeAudioDevicePlan.Plan(
+            hasMic: true, currentInput: "mic-a", requestedInput: "mic-a", availableInputIds: Inputs,
+            hasSink: true, currentOutput: "spk-a", requestedOutput: "spk-x", availableOutputIds: Outputs);
+
+        Assert.False(plan.ApplyOutput);
+        Assert.NotNull(plan.OutputError);
+    }
+}

--- a/tests/Zeus.Server.Tests/SaturnSpeakerAudioSinkTests.cs
+++ b/tests/Zeus.Server.Tests/SaturnSpeakerAudioSinkTests.cs
@@ -55,6 +55,7 @@ public sealed class SaturnSpeakerAudioSinkTests : IDisposable
         // Default-off: publishing audio must not have opened the UDP target.
         var frame = MakeMonoFrame(64);
         sink.Publish(frame);
+        WaitForIdle(sink);
 
         Assert.False(IsSocketOpen(sink));
 
@@ -77,13 +78,15 @@ public sealed class SaturnSpeakerAudioSinkTests : IDisposable
         settings.Set(true);
         radio.MarkProtocol2Connected("127.0.0.1:1024", 192_000, client: null, boardKind: HpsdrBoardKind.HermesII);
 
-        // One audio frame opens the socket lazily.
+        // One audio frame opens the socket lazily (handled on the worker).
         sink.Publish(MakeMonoFrame(64));
+        WaitForIdle(sink);
         Assert.True(IsSocketOpen(sink));
 
         // Flip the operator opt-in off — the sink must release the socket so
         // sequence numbers reset cleanly on a later re-enable.
         settings.Set(false);
+        WaitForIdle(sink);
         Assert.False(IsSocketOpen(sink));
 
         await sink.StopAsync(default);
@@ -109,6 +112,7 @@ public sealed class SaturnSpeakerAudioSinkTests : IDisposable
         Assert.False(radio.IsProtocol2Active);
 
         sink.Publish(MakeMonoFrame(64));
+        WaitForIdle(sink);
         Assert.False(IsSocketOpen(sink));
 
         await sink.StopAsync(default);
@@ -130,6 +134,7 @@ public sealed class SaturnSpeakerAudioSinkTests : IDisposable
         radio.MarkProtocol2Connected("127.0.0.1:1024", 192_000, client: null, boardKind: HpsdrBoardKind.HermesLite2);
 
         sink.Publish(MakeMonoFrame(64));
+        WaitForIdle(sink);
         Assert.False(IsSocketOpen(sink));
 
         await sink.StopAsync(default);
@@ -150,19 +155,94 @@ public sealed class SaturnSpeakerAudioSinkTests : IDisposable
         await sink.StartAsync(default);
         settings.Set(true);
         radio.MarkProtocol2Connected("127.0.0.1:1024", 192_000, client: null, boardKind: HpsdrBoardKind.HermesII);
+        WaitForIdle(sink);
 
         radio.SetMox(true);
         // Keyed: a full packet's worth of frames must produce no outgoing packet.
         sink.Publish(MakeMonoFrame(64));
+        WaitForIdle(sink);
         Assert.Equal(0u, SequenceOf(sink));
 
         radio.SetMox(false);
         // Unkey: RX audio flows out again (the 4-byte sequence advances).
         sink.Publish(MakeMonoFrame(64));
+        WaitForIdle(sink);
         Assert.True(SequenceOf(sink) >= 1u, "expected at least one packet sent after unkey");
 
         await sink.StopAsync(default);
         sink.Dispose();
+    }
+
+    // Issue #1148 — the producer (DSP RX) thread must not be blocked on UDP
+    // syscalls while the sender does its 16 packets per audio frame. Verify
+    // Publish returns in well under a frame-time even when the socket target
+    // is unreachable (so packets queue / drop on the worker side without
+    // back-pressuring the DSP thread that also has to refill the host
+    // soundcard ring on time).
+    [Fact]
+    public async Task Publish_DoesNotBlockProducerOnSocketWork()
+    {
+        using var radio = NewRadio();
+        using var settings = new RadioSpeakerSettingsStore(
+            NullLogger<RadioSpeakerSettingsStore>.Instance, _dbPath + ".spk");
+        var sink = new SaturnSpeakerAudioSink(radio, settings, NullLogger<SaturnSpeakerAudioSink>.Instance);
+
+        await sink.StartAsync(default);
+        settings.Set(true);
+        // 192.0.2.0/24 is TEST-NET-1 (RFC 5737) — packets get dropped on the
+        // way out, so the sender thread will spin retries / WOULD_BLOCK while
+        // the producer keeps pushing.
+        radio.MarkProtocol2Connected("192.0.2.7:1024", 192_000, client: null, boardKind: HpsdrBoardKind.HermesII);
+        WaitForIdle(sink);
+
+        // 1024 samples is one DSP-tick batch at 48 kHz mono (~21.3 ms of audio).
+        // Producing 50 of these back-to-back is ~1 s of audio; the call must
+        // return in a small fraction of that since work is deferred.
+        var frame = MakeMonoFrame(1024);
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        for (int i = 0; i < 50; i++) sink.Publish(frame);
+        sw.Stop();
+
+        Assert.True(sw.ElapsedMilliseconds < 200,
+            $"Publish loop took {sw.ElapsedMilliseconds} ms; expected the DSP-thread path to be near-free");
+
+        // ...and the deferred work must actually have happened: the sender
+        // thread drained the ring and emitted packets (sequence advanced). A
+        // regression where the worker silently skips all sends would keep the
+        // timing assertion green but fail here.
+        WaitForIdle(sink);
+        Assert.True(SequenceOf(sink) > 0u,
+            "expected the sender thread to have emitted packets after 50 Publish calls");
+
+        await sink.StopAsync(default);
+        sink.Dispose();
+    }
+
+    // Issue #1148 follow-up — the wake event is disposed in Dispose, but the
+    // sink stays registered as an IRxAudioSink, so a late RX frame can still be
+    // fanned to Publish during host shutdown. Signalling a disposed
+    // ManualResetEventSlim must not throw ObjectDisposedException onto the
+    // real-time audio thread.
+    [Fact]
+    public async Task Publish_AfterDispose_DoesNotThrow()
+    {
+        using var radio = NewRadio();
+        using var settings = new RadioSpeakerSettingsStore(
+            NullLogger<RadioSpeakerSettingsStore>.Instance, _dbPath + ".spk");
+        var sink = new SaturnSpeakerAudioSink(radio, settings, NullLogger<SaturnSpeakerAudioSink>.Instance);
+
+        await sink.StartAsync(default);
+        settings.Set(true);
+        radio.MarkProtocol2Connected("127.0.0.1:1024", 192_000, client: null, boardKind: HpsdrBoardKind.HermesII);
+
+        // Dispose without StopAsync — the harness can tear the sink down while
+        // the DSP pipeline is still ticking frames at it.
+        sink.Dispose();
+
+        // A frame fanned in after disposal must be a no-op, not a crash on the
+        // (now disposed) wake event.
+        var ex = Record.Exception(() => sink.Publish(MakeMonoFrame(64)));
+        Assert.Null(ex);
     }
 
     private static uint SequenceOf(SaturnSpeakerAudioSink sink)
@@ -170,6 +250,17 @@ public sealed class SaturnSpeakerAudioSinkTests : IDisposable
         var f = typeof(SaturnSpeakerAudioSink)
             .GetField("_sequence", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
         return f?.GetValue(sink) is uint v ? v : 0u;
+    }
+
+    // Wait for the sender thread (added in #1148) to flush every pending
+    // signal — settings change, MOX flip, state change, queued audio — so
+    // assertions on socket / sequence reflect the worker's view rather than
+    // racing it. Tight timeout: every signal in these tests is a flag flip
+    // that the worker handles in microseconds once it wakes.
+    private static void WaitForIdle(SaturnSpeakerAudioSink sink)
+    {
+        Assert.True(sink.WaitForIdleForTest(TimeSpan.FromSeconds(2)),
+            "sender thread did not become idle within 2 s");
     }
 
     private RadioService NewRadio() => new(

--- a/tests/Zeus.Server.Tests/Tci/SpotManagerTests.cs
+++ b/tests/Zeus.Server.Tests/Tci/SpotManagerTests.cs
@@ -151,4 +151,61 @@ public class SpotManagerTests
         Assert.Single(spots);
         Assert.Null(spots[0].Comment);
     }
+
+    [Fact]
+    public void AddSpot_PastCap_EvictsLeastRecentlySpotted()
+    {
+        // A DX-cluster firehose of unique callsigns must not accumulate without
+        // bound: the store is capped and evicts the least-recently-spotted call.
+        var manager = new SpotManager(maxSpots: 3);
+        manager.AddSpot("A1AA", "CW", 14000000, 0xFF000000);
+        manager.AddSpot("B2BB", "CW", 14001000, 0xFF000000);
+        manager.AddSpot("C3CC", "CW", 14002000, 0xFF000000);
+        manager.AddSpot("D4DD", "CW", 14003000, 0xFF000000); // evicts A1AA (oldest)
+
+        var spots = manager.GetAll();
+        Assert.Equal(3, spots.Length);
+        Assert.DoesNotContain(spots, s => s.Callsign == "A1AA");
+        Assert.Contains(spots, s => s.Callsign == "B2BB");
+        Assert.Contains(spots, s => s.Callsign == "C3CC");
+        Assert.Contains(spots, s => s.Callsign == "D4DD");
+    }
+
+    [Fact]
+    public void AddSpot_RespottingExisting_RefreshesRecency_DoesNotGrow()
+    {
+        var manager = new SpotManager(maxSpots: 3);
+        manager.AddSpot("A1AA", "CW", 14000000, 0xFF000000);
+        manager.AddSpot("B2BB", "CW", 14001000, 0xFF000000);
+        manager.AddSpot("C3CC", "CW", 14002000, 0xFF000000);
+
+        // Re-spot the oldest call — it becomes most-recent, so the NEXT add must
+        // evict B2BB (now the oldest), not A1AA.
+        manager.AddSpot("A1AA", "SSB", 14000500, 0xFF000000);
+        manager.AddSpot("D4DD", "CW", 14003000, 0xFF000000);
+
+        var spots = manager.GetAll();
+        Assert.Equal(3, spots.Length);
+        Assert.DoesNotContain(spots, s => s.Callsign == "B2BB");
+        Assert.Contains(spots, s => s.Callsign == "A1AA");
+        // The re-spot updated the value in place.
+        Assert.Equal("SSB", Assert.Single(spots, s => s.Callsign == "A1AA").Mode);
+    }
+
+    [Fact]
+    public void AddSpot_NeverExceedsCap_UnderFirehose()
+    {
+        var manager = new SpotManager(maxSpots: 50);
+        for (int i = 0; i < 5000; i++)
+            manager.AddSpot($"CALL{i}", "FT8", 14074000, 0xFF000000);
+
+        Assert.Equal(50, manager.GetAll().Length);
+    }
+
+    [Fact]
+    public void Ctor_NonPositiveCap_FallsBackToDefault()
+    {
+        Assert.Equal(SpotManager.DefaultMaxSpots, new SpotManager(0).MaxSpots);
+        Assert.Equal(SpotManager.DefaultMaxSpots, new SpotManager(-5).MaxSpots);
+    }
 }

--- a/tests/Zeus.Server.Tests/TelnetByteFilterTests.cs
+++ b/tests/Zeus.Server.Tests/TelnetByteFilterTests.cs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA), and contributors.
+
+using System.Text;
+using Zeus.Server.DxCluster;
+
+namespace Zeus.Server.Tests;
+
+public class TelnetByteFilterTests
+{
+    private static string Filter(params byte[][] chunks)
+    {
+        var f = new TelnetByteFilter();
+        var sink = new List<byte>();
+        foreach (var c in chunks)
+            f.Process(c, c.Length, sink);
+        return Encoding.Latin1.GetString(sink.ToArray());
+    }
+
+    [Fact]
+    public void PlainText_PassesThrough()
+    {
+        Assert.Equal("DX de W3LPL", Filter(Encoding.Latin1.GetBytes("DX de W3LPL")));
+    }
+
+    [Fact]
+    public void Strips_DoWillNegotiation()
+    {
+        // IAC DO ECHO (FF FD 01) + "hi" + IAC WILL SGA (FF FB 03)
+        var bytes = new byte[] { 0xFF, 0xFD, 0x01, (byte)'h', (byte)'i', 0xFF, 0xFB, 0x03 };
+        Assert.Equal("hi", Filter(bytes));
+    }
+
+    [Fact]
+    public void EscapedIac_YieldsLiteralFF()
+    {
+        // IAC IAC (FF FF) → a single literal 0xFF data byte.
+        var bytes = new byte[] { (byte)'a', 0xFF, 0xFF, (byte)'b' };
+        var result = Filter(bytes);
+        Assert.Equal(3, result.Length);
+        Assert.Equal('a', result[0]);
+        Assert.Equal((char)0xFF, result[1]);
+        Assert.Equal('b', result[2]);
+    }
+
+    [Fact]
+    public void Strips_Subnegotiation()
+    {
+        // IAC SB <opt> <data...> IAC SE  (FF FA ... FF F0)
+        var bytes = new byte[] { (byte)'x', 0xFF, 0xFA, 0x18, 0x00, (byte)'A', (byte)'B', 0xFF, 0xF0, (byte)'y' };
+        Assert.Equal("xy", Filter(bytes));
+    }
+
+    [Fact]
+    public void Sequence_SplitAcrossChunks_HandledStatefully()
+    {
+        // IAC at end of one chunk, DO ECHO continuing in the next.
+        var c1 = new byte[] { (byte)'a', 0xFF };
+        var c2 = new byte[] { 0xFD, 0x01, (byte)'b' };
+        Assert.Equal("ab", Filter(c1, c2));
+    }
+}

--- a/tests/Zeus.Server.Tests/VstChainDiffTests.cs
+++ b/tests/Zeus.Server.Tests/VstChainDiffTests.cs
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using System.Text.Json;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="VstChainDiff"/> — the incremental VST-engine chain
+/// diff that replaced the unconditional full <c>load_chain</c> on every edit.
+/// Each emitted command is validated two ways: representative op sequences are
+/// asserted directly, and an engine-semantics simulator applies the commands to
+/// the current chain and asserts the result equals the desired order (so the
+/// generated indices are provably correct, never out of range).
+/// </summary>
+public class VstChainDiffTests
+{
+    private static VstChainDiff.DesiredSlot Slot(string id, string state = "") =>
+        // uid == id so the simulator can map add_plugin back to a Zeus id.
+        new(id, File: "f_" + id, Uid: id, State: state);
+
+    private static List<VstChainDiff.DesiredSlot> Desired(params string[] ids)
+    {
+        var list = new List<VstChainDiff.DesiredSlot>();
+        foreach (var id in ids) list.Add(Slot(id));
+        return list;
+    }
+
+    /// <summary>Apply the emitted commands to <paramref name="current"/> using the
+    /// engine's documented slot semantics, returning the resulting id order.</summary>
+    private static List<string> Apply(IReadOnlyList<string> current, IReadOnlyList<object> cmds)
+    {
+        var work = new List<string>(current);
+        foreach (var c in cmds)
+        {
+            var e = JsonSerializer.SerializeToElement(c);
+            switch (e.GetProperty("cmd").GetString())
+            {
+                case "remove_plugin":
+                    work.RemoveAt(e.GetProperty("index").GetInt32());
+                    break;
+                case "add_plugin":
+                    work.Insert(e.GetProperty("index").GetInt32(), e.GetProperty("uid").GetString()!);
+                    break;
+                case "move_plugin":
+                    var from = e.GetProperty("from").GetInt32();
+                    var to = e.GetProperty("to").GetInt32();
+                    var moved = work[from];
+                    work.RemoveAt(from);
+                    work.Insert(to, moved);
+                    break;
+                case "set_plugin_state":
+                    break; // no order effect
+                default:
+                    Assert.Fail($"unexpected cmd {e.GetProperty("cmd").GetString()}");
+                    break;
+            }
+        }
+        return work;
+    }
+
+    private static string CmdName(object c) =>
+        JsonSerializer.SerializeToElement(c).GetProperty("cmd").GetString()!;
+
+    [Fact]
+    public void EmptyCurrent_ReturnsNull_SoCallerFullLoads()
+    {
+        Assert.Null(VstChainDiff.Compute(Array.Empty<string>(), Desired("a", "b")));
+    }
+
+    [Fact]
+    public void IdenticalChains_ReturnEmpty_NoRedundantReload()
+    {
+        var cmds = VstChainDiff.Compute(new[] { "a", "b", "c" }, Desired("a", "b", "c"));
+        Assert.NotNull(cmds);
+        Assert.Empty(cmds!);
+    }
+
+    [Fact]
+    public void AppendOnePlugin_EmitsSingleAddAtEnd()
+    {
+        var current = new[] { "a", "b" };
+        var cmds = VstChainDiff.Compute(current, Desired("a", "b", "c"))!;
+        Assert.Single(cmds);
+        Assert.Equal("add_plugin", CmdName(cmds[0]));
+        var add = JsonSerializer.SerializeToElement(cmds[0]);
+        Assert.Equal(2, add.GetProperty("index").GetInt32());
+        Assert.Equal("c", add.GetProperty("uid").GetString());
+        Assert.Equal("f_c", add.GetProperty("file").GetString());
+        Assert.Equal(new[] { "a", "b", "c" }, Apply(current, cmds));
+    }
+
+    [Fact]
+    public void AddPluginWithState_EmitsAddThenSetState()
+    {
+        var current = new[] { "a" };
+        var desired = new List<VstChainDiff.DesiredSlot> { Slot("a"), Slot("b", state: "BLOB==") };
+        var cmds = VstChainDiff.Compute(current, desired)!;
+        Assert.Equal(2, cmds.Count);
+        Assert.Equal("add_plugin", CmdName(cmds[0]));
+        Assert.Equal("set_plugin_state", CmdName(cmds[1]));
+        var st = JsonSerializer.SerializeToElement(cmds[1]);
+        Assert.Equal(1, st.GetProperty("index").GetInt32());
+        Assert.Equal("BLOB==", st.GetProperty("state").GetString());
+    }
+
+    [Fact]
+    public void AddPluginWithoutState_DoesNotEmitSetState()
+    {
+        var cmds = VstChainDiff.Compute(new[] { "a" }, Desired("a", "b"))!;
+        Assert.Single(cmds);
+        Assert.Equal("add_plugin", CmdName(cmds[0]));
+    }
+
+    [Fact]
+    public void RemoveMiddlePlugin_EmitsSingleRemoveAtCorrectIndex()
+    {
+        var current = new[] { "a", "b", "c" };
+        var cmds = VstChainDiff.Compute(current, Desired("a", "c"))!;
+        Assert.Single(cmds);
+        Assert.Equal("remove_plugin", CmdName(cmds[0]));
+        Assert.Equal(1, JsonSerializer.SerializeToElement(cmds[0]).GetProperty("index").GetInt32());
+        Assert.Equal(new[] { "a", "c" }, Apply(current, cmds));
+    }
+
+    [Theory]
+    [InlineData("a,b,c", "c,b,a")]              // full reverse
+    [InlineData("a,b,c,d", "a,c,b,d")]          // adjacent swap
+    [InlineData("a,b,c", "b,c,a")]              // rotate
+    [InlineData("a,b,c,d", "d,a,b,c")]          // move last to front
+    public void Reorder_ProducesDesiredOrder(string currentCsv, string desiredCsv)
+    {
+        var current = currentCsv.Split(',');
+        var desiredIds = desiredCsv.Split(',');
+        var cmds = VstChainDiff.Compute(current, Desired(desiredIds))!;
+        // Pure reorder uses only move_plugin (no add/remove).
+        Assert.All(cmds, c => Assert.Equal("move_plugin", CmdName(c)));
+        Assert.Equal(desiredIds, Apply(current, cmds));
+    }
+
+    [Theory]
+    [InlineData("a,b,c", "a,b,c")]              // no-op
+    [InlineData("a,b,c", "x,y,z")]              // full replacement
+    [InlineData("a,b,c,d,e", "e,c,f")]          // mixed remove + add + reorder
+    [InlineData("comp,eq,gate", "gate,comp,reverb")]
+    public void MixedEdits_ApplyToDesiredOrder(string currentCsv, string desiredCsv)
+    {
+        var current = currentCsv.Split(',');
+        var desiredIds = desiredCsv.Split(',');
+        var cmds = VstChainDiff.Compute(current, Desired(desiredIds));
+        Assert.NotNull(cmds);
+        Assert.Equal(desiredIds, Apply(current, cmds!));
+    }
+
+    [Fact]
+    public void RemoveAllPlugins_EmitsRemovesAndEndsEmpty()
+    {
+        var current = new[] { "a", "b" };
+        var cmds = VstChainDiff.Compute(current, Desired())!;
+        Assert.All(cmds, c => Assert.Equal("remove_plugin", CmdName(c)));
+        Assert.Empty(Apply(current, cmds));
+    }
+}

--- a/zeus-web/src/api/dxcluster.ts
+++ b/zeus-web/src/api/dxcluster.ts
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+import { ApiError } from './client';
+
+export type DxClusterConnectionState =
+  | 'Disconnected'
+  | 'Connecting'
+  | 'Connected'
+  | 'Reconnecting';
+
+export type DxClusterStatus = {
+  enabled: boolean;
+  host: string;
+  port: number;
+  callsign: string;
+  hasPassword: boolean;
+  loginCommands: string;
+  autoConnect: boolean;
+  state: DxClusterConnectionState;
+  spotsReceived: number;
+  lastSpotCallsign: string | null;
+  error: string | null;
+};
+
+export type DxClusterConfig = {
+  enabled: boolean;
+  host: string;
+  port: number;
+  callsign: string;
+  password: string;
+  loginCommands: string;
+  autoConnect: boolean;
+};
+
+const STATES: DxClusterConnectionState[] = [
+  'Disconnected',
+  'Connecting',
+  'Connected',
+  'Reconnecting',
+];
+
+function normalizeState(raw: unknown): DxClusterConnectionState {
+  if (typeof raw === 'string' && (STATES as string[]).includes(raw)) {
+    return raw as DxClusterConnectionState;
+  }
+  // The enum may arrive numeric depending on serializer config.
+  if (typeof raw === 'number' && raw >= 0 && raw < STATES.length) {
+    return STATES[raw] ?? 'Disconnected';
+  }
+  return 'Disconnected';
+}
+
+export function normalizeStatus(raw: unknown): DxClusterStatus {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  return {
+    enabled: Boolean(r.enabled),
+    host: typeof r.host === 'string' ? r.host : '',
+    port: typeof r.port === 'number' ? r.port : 7373,
+    callsign: typeof r.callsign === 'string' ? r.callsign : '',
+    hasPassword: Boolean(r.hasPassword),
+    loginCommands: typeof r.loginCommands === 'string' ? r.loginCommands : '',
+    autoConnect: Boolean(r.autoConnect),
+    state: normalizeState(r.state),
+    spotsReceived: typeof r.spotsReceived === 'number' ? r.spotsReceived : 0,
+    lastSpotCallsign:
+      typeof r.lastSpotCallsign === 'string' && r.lastSpotCallsign.length > 0
+        ? r.lastSpotCallsign
+        : null,
+    error: typeof r.error === 'string' && r.error.length > 0 ? r.error : null,
+  };
+}
+
+async function jsonFetch<T>(
+  input: RequestInfo,
+  init: RequestInit | undefined,
+  parse: (raw: unknown) => T,
+): Promise<T> {
+  const res = await fetch(input, init);
+  if (!res.ok) {
+    let message = `${res.status} ${res.statusText}`;
+    try {
+      const body = (await res.json()) as unknown;
+      if (
+        body &&
+        typeof body === 'object' &&
+        'error' in body &&
+        typeof (body as { error: unknown }).error === 'string'
+      ) {
+        message = (body as { error: string }).error;
+      }
+    } catch {
+      /* non-JSON */
+    }
+    throw new ApiError(res.status, message);
+  }
+  return parse((await res.json()) as unknown);
+}
+
+export function getDxClusterStatus(signal?: AbortSignal): Promise<DxClusterStatus> {
+  return jsonFetch('/api/dxcluster/status', { signal }, normalizeStatus);
+}
+
+export function putDxClusterConfig(cfg: DxClusterConfig, signal?: AbortSignal): Promise<DxClusterStatus> {
+  return jsonFetch(
+    '/api/dxcluster/config',
+    {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(cfg),
+      signal,
+    },
+    normalizeStatus,
+  );
+}
+
+export function connectDxCluster(signal?: AbortSignal): Promise<DxClusterStatus> {
+  return jsonFetch('/api/dxcluster/connect', { method: 'POST', signal }, normalizeStatus);
+}
+
+export function disconnectDxCluster(signal?: AbortSignal): Promise<DxClusterStatus> {
+  return jsonFetch('/api/dxcluster/disconnect', { method: 'POST', signal }, normalizeStatus);
+}

--- a/zeus-web/src/components/ChatRosterOverlay.tsx
+++ b/zeus-web/src/components/ChatRosterOverlay.tsx
@@ -190,6 +190,8 @@ export function ChatRosterOverlay() {
   const openDm = useChatStore((s) => s.openDm);
   const freqPublic = useChatStore((s) => s.freqPublic);
   const myCallsign = useChatStore((s) => s.callsign);
+  const acceptedFriends = useChatStore((s) => s.acceptedFriends);
+  const seeAllFreq = useChatStore((s) => s.seeAllFreq);
   const show = useDisplaySettingsStore((s) => s.showChatRosterOverlay);
 
   const centerHz = useDisplayStore((s) => s.centerHz);
@@ -226,8 +228,22 @@ export function ChatRosterOverlay() {
     // pinned to your own panadapter after you've hidden. Drop it so "hidden"
     // means hidden everywhere, including your own view.
     const mine = (myCallsign ?? '').toUpperCase();
+    // Friend gate — mirror the chat roster's rule: you only see a friend's
+    // callsign on the panadapter, never a stranger's. The relay already enforces
+    // this (it strips freqHz from every non-friend before the roster leaves the
+    // server, so a stranger arrives unplaceable), but assert it here too so the
+    // intent is explicit and a future relay change can't silently leak callsigns.
+    // Yourself and the admin "see all" override are the deliberate exceptions:
+    // see-all is meant to reveal every operator on the panadapter regardless of
+    // friendship, so it bypasses the gate exactly as it does on the relay.
+    const friendSet = new Set(acceptedFriends.map((c) => c.toUpperCase()));
+    const canPlace = (op: ChatOperator) => {
+      const call = op.callsign.toUpperCase();
+      return call === mine || seeAllFreq || friendSet.has(call);
+    };
     const inView = roster
       .filter((op) => typeof op.freqHz === 'number' && Number.isFinite(op.freqHz))
+      .filter(canPlace)
       .filter((op) => freqPublic || !mine || op.callsign.toUpperCase() !== mine)
       .map((op) => ({ op, pct: ((op.freqHz! - startHz) / spanHz) * 100 }))
       .filter(({ pct }) => pct >= -2 && pct <= 102)
@@ -247,7 +263,7 @@ export function ChatRosterOverlay() {
       laneLastPct[lane] = pct;
       return { op, pct, lane };
     });
-  }, [show, enabled, connected, roster, centerHz, hzPerPixel, width, freqPublic, myCallsign]);
+  }, [show, enabled, connected, roster, centerHz, hzPerPixel, width, freqPublic, myCallsign, acceptedFriends, seeAllFreq]);
 
   if (placed.length === 0) return null;
 

--- a/zeus-web/src/components/ChatRosterOverlay.tsx
+++ b/zeus-web/src/components/ChatRosterOverlay.tsx
@@ -90,7 +90,11 @@ function RosterMarker({
 
   return (
     <div
-      className="pointer-events-none absolute inset-y-0 z-[9] -translate-x-1/2"
+      // z-[16] keeps the callsign pill ABOVE the frequency-scale chrome — the
+      // ruler (z-10), band overlay (z-11), and especially the green VFO dial
+      // marker / frequency line (z-15) — so the line never draws across a
+      // callsign. Stays below the VFO readout box (z-25), which owns the corner.
+      className="pointer-events-none absolute inset-y-0 z-[16] -translate-x-1/2"
       style={{ left: `${pct}%` }}
     >
       {/* vertical tick — non-interactive so it never blocks click-to-tune */}

--- a/zeus-web/src/components/ChatRosterOverlay.tsx
+++ b/zeus-web/src/components/ChatRosterOverlay.tsx
@@ -184,6 +184,8 @@ export function ChatRosterOverlay() {
   const connected = useChatStore((s) => s.connected);
   const roster = useChatStore((s) => s.roster);
   const openDm = useChatStore((s) => s.openDm);
+  const freqPublic = useChatStore((s) => s.freqPublic);
+  const myCallsign = useChatStore((s) => s.callsign);
   const show = useDisplaySettingsStore((s) => s.showChatRosterOverlay);
 
   const centerHz = useDisplayStore((s) => s.centerHz);
@@ -213,8 +215,16 @@ export function ChatRosterOverlay() {
     }
     const spanHz = width * hzPerPixel;
     const startHz = Number(centerHz) - spanHz / 2;
+    // Respect the eye toggle for your OWN marker. The relay strips your freq
+    // from every other operator's roster the moment you hide it, so they stop
+    // seeing your callsign here — but it always sends you your own freq (so the
+    // rest of the UI can use it), which would otherwise leave your callsign
+    // pinned to your own panadapter after you've hidden. Drop it so "hidden"
+    // means hidden everywhere, including your own view.
+    const mine = (myCallsign ?? '').toUpperCase();
     const inView = roster
       .filter((op) => typeof op.freqHz === 'number' && Number.isFinite(op.freqHz))
+      .filter((op) => freqPublic || !mine || op.callsign.toUpperCase() !== mine)
       .map((op) => ({ op, pct: ((op.freqHz! - startHz) / spanHz) * 100 }))
       .filter(({ pct }) => pct >= -2 && pct <= 102)
       .sort((a, b) => a.pct - b.pct);
@@ -233,7 +243,7 @@ export function ChatRosterOverlay() {
       laneLastPct[lane] = pct;
       return { op, pct, lane };
     });
-  }, [show, enabled, connected, roster, centerHz, hzPerPixel, width]);
+  }, [show, enabled, connected, roster, centerHz, hzPerPixel, width, freqPublic, myCallsign]);
 
   if (placed.length === 0) return null;
 

--- a/zeus-web/src/components/DxClusterSettingsPanel.test.tsx
+++ b/zeus-web/src/components/DxClusterSettingsPanel.test.tsx
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// DxClusterSettingsPanel — Network-tab DX-cluster section test. Verifies the
+// default-OFF form, that SAVE persists the operator-entered host/callsign/port,
+// and that CONNECT calls the store. The harness import installs the localStorage
+// polyfill + act flag before the store loads; store methods are stubbed so no
+// real fetch fires.
+
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { createElement } from 'react';
+import { act, render } from './meters/__tests__/harness';
+import { DxClusterSettingsPanel } from './DxClusterSettingsPanel';
+import { useDxClusterStore } from '../state/dxcluster-store';
+import type { DxClusterConfig } from '../api/dxcluster';
+
+const OFF: DxClusterConfig = {
+  enabled: false,
+  host: '',
+  port: 7373,
+  callsign: '',
+  password: '',
+  loginCommands: '',
+  autoConnect: false,
+};
+
+function setInputValue(input: HTMLInputElement | HTMLTextAreaElement, value: string) {
+  const proto =
+    input instanceof HTMLTextAreaElement
+      ? window.HTMLTextAreaElement.prototype
+      : window.HTMLInputElement.prototype;
+  const setter = Object.getOwnPropertyDescriptor(proto, 'value')!.set!;
+  act(() => {
+    setter.call(input, value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+}
+
+function clickByText(container: HTMLElement, text: string) {
+  const btn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === text);
+  expect(btn, `button "${text}"`).toBeTruthy();
+  act(() => (btn as HTMLButtonElement).click());
+}
+
+describe('DxClusterSettingsPanel', () => {
+  beforeEach(() => {
+    act(() => {
+      useDxClusterStore.setState({
+        config: { ...OFF },
+        status: null,
+        refreshStatus: async () => {},
+        saveConfig: async () => ({
+          ...OFF,
+          hasPassword: false,
+          state: 'Disconnected',
+          spotsReceived: 0,
+          lastSpotCallsign: null,
+          error: null,
+        }),
+        connect: async () => ({
+          ...OFF,
+          hasPassword: false,
+          state: 'Connecting',
+          spotsReceived: 0,
+          lastSpotCallsign: null,
+          error: null,
+        }),
+        disconnect: async () => ({
+          ...OFF,
+          hasPassword: false,
+          state: 'Disconnected',
+          spotsReceived: 0,
+          lastSpotCallsign: null,
+          error: null,
+        }),
+      } as never);
+    });
+  });
+
+  it('renders the DX cluster section, default disabled', () => {
+    const { container, unmount } = render(createElement(DxClusterSettingsPanel));
+    expect(container.textContent).toContain('DX CLUSTER (TELNET)');
+    const enabled = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(enabled.checked).toBe(false);
+    unmount();
+  });
+
+  it('SAVE persists the operator-entered host/port/callsign', () => {
+    const saveConfig = vi.fn(async () => ({
+      ...OFF,
+      hasPassword: false,
+      state: 'Disconnected' as const,
+      spotsReceived: 0,
+      lastSpotCallsign: null,
+      error: null,
+    }));
+    act(() => useDxClusterStore.setState({ saveConfig } as never));
+
+    const { container, unmount } = render(createElement(DxClusterSettingsPanel));
+    const enabled = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    act(() => enabled.click());
+
+    setInputValue(container.querySelector('input[placeholder="dxc.example.org"]') as HTMLInputElement, 'dxc.example.org');
+    setInputValue(container.querySelector('input[type="number"]') as HTMLInputElement, '7300');
+    setInputValue(container.querySelector('input[placeholder="K1ABC"]') as HTMLInputElement, 'k1abc');
+
+    clickByText(container, 'SAVE');
+    expect(saveConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: true,
+        host: 'dxc.example.org',
+        port: 7300,
+        callsign: 'K1ABC',
+      }),
+    );
+    unmount();
+  });
+
+  it('SAVE with an out-of-range port surfaces an error and does not persist', async () => {
+    const saveConfig = vi.fn(async () => ({
+      ...OFF,
+      hasPassword: false,
+      state: 'Disconnected' as const,
+      spotsReceived: 0,
+      lastSpotCallsign: null,
+      error: null,
+    }));
+    act(() => useDxClusterStore.setState({ saveConfig } as never));
+
+    const { container, unmount } = render(createElement(DxClusterSettingsPanel));
+    setInputValue(container.querySelector('input[placeholder="dxc.example.org"]') as HTMLInputElement, 'dxc.example.org');
+    setInputValue(container.querySelector('input[type="number"]') as HTMLInputElement, '99999');
+
+    clickByText(container, 'SAVE');
+    // The submit handler is async; flush its synchronous state update to the DOM.
+    await act(async () => {});
+    expect(saveConfig).not.toHaveBeenCalled();
+    expect(container.textContent).toContain('Port must be a whole number between 1 and 65535.');
+
+    // Editing the port clears the error, and a valid value now saves.
+    setInputValue(container.querySelector('input[type="number"]') as HTMLInputElement, '7300');
+    expect(container.textContent).not.toContain('Port must be a whole number');
+    clickByText(container, 'SAVE');
+    await act(async () => {});
+    expect(saveConfig).toHaveBeenCalledWith(expect.objectContaining({ port: 7300 }));
+    unmount();
+  });
+
+  it('CONNECT calls the store connect action', () => {
+    const connect = vi.fn(async () => ({
+      ...OFF,
+      hasPassword: false,
+      state: 'Connecting' as const,
+      spotsReceived: 0,
+      lastSpotCallsign: null,
+      error: null,
+    }));
+    act(() =>
+      useDxClusterStore.setState({ config: { ...OFF, enabled: true }, connect } as never),
+    );
+
+    const { container, unmount } = render(createElement(DxClusterSettingsPanel));
+    clickByText(container, 'CONNECT');
+    expect(connect).toHaveBeenCalled();
+    unmount();
+  });
+});

--- a/zeus-web/src/components/DxClusterSettingsPanel.tsx
+++ b/zeus-web/src/components/DxClusterSettingsPanel.tsx
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+import { useEffect, useState } from 'react';
+import { useDxClusterStore } from '../state/dxcluster-store';
+import type { DxClusterConnectionState } from '../api/dxcluster';
+
+const inputStyle: React.CSSProperties = {
+  padding: '6px 8px',
+  fontSize: 12,
+  fontFamily: 'monospace',
+  background: 'var(--bg-0)',
+  border: '1px solid var(--panel-border)',
+  borderRadius: 'var(--r-sm)',
+  color: 'var(--fg-0)',
+};
+
+function stateColor(state: DxClusterConnectionState): string {
+  switch (state) {
+    case 'Connected':
+      return 'var(--accent)';
+    case 'Connecting':
+    case 'Reconnecting':
+      return 'var(--power)';
+    default:
+      return 'var(--fg-3)';
+  }
+}
+
+export function DxClusterSettingsPanel() {
+  const config = useDxClusterStore((s) => s.config);
+  const status = useDxClusterStore((s) => s.status);
+  const saveConfig = useDxClusterStore((s) => s.saveConfig);
+  const connect = useDxClusterStore((s) => s.connect);
+  const disconnect = useDxClusterStore((s) => s.disconnect);
+
+  const [enabled, setEnabled] = useState(config.enabled);
+  const [host, setHost] = useState(config.host);
+  const [port, setPort] = useState(String(config.port));
+  const [callsign, setCallsign] = useState(config.callsign);
+  const [password, setPassword] = useState(config.password);
+  const [loginCommands, setLoginCommands] = useState(config.loginCommands);
+  const [autoConnect, setAutoConnect] = useState(config.autoConnect);
+  const [saving, setSaving] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [portError, setPortError] = useState<string | null>(null);
+
+  // Rehydrate the form when the store syncs from the backend.
+  useEffect(() => {
+    setEnabled(config.enabled);
+    setHost(config.host);
+    setPort(String(config.port));
+    setCallsign(config.callsign);
+    setLoginCommands(config.loginCommands);
+    setAutoConnect(config.autoConnect);
+  }, [config.enabled, config.host, config.port, config.callsign, config.loginCommands, config.autoConnect]);
+
+  const state: DxClusterConnectionState = status?.state ?? 'Disconnected';
+  const spotsReceived = status?.spotsReceived ?? 0;
+  const connected = state === 'Connected';
+
+  async function onSave(e: React.FormEvent) {
+    e.preventDefault();
+    const portNum = Number(port);
+    if (!Number.isInteger(portNum) || portNum <= 0 || portNum >= 65536) {
+      // Don't silently swallow an out-of-range / pasted value — tell the operator
+      // why SAVE did nothing instead of leaving a dead button.
+      setPortError('Port must be a whole number between 1 and 65535.');
+      return;
+    }
+    setPortError(null);
+    setSaving(true);
+    try {
+      await saveConfig({
+        enabled,
+        host: host.trim(),
+        port: portNum,
+        callsign: callsign.trim().toUpperCase(),
+        password,
+        loginCommands,
+        autoConnect,
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function onConnect() {
+    setBusy(true);
+    try {
+      await connect();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onDisconnect() {
+    setBusy(true);
+    try {
+      await disconnect();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div style={{ maxWidth: 700 }}>
+      <h3
+        style={{
+          margin: '0 0 14px',
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: '0.12em',
+          textTransform: 'uppercase',
+          color: 'var(--fg-2)',
+        }}
+      >
+        DX CLUSTER (TELNET)
+      </h3>
+
+      <div
+        style={{
+          padding: 12,
+          marginBottom: 16,
+          fontSize: 11,
+          lineHeight: 1.5,
+          color: 'var(--fg-2)',
+          background: 'var(--bg-0)',
+          border: '1px solid var(--panel-border)',
+          borderRadius: 'var(--r-sm)',
+        }}
+      >
+        Connect directly to a Telnet DX cluster (DXSpider / AR-Cluster / CC-Cluster). Spots land on
+        the panadapter automatically — no Cluster-TCI bridge needed. Enter the cluster host and your
+        callsign; add a password only if your cluster requires one.
+      </div>
+
+      {/* noValidate: bypass the browser's native constraint-validation bubble for
+          the number field (its max would silently block submit and the operator
+          never learns why). We validate the port in onSave and surface an
+          in-app, in-palette message instead. */}
+      <form noValidate onSubmit={onSave} style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+        <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+            style={{ accentColor: 'var(--accent)' }}
+          />
+          <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--fg-1)' }}>Enabled</span>
+        </label>
+
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--fg-2)' }}>Host</span>
+          <input
+            type="text"
+            value={host}
+            onChange={(e) => setHost(e.target.value)}
+            spellCheck={false}
+            placeholder="dxc.example.org"
+            style={inputStyle}
+          />
+        </label>
+
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--fg-2)' }}>Port</span>
+          <input
+            type="number"
+            value={port}
+            onChange={(e) => {
+              setPort(e.target.value);
+              if (portError) setPortError(null);
+            }}
+            min={1}
+            max={65535}
+            style={portError ? { ...inputStyle, borderColor: 'var(--tx)' } : inputStyle}
+          />
+          {portError ? (
+            <span style={{ fontSize: 10, color: 'var(--tx)' }}>{portError}</span>
+          ) : (
+            <span style={{ fontSize: 10, color: 'var(--fg-3)' }}>
+              Default: 7373. Common cluster telnet ports are 7300, 7373, and 8000.
+            </span>
+          )}
+        </label>
+
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--fg-2)' }}>Callsign</span>
+          <input
+            type="text"
+            value={callsign}
+            onChange={(e) => setCallsign(e.target.value)}
+            spellCheck={false}
+            placeholder="K1ABC"
+            style={{ ...inputStyle, textTransform: 'uppercase' }}
+          />
+          <span style={{ fontSize: 10, color: 'var(--fg-3)' }}>
+            Sent automatically when the cluster asks for your call.
+          </span>
+        </label>
+
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--fg-2)' }}>
+            Password <span style={{ color: 'var(--fg-3)', fontWeight: 400 }}>(optional)</span>
+          </span>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            spellCheck={false}
+            placeholder={status?.hasPassword ? '•••••••• (saved)' : 'leave blank if not required'}
+            autoComplete="off"
+            style={inputStyle}
+          />
+        </label>
+
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--fg-2)' }}>
+            Login commands <span style={{ color: 'var(--fg-3)', fontWeight: 400 }}>(optional, one per line)</span>
+          </span>
+          <textarea
+            value={loginCommands}
+            onChange={(e) => setLoginCommands(e.target.value)}
+            spellCheck={false}
+            rows={3}
+            placeholder={'set/filter on\nset/dx/extension'}
+            style={{ ...inputStyle, resize: 'vertical' }}
+          />
+          <span style={{ fontSize: 10, color: 'var(--fg-3)' }}>
+            Sent once after login (e.g. spot filters).
+          </span>
+        </label>
+
+        <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <input
+            type="checkbox"
+            checked={autoConnect}
+            onChange={(e) => setAutoConnect(e.target.checked)}
+            style={{ accentColor: 'var(--accent)' }}
+          />
+          <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--fg-1)' }}>
+            Connect automatically on startup
+          </span>
+        </label>
+
+        {status?.error && (
+          <div
+            style={{
+              padding: 10,
+              fontSize: 12,
+              color: 'var(--tx)',
+              background: 'rgba(230, 58, 43, 0.1)',
+              border: '1px solid var(--tx)',
+              borderRadius: 'var(--r-sm)',
+            }}
+          >
+            {status.error}
+          </div>
+        )}
+
+        <div
+          style={{
+            padding: 10,
+            background: 'var(--bg-0)',
+            border: '1px solid var(--panel-border)',
+            borderRadius: 'var(--r-sm)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            fontSize: 12,
+            color: 'var(--fg-1)',
+          }}
+        >
+          <span
+            style={{
+              width: 8,
+              height: 8,
+              borderRadius: '50%',
+              background: stateColor(state),
+              flexShrink: 0,
+            }}
+          />
+          <span style={{ color: 'var(--fg-2)' }}>Status:</span>
+          <span style={{ fontWeight: 600, color: stateColor(state) }}>{state}</span>
+          <span style={{ color: 'var(--fg-2)' }}>·</span>
+          <span style={{ color: 'var(--fg-2)' }}>Spots:</span>
+          <span style={{ fontFamily: 'monospace', fontWeight: 600 }}>{spotsReceived}</span>
+          {status?.lastSpotCallsign && (
+            <>
+              <span style={{ color: 'var(--fg-2)' }}>·</span>
+              <span style={{ color: 'var(--fg-2)' }}>Last:</span>
+              <span style={{ fontFamily: 'monospace', fontWeight: 600 }}>{status.lastSpotCallsign}</span>
+            </>
+          )}
+        </div>
+
+        <div style={{ display: 'flex', gap: 6 }}>
+          <button
+            type="button"
+            onClick={onConnect}
+            disabled={busy || connected || !enabled}
+            className="btn sm"
+          >
+            CONNECT
+          </button>
+          <button
+            type="button"
+            onClick={onDisconnect}
+            disabled={busy || state === 'Disconnected'}
+            className="btn sm"
+          >
+            DISCONNECT
+          </button>
+          <span style={{ flex: 1 }} />
+          <button type="submit" disabled={saving} className="btn sm active">
+            {saving ? 'SAVING…' : 'SAVE'}
+          </button>
+        </div>
+
+        <div style={{ fontSize: 10, lineHeight: 1.4, color: 'var(--fg-3)' }}>
+          Spots appear on the panadapter through the same overlay as TCI spots. Save your settings,
+          then Connect. Enabling “Connect automatically on startup” reconnects on the next launch.
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/zeus-web/src/components/HamClockSettingsPanel.test.tsx
+++ b/zeus-web/src/components/HamClockSettingsPanel.test.tsx
@@ -2,9 +2,10 @@
 //
 // HamClockSettingsPanel — "Push DX to HamClock" section test. Verifies the
 // outbound DX-push form: default OFF, opting in reveals trigger/target/host/port,
-// the bundled target is disabled (unsupported), and SAVE persists the config.
-// Harness import first installs the localStorage polyfill + act flag before any
-// store loads; store methods are stubbed so no real fetch fires.
+// selecting the bundled target surfaces a clear "map won't auto-pin" notice (the
+// bundled OpenHamClock has no set-DX web command, #1110), and SAVE persists the
+// config. Harness import first installs the localStorage polyfill + act flag
+// before any store loads; store methods are stubbed so no real fetch fires.
 
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import { createElement } from 'react';
@@ -73,7 +74,7 @@ describe('HamClockSettingsPanel — Push DX', () => {
     unmount();
   });
 
-  it('opting in reveals trigger/target/host/port and marks the bundled target unsupported', () => {
+  it('opting in reveals trigger/target/host/port with both targets selectable', () => {
     const { container, unmount } = render(createElement(HamClockSettingsPanel));
     const toggle = container.querySelector(
       'button[aria-label="Push DX to HamClock"]',
@@ -81,10 +82,41 @@ describe('HamClockSettingsPanel — Push DX', () => {
     act(() => toggle.click());
     expect(container.querySelector('select[aria-label="Push trigger"]')).toBeTruthy();
     expect(container.querySelector('input[aria-label="HamClock host"]')).toBeTruthy();
-    // Bundled target option is present but disabled (no set-DX endpoint yet).
+    // Both targets are present and selectable; the bundled one is annotated, not
+    // disabled, so a persisted bundled config still surfaces its limitation.
     const targetSel = container.querySelector('select[aria-label="Push target"]') as HTMLSelectElement;
     const bundled = Array.from(targetSel.options).find((o) => o.value === 'bundled');
-    expect(bundled?.disabled).toBe(true);
+    expect(bundled).toBeTruthy();
+    expect(bundled?.disabled).toBe(false);
+    unmount();
+  });
+
+  it('shows the "map won\'t auto-pin" notice only when the bundled target is selected', () => {
+    const { container, unmount } = render(createElement(HamClockSettingsPanel));
+    const toggle = container.querySelector(
+      'button[aria-label="Push DX to HamClock"]',
+    ) as HTMLButtonElement;
+    act(() => toggle.click());
+
+    // External (default) target: no limitation notice.
+    expect(container.querySelector('[data-testid="bundled-dx-notice"]')).toBeNull();
+
+    setSelectValue(
+      container.querySelector('select[aria-label="Push target"]') as HTMLSelectElement,
+      'bundled',
+    );
+    const notice = container.querySelector('[data-testid="bundled-dx-notice"]');
+    expect(notice).toBeTruthy();
+    expect(notice?.textContent).toContain("can't receive auto-pins");
+    // The bundled target hides the external host/port inputs.
+    expect(container.querySelector('input[aria-label="HamClock host"]')).toBeNull();
+
+    // Switching back to external removes the notice again.
+    setSelectValue(
+      container.querySelector('select[aria-label="Push target"]') as HTMLSelectElement,
+      'external',
+    );
+    expect(container.querySelector('[data-testid="bundled-dx-notice"]')).toBeNull();
     unmount();
   });
 

--- a/zeus-web/src/components/HamClockSettingsPanel.tsx
+++ b/zeus-web/src/components/HamClockSettingsPanel.tsx
@@ -239,8 +239,10 @@ export function HamClockSettingsPanel() {
 // the backend issues a single HTTP GET to the HamClock REST API (set_newdx?grid=)
 // when a QSO partner is clicked or goes active in the FT8 pop-out. Egress is OFF
 // by default; the server-side forward avoids browser CORS / HTTPS mixed-content.
-// The bundled OpenHamClock sidecar has no set-DX endpoint yet, so that target is
-// surfaced as unsupported (an upstream PR is needed).
+// The bundled OpenHamClock sidecar has no set-DX web command, so a push to it is
+// a backend no-op. The target stays selectable but, when chosen, surfaces a clear
+// "map won't auto-pin" notice so auto-pins never fail silently (#1110); live
+// auto-pins require an external classic HamClock.
 function PushDxSection() {
   const pushConfig = useHamClockStore((s) => s.pushConfig);
   const loadPushConfig = useHamClockStore((s) => s.loadPushConfig);
@@ -334,11 +336,37 @@ function PushDxSection() {
               onChange={(e) => patch({ target: e.target.value as HamClockPushConfig['target'] })}
             >
               <option value="external">External HamClock (host : port)</option>
-              <option value="bundled" disabled>
-                Bundled OpenHamClock (set-DX not supported yet)
-              </option>
+              <option value="bundled">Bundled OpenHamClock (map won't auto-pin)</option>
             </select>
           </div>
+
+          {/* The bundled OpenHamClock sidecar has no set-DX web command, so a
+              push to it is a no-op on the backend. Make that unmistakable rather
+              than letting auto-pins fail silently. */}
+          {form.target === 'bundled' && (
+            <div
+              role="alert"
+              data-testid="bundled-dx-notice"
+              style={{
+                padding: 10,
+                marginBottom: 10,
+                borderRadius: 'var(--r-sm, 4px)',
+                background: 'rgba(230, 58, 43, 0.1)',
+                border: '1px solid rgba(230, 58, 43, 0.3)',
+                color: 'var(--fg-1)',
+                fontSize: 12,
+                lineHeight: 1.5,
+              }}
+            >
+              <strong style={{ color: 'var(--tx)' }}>
+                The bundled OpenHamClock map can't receive auto-pins.
+              </strong>{' '}
+              It has no set-DX web command, so worked stations will not appear on
+              it — the push does nothing. To get live DX auto-pins, set Target to{' '}
+              <strong>External HamClock</strong> and point Zeus at a classic
+              HamClock's REST host and port (default {HAMCLOCK_PUSH_DEFAULT_PORT}).
+            </div>
+          )}
 
           {form.target === 'external' && (
             <>

--- a/zeus-web/src/components/NetworkSettingsPanel.tsx
+++ b/zeus-web/src/components/NetworkSettingsPanel.tsx
@@ -11,6 +11,7 @@
 import { CatSettingsPanel } from './CatSettingsPanel';
 import { CatSerialPortsPanel } from './CatSerialPortsPanel';
 import { TciSettingsPanel } from './TciSettingsPanel';
+import { DxClusterSettingsPanel } from './DxClusterSettingsPanel';
 import { WsjtxSettingsPanel } from './WsjtxSettingsPanel';
 import { SpottingSettingsPanel } from './SpottingSettingsPanel';
 
@@ -29,6 +30,8 @@ export function NetworkSettingsPanel() {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
       <TciSettingsPanel />
+      <div style={{ borderTop: '1px solid var(--panel-border)' }} />
+      <DxClusterSettingsPanel />
       <div style={{ borderTop: '1px solid var(--panel-border)' }} />
       <CatSettingsPanel />
       <div style={{ borderTop: '1px solid var(--panel-border)' }} />

--- a/zeus-web/src/components/ZeusDigitalSettingsPanel.test.tsx
+++ b/zeus-web/src/components/ZeusDigitalSettingsPanel.test.tsx
@@ -223,7 +223,7 @@ describe('ZeusDigitalSettingsPanel', () => {
 
   it('writing My Call persists the shared (global) operator identity', () => {
     const { container, unmount } = render(createElement(ZeusDigitalSettingsPanel));
-    const callInput = container.querySelector('input.ft8-set-input') as HTMLInputElement;
+    const callInput = container.querySelector('input.zd-input') as HTMLInputElement;
     setInputValue(callInput, 'k1abc');
     expect(operatorApi.postOperator).toHaveBeenCalledWith({ callsign: 'K1ABC', grid: '' });
     unmount();
@@ -275,13 +275,13 @@ describe('ZeusDigitalSettingsPanel', () => {
     act(() => palette!.click());
     expect(ft8SettingsApi.postFt8Settings).not.toHaveBeenCalled();
     // The numeric inputs WITHIN the waterfall section are disabled too (scope to
-    // that section so the live TX-section number inputs aren't swept in).
-    const wfSection = Array.from(container.querySelectorAll('section')).find((s) =>
-      s.querySelector('.ft8-region__head')?.textContent?.includes('Waterfall / display'),
+    // that card so the live TX-section number inputs aren't swept in).
+    const wfSection = Array.from(container.querySelectorAll('.ps-card')).find((s) =>
+      s.querySelector('h4')?.textContent?.includes('Waterfall / display'),
     );
     expect(wfSection).toBeTruthy();
     const numInputs = Array.from(
-      wfSection!.querySelectorAll('input.ft8-set-input--num'),
+      wfSection!.querySelectorAll('input.zd-num'),
     ) as HTMLInputElement[];
     expect(numInputs.length).toBeGreaterThan(0);
     expect(numInputs.every((i) => i.disabled)).toBe(true);
@@ -407,7 +407,7 @@ describe('ZeusDigitalSettingsPanel', () => {
       'div[aria-label="Cloud logging (Wavelog / Club Log)"]',
     ) as HTMLElement;
     const baseUrl = group.querySelector(
-      'input.ft8-set-input:not([type="password"]):not([type="number"])',
+      'input.zd-input:not([type="password"]):not([type="number"])',
     ) as HTMLInputElement;
     setInputValue(baseUrl, 'https://log.example.com');
     const apiKey = group.querySelector('input[type="password"]') as HTMLInputElement;

--- a/zeus-web/src/components/ZeusDigitalSettingsPanel.tsx
+++ b/zeus-web/src/components/ZeusDigitalSettingsPanel.tsx
@@ -26,7 +26,11 @@
 // external-logger form reuses the same wsjtx-store/api the Network tab uses (not
 // a fork); egress is OFF until the operator opts in and SAVES.
 //
-// Styling is HUD-token-only (ft8-theme.css --hud-*) — no raw hex.
+// Styling: this tab renders in the SAME surface family as every other Settings
+// tab — `.ps-shell` ▸ `.ps-card` ▸ `.ps-field`, shared with PsSettings / DSP /
+// Radio — using the house-skinned rows in zeus-digital-settings-controls. The
+// dark-HUD pop-out keeps its own controls; this menu reads as Settings, not as
+// the operating view. Global tokens only (tokens.css), no raw hex.
 
 import { useEffect, useState } from 'react';
 import { useOperatorStore } from '../state/operator-store';
@@ -59,7 +63,7 @@ import {
   SelectRow,
   TextRow,
   ToggleRow,
-} from '../layout/ft8/ft8-settings-controls';
+} from './zeus-digital-settings-controls';
 
 export function ZeusDigitalSettingsPanel({
   initialMode = 'FT8',
@@ -133,166 +137,162 @@ export function ZeusDigitalSettingsPanel({
     v === 'normal' ? 1 : v === 'deepest' ? 4 : 3;
 
   return (
-    <div className="ft8-settings" aria-label="Zeus Digital settings">
+    <div className="ps-shell zd-settings" aria-label="Zeus Digital settings">
       {/* § Mode selector — which per-mode config is being edited. */}
-      <section className="ft8-region ft8-set-section">
-        <div className="ft8-region__head">Mode</div>
-        <div className="ft8-set-body">
-          <SegRow
-            label="Editing settings for"
-            hint="FT8, FT4 and WSPR each remember their own configuration."
-            value={mode}
-            options={DIGITAL_MODES.map((m) => ({ value: m, label: m }))}
-            onChange={(m) => setMode(m)}
-          />
-        </div>
-      </section>
+      <div className="ps-card">
+        <h4>Mode</h4>
+        <SegRow
+          label="Editing settings for"
+          hint="FT8, FT4 and WSPR each remember their own configuration."
+          value={mode}
+          options={DIGITAL_MODES.map((m) => ({ value: m, label: m }))}
+          onChange={(m) => setMode(m)}
+        />
+      </div>
 
       {/* § Station / Operator — GLOBAL (shared across all modes). */}
-      <section className="ft8-region ft8-set-section">
-        <div className="ft8-region__head">Station / Operator</div>
-        <div className="ft8-set-body">
-          <TextRow
-            label="My Call"
-            hint="Your station callsign — required to transmit. Shared with spotting & FreeDV."
-            value={opCall}
-            placeholder={resolvedCall && callFromQrz ? resolvedCall : 'MYCALL'}
-            upper
-            resolved={{ value: resolvedCall, fromQrz: callFromQrz }}
-            onChange={setCall}
-          />
-          <TextRow
-            label="My Grid"
-            hint="Maidenhead locator (4 or 6 chars). Falls back to your QRZ home grid."
-            value={opGrid}
-            placeholder={resolvedGrid && gridFromQrz ? resolvedGrid : 'FN42'}
-            maxLength={6}
-            upper
-            resolved={{ value: resolvedGrid, fromQrz: gridFromQrz }}
-            onChange={setGrid}
-          />
-          <p className="ft8-set-note">
-            Identity is stored on the server, shared across FT8/FT4/WSPR, and survives restarts.
-            Leave a field blank to use your QRZ home station.
-          </p>
-        </div>
-      </section>
+      <div className="ps-card">
+        <h4>Station / Operator</h4>
+        <TextRow
+          label="My Call"
+          hint="Your station callsign — required to transmit. Shared with spotting & FreeDV."
+          value={opCall}
+          placeholder={resolvedCall && callFromQrz ? resolvedCall : 'MYCALL'}
+          upper
+          resolved={{ value: resolvedCall, fromQrz: callFromQrz }}
+          onChange={setCall}
+        />
+        <TextRow
+          label="My Grid"
+          hint="Maidenhead locator (4 or 6 chars). Falls back to your QRZ home grid."
+          value={opGrid}
+          placeholder={resolvedGrid && gridFromQrz ? resolvedGrid : 'FN42'}
+          maxLength={6}
+          upper
+          resolved={{ value: resolvedGrid, fromQrz: gridFromQrz }}
+          onChange={setGrid}
+        />
+        <p className="zd-note">
+          Identity is stored on the server, shared across FT8/FT4/WSPR, and survives restarts.
+          Leave a field blank to use your QRZ home station.
+        </p>
+      </div>
 
       {/* § TX & Auto-sequence — PER-MODE. Not shown for WSPR (beacon, no QSO). */}
       {!isWspr && (
-        <section className="ft8-region ft8-set-section">
-          <div className="ft8-region__head">TX &amp; Auto-sequence · {mode}</div>
-          <div className="ft8-set-body">
+        <div className="ps-card">
+          <h4>
+            TX &amp; Auto-sequence
+            <span className="ps-card-hint">{mode}</span>
+          </h4>
+          <ToggleRow
+            label="Auto-sequence"
+            hint="Run the QSO state machine. TX still requires ENABLE/arm — this never keys on its own."
+            checked={settings.autoSequence}
+            onChange={(v) => void update(mode, { autoSequence: v })}
+          />
+          <ToggleRow
+            label="Call 1st"
+            hint="Auto-answer the first decoded CQ while armed."
+            checked={settings.callFirst}
+            onChange={(v) => void update(mode, { callFirst: v })}
+          />
+          <ToggleRow
+            label="Hold TX freq"
+            hint="Lock the TX audio offset against waterfall clicks."
+            checked={settings.holdTxFreq}
+            onChange={(v) => void update(mode, { holdTxFreq: v })}
+          />
+          <ToggleRow
+            label="Disable TX after 73"
+            hint="Auto-disarm once a QSO completes (73 sent)."
+            checked={settings.disableTxAfter73}
+            onChange={(v) => void update(mode, { disableTxAfter73: v })}
+          />
+          <SegRow
+            label="Default TX slot"
+            hint="Which 15 s slot a fresh QSO transmits in."
+            value={settings.defaultTxSlot === 0 ? 'even' : 'odd'}
+            options={[
+              { value: 'even', label: '1ST (even)' },
+              { value: 'odd', label: '2ND (odd)' },
+            ]}
+            onChange={(v) => void update(mode, { defaultTxSlot: v === 'even' ? 0 : 1 })}
+          />
+          <NumberRow
+            label="Default TX audio offset"
+            hint="Where a fresh TX tone defaults inside the SSB passband."
+            value={settings.defaultTxOffsetHz}
+            min={FT8_MIN_OFFSET_HZ}
+            max={FT8_MAX_TX_OFFSET_HZ}
+            suffix="Hz"
+            onChange={(v) => void update(mode, { defaultTxOffsetHz: v })}
+          />
+          <div className="ps-field">
+            <div className="ps-name">
+              TX watchdog
+              <em>Backend hard cap on unattended TX. Fixed for safety.</em>
+            </div>
+            <span className="zd-readonly-val">10 min</span>
+          </div>
+
+          <details className="zd-advanced">
+            <summary>Advanced sequence (JTDX) — default off</summary>
             <ToggleRow
-              label="Auto-sequence"
-              hint="Run the QSO state machine. TX still requires ENABLE/arm — this never keys on its own."
-              checked={settings.autoSequence}
-              onChange={(v) => void update(mode, { autoSequence: v })}
+              label="Send RR73 instead of RRR"
+              checked={settings.rr73InsteadOfRrr}
+              onChange={(v) => void update(mode, { rr73InsteadOfRrr: v })}
             />
             <ToggleRow
-              label="Call 1st"
-              hint="Auto-answer the first decoded CQ while armed."
-              checked={settings.callFirst}
-              onChange={(v) => void update(mode, { callFirst: v })}
-            />
-            <ToggleRow
-              label="Hold TX freq"
-              hint="Lock the TX audio offset against waterfall clicks."
-              checked={settings.holdTxFreq}
-              onChange={(v) => void update(mode, { holdTxFreq: v })}
-            />
-            <ToggleRow
-              label="Disable TX after 73"
-              hint="Auto-disarm once a QSO completes (73 sent)."
-              checked={settings.disableTxAfter73}
-              onChange={(v) => void update(mode, { disableTxAfter73: v })}
-            />
-            <SegRow
-              label="Default TX slot"
-              hint="Which 15 s slot a fresh QSO transmits in."
-              value={settings.defaultTxSlot === 0 ? 'even' : 'odd'}
-              options={[
-                { value: 'even', label: '1ST (even)' },
-                { value: 'odd', label: '2ND (odd)' },
-              ]}
-              onChange={(v) => void update(mode, { defaultTxSlot: v === 'even' ? 0 : 1 })}
+              label="Skip grid (send report first)"
+              hint="JTDX-style opening with the report instead of the grid."
+              checked={settings.skipGrid}
+              comingSoon
+              onChange={(v) => void update(mode, { skipGrid: v })}
             />
             <NumberRow
-              label="Default TX audio offset"
-              hint="Where a fresh TX tone defaults inside the SSB passband."
-              value={settings.defaultTxOffsetHz}
-              min={FT8_MIN_OFFSET_HZ}
-              max={FT8_MAX_TX_OFFSET_HZ}
-              suffix="Hz"
-              onChange={(v) => void update(mode, { defaultTxOffsetHz: v })}
+              label="Caller max retries"
+              hint="0 = unlimited."
+              value={settings.callerMaxRetries}
+              min={0}
+              max={30}
+              onChange={(v) => void update(mode, { callerMaxRetries: v })}
             />
-            <div className="ft8-set-row ft8-set-row--readonly">
-              <span className="ft8-set-row__text">
-                <span className="ft8-set-row__label">TX watchdog</span>
-                <span className="ft8-set-row__hint">
-                  Backend hard cap on unattended TX. Fixed for safety.
-                </span>
-              </span>
-              <span className="ft8-set-readonly-value">10 min</span>
-            </div>
-
-            <details className="ft8-set-advanced">
-              <summary>Advanced sequence (JTDX) — default off</summary>
-              <ToggleRow
-                label="Send RR73 instead of RRR"
-                checked={settings.rr73InsteadOfRrr}
-                onChange={(v) => void update(mode, { rr73InsteadOfRrr: v })}
-              />
-              <ToggleRow
-                label="Skip grid (send report first)"
-                hint="JTDX-style opening with the report instead of the grid."
-                checked={settings.skipGrid}
-                comingSoon
-                onChange={(v) => void update(mode, { skipGrid: v })}
-              />
-              <NumberRow
-                label="Caller max retries"
-                hint="0 = unlimited."
-                value={settings.callerMaxRetries}
-                min={0}
-                max={30}
-                onChange={(v) => void update(mode, { callerMaxRetries: v })}
-              />
-            </details>
-          </div>
-        </section>
+          </details>
+        </div>
       )}
 
       {/* § Decode — PER-MODE. Not shown for WSPR (separate decoder). */}
       {!isWspr && (
-        <section className="ft8-region ft8-set-section">
-          <div className="ft8-region__head">Decode · {mode}</div>
-          <div className="ft8-set-body">
-            <SegRow
-              label="Decode depth"
-              hint="Deeper digs out weaker signals at higher CPU cost."
-              value={depth}
-              options={[
-                { value: 'normal', label: 'Normal' },
-                { value: 'deep', label: 'Deep' },
-                { value: 'deepest', label: 'Deepest' },
-              ]}
-              onChange={(v) => setDecodeDepth(depthToPasses(v))}
-            />
-            <ToggleRow
-              label="Show only CQ"
-              hint="Hide non-CQ rows (still shows stations calling you)."
-              checked={settings.showOnlyCq}
-              onChange={(v) => void update(mode, { showOnlyCq: v })}
-            />
-            <ToggleRow
-              label="Hide worked-before"
-              hint="Hide stations already in your logbook."
-              checked={settings.hideWorkedBefore}
-              onChange={(v) => void update(mode, { hideWorkedBefore: v })}
-            />
-          </div>
-        </section>
+        <div className="ps-card">
+          <h4>
+            Decode
+            <span className="ps-card-hint">{mode}</span>
+          </h4>
+          <SegRow
+            label="Decode depth"
+            hint="Deeper digs out weaker signals at higher CPU cost."
+            value={depth}
+            options={[
+              { value: 'normal', label: 'Normal' },
+              { value: 'deep', label: 'Deep' },
+              { value: 'deepest', label: 'Deepest' },
+            ]}
+            onChange={(v) => setDecodeDepth(depthToPasses(v))}
+          />
+          <ToggleRow
+            label="Show only CQ"
+            hint="Hide non-CQ rows (still shows stations calling you)."
+            checked={settings.showOnlyCq}
+            onChange={(v) => void update(mode, { showOnlyCq: v })}
+          />
+          <ToggleRow
+            label="Hide worked-before"
+            hint="Hide stations already in your logbook."
+            checked={settings.hideWorkedBefore}
+            onChange={(v) => void update(mode, { hideWorkedBefore: v })}
+          />
+        </div>
       )}
 
       {/* § Waterfall / display — PER-MODE. Persisted per mode (server-backed) and
@@ -301,182 +301,179 @@ export function ZeusDigitalSettingsPanel({
           "coming soon" (disabled) rather than as a live no-op. When the digital
           waterfall lands it reads byMode[mode] for these fields and the
           comingSoon flags come off. */}
-      <section className="ft8-region ft8-set-section">
-        <div className="ft8-region__head">Waterfall / display · {mode}</div>
-        <div className="ft8-set-body">
-          <p className="ft8-set-note">
-            The digital waterfall is still in progress (#1014). These views are saved per mode and
-            will take effect once it ships.
-          </p>
-          <NumberRow
-            label="Waterfall dB min"
-            hint="Bottom of the colour map (noise floor)."
-            value={settings.wfDbMin}
-            min={-200}
-            max={0}
-            suffix="dB"
-            comingSoon
-            onChange={(v) => void update(mode, { wfDbMin: v })}
-          />
-          <NumberRow
-            label="Waterfall dB max"
-            hint="Top of the colour map (strong signals)."
-            value={settings.wfDbMax}
-            min={-200}
-            max={200}
-            suffix="dB"
-            comingSoon
-            onChange={(v) => void update(mode, { wfDbMax: v })}
-          />
-          <SegRow
-            label="Palette"
-            value={settings.palette}
-            options={WF_PALETTES.map((p) => ({
-              value: p,
-              label: p.charAt(0).toUpperCase() + p.slice(1),
-            }))}
-            comingSoon
-            onChange={(v) => void update(mode, { palette: v })}
-          />
-          <TextRow
-            label="RBW"
-            hint='Resolution bandwidth ("auto" or an Hz value).'
-            value={settings.rbw}
-            maxLength={16}
-            comingSoon
-            onChange={(v) => void update(mode, { rbw: v })}
-          />
-          <NumberRow
-            label="Smoothing"
-            hint="Waterfall averaging frames (0 = none)."
-            value={settings.smoothing}
-            min={WF_SMOOTHING_MIN}
-            max={WF_SMOOTHING_MAX}
-            comingSoon
-            onChange={(v) => void update(mode, { smoothing: v })}
-          />
-          <NumberRow
-            label="Zoom"
-            hint="Display zoom factor (1 = full span)."
-            value={settings.zoom}
-            min={WF_ZOOM_MIN}
-            max={WF_ZOOM_MAX}
-            step={0.5}
-            suffix="×"
-            comingSoon
-            onChange={(v) => void update(mode, { zoom: v })}
-          />
-          <NumberRow
-            label="Span"
-            hint="Display span."
-            value={settings.spanHz}
-            min={WF_SPAN_MIN_HZ}
-            max={WF_SPAN_MAX_HZ}
-            step={100}
-            suffix="Hz"
-            comingSoon
-            onChange={(v) => void update(mode, { spanHz: v })}
-          />
-        </div>
-      </section>
+      <div className="ps-card">
+        <h4>
+          Waterfall / display
+          <span className="ps-card-hint">{mode}</span>
+        </h4>
+        <p className="zd-note">
+          The digital waterfall is still in progress (#1014). These views are saved per mode and
+          will take effect once it ships.
+        </p>
+        <NumberRow
+          label="Waterfall dB min"
+          hint="Bottom of the colour map (noise floor)."
+          value={settings.wfDbMin}
+          min={-200}
+          max={0}
+          suffix="dB"
+          comingSoon
+          onChange={(v) => void update(mode, { wfDbMin: v })}
+        />
+        <NumberRow
+          label="Waterfall dB max"
+          hint="Top of the colour map (strong signals)."
+          value={settings.wfDbMax}
+          min={-200}
+          max={200}
+          suffix="dB"
+          comingSoon
+          onChange={(v) => void update(mode, { wfDbMax: v })}
+        />
+        <SegRow
+          label="Palette"
+          value={settings.palette}
+          options={WF_PALETTES.map((p) => ({
+            value: p,
+            label: p.charAt(0).toUpperCase() + p.slice(1),
+          }))}
+          comingSoon
+          onChange={(v) => void update(mode, { palette: v })}
+        />
+        <TextRow
+          label="RBW"
+          hint='Resolution bandwidth ("auto" or an Hz value).'
+          value={settings.rbw}
+          maxLength={16}
+          comingSoon
+          onChange={(v) => void update(mode, { rbw: v })}
+        />
+        <NumberRow
+          label="Smoothing"
+          hint="Waterfall averaging frames (0 = none)."
+          value={settings.smoothing}
+          min={WF_SMOOTHING_MIN}
+          max={WF_SMOOTHING_MAX}
+          comingSoon
+          onChange={(v) => void update(mode, { smoothing: v })}
+        />
+        <NumberRow
+          label="Zoom"
+          hint="Display zoom factor (1 = full span)."
+          value={settings.zoom}
+          min={WF_ZOOM_MIN}
+          max={WF_ZOOM_MAX}
+          step={0.5}
+          suffix="×"
+          comingSoon
+          onChange={(v) => void update(mode, { zoom: v })}
+        />
+        <NumberRow
+          label="Span"
+          hint="Display span."
+          value={settings.spanHz}
+          min={WF_SPAN_MIN_HZ}
+          max={WF_SPAN_MAX_HZ}
+          step={100}
+          suffix="Hz"
+          comingSoon
+          onChange={(v) => void update(mode, { spanHz: v })}
+        />
+      </div>
 
       {/* § Reporting — spotting networks (owned by the Network tab, surfaced). */}
-      <section className="ft8-region ft8-set-section">
-        <div className="ft8-region__head">Reporting</div>
-        <div className="ft8-set-body">
-          <div className="ft8-set-chips">
-            <Chip label="PSK Reporter" on={!!spotStatus?.pskReporterEnabled} />
-            <Chip label="WSPRnet" on={!!spotStatus?.wsprnetEnabled} />
-          </div>
-          <button type="button" className="ft8-set-link" onClick={openNetworkSettings}>
-            Open Network settings →
-          </button>
-          <p className="ft8-set-note">
-            PSK Reporter and WSPRnet automatic spotting are configured on the Network tab.
-          </p>
+      <div className="ps-card">
+        <h4>Reporting</h4>
+        <div className="zd-chips">
+          <Chip label="PSK Reporter" on={!!spotStatus?.pskReporterEnabled} />
+          <Chip label="WSPRnet" on={!!spotStatus?.wsprnetEnabled} />
         </div>
-      </section>
+        <button type="button" className="btn sm" onClick={openNetworkSettings}>
+          Open Network settings →
+        </button>
+        <p className="zd-note">
+          PSK Reporter and WSPRnet automatic spotting are configured on the Network tab.
+        </p>
+      </div>
 
       {/* § Logging — Zeus internal logbook (ALWAYS on) + ADDITIVE external copies.
           The internal logbook is the default and is never bypassed; the external
           logger (WSJT-X UDP) and QRZ cloud upload only ADD copies. */}
-      <section className="ft8-region ft8-set-section">
-        <div className="ft8-region__head">Logging</div>
-        <div className="ft8-set-body">
-          <div className="ft8-set-chips">
-            <Chip label="Zeus internal logbook" on />
-          </div>
-          <p className="ft8-set-note">
-            Every QSO is always saved to the Zeus internal logbook. The options below ADD
-            external copies — they never replace it.
-          </p>
-
-          {/* Internal QSO-logging behaviour — non-WSPR (WSPR is a beacon mode
-              with no QSO/logbook path, so these toggles are hidden for it). */}
-          {!isWspr && (
-            <>
-              <ToggleRow
-                label="Auto-log QSO"
-                hint="Write completed QSOs to the logbook automatically."
-                checked={settings.autoLog}
-                onChange={(v) => void update(mode, { autoLog: v })}
-              />
-              <ToggleRow
-                label="Prompt before logging"
-                hint="Confirm each QSO before it is logged."
-                checked={settings.promptBeforeLog}
-                onChange={(v) => void update(mode, { promptBeforeLog: v })}
-              />
-              <ToggleRow
-                label="Clear DX call/grid after log"
-                hint="Reset the QSO panel once a contact is logged."
-                checked={settings.clearDxAfterLog}
-                comingSoon
-                onChange={(v) => void update(mode, { clearDxAfterLog: v })}
-              />
-              <ToggleRow
-                label="dB report → comment"
-                hint="Record the signal report in the QSO comment."
-                checked={settings.reportToComment}
-                onChange={(v) => void update(mode, { reportToComment: v })}
-              />
-              <p className="ft8-set-note">
-                Edit the CQ / CQ DX / free-text macros in the digital pop-out — they persist per
-                mode.
-              </p>
-            </>
-          )}
-
-          <div className="ft8-set-divider" />
-
-          {/* Additive external logger over the WSJT-X UDP protocol. */}
-          <ExternalLoggingGroup />
-
-          <div className="ft8-set-divider" />
-
-          {/* Additive N1MM-format UDP logger (HRD Logbook / DXKeeper gateway). */}
-          <N1mmLoggingGroup />
-
-          <div className="ft8-set-divider" />
-
-          {/* Additive per-QSO HTTP cloud loggers (Wavelog/Cloudlog + Club Log). */}
-          <CloudLoggingGroup />
-
-          <div className="ft8-set-divider" />
-
-          {/* QRZ cloud logbook — credential lives on the QRZ tab. */}
-          <div className="ft8-set-chips">
-            <Chip label="QRZ Logbook (cloud)" on={qrzHasApiKey} />
-          </div>
-          <button type="button" className="ft8-set-link" onClick={openQrzSettings}>
-            Open QRZ settings →
-          </button>
-          <p className="ft8-set-note">
-            Push logged QSOs to your QRZ.com logbook from the Logbook panel. Requires a QRZ
-            logbook API key, set on the QRZ tab.
-          </p>
+      <div className="ps-card">
+        <h4>Logging</h4>
+        <div className="zd-chips">
+          <Chip label="Zeus internal logbook" on />
         </div>
-      </section>
+        <p className="zd-note">
+          Every QSO is always saved to the Zeus internal logbook. The options below ADD
+          external copies — they never replace it.
+        </p>
+
+        {/* Internal QSO-logging behaviour — non-WSPR (WSPR is a beacon mode
+            with no QSO/logbook path, so these toggles are hidden for it). */}
+        {!isWspr && (
+          <>
+            <ToggleRow
+              label="Auto-log QSO"
+              hint="Write completed QSOs to the logbook automatically."
+              checked={settings.autoLog}
+              onChange={(v) => void update(mode, { autoLog: v })}
+            />
+            <ToggleRow
+              label="Prompt before logging"
+              hint="Confirm each QSO before it is logged."
+              checked={settings.promptBeforeLog}
+              onChange={(v) => void update(mode, { promptBeforeLog: v })}
+            />
+            <ToggleRow
+              label="Clear DX call/grid after log"
+              hint="Reset the QSO panel once a contact is logged."
+              checked={settings.clearDxAfterLog}
+              comingSoon
+              onChange={(v) => void update(mode, { clearDxAfterLog: v })}
+            />
+            <ToggleRow
+              label="dB report → comment"
+              hint="Record the signal report in the QSO comment."
+              checked={settings.reportToComment}
+              onChange={(v) => void update(mode, { reportToComment: v })}
+            />
+            <p className="zd-note">
+              Edit the CQ / CQ DX / free-text macros in the digital pop-out — they persist per
+              mode.
+            </p>
+          </>
+        )}
+
+        <div className="zd-divider" />
+
+        {/* Additive external logger over the WSJT-X UDP protocol. */}
+        <ExternalLoggingGroup />
+
+        <div className="zd-divider" />
+
+        {/* Additive N1MM-format UDP logger (HRD Logbook / DXKeeper gateway). */}
+        <N1mmLoggingGroup />
+
+        <div className="zd-divider" />
+
+        {/* Additive per-QSO HTTP cloud loggers (Wavelog/Cloudlog + Club Log). */}
+        <CloudLoggingGroup />
+
+        <div className="zd-divider" />
+
+        {/* QRZ cloud logbook — credential lives on the QRZ tab. */}
+        <div className="zd-chips">
+          <Chip label="QRZ Logbook (cloud)" on={qrzHasApiKey} />
+        </div>
+        <button type="button" className="btn sm" onClick={openQrzSettings}>
+          Open QRZ settings →
+        </button>
+        <p className="zd-note">
+          Push logged QSOs to your QRZ.com logbook from the Logbook panel. Requires a QRZ
+          logbook API key, set on the QRZ tab.
+        </p>
+      </div>
     </div>
   );
 }
@@ -651,24 +648,19 @@ export function ExternalLoggingGroup() {
         </>
       )}
 
-      <div className="ft8-set-row ft8-set-row--readonly">
-        <span className="ft8-set-row__text">
-          <span className="ft8-set-row__label">
-            <span
-              className="ft8-set-chip__dot"
-              style={{ background: live ? 'var(--hud-cq)' : 'var(--hud-text-dim)' }}
-            />{' '}
-            External logger
-          </span>
-          <span className="ft8-set-row__hint">
+      <div className="ps-field">
+        <div className="ps-name">
+          <span className={`zd-dot${live ? ' is-on' : ''}`} />
+          External logger
+          <em>
             {live
               ? status?.transport === 'multicast'
                 ? `Sending to multicast ${status?.multicastGroup}:${status?.port}`
                 : `Sending to ${status?.host}:${status?.port}`
               : 'Disabled — no QSO data leaves this machine.'}
-          </span>
-        </span>
-        <button type="button" className="ft8-set-link" disabled={saving} onClick={() => void onSave()}>
+          </em>
+        </div>
+        <button type="button" className="btn sm active" disabled={saving} onClick={() => void onSave()}>
           {saving ? 'SAVING…' : 'SAVE'}
         </button>
       </div>
@@ -740,22 +732,17 @@ function N1mmLoggingGroup() {
         </>
       )}
 
-      <div className="ft8-set-row ft8-set-row--readonly">
-        <span className="ft8-set-row__text">
-          <span className="ft8-set-row__label">
-            <span
-              className="ft8-set-chip__dot"
-              style={{ background: config.enabled ? 'var(--hud-cq)' : 'var(--hud-text-dim)' }}
-            />{' '}
-            N1MM-format logger
-          </span>
-          <span className="ft8-set-row__hint">
+      <div className="ps-field">
+        <div className="ps-name">
+          <span className={`zd-dot${config.enabled ? ' is-on' : ''}`} />
+          N1MM-format logger
+          <em>
             {config.enabled
               ? `Sending to ${config.host}:${config.port}`
               : 'Disabled — no QSO data leaves this machine.'}
-          </span>
-        </span>
-        <button type="button" className="ft8-set-link" disabled={saving} onClick={() => void onSave()}>
+          </em>
+        </div>
+        <button type="button" className="btn sm active" disabled={saving} onClick={() => void onSave()}>
           {saving ? 'SAVING…' : 'SAVE'}
         </button>
       </div>
@@ -780,13 +767,13 @@ function SecretRow(props: {
   onChange: (v: string) => void;
 }) {
   return (
-    <div className="ft8-set-row">
-      <span className="ft8-set-row__text">
-        <span className="ft8-set-row__label">{props.label}</span>
-        {props.hint && <span className="ft8-set-row__hint">{props.hint}</span>}
-      </span>
+    <div className="ps-field">
+      <div className="ps-name">
+        {props.label}
+        {props.hint && <em>{props.hint}</em>}
+      </div>
       <input
-        className="ft8-set-input"
+        className="zd-input"
         type="password"
         autoComplete="off"
         value={props.value}
@@ -900,7 +887,7 @@ function CloudLoggingGroup() {
         </>
       )}
 
-      <div className="ft8-set-divider" />
+      <div className="zd-divider" />
 
       {/* Club Log */}
       <ToggleRow
@@ -951,29 +938,21 @@ function CloudLoggingGroup() {
         </>
       )}
 
-      <div className="ft8-set-row ft8-set-row--readonly">
-        <span className="ft8-set-row__text">
-          <span className="ft8-set-row__label">
-            <span
-              className="ft8-set-chip__dot"
-              style={{
-                background:
-                  status.wavelog.enabled || status.clubLog.enabled
-                    ? 'var(--hud-cq)'
-                    : 'var(--hud-text-dim)',
-              }}
-            />{' '}
-            Cloud loggers
-          </span>
-          <span className="ft8-set-row__hint">
+      <div className="ps-field">
+        <div className="ps-name">
+          <span
+            className={`zd-dot${status.wavelog.enabled || status.clubLog.enabled ? ' is-on' : ''}`}
+          />
+          Cloud loggers
+          <em>
             {status.wavelog.enabled || status.clubLog.enabled
               ? `Active: ${[status.wavelog.enabled ? 'Wavelog' : null, status.clubLog.enabled ? 'Club Log' : null]
                   .filter(Boolean)
                   .join(' + ')}`
               : 'Disabled — no QSO data leaves this machine.'}
-          </span>
-        </span>
-        <button type="button" className="ft8-set-link" disabled={saving} onClick={() => void onSave()}>
+          </em>
+        </div>
+        <button type="button" className="btn sm active" disabled={saving} onClick={() => void onSave()}>
           {saving ? 'SAVING…' : 'SAVE'}
         </button>
       </div>

--- a/zeus-web/src/components/meter-group/meterGroupConfig.test.ts
+++ b/zeus-web/src/components/meter-group/meterGroupConfig.test.ts
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+
+import { describe, expect, it } from 'vitest';
+import { computeMeterGroupAutoFit } from './meterGroupConfig';
+
+describe('computeMeterGroupAutoFit', () => {
+  // Issue #1160: opening Settings tears down FlexWorkspace and remounts
+  // it on close. The first effect run after a fresh mount must leave the
+  // operator's saved size alone — otherwise the Meter Group tile snaps
+  // back to its auto-fit size every time the gear panel is visited.
+  it('returns null on the first mount even when current size differs from auto-fit', () => {
+    const result = computeMeterGroupAutoFit({
+      prevWidgetCount: null,
+      prevDirection: null,
+      widgetCount: 2,
+      direction: 'row',
+      tileW: 8,
+      tileH: 4,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns null when widget count and direction are unchanged from the previous run', () => {
+    const result = computeMeterGroupAutoFit({
+      prevWidgetCount: 3,
+      prevDirection: 'row',
+      widgetCount: 3,
+      direction: 'row',
+      tileW: 8,
+      tileH: 4,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('snaps width to widget count when a widget is added in row direction', () => {
+    const result = computeMeterGroupAutoFit({
+      prevWidgetCount: 2,
+      prevDirection: 'row',
+      widgetCount: 4,
+      direction: 'row',
+      tileW: 2,
+      tileH: 6,
+    });
+    expect(result).toEqual({ w: 4, h: 6 });
+  });
+
+  it('snaps height to widget count*3 (min 3) when a widget is added in column direction', () => {
+    const result = computeMeterGroupAutoFit({
+      prevWidgetCount: 1,
+      prevDirection: 'column',
+      widgetCount: 3,
+      direction: 'column',
+      tileW: 2,
+      tileH: 3,
+    });
+    expect(result).toEqual({ w: 2, h: 9 });
+  });
+
+  it('snaps on direction flip from row to column', () => {
+    const result = computeMeterGroupAutoFit({
+      prevWidgetCount: 2,
+      prevDirection: 'row',
+      widgetCount: 2,
+      direction: 'column',
+      tileW: 2,
+      tileH: 3,
+    });
+    expect(result).toEqual({ w: 2, h: 6 });
+  });
+
+  it('clamps widget count to at least 1 so an empty panel still has a minimum footprint', () => {
+    const result = computeMeterGroupAutoFit({
+      prevWidgetCount: 1,
+      prevDirection: 'row',
+      widgetCount: 0,
+      direction: 'row',
+      tileW: 4,
+      tileH: 6,
+    });
+    expect(result).toEqual({ w: 1, h: 6 });
+  });
+
+  it('clamps column height to at least 3 grid rows', () => {
+    const result = computeMeterGroupAutoFit({
+      prevWidgetCount: 2,
+      prevDirection: 'column',
+      widgetCount: 0,
+      direction: 'column',
+      tileW: 2,
+      tileH: 6,
+    });
+    expect(result).toEqual({ w: 2, h: 3 });
+  });
+
+  it('returns null when the computed auto-fit target equals current geometry', () => {
+    // Widget count changed but target width matches what the tile
+    // already has — no placement update needed.
+    const result = computeMeterGroupAutoFit({
+      prevWidgetCount: 2,
+      prevDirection: 'row',
+      widgetCount: 3,
+      direction: 'row',
+      tileW: 3,
+      tileH: 6,
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/zeus-web/src/components/meter-group/meterGroupConfig.ts
+++ b/zeus-web/src/components/meter-group/meterGroupConfig.ts
@@ -97,3 +97,47 @@ export function effectiveKind(widget: MeterGroupWidget): MeterDefaultKind {
   const def = METER_CATALOG[widget.reading];
   return def.defaultKind;
 }
+
+export interface MeterGroupAutoFitInput {
+  /** widgets.length observed on the previous effect run, or null when
+   *  this is the first run after a fresh mount. */
+  prevWidgetCount: number | null;
+  /** direction observed on the previous effect run, or null on first run. */
+  prevDirection: MeterGroupDirection | null;
+  /** widgets.length on the current effect run. */
+  widgetCount: number;
+  /** direction on the current effect run. */
+  direction: MeterGroupDirection;
+  /** Current tile width (grid units). */
+  tileW: number;
+  /** Current tile height (grid units). */
+  tileH: number;
+}
+
+/** Decide whether the Meter Group tile should auto-snap to fit its widget
+ *  set on this effect run. Returns the target {w, h} when a snap is
+ *  warranted, or null when the effect should leave the tile alone.
+ *
+ *  The first call after mount (prev* === null) is always null so the
+ *  operator's saved size survives FlexWorkspace teardown/remount on
+ *  Settings open/close. Subsequent calls only snap when widget count or
+ *  direction changed since the previous run (i.e. a real add/remove or
+ *  direction flip), and only when the computed target differs from the
+ *  current geometry. */
+export function computeMeterGroupAutoFit(
+  input: MeterGroupAutoFitInput,
+): { w: number; h: number } | null {
+  if (input.prevWidgetCount === null) return null;
+  if (
+    input.prevWidgetCount === input.widgetCount &&
+    input.prevDirection === input.direction
+  ) {
+    return null;
+  }
+  const count = Math.max(1, input.widgetCount);
+  const targetW = input.direction === 'row' ? count : input.tileW;
+  const targetH =
+    input.direction === 'column' ? Math.max(3, count * 3) : input.tileH;
+  if (targetW === input.tileW && targetH === input.tileH) return null;
+  return { w: targetW, h: targetH };
+}

--- a/zeus-web/src/components/zeus-digital-settings-controls.tsx
+++ b/zeus-web/src/components/zeus-digital-settings-controls.tsx
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// House-styled settings rows for the main-Settings "Zeus Digital" tab. These
+// mirror the API of the digital pop-out's HUD controls (layout/ft8/
+// ft8-settings-controls.tsx) one-for-one — ToggleRow / SegRow / SelectRow /
+// TextRow / NumberRow / Chip with identical props — but render in the SAME
+// surface family as every other Settings tab: a `.ps-card` ▸ `.ps-field`
+// (name + <em> hint, control on the right), `btn sm` toggles & segmented
+// buttons, and tokenised inputs. That way the Zeus Digital menu reads as part
+// of the Settings menu (PsSettings / DSP / Radio …) instead of the dark-HUD
+// operating pop-out.
+//
+// The pop-out keeps its own HUD controls — these are deliberately a separate,
+// house-skinned set so changing the menu never disturbs the live operating
+// view. Styling is global-token only (tokens.css + zeus-digital-settings.css);
+// no raw hex, no --hud-* layer.
+
+import '../styles/zeus-digital-settings.css';
+
+function Soon() {
+  return <span className="zd-soon">soon</span>;
+}
+
+export function ToggleRow(props: {
+  label: string;
+  hint?: string;
+  checked: boolean;
+  /** Render disabled with a "coming soon" badge — persisted but not yet wired. */
+  comingSoon?: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <div className={`ps-field${props.comingSoon ? ' is-disabled' : ''}`}>
+      <div className="ps-name">
+        {props.label}
+        {props.comingSoon && <Soon />}
+        {props.hint && <em>{props.hint}</em>}
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={props.checked}
+        aria-label={props.label}
+        aria-disabled={props.comingSoon}
+        disabled={props.comingSoon}
+        className={`btn sm${props.checked ? ' active' : ''}`}
+        onClick={() => !props.comingSoon && props.onChange(!props.checked)}
+      >
+        {props.checked ? 'ON' : 'OFF'}
+      </button>
+    </div>
+  );
+}
+
+export function SegRow<T extends string>(props: {
+  label: string;
+  hint?: string;
+  value: T;
+  options: ReadonlyArray<{ value: T; label: string }>;
+  /** Render disabled with a "coming soon" badge — persisted but not yet wired. */
+  comingSoon?: boolean;
+  onChange: (v: T) => void;
+}) {
+  return (
+    <div className={`ps-field${props.comingSoon ? ' is-disabled' : ''}`}>
+      <div className="ps-name">
+        {props.label}
+        {props.comingSoon && <Soon />}
+        {props.hint && <em>{props.hint}</em>}
+      </div>
+      <div className="btn-row" role="group" aria-label={props.label}>
+        {props.options.map((o) => (
+          <button
+            key={o.value}
+            type="button"
+            aria-pressed={props.value === o.value}
+            aria-disabled={props.comingSoon}
+            disabled={props.comingSoon}
+            className={`btn sm${props.value === o.value ? ' active' : ''}`}
+            onClick={() => !props.comingSoon && props.onChange(o.value)}
+          >
+            {o.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function SelectRow<T extends string>(props: {
+  label: string;
+  hint?: string;
+  value: T;
+  options: ReadonlyArray<{ value: T; label: string }>;
+  disabled?: boolean;
+  onChange: (v: T) => void;
+}) {
+  return (
+    <div className={`ps-field${props.disabled ? ' is-disabled' : ''}`}>
+      <div className="ps-name">
+        {props.label}
+        {props.hint && <em>{props.hint}</em>}
+      </div>
+      <select
+        className="ps-select-mini"
+        aria-label={props.label}
+        value={props.value}
+        disabled={props.disabled}
+        onChange={(e) => props.onChange(e.target.value as T)}
+      >
+        {props.options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+export function TextRow(props: {
+  label: string;
+  hint?: string;
+  value: string;
+  placeholder?: string;
+  maxLength?: number;
+  upper?: boolean;
+  /** Render disabled with a "coming soon" badge — persisted but not yet wired. */
+  comingSoon?: boolean;
+  resolved?: { value: string; fromQrz: boolean };
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div className={`ps-field${props.comingSoon ? ' is-disabled' : ''}`}>
+      <div className="ps-name">
+        {props.label}
+        {props.comingSoon && <Soon />}
+        {props.hint && <em>{props.hint}</em>}
+        {props.resolved && props.resolved.fromQrz && props.resolved.value && (
+          <em className="zd-resolved">
+            Using QRZ home: <strong>{props.resolved.value}</strong>
+          </em>
+        )}
+      </div>
+      <input
+        className="zd-input"
+        value={props.value}
+        placeholder={props.placeholder}
+        maxLength={props.maxLength}
+        spellCheck={false}
+        disabled={props.comingSoon}
+        style={props.upper ? { textTransform: 'uppercase' } : undefined}
+        onChange={(e) => props.onChange(e.target.value)}
+      />
+    </div>
+  );
+}
+
+export function NumberRow(props: {
+  label: string;
+  hint?: string;
+  value: number;
+  min?: number;
+  max?: number;
+  step?: number;
+  suffix?: string;
+  disabled?: boolean;
+  /** Render disabled with a "coming soon" badge — persisted but not yet wired. */
+  comingSoon?: boolean;
+  onChange: (v: number) => void;
+}) {
+  const disabled = props.disabled || props.comingSoon;
+  return (
+    <div className={`ps-field${props.comingSoon ? ' is-disabled' : ''}`}>
+      <div className="ps-name">
+        {props.label}
+        {props.comingSoon && <Soon />}
+        {props.hint && <em>{props.hint}</em>}
+      </div>
+      <span className="ps-ninput">
+        <input
+          type="number"
+          className={`zd-num${props.suffix ? '' : ' no-unit'}`}
+          value={props.value}
+          min={props.min}
+          max={props.max}
+          step={props.step ?? 1}
+          disabled={disabled}
+          onChange={(e) => props.onChange(Number(e.target.value))}
+        />
+        {props.suffix && <span className="ps-unit">{props.suffix}</span>}
+      </span>
+    </div>
+  );
+}
+
+export function Chip(props: { label: string; on: boolean }) {
+  return (
+    <span className={`zd-chip${props.on ? ' is-on' : ''}`}>
+      <span className="zd-chip__dot" />
+      {props.label} {props.on ? 'ON' : 'OFF'}
+    </span>
+  );
+}

--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -84,6 +84,19 @@ import {
 
 const WORKSPACE_GRID_MARGIN_PX = 3;
 
+// Column-pitch latch retract guard (issue #1146). The 150 ms debounce above
+// catches a width that is still changing, but some Windows + Photino startups
+// hold the container at a too-narrow width STABLE for longer than that before
+// the flex pass settles. SETTLE_WINDOW_MS is how long after mount we still
+// trust a later, much larger width to override the latched value; once it
+// closes the pitch is committed and a window resize behaves as before.
+// RETRACT_GROWTH_RATIO is the multiplier on the latched width that flags the
+// growth as "the latch caught a transient" rather than a tiny mid-settle
+// jitter — 1.4× is well past layout noise and well under the actual bug ratios
+// observed (e.g. ~300 px transient on a 1900 px container).
+const SETTLE_WINDOW_MS = 3000;
+const RETRACT_GROWTH_RATIO = 1.4;
+
 type GridInteraction = 'drag' | 'resize' | null;
 
 interface FlexWorkspaceProps {
@@ -358,9 +371,25 @@ function WorkspaceCanvas({
   // (While frozenWidth is still 0 the render falls back to baseColWidth=0 →
   // cols=24 → gridWidth=live width, which already renders correctly; the latch
   // only fixes the pitch held constant across subsequent window resizes.)
+  //
+  // The debounce alone is not always enough: some Windows + Photino startups
+  // hold a too-narrow container width STABLE for longer than the debounce
+  // window before the real flex pass widens it (issue #1146). To catch that,
+  // we also allow ONE retract — if, within a short post-mount settling window,
+  // the live width grows substantially past the latched value, the latch was
+  // a transient and we re-evaluate from the new width. After the settling
+  // window closes, the pitch is committed and a window resize behaves as
+  // before (cells stay constant, columns grow/shrink).
   const [frozenWidth, setFrozenWidth] = useState(0);
+  const mountAtMsRef = useRef<number>(performance.now());
   useEffect(() => {
-    if (frozenWidth > 0) return;
+    if (frozenWidth > 0) {
+      const elapsedMs = performance.now() - mountAtMsRef.current;
+      if (elapsedMs < SETTLE_WINDOW_MS && width > frozenWidth * RETRACT_GROWTH_RATIO) {
+        setFrozenWidth(0);
+      }
+      return;
+    }
     if (!mounted || !(width > 0)) return;
     const id = window.setTimeout(() => setFrozenWidth(width), 150);
     return () => window.clearTimeout(id);

--- a/zeus-web/src/layout/FlexWorkspace.tsx
+++ b/zeus-web/src/layout/FlexWorkspace.tsx
@@ -65,6 +65,7 @@ import { ConfirmDialog } from './ConfirmDialog';
 import { TerminatorLines } from '../components/design/TerminatorLines';
 import { MeterGroupPanel } from '../components/meter-group/MeterGroupPanel';
 import {
+  computeMeterGroupAutoFit,
   parseMeterGroupConfig,
   type MeterGroupConfig,
 } from '../components/meter-group/meterGroupConfig';
@@ -1092,28 +1093,38 @@ function MeterGroupTileBody({
 
   // Auto-fit the tile to its widget set. Operators add a Meter Group, drop
   // in two vertical bars, and expect the tile to snap to bar-width — not
-  // to leave four grid columns of empty space waiting to be filled. The
-  // effect deps are widget count + direction only (live tile geometry is
-  // read through a ref) so an operator can still drag-resize the cross
-  // axis without the effect snapping it back on every render.
+  // to leave four grid columns of empty space waiting to be filled.
+  //
+  // The first run after a fresh mount is a no-op: FlexWorkspace tears
+  // down and remounts whenever the operator opens Settings, so a
+  // mount-time snap would clobber the operator's manual resize every
+  // time they closed the gear panel (issue #1160). Subsequent runs only
+  // snap on a real widget add/remove or direction flip. Live tile
+  // geometry is read through a ref so drag-resizing the cross axis does
+  // not retrigger the effect.
   const tileRef = useRef(tile);
   tileRef.current = tile;
+  const prevWidgetCountRef = useRef<number | null>(null);
+  const prevDirectionRef = useRef<MeterGroupConfig['direction'] | null>(null);
   useEffect(() => {
     const t = tileRef.current;
-    const widgetCount = Math.max(1, config.widgets.length);
-    // Row: one grid col per widget on the main axis. Column: ~3 grid rows
-    // per widget so vertical bars get enough vertical span to read.
-    const targetW = config.direction === 'row' ? widgetCount : t.w;
-    const targetH =
-      config.direction === 'column' ? Math.max(3, widgetCount * 3) : t.h;
-    if (targetW !== t.w || targetH !== t.h) {
-      updateTilePlacement(layoutId, t.uid, {
-        x: t.x,
-        y: t.y,
-        w: targetW,
-        h: targetH,
-      });
-    }
+    const result = computeMeterGroupAutoFit({
+      prevWidgetCount: prevWidgetCountRef.current,
+      prevDirection: prevDirectionRef.current,
+      widgetCount: config.widgets.length,
+      direction: config.direction,
+      tileW: t.w,
+      tileH: t.h,
+    });
+    prevWidgetCountRef.current = config.widgets.length;
+    prevDirectionRef.current = config.direction;
+    if (!result) return;
+    updateTilePlacement(layoutId, t.uid, {
+      x: t.x,
+      y: t.y,
+      w: result.w,
+      h: result.h,
+    });
   }, [config.widgets.length, config.direction, layoutId, updateTilePlacement]);
 
   return (

--- a/zeus-web/src/layout/panels/ChatPanel.tsx
+++ b/zeus-web/src/layout/panels/ChatPanel.tsx
@@ -1823,12 +1823,17 @@ export function ChatPanel() {
     };
   }, [syncTabScroll]);
 
-  // Auto-grow textarea
+  // Auto-grow textarea. The empty field MUST stay a single row: a textarea's
+  // scrollHeight counts the (word-wrapped) placeholder, and ours wraps to two
+  // lines, so measuring scrollHeight here would inflate the empty composer to
+  // the placeholder's height — the "starts big until you click into it" bug.
+  // Clear the inline height when empty so rows=1 / minHeight govern; only grow
+  // to fit real content.
   useEffect(() => {
     const el = inputRef.current;
     if (!el) return;
     el.style.height = 'auto';
-    el.style.height = `${Math.min(el.scrollHeight, 90)}px`;
+    el.style.height = el.value ? `${Math.min(el.scrollHeight, 90)}px` : '';
   }, [draft]);
 
   // Hydrate on mount

--- a/zeus-web/src/layout/panels/HamClockPanel.test.tsx
+++ b/zeus-web/src/layout/panels/HamClockPanel.test.tsx
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/** @vitest-environment jsdom */
+
+import { createElement } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { act, render } from '../../components/meters/__tests__/harness';
+
+// Mock the OS-browser bridge so we can assert it's invoked without launching a
+// real browser. Must be hoisted above the component import.
+const openExternalUrlMock = vi.fn();
+vi.mock('../../components/report-problem/openExternalUrl', () => ({
+  openExternalUrl: (url: string) => openExternalUrlMock(url),
+}));
+
+import { HamClockPanel } from './HamClockPanel';
+import { hamclockIframeUrl, useHamClockStore, type HamClockStatus } from '../../state/hamclock-store';
+
+const RUNNING_PORT = 59950;
+
+const RUNNING_STATUS: HamClockStatus = {
+  phase: 'Running',
+  installed: true,
+  running: true,
+  busy: false,
+  port: RUNNING_PORT,
+  version: '26.4.1',
+  nodeAvailable: true,
+  nodeVersion: 'v22.23.0',
+  error: null,
+  log: [],
+};
+
+async function flush() {
+  await act(async () => {
+    for (let i = 0; i < 8; i++) await Promise.resolve();
+  });
+}
+
+describe('HamClockPanel external-link forwarding', () => {
+  beforeEach(() => {
+    openExternalUrlMock.mockReset();
+    useHamClockStore.setState({ status: RUNNING_STATUS });
+    // The panel's mount effect calls loadStatus() (GET /api/hamclock/status);
+    // keep it returning the running status so the iframe stays mounted.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        new Response(JSON.stringify(RUNNING_STATUS), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    useHamClockStore.setState({ status: { ...RUNNING_STATUS, running: false, port: 0 } });
+  });
+
+  function dispatchFromIframe(iframe: HTMLIFrameElement, data: unknown, origin: string) {
+    const event = new MessageEvent('message', {
+      data,
+      origin,
+      source: iframe.contentWindow,
+    });
+    act(() => {
+      window.dispatchEvent(event);
+    });
+  }
+
+  it('forwards a zeus.openExternal message from the iframe to the OS browser', async () => {
+    const { container, unmount } = render(createElement(HamClockPanel));
+    await flush();
+
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement;
+    expect(iframe).not.toBeNull();
+
+    const origin = new URL(hamclockIframeUrl(RUNNING_PORT)).origin;
+    const url = 'https://github.com/accius/openhamclock#readme';
+    dispatchFromIframe(iframe, { type: 'zeus.openExternal', url }, origin);
+
+    expect(openExternalUrlMock).toHaveBeenCalledTimes(1);
+    expect(openExternalUrlMock).toHaveBeenCalledWith(url);
+
+    unmount();
+  });
+
+  it('ignores a zeus.openExternal message from a wrong origin', async () => {
+    const { container, unmount } = render(createElement(HamClockPanel));
+    await flush();
+
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement;
+    dispatchFromIframe(
+      iframe,
+      { type: 'zeus.openExternal', url: 'https://evil.example/phish' },
+      'http://evil.example',
+    );
+
+    expect(openExternalUrlMock).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('ignores a non-http url in a zeus.openExternal message', async () => {
+    const { container, unmount } = render(createElement(HamClockPanel));
+    await flush();
+
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement;
+    const origin = new URL(hamclockIframeUrl(RUNNING_PORT)).origin;
+    dispatchFromIframe(iframe, { type: 'zeus.openExternal', url: 'file:///etc/passwd' }, origin);
+
+    expect(openExternalUrlMock).not.toHaveBeenCalled();
+    unmount();
+  });
+});

--- a/zeus-web/src/layout/panels/HamClockPanel.tsx
+++ b/zeus-web/src/layout/panels/HamClockPanel.tsx
@@ -12,10 +12,27 @@
 
 import { useEffect, useRef, useState } from 'react';
 import type { ActivationSpotDto } from '../../api/client';
+import { openExternalUrl } from '../../components/report-problem/openExternalUrl';
 import { hamclockIframeUrl, useHamClockStore } from '../../state/hamclock-store';
 import { useSpotsStore } from '../../state/spots-store';
 
 const HAMCLOCK_DX_TUNE_MESSAGE = 'zeus.hamclock.dxSpotTune';
+const ZEUS_OPEN_EXTERNAL_MESSAGE = 'zeus.openExternal';
+
+interface ZeusOpenExternalMessage {
+  type: typeof ZEUS_OPEN_EXTERNAL_MESSAGE;
+  url: string;
+}
+
+function isZeusOpenExternalMessage(value: unknown): value is ZeusOpenExternalMessage {
+  if (!value || typeof value !== 'object') return false;
+  const msg = value as Partial<ZeusOpenExternalMessage>;
+  return (
+    msg.type === ZEUS_OPEN_EXTERNAL_MESSAGE &&
+    typeof msg.url === 'string' &&
+    /^https?:\/\//i.test(msg.url)
+  );
+}
 
 interface HamClockDxTuneMessage {
   type: typeof HAMCLOCK_DX_TUNE_MESSAGE;
@@ -136,6 +153,16 @@ export function HamClockPanel() {
     const onMessage = (event: MessageEvent<unknown>) => {
       if (event.source !== iframeRef.current?.contentWindow) return;
       if (event.origin !== expectedOrigin) return;
+
+      // External links / Rig-Bridge downloads the iframe forwarded because the
+      // Photino webview swallows window.open and has no download handler. Hand
+      // them to the OS browser via the existing host bridge (which re-validates
+      // http/https C#-side before launching).
+      if (isZeusOpenExternalMessage(event.data)) {
+        openExternalUrl(event.data.url);
+        return;
+      }
+
       if (!isHamClockDxTuneMessage(event.data)) return;
       const msg = event.data;
 
@@ -161,7 +188,7 @@ export function HamClockPanel() {
         style={{ flex: 1, width: '100%', height: '100%', border: 'none', display: 'block', minHeight: 0 }}
         // HamClock is a trusted local sidecar; allow scripts + same-origin so
         // its app (storage, its own /api fetches) works.
-        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
+        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals allow-downloads"
       />
     );
   }

--- a/zeus-web/src/main.tsx
+++ b/zeus-web/src/main.tsx
@@ -83,6 +83,7 @@ import './styles/nr-settings.css';
 import './styles/meters-grid.css';
 import './styles/all-panels.css';
 import './styles/ps-settings.css';
+import './styles/zeus-digital-settings.css';
 import './styles/pa-settings.css';
 import './styles/analog-meter.css';
 import './styles/rotator-dial.css';

--- a/zeus-web/src/plugins/api/plugins.test.ts
+++ b/zeus-web/src/plugins/api/plugins.test.ts
@@ -28,6 +28,7 @@ describe('parsePluginDto', () => {
   it('coerces a complete payload', () => {
     const dto = parsePluginDto({
       id: 'hello',
+      scanned: true,
       name: 'Hello World',
       version: '1.2.3',
       author: 'EI6LF',
@@ -47,6 +48,7 @@ describe('parsePluginDto', () => {
       },
     });
     expect(dto.id).toBe('hello');
+    expect(dto.scanned).toBe(true);
     expect(dto.capabilities).toEqual(['hub:emit', 'storage']);
     expect(dto.ui?.panels[0]?.slot).toBe('workspace');
     expect(dto.audio?.sampleRate).toBe(48000);
@@ -55,6 +57,7 @@ describe('parsePluginDto', () => {
   it('falls back to safe defaults on garbage input', () => {
     const dto = parsePluginDto({});
     expect(dto.id).toBe('');
+    expect(dto.scanned).toBe(false);
     expect(dto.capabilities).toEqual([]);
     expect(dto.ui).toBeNull();
     expect(dto.audio).toBeNull();

--- a/zeus-web/src/plugins/api/plugins.ts
+++ b/zeus-web/src/plugins/api/plugins.ts
@@ -45,6 +45,13 @@ export type PluginAudioDto = {
 
 export type PluginDto = {
   id: string;
+  /**
+   * True for operator-scanned VST3 / Audio Unit plugins (server id
+   * namespaces `com.openhpsdr.zeus.{vst,rxvst,au,rxau}.*`). These live only in
+   * the Audio Suite rack; the Settings ▸ Plugins list filters them out so it
+   * shows just Zeus plugin-repo plugins. Defaults false for older servers.
+   */
+  scanned: boolean;
   name: string;
   version: string;
   author: string;
@@ -162,6 +169,7 @@ export function parsePluginDto(raw: unknown): PluginDto {
   const o = (raw ?? {}) as Record<string, unknown>;
   return {
     id: asString(o.id),
+    scanned: asBool(o.scanned),
     name: asString(o.name),
     version: asString(o.version),
     author: asString(o.author),

--- a/zeus-web/src/plugins/components/PluginsPanel.test.tsx
+++ b/zeus-web/src/plugins/components/PluginsPanel.test.tsx
@@ -184,6 +184,7 @@ describe('InstalledPlugins', () => {
       installed: [
         {
           id: 'demo',
+          scanned: false,
           name: 'Demo Plugin',
           version: '0.1.0',
           author: 'EI6LF',
@@ -241,6 +242,7 @@ describe('InstalledPlugins', () => {
       installed: [
         {
           id: 'demo',
+          scanned: false,
           name: 'Demo Plugin',
           version: '0.1.0',
           author: '',

--- a/zeus-web/src/plugins/state/plugins-store.test.ts
+++ b/zeus-web/src/plugins/state/plugins-store.test.ts
@@ -67,6 +67,34 @@ describe('usePluginsStore', () => {
     expect(s.sdkAbi).toBe(1);
   });
 
+  it('refreshInstalled excludes operator-scanned VST3 / AU plugins', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn<typeof fetch>().mockResolvedValue(
+        jsonResponse({
+          sdkAbi: 1,
+          sdkVersion: '0.6.0',
+          plugins: [
+            { id: 'com.openhpsdr.zeus.samples.eq', name: 'EQ', version: '1', author: '', description: '', license: 'GPL', capabilities: [] },
+            { id: 'com.example.repo', name: 'Repo Plugin', version: '1', author: '', description: '', license: 'GPL', capabilities: [] },
+            { id: 'com.openhpsdr.zeus.vst.tdrnova', name: 'TDR Nova', version: '1', author: '', description: '', license: 'Unknown', capabilities: [], scanned: true },
+            { id: 'com.openhpsdr.zeus.rxau.clear', name: 'Clear RX', version: '1', author: '', description: '', license: 'Unknown', capabilities: [], scanned: true },
+          ],
+        }),
+      ),
+    );
+
+    await usePluginsStore.getState().refreshInstalled();
+
+    const s = usePluginsStore.getState();
+    expect(s.installedLoad.loaded).toBe(true);
+    // Both scanned audio plugins are filtered out; only the repo plugins remain.
+    expect(s.installed.map((p) => p.id)).toEqual([
+      'com.openhpsdr.zeus.samples.eq',
+      'com.example.repo',
+    ]);
+  });
+
   it('refreshInstalled records loadError on a 500', async () => {
     vi.stubGlobal(
       'fetch',

--- a/zeus-web/src/plugins/state/plugins-store.ts
+++ b/zeus-web/src/plugins/state/plugins-store.ts
@@ -116,7 +116,11 @@ export const usePluginsStore = create<PluginsStoreState>((set, get) => ({
     try {
       const resp: PluginListResponse = await fetchInstalledPlugins();
       set({
-        installed: resp.plugins,
+        // Operator-scanned VST3 / AU plugins (resp.plugins[].scanned) live in
+        // the Audio Suite rack only — they are not Zeus plugin-repo plugins, so
+        // the Settings ▸ Plugins list excludes them. The Audio Suite has its own
+        // consumer (pluginRuntime.fetchInstalledPlugins) that still sees them.
+        installed: resp.plugins.filter((p) => !p.scanned),
         sdkAbi: resp.sdkAbi,
         sdkVersion: resp.sdkVersion,
         installedLoad: { loaded: true, inflight: false, loadError: null },

--- a/zeus-web/src/state/dxcluster-store.test.ts
+++ b/zeus-web/src/state/dxcluster-store.test.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+import { describe, expect, it, vi } from 'vitest';
+import type { DxClusterStatus } from '../api/dxcluster';
+
+// Mock the REST layer BEFORE the store imports it — the store fires a one-shot
+// status probe on module load. The client defaults OFF (no network egress).
+const disabledStatus: DxClusterStatus = {
+  enabled: false,
+  host: '',
+  port: 7373,
+  callsign: '',
+  hasPassword: false,
+  loginCommands: '',
+  autoConnect: false,
+  state: 'Disconnected',
+  spotsReceived: 0,
+  lastSpotCallsign: null,
+  error: null,
+};
+
+vi.mock('../api/dxcluster', () => ({
+  getDxClusterStatus: vi.fn(async () => disabledStatus),
+  putDxClusterConfig: vi.fn(
+    async (cfg: { enabled: boolean; host: string; port: number; callsign: string }) => ({
+      ...disabledStatus,
+      enabled: cfg.enabled,
+      host: cfg.host,
+      port: cfg.port,
+      callsign: cfg.callsign,
+    }),
+  ),
+  connectDxCluster: vi.fn(async () => ({ ...disabledStatus, enabled: true, state: 'Connecting' })),
+  disconnectDxCluster: vi.fn(async () => ({ ...disabledStatus, state: 'Disconnected' })),
+}));
+
+import { useDxClusterStore } from './dxcluster-store';
+import * as api from '../api/dxcluster';
+
+describe('dxcluster-store', () => {
+  it('defaults to disabled (opt-in egress)', () => {
+    const { config } = useDxClusterStore.getState();
+    expect(config.enabled).toBe(false);
+    expect(config.port).toBe(7373);
+  });
+
+  it('never auto-PUTs config on load (no silent connect)', () => {
+    expect(api.putDxClusterConfig).not.toHaveBeenCalled();
+    expect(api.connectDxCluster).not.toHaveBeenCalled();
+  });
+
+  it('saveConfig pushes the operator choice to the backend', async () => {
+    const cfg = {
+      enabled: true,
+      host: 'dxc.example.org',
+      port: 7300,
+      callsign: 'K1ABC',
+      password: 'secret',
+      loginCommands: 'set/filter on',
+      autoConnect: true,
+    };
+    const status = await useDxClusterStore.getState().saveConfig(cfg);
+    expect(api.putDxClusterConfig).toHaveBeenCalledWith(cfg);
+    expect(status.enabled).toBe(true);
+    expect(status.host).toBe('dxc.example.org');
+    expect(useDxClusterStore.getState().config.callsign).toBe('K1ABC');
+    // The password is retained locally (the API never echoes it back).
+    expect(useDxClusterStore.getState().config.password).toBe('secret');
+  });
+
+  it('connect/disconnect update the live status', async () => {
+    const c = await useDxClusterStore.getState().connect();
+    expect(api.connectDxCluster).toHaveBeenCalled();
+    expect(c.state).toBe('Connecting');
+
+    const d = await useDxClusterStore.getState().disconnect();
+    expect(api.disconnectDxCluster).toHaveBeenCalled();
+    expect(d.state).toBe('Disconnected');
+  });
+});

--- a/zeus-web/src/state/dxcluster-store.ts
+++ b/zeus-web/src/state/dxcluster-store.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+import { create } from 'zustand';
+import {
+  getDxClusterStatus,
+  putDxClusterConfig,
+  connectDxCluster,
+  disconnectDxCluster,
+  type DxClusterConfig,
+  type DxClusterStatus,
+} from '../api/dxcluster';
+
+// The backend (DxClusterConfigStore on disk) is the source of truth. The form
+// initialises from /api/dxcluster/status once it arrives; this constant is only
+// a transient placeholder. The password is never returned by the API (only
+// hasPassword), so the local password field stays whatever the operator typed.
+const DEFAULT_CONFIG: DxClusterConfig = {
+  enabled: false,
+  host: '',
+  port: 7373,
+  callsign: '',
+  password: '',
+  loginCommands: '',
+  autoConnect: false,
+};
+
+export type DxClusterStoreState = {
+  config: DxClusterConfig;
+  status: DxClusterStatus | null;
+
+  refreshStatus: () => Promise<void>;
+  saveConfig: (cfg: DxClusterConfig) => Promise<DxClusterStatus>;
+  connect: () => Promise<DxClusterStatus>;
+  disconnect: () => Promise<DxClusterStatus>;
+};
+
+export const useDxClusterStore = create<DxClusterStoreState>((set, get) => ({
+  config: DEFAULT_CONFIG,
+  status: null,
+
+  refreshStatus: async () => {
+    try {
+      const status = await getDxClusterStatus();
+      // Sync non-secret config fields from the backend so the form never
+      // disagrees with disk. Preserve the locally-typed password (the API
+      // never echoes it back) and skip the sync if the operator has unsaved
+      // edits to the synced fields.
+      const current = get().config;
+      const synced =
+        current.enabled === status.enabled &&
+        current.host === status.host &&
+        current.port === status.port &&
+        current.callsign === status.callsign &&
+        current.loginCommands === status.loginCommands &&
+        current.autoConnect === status.autoConnect;
+      set({
+        status,
+        config: synced
+          ? current
+          : {
+              enabled: status.enabled,
+              host: status.host,
+              port: status.port,
+              callsign: status.callsign,
+              password: current.password,
+              loginCommands: status.loginCommands,
+              autoConnect: status.autoConnect,
+            },
+      });
+    } catch {
+      /* transient — next poll recovers */
+    }
+  },
+
+  saveConfig: async (cfg) => {
+    const status = await putDxClusterConfig(cfg);
+    set({ config: cfg, status });
+    return status;
+  },
+
+  connect: async () => {
+    const status = await connectDxCluster();
+    set({ status });
+    return status;
+  },
+
+  disconnect: async () => {
+    const status = await disconnectDxCluster();
+    set({ status });
+    return status;
+  },
+}));
+
+// Initial status probe + 3 s polling while the page is alive AND the cluster is
+// enabled. Status changes drive the panel's connection indicator / spot count.
+if (typeof window !== 'undefined') {
+  void useDxClusterStore.getState().refreshStatus();
+  window.setInterval(() => {
+    if (!useDxClusterStore.getState().config.enabled) return;
+    void useDxClusterStore.getState().refreshStatus();
+  }, 3000);
+}

--- a/zeus-web/src/styles/zeus-digital-settings.css
+++ b/zeus-web/src/styles/zeus-digital-settings.css
@@ -1,0 +1,156 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Zeus Digital — main-Settings tab skin.
+ *
+ * The Zeus Digital settings tab uses the SAME surface family as every other
+ * Settings tab: `.ps-shell` ▸ `.ps-card` ▸ `.ps-field` (shared with
+ * PsSettings / DSP / Radio …, defined in ps-settings.css). This file only adds
+ * the few digital-specific bits that the shared `.ps-*` set does not cover —
+ * a tokenised text input, a "soon" badge, status chips, a sub-section divider,
+ * an advanced disclosure and the read-only value cell. Everything is global
+ * tokens (tokens.css); no raw hex, no --hud-* layer.
+ *
+ * Scoped under `.zd-settings` so it can never leak onto another panel. */
+
+/* "Coming soon" rows — persisted but not yet wired: dimmed, with a small badge.
+   (Mirrors the live controls so the disabled state still reads as a setting.) */
+.zd-settings .ps-field.is-disabled {
+  opacity: 0.55;
+}
+.zd-settings .zd-soon {
+  margin-left: 6px;
+  padding: 0 5px;
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--r-xs);
+  vertical-align: middle;
+}
+
+/* QRZ-home fallback hint inside a .ps-name <em>. */
+.zd-settings .zd-resolved {
+  color: var(--fg-2);
+}
+.zd-settings .zd-resolved strong {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+/* Tokenised text input — matches the .ps-ninput / .ps-select-mini house look
+   but left-aligned and flexible-width for callsigns, hosts, URLs, macros. */
+.zd-settings .zd-input {
+  min-width: 150px;
+  background: var(--bg-0);
+  border: 1px solid var(--panel-border);
+  color: var(--fg-0);
+  border-radius: var(--r-sm);
+  padding: 6px 10px;
+  font: inherit;
+  font-size: 12.5px;
+  letter-spacing: 0.02em;
+}
+.zd-settings .zd-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
+}
+.zd-settings .zd-input:disabled {
+  opacity: 0.5;
+}
+/* Number cells reuse the shared .ps-ninput input styling; just tag them. */
+.zd-settings .zd-num {
+  font-variant-numeric: tabular-nums;
+}
+
+/* The shared .ps-select-mini is a fixed 110px; the digital panel has longer
+   option labels (e.g. "Custom (raw WSJT-X UDP)"), so let it grow a little. */
+.zd-settings .ps-select-mini {
+  width: auto;
+  min-width: 110px;
+  max-width: 220px;
+}
+
+/* Standalone explanatory note (not a field). */
+.zd-settings .zd-note {
+  margin: 8px 0 0;
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--fg-3);
+}
+
+/* Read-only value cell (e.g. the fixed TX watchdog). */
+.zd-settings .zd-readonly-val {
+  font-size: 12.5px;
+  color: var(--fg-2);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Status chips (PSK Reporter / WSPRnet / internal logbook / cloud loggers). */
+.zd-settings .zd-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 4px 0 8px;
+}
+.zd-settings .zd-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--fg-3);
+  border: 1px solid var(--panel-border);
+  border-radius: 12px;
+  padding: 2px 10px;
+}
+.zd-settings .zd-chip__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--fg-3);
+}
+.zd-settings .zd-chip.is-on {
+  color: var(--ok);
+  border-color: var(--ok);
+}
+.zd-settings .zd-chip.is-on .zd-chip__dot {
+  background: var(--ok);
+}
+
+/* Small live-status dot reused inline in the logger SAVE rows. */
+.zd-settings .zd-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  margin-right: 6px;
+  vertical-align: middle;
+  background: var(--fg-3);
+}
+.zd-settings .zd-dot.is-on {
+  background: var(--ok);
+}
+
+/* Sub-section divider WITHIN a card (between additive logger groups). */
+.zd-settings .zd-divider {
+  height: 1px;
+  background: var(--panel-border);
+  margin: 12px 0;
+}
+
+/* Advanced disclosure (JTDX sequence options). */
+.zd-settings .zd-advanced {
+  margin-top: 4px;
+}
+.zd-settings .zd-advanced > summary {
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  cursor: pointer;
+  padding: 8px 0;
+}
+.zd-settings .zd-advanced[open] > summary {
+  color: var(--fg-2);
+}


### PR DESCRIPTION
## v0.10.6 — hotfix on 0.10.5

**Headline:** Windows sound devices are selectable again for RX audio — an output-device change no longer fails when the saved input (mic) device is stale or missing (#1128, Christian / N9WAR).

Bundles every fix plus the one new feature merged to develop since v0.10.5:

- 🔊 **Audio** — Windows device selection fix (#1128); Protocol-2 radio-speaker UDP decoupled from the DSP tick (#1148)
- 🛰️ **New: DX Cluster (direct Telnet)** — native client logs into DXSpider/AR/CC clusters, spots land on the panadapter, configured under Settings → Network (#1140)
- 🗺️ **HamClock** — external links + rig-bridge downloads open in the OS browser (#1112); bundled-map DX auto-pin notice (#1110)
- 🎚️ **Audio suite / VST** — incremental chain edits (#1153); TX VST reserved for OOP engine + load-failure handling (#1157, #1159)
- 💬🖥️ **Chat & Web UI** — QRZ session self-heal (#1149), composer height (#1152), panadapter callsign rendering/gating (#1151, #1155, #1158), workspace/meter-layout + Zeus Digital settings + scanned-plugin hiding (#1146, #1160, #1166, #1168)

Release mechanics:
- `Directory.Build.props` VersionPrefix → 0.10.6
- CHANGELOG: new top section (= the GitHub Release body), per-author credits (N9WAR + KB2UKA)
- Operator manual: edition → v0.10.6, new DX-cluster section (Accessories + Settings); assembles clean and ships inside every installer

Tagging `v0.10.6` from main after merge.