### PR TITLE
feat(remote-diag): enrich operator presence 

### DIFF
--- a/Zeus.Server.Hosting/Support/SupportSidecarBridge.cs
+++ b/Zeus.Server.Hosting/Support/SupportSidecarBridge.cs
@@ -54,6 +54,7 @@ public sealed class SupportSidecarBridge : BackgroundService
 
     private readonly SupportAvailabilityStore _availability;
     private readonly Zeus.Server.QrzService _qrz;
+    private readonly Zeus.Server.RadioService _radio;
     private readonly ILogger<SupportSidecarBridge> _log;
 
     // Signalled (max count 1) when posture changes so the loop pushes a fresh
@@ -63,10 +64,12 @@ public sealed class SupportSidecarBridge : BackgroundService
     public SupportSidecarBridge(
         SupportAvailabilityStore availability,
         Zeus.Server.QrzService qrz,
+        Zeus.Server.RadioService radio,
         ILogger<SupportSidecarBridge> log)
     {
         _availability = availability;
         _qrz = qrz;
+        _radio = radio;
         _log = log;
 
         // The endpoint forwards the operator's availability toggle here.
@@ -157,6 +160,7 @@ public sealed class SupportSidecarBridge : BackgroundService
     private async Task<SupportHello> BuildHelloAsync(CancellationToken ct)
     {
         var (callsign, sessionKey) = await ResolveIdentityAsync(ct).ConfigureAwait(false);
+        var (radioBoard, radioModel, radioConnected) = ResolveRadioMetadata();
         return new SupportHello(
             ProtocolVersion: SupportIpc.ProtocolVersion,
             BackendPid: Environment.ProcessId,
@@ -167,18 +171,78 @@ public sealed class SupportSidecarBridge : BackgroundService
             AutoShareOnCrash: _availability.AutoShareOnCrash,
             AppLogPath: PrefsDbPath.AppLogPath(),
             StartupLogPath: Path.Combine(PrefsDbPath.DataDir, "zeus-startup.log"),
-            QrzSessionKey: sessionKey);
+            QrzSessionKey: sessionKey,
+            RadioBoard: radioBoard,
+            RadioModel: radioModel,
+            RadioConnected: radioConnected);
     }
 
     private async Task<SupportStateChanged> BuildStateAsync(CancellationToken ct)
     {
         var (callsign, sessionKey) = await ResolveIdentityAsync(ct).ConfigureAwait(false);
+        var (radioBoard, radioModel, radioConnected) = ResolveRadioMetadata();
         return new SupportStateChanged(
             QrzCallsign: callsign,
             RemoteDiagnosticsEnabled: _availability.IsAvailable,
             AutoShareOnCrash: _availability.AutoShareOnCrash,
-            QrzSessionKey: sessionKey);
+            QrzSessionKey: sessionKey,
+            RadioBoard: radioBoard,
+            RadioModel: radioModel,
+            RadioConnected: radioConnected);
     }
+
+    // Resolve the operator's connected radio for the broker presence body. Null-safe:
+    // when nothing is connected we report (null, null, false). The board name is the
+    // discovered ConnectedBoardKind, refined by EffectiveOrionMkIIVariant for the
+    // 0x0A alias family; the model is the variant name (or null for non-0x0A boards).
+    // Best-effort — never throws out of the build path.
+    private (string? Board, string? Model, bool Connected) ResolveRadioMetadata()
+    {
+        try
+        {
+            if (!_radio.IsConnected) return (null, null, false);
+
+            var board = _radio.ConnectedBoardKind;
+            if (board == Zeus.Contracts.HpsdrBoardKind.Unknown) return (null, null, true);
+
+            if (board == Zeus.Contracts.HpsdrBoardKind.OrionMkII)
+            {
+                var variant = _radio.EffectiveOrionMkIIVariant;
+                return (DescribeBoard(board, variant), variant.ToString(), true);
+            }
+
+            return (DescribeBoard(board, null), null, true);
+        }
+        catch
+        {
+            return (null, null, false);
+        }
+    }
+
+    // Human-readable board name. The 0x0A wire byte aliases several radios, so the
+    // variant refines the display string when present.
+    private static string DescribeBoard(Zeus.Contracts.HpsdrBoardKind board, Zeus.Contracts.OrionMkIIVariant? variant) => board switch
+    {
+        Zeus.Contracts.HpsdrBoardKind.Metis => "Metis",
+        Zeus.Contracts.HpsdrBoardKind.Hermes => "Hermes",
+        Zeus.Contracts.HpsdrBoardKind.HermesII => "Hermes-II",
+        Zeus.Contracts.HpsdrBoardKind.Angelia => "Angelia",
+        Zeus.Contracts.HpsdrBoardKind.Orion => "Orion",
+        Zeus.Contracts.HpsdrBoardKind.HermesLite2 => "Hermes-Lite 2",
+        Zeus.Contracts.HpsdrBoardKind.HermesC10 => "ANAN-G2E",
+        Zeus.Contracts.HpsdrBoardKind.OrionMkII => variant switch
+        {
+            Zeus.Contracts.OrionMkIIVariant.G2 => "ANAN-G2",
+            Zeus.Contracts.OrionMkIIVariant.G2_1K => "ANAN-G2-1K",
+            Zeus.Contracts.OrionMkIIVariant.Anan7000DLE => "ANAN-7000DLE",
+            Zeus.Contracts.OrionMkIIVariant.Anan8000DLE => "ANAN-8000DLE",
+            Zeus.Contracts.OrionMkIIVariant.OrionMkII => "OrionMkII",
+            Zeus.Contracts.OrionMkIIVariant.AnvelinaPro3 => "ANVELINA-PRO3",
+            Zeus.Contracts.OrionMkIIVariant.RedPitaya => "Red Pitaya",
+            _ => "ANAN-G2",
+        },
+        _ => board.ToString(),
+    };
 
     // Resolve the operator's QRZ identity fresh, bounded so a slow/blocked QRZ
     // call never stalls the loop. Null identity → the sidecar stays unconfigured

--- a/Zeus.Support.Contracts/SupportIpc.cs
+++ b/Zeus.Support.Contracts/SupportIpc.cs
@@ -33,8 +33,13 @@ public static class SupportIpc
     /// v2 adds the optional <c>QrzSessionKey</c> to the identity-bearing messages so
     /// the sidecar can build its broker client lazily when QRZ identity arrives over
     /// IPC, instead of depending on a launch-time env var that races QRZ login.
+    /// v3 appends the optional operator-RADIO metadata (<c>RadioBoard</c> /
+    /// <c>RadioModel</c> / <c>RadioConnected</c>) to the identity-bearing messages so
+    /// the sidecar can publish "what hardware is this operator on, and is it live" in
+    /// its broker presence body. Older v2 peers omit the trailing params and still
+    /// deserialise (positional optionals with defaults).
     /// </summary>
-    public const int ProtocolVersion = 2;
+    public const int ProtocolVersion = 3;
 
     /// <summary>
     /// Hard ceiling on a single framed message (a diagnostics snapshot is the
@@ -114,6 +119,12 @@ public abstract record SupportIpcMessage;
 /// launcher already uses — so the sidecar can authenticate presence/crash without
 /// the env var being present (and correct) at the instant of launch. Null when the
 /// operator is signed out.</para>
+///
+/// <para><see cref="RadioBoard"/> / <see cref="RadioModel"/> /
+/// <see cref="RadioConnected"/> (v3+) describe the operator's current radio for the
+/// broker presence body: a human-readable board name (e.g. "Hermes-Lite 2"), an
+/// optional variant/model refinement (e.g. "G2-1K", null when N/A), and whether a
+/// radio is actually connected right now. All null/false when no radio is up.</para>
 /// </summary>
 public sealed record SupportHello(
     int ProtocolVersion,
@@ -125,7 +136,10 @@ public sealed record SupportHello(
     bool AutoShareOnCrash,
     string AppLogPath,
     string StartupLogPath,
-    string? QrzSessionKey = null) : SupportIpcMessage;
+    string? QrzSessionKey = null,
+    string? RadioBoard = null,
+    string? RadioModel = null,
+    bool RadioConnected = false) : SupportIpcMessage;
 
 /// <summary>
 /// Backend → sidecar. The operator changed an opt-in setting (the L1 master
@@ -135,12 +149,20 @@ public sealed record SupportHello(
 /// <para><see cref="QrzSessionKey"/> (v2+) lets the sidecar (re)build its broker
 /// client when QRZ identity becomes available after launch — see
 /// <see cref="SupportHello.QrzSessionKey"/>. Null when signed out.</para>
+///
+/// <para><see cref="RadioBoard"/> / <see cref="RadioModel"/> /
+/// <see cref="RadioConnected"/> (v3+) refresh the operator's radio metadata in the
+/// broker presence body — see <see cref="SupportHello.RadioBoard"/>. All null/false
+/// when no radio is connected.</para>
 /// </summary>
 public sealed record SupportStateChanged(
     string? QrzCallsign,
     bool RemoteDiagnosticsEnabled,
     bool AutoShareOnCrash,
-    string? QrzSessionKey = null) : SupportIpcMessage;
+    string? QrzSessionKey = null,
+    string? RadioBoard = null,
+    string? RadioModel = null,
+    bool RadioConnected = false) : SupportIpcMessage;
 
 /// <summary>Either direction. Liveness ping; the peer is considered gone if these stop.</summary>
 public sealed record SupportHeartbeat(long UnixMs) : SupportIpcMessage;

--- a/Zeus.SupportAgent/HttpSupportBrokerClient.cs
+++ b/Zeus.SupportAgent/HttpSupportBrokerClient.cs
@@ -10,6 +10,7 @@
 
 using System.Net.Http;
 using System.Text;
+using System.Text.Json;
 using Zeus.Support.Contracts;
 
 namespace Zeus.SupportAgent;
@@ -35,6 +36,11 @@ public sealed class HttpSupportBrokerClient : IMutableSupportBrokerClient
     private readonly HttpClient _http;
     private readonly BrokerEndpoints _endpoints;
 
+    // Static process identity for the presence body: the host's platform and the
+    // app version. Set once at construction (they never change for a process).
+    private readonly string _platform;
+    private readonly string _appVersion;
+
     // Identity is mutable: the host hands the sidecar a launch-time seed (often
     // blank, because QRZ silent-login races process launch) and then refreshes it
     // over the IPC pipe once QRZ identity is available. Each is a lone reference
@@ -43,12 +49,23 @@ public sealed class HttpSupportBrokerClient : IMutableSupportBrokerClient
     private volatile string _callsign;
     private volatile string _sessionKey;
 
-    public HttpSupportBrokerClient(HttpClient http, BrokerEndpoints endpoints, string callsign, string sessionKey)
+    // Radio metadata for the presence body, refreshed over IPC as the operator
+    // connects/disconnects a radio. Volatile reference/flag writes — a presence
+    // POST that observes a transient mix just publishes slightly stale metadata.
+    private volatile string? _radioBoard;
+    private volatile string? _radioModel;
+    private volatile bool _radioConnected;
+
+    public HttpSupportBrokerClient(
+        HttpClient http, BrokerEndpoints endpoints, string callsign, string sessionKey,
+        string platform, string appVersion)
     {
         _http = http;
         _endpoints = endpoints;
         _callsign = callsign ?? "";
         _sessionKey = sessionKey ?? "";
+        _platform = platform ?? "";
+        _appVersion = appVersion ?? "";
     }
 
     /// <summary>
@@ -67,8 +84,23 @@ public sealed class HttpSupportBrokerClient : IMutableSupportBrokerClient
     public bool IsConfigured =>
         !string.IsNullOrWhiteSpace(_callsign) && !string.IsNullOrWhiteSpace(_sessionKey);
 
-    public Task<bool> RegisterAsync(CancellationToken ct) => PostAsync(_endpoints.PresenceRegister, null, ct);
-    public Task<bool> HeartbeatAsync(CancellationToken ct) => PostAsync(_endpoints.PresenceHeartbeat, null, ct);
+    /// <summary>
+    /// Swap the operator's radio metadata advertised in the presence body. Called
+    /// over IPC as the operator connects/disconnects a radio. A no-op on auth — only
+    /// affects what register/heartbeat bodies report.
+    /// </summary>
+    public void UpdateMetadata(string? radioBoard, string? radioModel, bool radioConnected)
+    {
+        _radioBoard = radioBoard;
+        _radioModel = radioModel;
+        _radioConnected = radioConnected;
+    }
+
+    // Presence register/heartbeat carry a metadata body so the broker can show the
+    // operator's platform / app version / radio. Drop stays body-less (it only needs
+    // identity headers to clear presence).
+    public Task<bool> RegisterAsync(CancellationToken ct) => PostAsync(_endpoints.PresenceRegister, BuildPresenceBody(), ct);
+    public Task<bool> HeartbeatAsync(CancellationToken ct) => PostAsync(_endpoints.PresenceHeartbeat, BuildPresenceBody(), ct);
     public Task<bool> DropAsync(CancellationToken ct) => PostAsync(_endpoints.PresenceDrop, null, ct);
 
     public Task<bool> UploadCrashAsync(string crashRecordJson, CancellationToken ct) =>
@@ -94,5 +126,29 @@ public sealed class HttpSupportBrokerClient : IMutableSupportBrokerClient
             // throw out of the sidecar's presence/crash path.
             return false;
         }
+    }
+
+    // Build the presence body the broker reads off register/heartbeat. Written with
+    // a Utf8JsonWriter (no reflection, trim-safe) so every string is correctly
+    // escaped and nulls are emitted as JSON null. Snapshot the volatile fields once
+    // so the body is internally consistent.
+    private string BuildPresenceBody()
+    {
+        var board = _radioBoard;
+        var model = _radioModel;
+        var connected = _radioConnected;
+
+        using var buffer = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("platform", _platform);
+            writer.WriteString("appVersion", _appVersion);
+            if (board is null) writer.WriteNull("radioBoard"); else writer.WriteString("radioBoard", board);
+            if (model is null) writer.WriteNull("radioModel"); else writer.WriteString("radioModel", model);
+            writer.WriteBoolean("radioConnected", connected);
+            writer.WriteEndObject();
+        }
+        return Encoding.UTF8.GetString(buffer.ToArray());
     }
 }

--- a/Zeus.SupportAgent/IMutableSupportBrokerClient.cs
+++ b/Zeus.SupportAgent/IMutableSupportBrokerClient.cs
@@ -25,4 +25,12 @@ public interface IMutableSupportBrokerClient : ISupportBrokerClient
 
     /// <summary>Swap the operator identity used to authenticate broker calls. Blank parts ⇒ not configured.</summary>
     void UpdateIdentity(string? callsign, string? sessionKey);
+
+    /// <summary>
+    /// Swap the operator's radio metadata advertised in the broker presence body
+    /// (board name, variant/model, connected state). Static identity (platform /
+    /// app version) is set once at construction; this carries the parts that change
+    /// as the operator connects/disconnects a radio.
+    /// </summary>
+    void UpdateMetadata(string? radioBoard, string? radioModel, bool radioConnected);
 }

--- a/Zeus.SupportAgent/PresenceCoordinator.cs
+++ b/Zeus.SupportAgent/PresenceCoordinator.cs
@@ -65,6 +65,7 @@ public sealed class PresenceCoordinator
     public void Apply(SupportIpcListener.SupportState state)
     {
         _broker.UpdateIdentity(state.QrzCallsign, state.QrzSessionKey);
+        _broker.UpdateMetadata(state.RadioBoard, state.RadioModel, state.RadioConnected);
         AutoShareOnCrash = state.AutoShareOnCrash;
 
         var available = state.RemoteDiagnosticsEnabled && _broker.IsConfigured;
@@ -73,6 +74,7 @@ public sealed class PresenceCoordinator
         _log?.Invoke(
             $"ipc: state remoteDiag={state.RemoteDiagnosticsEnabled} " +
             $"autoShare={state.AutoShareOnCrash} " +
-            $"identity={(_broker.IsConfigured ? "set" : "-")} -> available={available}");
+            $"identity={(_broker.IsConfigured ? "set" : "-")} " +
+            $"radio={(state.RadioConnected ? state.RadioBoard ?? "?" : "-")} -> available={available}");
     }
 }

--- a/Zeus.SupportAgent/Program.cs
+++ b/Zeus.SupportAgent/Program.cs
@@ -63,7 +63,10 @@ if (endpoints is not null)
     // Seed identity from the launch env (best-effort; usually blank because QRZ
     // login hadn't settled at launch). The IPC SupportHello/SupportStateChanged
     // refresh it the moment the operator's QRZ identity is known.
-    broker = new HttpSupportBrokerClient(http, endpoints, opts.OperatorCallsign ?? "", qrzSession);
+    broker = new HttpSupportBrokerClient(
+        http, endpoints, opts.OperatorCallsign ?? "", qrzSession,
+        platform: RuntimeInformation.OSDescription,
+        appVersion: opts.AppVersion ?? "");
 
     // initiallyAvailable is false: presence only advertises once the backend
     // confirms BOTH the L1 switch on and a usable identity over IPC.

--- a/Zeus.SupportAgent/SupportIpcListener.cs
+++ b/Zeus.SupportAgent/SupportIpcListener.cs
@@ -38,11 +38,17 @@ public sealed class SupportIpcListener
     /// <param name="RemoteDiagnosticsEnabled">L1 master switch.</param>
     /// <param name="AutoShareOnCrash">Crash auto-share sub-toggle.</param>
     /// <param name="QrzSessionKey">QRZ session key for broker auth (v2+), or null when signed out.</param>
+    /// <param name="RadioBoard">Human-readable connected board name (v3+), or null when no radio.</param>
+    /// <param name="RadioModel">Variant/model refinement (v3+), or null when N/A.</param>
+    /// <param name="RadioConnected">True when a radio is actually connected (v3+).</param>
     public readonly record struct SupportState(
         string? QrzCallsign,
         bool RemoteDiagnosticsEnabled,
         bool AutoShareOnCrash,
-        string? QrzSessionKey = null);
+        string? QrzSessionKey = null,
+        string? RadioBoard = null,
+        string? RadioModel = null,
+        bool RadioConnected = false);
 
     private readonly string _pipeName;
     private readonly Action<SupportState> _onState;
@@ -123,12 +129,14 @@ public sealed class SupportIpcListener
                 case SupportHello hello:
                     _onState(new SupportState(
                         hello.QrzCallsign, hello.RemoteDiagnosticsEnabled, hello.AutoShareOnCrash,
-                        hello.QrzSessionKey));
+                        hello.QrzSessionKey,
+                        hello.RadioBoard, hello.RadioModel, hello.RadioConnected));
                     break;
                 case SupportStateChanged state:
                     _onState(new SupportState(
                         state.QrzCallsign, state.RemoteDiagnosticsEnabled, state.AutoShareOnCrash,
-                        state.QrzSessionKey));
+                        state.QrzSessionKey,
+                        state.RadioBoard, state.RadioModel, state.RadioConnected));
                     break;
                 // Heartbeats and other kinds are not needed by the presence/crash
                 // subsystem; ignore them so the contract can grow without breaking us.

--- a/cloud/zeus-remote-broker/package.json
+++ b/cloud/zeus-remote-broker/package.json
@@ -8,7 +8,7 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
     "typecheck": "tsc --noEmit",
-    "test": "node --import tsx --test test/admin-auth.test.ts test/crash-validate.test.ts test/admin-cors.test.ts",
+    "test": "node --import tsx --test test/admin-auth.test.ts test/crash-validate.test.ts test/admin-cors.test.ts test/presence-meta.test.ts",
     "cf-typegen": "wrangler types"
   },
   "devDependencies": {

--- a/cloud/zeus-remote-broker/src/crash-store.ts
+++ b/cloud/zeus-remote-broker/src/crash-store.ts
@@ -1,6 +1,6 @@
 import { DurableObject } from 'cloudflare:workers';
 import type { Env } from './types';
-import { MAX_CRASH_PER_CALLSIGN, retainNewest } from './crash-validate';
+import { retainNewest } from './crash-validate';
 
 /**
  * Single Durable Object holding the most recent auto-shared crash records, keyed
@@ -13,24 +13,29 @@ import { MAX_CRASH_PER_CALLSIGN, retainNewest } from './crash-validate';
  *      sidecar (Zeus.SupportAgent) — which survives the crash — writes a
  *      SupportCrashRecord to disk and, only if auto-share is on, POSTs it to the
  *      broker's `/crash` endpoint (QRZ-authenticated as the operator's callsign).
- *   3. index.ts verifies the QRZ headers, then forwards the body here under the
- *      verified callsign. The record is ALREADY redacted server-side by the
- *      backend's diagnostics layer; the broker stores it verbatim and adds nothing.
- *   4. A maintainer lists/fetches a consented operator's crashes via the
- *      admin-only `GET /admin/crashes?callsign=<cs>` route (Bearer admin auth).
+ *   3. index.ts verifies the QRZ headers, derives the edge IP/country, then
+ *      forwards the body here under the verified callsign. The record is ALREADY
+ *      redacted server-side by the backend's diagnostics layer; the broker stores
+ *      it verbatim and adds only receipt metadata (receivedAt, ip, country).
+ *   4. A maintainer browses the crash-bearing operators via `GET /admin/crashes`
+ *      (index) and drills into one via `GET /admin/crashes?callsign=<cs>` — both
+ *      admin-Bearer-gated.
  *
- * Storage policy: in-DO transactional SQLite-free map persisted via the DO storage
- * API would be ideal, but to stay free-plan/SQLite-class friendly and simple we
- * keep an in-memory ring per callsign capped at MAX_CRASH_PER_CALLSIGN. Crash
- * records are a best-effort diagnostic convenience, not a system of record, so a
- * DO eviction simply loses the oldest unsent history — acceptable for this use.
- * Each upload is size-capped (MAX_CRASH_BYTES) at the edge before it reaches here.
+ * Storage policy: an in-memory ring per callsign capped at MAX_CRASH_PER_CALLSIGN
+ * keeps this free-plan/SQLite-class friendly. Crash records are a best-effort
+ * diagnostic convenience, not a system of record, so a DO eviction simply loses
+ * the oldest history — acceptable for this use. Each upload is size-capped
+ * (MAX_CRASH_BYTES) at the edge before it reaches here.
  */
 
 /** A stored crash entry: the raw record JSON plus broker-side receipt metadata. */
 interface StoredCrash {
   /** Broker receive time (unix ms) — authoritative ordering, independent of the record's own clock. */
   receivedAt: number;
+  /** Edge-observed client IP at upload time (cf-connecting-ip), or null. */
+  ip: string | null;
+  /** Edge-observed 2-letter country at upload time (cf.country), or null. */
+  country: string | null;
   /** The verbatim SupportCrashRecord JSON as uploaded (already redacted by the backend). */
   record: unknown;
 }
@@ -54,8 +59,10 @@ export class CrashStore extends DurableObject<Env> {
         } catch {
           return new Response('invalid json', { status: 400 });
         }
+        const ip = (url.searchParams.get('ip') ?? '').trim() || null;
+        const country = (url.searchParams.get('country') ?? '').trim().toUpperCase() || null;
         const list = this.byCallsign.get(callsign) ?? [];
-        list.push({ receivedAt: now, record });
+        list.push({ receivedAt: now, ip, country, record });
         // Bound the history — drop the oldest beyond the cap.
         retainNewest(list);
         this.byCallsign.set(callsign, list);
@@ -65,8 +72,28 @@ export class CrashStore extends DurableObject<Env> {
         if (!callsign) return new Response('callsign required', { status: 400 });
         const list = this.byCallsign.get(callsign) ?? [];
         // Newest first for the maintainer view.
-        const crashes = [...list].reverse().map((e) => ({ receivedAt: e.receivedAt, record: e.record }));
+        const crashes = [...list]
+          .reverse()
+          .map((e) => ({ receivedAt: e.receivedAt, ip: e.ip, country: e.country, record: e.record }));
         return Response.json({ callsign, count: crashes.length, crashes });
+      }
+      case 'index': {
+        // Maintainer overview: one row per operator that has shared any crash,
+        // so the dashboard can list crash-bearing operators without knowing the
+        // callsigns in advance. Newest-crash first.
+        const operators = [...this.byCallsign.entries()]
+          .map(([cs, list]) => {
+            const last = list[list.length - 1];
+            return {
+              callsign: cs,
+              count: list.length,
+              lastReceivedAt: last?.receivedAt ?? 0,
+              lastIp: last?.ip ?? null,
+            };
+          })
+          .filter((o) => o.count > 0)
+          .sort((a, b) => b.lastReceivedAt - a.lastReceivedAt);
+        return Response.json({ operators });
       }
       default:
         return new Response('not found', { status: 404 });

--- a/cloud/zeus-remote-broker/src/index.ts
+++ b/cloud/zeus-remote-broker/src/index.ts
@@ -3,6 +3,7 @@ import { verifyQrzSessionCached } from './qrz';
 import { mintIceServers } from './turn';
 import { handleAdmin, verifyAdminToken, ensureAdminBootstrap } from './admin-api';
 import { validateCrashBody } from './crash-validate';
+import { sanitizeOperatorMeta, cleanCountry } from './presence-meta';
 
 export { SignalRoom } from './signal-room';
 export { RateLimiter } from './rate-limiter';
@@ -64,9 +65,24 @@ export default {
       const verified = await verifyOperator(request, env, ctx);
       if (!verified) return new Response('qrz auth required', { status: 401 });
       const presenceAction = url.pathname.slice('/presence/'.length); // register | heartbeat | drop
+      // register/heartbeat may carry an untrusted JSON metadata body (platform,
+      // app version, connected radio); sanitise it here and stamp the verified
+      // callsign + edge-observed IP/country before forwarding to the DO so the
+      // operator can never spoof its own callsign/IP.
+      const meta = presenceAction === 'drop' ? null : sanitizeOperatorMeta(await request.text());
+      const upsert = {
+        callsign: verified,
+        ip: clientIp(request),
+        country: clientCountry(request),
+        ...(meta ?? {}),
+      };
       const id = env.PRESENCE.idFromName('global');
       return env.PRESENCE.get(id).fetch(
-        `https://presence.internal/${presenceAction}?callsign=${encodeURIComponent(verified)}`,
+        new Request(`https://presence.internal/${presenceAction}`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(upsert),
+        }),
       );
     }
 
@@ -84,8 +100,14 @@ export default {
       if (!verdict.ok) return new Response(verdict.message, { status: verdict.status });
 
       const id = env.CRASH_STORE.idFromName('global');
+      const ip = clientIp(request);
+      const country = clientCountry(request);
+      const putUrl =
+        `https://crash.internal/put?callsign=${encodeURIComponent(verified)}` +
+        `&ip=${encodeURIComponent(ip)}` +
+        (country ? `&country=${encodeURIComponent(country)}` : '');
       return env.CRASH_STORE.get(id).fetch(
-        new Request(`https://crash.internal/put?callsign=${encodeURIComponent(verified)}`, {
+        new Request(putUrl, {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
           body,
@@ -156,6 +178,16 @@ function clientIp(request: Request): string {
 }
 
 /**
+ * Edge-observed 2-letter country for the request (Cloudflare's geo-IP), or null.
+ * Used to annotate presence/crash rows in the maintainer dashboard. Never an
+ * identity signal — purely informational triage context.
+ */
+function clientCountry(request: Request): string | null {
+  const cf = (request as Request & { cf?: { country?: string } }).cf;
+  return cleanCountry(cf?.country);
+}
+
+/**
  * QRZ-gate an operator-authenticated request (presence/crash), returning the
  * verified upper-cased callsign or null. Identical model to the host side of
  * /signal: when QRZ_VERIFY is on (default), the X-QRZ-Session must validate the
@@ -201,13 +233,15 @@ async function handleAdminCrashes(
   if (!auth) return Response.json({ error: 'unauthorized' }, { status: 401, headers: cors });
 
   const callsign = (new URL(request.url).searchParams.get('callsign') ?? '').trim().toUpperCase();
-  if (!callsign) return Response.json({ error: 'callsign required' }, { status: 400, headers: cors });
 
   void ctx; // reserved (audit logging could go here as the admin-api routes do)
   const id = env.CRASH_STORE.idFromName('global');
-  const res = await env.CRASH_STORE.get(id).fetch(
-    `https://crash.internal/list?callsign=${encodeURIComponent(callsign)}`,
-  );
+  // No callsign → the crash-bearing-operator index (overview); with a callsign →
+  // that operator's records. Both are admin-Bearer-gated above.
+  const internalUrl = callsign
+    ? `https://crash.internal/list?callsign=${encodeURIComponent(callsign)}`
+    : 'https://crash.internal/index';
+  const res = await env.CRASH_STORE.get(id).fetch(internalUrl);
   const body = await res.json<unknown>();
   return Response.json(body, { status: res.status, headers: cors });
 }

--- a/cloud/zeus-remote-broker/src/presence-meta.ts
+++ b/cloud/zeus-remote-broker/src/presence-meta.ts
@@ -1,0 +1,92 @@
+/**
+ * Pure (runtime-free) parsing + sanitation for the optional operator-metadata
+ * body a sidecar POSTs to /presence/register and /presence/heartbeat, plus the
+ * edge-derived network fields (IP / country). Kept out of index.ts / presence.ts
+ * — which pull in `cloudflare:workers` globals — so it is unit-testable under
+ * plain `node --test` exactly as the crash-validate core is.
+ *
+ * The sidecar is QRZ-authenticated as the operator, but the metadata it sends is
+ * still untrusted free-form text (platform string, app version, radio name), so
+ * every field is length-clamped and type-checked here before it is stored and
+ * later shown to a maintainer in the dashboard. Never throws.
+ */
+
+/** Defensive clamp on any single operator metadata string. */
+export const MAX_META_FIELD = 120;
+
+/** A sanitised operator-metadata snapshot stored in the presence DO. */
+export interface OperatorMeta {
+  /** Operator's reported OS/platform string (e.g. "Microsoft Windows 11 ..."). */
+  platform: string | null;
+  /** Operator's reported Zeus app version (e.g. "0.10.0-dev"). */
+  appVersion: string | null;
+  /** Human-readable connected radio board (e.g. "Hermes-Lite 2"), or null. */
+  radioBoard: string | null;
+  /** Variant/model refinement of the board (e.g. "G2"), or null. */
+  radioModel: string | null;
+  /** Whether a radio is currently connected at the operator's station. */
+  radioConnected: boolean;
+}
+
+/** An OperatorMeta with every field empty (older operators send no body). */
+export function emptyMeta(): OperatorMeta {
+  return {
+    platform: null,
+    appVersion: null,
+    radioBoard: null,
+    radioModel: null,
+    radioConnected: false,
+  };
+}
+
+/**
+ * Clean a single untrusted field to a trimmed, length-clamped non-empty string,
+ * or null. Drops non-strings, empty/whitespace, and collapses control characters
+ * (so a maintainer's dashboard never renders a stray newline/escape from the
+ * wire). Exported for the IP/country edge fields too.
+ */
+export function cleanField(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  // Collapse ASCII control chars (incl. CR/LF/tab) to spaces so stored metadata
+  // is single-line, then trim.
+  const cleaned = value.replace(/[\x00-\x1f\x7f]/g, ' ').trim();
+  if (!cleaned) return null;
+  return cleaned.length > MAX_META_FIELD ? cleaned.slice(0, MAX_META_FIELD) : cleaned;
+}
+
+/**
+ * Parse + sanitise the raw request body of a POST /presence/register|heartbeat.
+ * An empty body, invalid JSON, a non-object, or any missing field all degrade
+ * gracefully to {@link emptyMeta} / null fields — the sidecar metadata is a
+ * best-effort convenience, never a hard requirement for presence.
+ */
+export function sanitizeOperatorMeta(rawBody: string): OperatorMeta {
+  const meta = emptyMeta();
+  if (!rawBody) return meta;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawBody);
+  } catch {
+    return meta;
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return meta;
+  const o = parsed as Record<string, unknown>;
+  meta.platform = cleanField(o.platform);
+  meta.appVersion = cleanField(o.appVersion);
+  meta.radioBoard = cleanField(o.radioBoard);
+  meta.radioModel = cleanField(o.radioModel);
+  meta.radioConnected = o.radioConnected === true;
+  return meta;
+}
+
+/**
+ * Normalise a Cloudflare 2-letter country code (cf.country) to an upper-case
+ * A–Z pair, or null. Cloudflare uses "XX"/"T1" for unknown/Tor — those are
+ * dropped so the dashboard shows nothing rather than a meaningless badge.
+ */
+export function cleanCountry(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const cc = value.trim().toUpperCase();
+  if (!/^[A-Z]{2}$/.test(cc) || cc === 'XX' || cc === 'T1') return null;
+  return cc;
+}

--- a/cloud/zeus-remote-broker/src/presence.ts
+++ b/cloud/zeus-remote-broker/src/presence.ts
@@ -1,11 +1,14 @@
 import { DurableObject } from 'cloudflare:workers';
 import type { Env } from './types';
+import { emptyMeta, type OperatorMeta } from './presence-meta';
 
 /**
  * Single Durable Object tracking operators whose sidecar has registered as
  * support-available (the operator's L1 "available for remote diagnostics" switch
  * is on). The broker's /admin/presence reads it; the sidecar registers/heartbeats
- * (wired in P3 — for now only /admin/presence's `list` is reachable).
+ * (wired in P3) and now also carries a metadata snapshot (platform, app version,
+ * connected radio) plus the edge-derived network fields (IP, country) so a
+ * maintainer can triage at a glance before opening a live session.
  *
  * In-memory map only: presence is ephemeral by nature, and a DO restart simply
  * waits for the next heartbeat. Entries whose lastSeen is older than ~90s are
@@ -16,10 +19,32 @@ interface Entry {
   since: number;
   /** Last heartbeat (unix ms). */
   lastSeen: number;
+  /** Edge-observed client IP (cf-connecting-ip), or null. */
+  ip: string | null;
+  /** Edge-observed 2-letter country (cf.country), or null. */
+  country: string | null;
+  /** Sidecar-reported metadata (platform / app version / radio). */
+  meta: OperatorMeta;
 }
 
 /** An operator is considered offline if we haven't heard from them in this long. */
 const PRESENCE_EXPIRY_MS = 90_000;
+
+/** The wire shape of a register/heartbeat body forwarded by index.ts. */
+interface PresenceUpsert extends Partial<OperatorMeta> {
+  callsign?: string;
+  ip?: string | null;
+  country?: string | null;
+}
+
+/** A single operator row in the /admin/presence response. */
+interface OperatorView extends OperatorMeta {
+  callsign: string;
+  since: number;
+  lastSeen: number;
+  ip: string | null;
+  country: string | null;
+}
 
 export class PresenceRoom extends DurableObject<Env> {
   private entries = new Map<string, Entry>();
@@ -27,24 +52,28 @@ export class PresenceRoom extends DurableObject<Env> {
   override async fetch(request: Request): Promise<Response> {
     const url = new URL(request.url);
     const action = url.pathname.replace(/^\/+/, '');
-    const callsign = (url.searchParams.get('callsign') ?? '').trim().toUpperCase();
     const now = Date.now();
 
     switch (action) {
-      case 'register': {
-        if (!callsign) return new Response('callsign required', { status: 400 });
-        const existing = this.entries.get(callsign);
-        this.entries.set(callsign, { since: existing?.since ?? now, lastSeen: now });
-        return Response.json({ ok: true });
-      }
+      case 'register':
       case 'heartbeat': {
+        const body = await this.readBody(request);
+        const callsign = (body.callsign ?? '').trim().toUpperCase();
         if (!callsign) return new Response('callsign required', { status: 400 });
         const existing = this.entries.get(callsign);
         // A heartbeat for an unknown/expired operator implicitly re-registers.
-        this.entries.set(callsign, { since: existing?.since ?? now, lastSeen: now });
+        this.entries.set(callsign, {
+          since: existing?.since ?? now,
+          lastSeen: now,
+          ip: body.ip ?? existing?.ip ?? null,
+          country: body.country ?? existing?.country ?? null,
+          meta: this.mergeMeta(existing?.meta, body),
+        });
         return Response.json({ ok: true });
       }
       case 'drop': {
+        const body = await this.readBody(request);
+        const callsign = (body.callsign ?? '').trim().toUpperCase();
         if (callsign) this.entries.delete(callsign);
         return Response.json({ ok: true });
       }
@@ -56,15 +85,51 @@ export class PresenceRoom extends DurableObject<Env> {
     }
   }
 
+  /** Parse the forwarded JSON upsert body; never throws (degrades to {}). */
+  private async readBody(request: Request): Promise<PresenceUpsert> {
+    try {
+      const v = await request.json();
+      return v && typeof v === 'object' ? (v as PresenceUpsert) : {};
+    } catch {
+      return {};
+    }
+  }
+
+  /**
+   * Carry forward known metadata across heartbeats: a heartbeat may legitimately
+   * omit fields, so prefer the freshly-sent value, else keep the last known one,
+   * rather than blanking a radio that is still connected.
+   */
+  private mergeMeta(prev: OperatorMeta | undefined, body: PresenceUpsert): OperatorMeta {
+    const base = prev ?? emptyMeta();
+    return {
+      platform: body.platform ?? base.platform ?? null,
+      appVersion: body.appVersion ?? base.appVersion ?? null,
+      radioBoard: body.radioBoard ?? base.radioBoard ?? null,
+      radioModel: body.radioModel ?? base.radioModel ?? null,
+      // radioConnected is authoritative per-beat (a radio can disconnect), so take
+      // the body value whenever it is a boolean; only fall back when absent.
+      radioConnected:
+        typeof body.radioConnected === 'boolean' ? body.radioConnected : base.radioConnected,
+    };
+  }
+
   /** Live operators (lastSeen within the expiry window); expired ones are pruned. */
-  private snapshot(now: number): Array<{ callsign: string; since: number; lastSeen: number }> {
-    const out: Array<{ callsign: string; since: number; lastSeen: number }> = [];
+  private snapshot(now: number): OperatorView[] {
+    const out: OperatorView[] = [];
     for (const [callsign, e] of this.entries) {
       if (now - e.lastSeen > PRESENCE_EXPIRY_MS) {
         this.entries.delete(callsign);
         continue;
       }
-      out.push({ callsign, since: e.since, lastSeen: e.lastSeen });
+      out.push({
+        callsign,
+        since: e.since,
+        lastSeen: e.lastSeen,
+        ip: e.ip,
+        country: e.country,
+        ...e.meta,
+      });
     }
     return out;
   }

--- a/cloud/zeus-remote-broker/test/presence-meta.test.ts
+++ b/cloud/zeus-remote-broker/test/presence-meta.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for the pure, runtime-free operator-metadata sanitation used by the
+ * presence path (POST /presence/register|heartbeat body + edge country code).
+ * Exercised under plain Node exactly as deployed.
+ *
+ *   node --import tsx --test test/presence-meta.test.ts
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  sanitizeOperatorMeta,
+  cleanField,
+  cleanCountry,
+  emptyMeta,
+  MAX_META_FIELD,
+} from '../src/presence-meta.ts';
+
+test('empty / missing body degrades to all-null meta', () => {
+  assert.deepEqual(sanitizeOperatorMeta(''), emptyMeta());
+});
+
+test('invalid JSON degrades to empty meta (never throws)', () => {
+  assert.deepEqual(sanitizeOperatorMeta('{not json'), emptyMeta());
+  assert.deepEqual(sanitizeOperatorMeta('[1,2,3]'), emptyMeta());
+  assert.deepEqual(sanitizeOperatorMeta('"a string"'), emptyMeta());
+});
+
+test('well-formed body is parsed and typed', () => {
+  const m = sanitizeOperatorMeta(
+    JSON.stringify({
+      platform: 'Microsoft Windows 11 (10.0.26100)',
+      appVersion: '0.10.0-dev',
+      radioBoard: 'Hermes-Lite 2',
+      radioModel: 'G2',
+      radioConnected: true,
+    }),
+  );
+  assert.equal(m.platform, 'Microsoft Windows 11 (10.0.26100)');
+  assert.equal(m.appVersion, '0.10.0-dev');
+  assert.equal(m.radioBoard, 'Hermes-Lite 2');
+  assert.equal(m.radioModel, 'G2');
+  assert.equal(m.radioConnected, true);
+});
+
+test('radioConnected is strictly boolean true', () => {
+  assert.equal(sanitizeOperatorMeta(JSON.stringify({ radioConnected: 'true' })).radioConnected, false);
+  assert.equal(sanitizeOperatorMeta(JSON.stringify({ radioConnected: 1 })).radioConnected, false);
+  assert.equal(sanitizeOperatorMeta(JSON.stringify({ radioConnected: true })).radioConnected, true);
+});
+
+test('hyphens and spaces in a radio name are preserved', () => {
+  // Regression: the control-char scrub must not eat normal "-"/" ".
+  assert.equal(cleanField('Hermes-Lite 2'), 'Hermes-Lite 2');
+});
+
+test('control characters are collapsed to spaces and trimmed', () => {
+  assert.equal(cleanField('a\nb\tc\r'), 'a b c');
+  assert.equal(cleanField('   spaced   '), 'spaced');
+});
+
+test('non-strings and empties become null', () => {
+  assert.equal(cleanField(123), null);
+  assert.equal(cleanField(null), null);
+  assert.equal(cleanField('   '), null);
+});
+
+test('over-long fields are clamped', () => {
+  const long = 'x'.repeat(MAX_META_FIELD + 50);
+  assert.equal(cleanField(long)?.length, MAX_META_FIELD);
+});
+
+test('country code is normalised; junk/unknown dropped', () => {
+  assert.equal(cleanCountry('us'), 'US');
+  assert.equal(cleanCountry('DE'), 'DE');
+  assert.equal(cleanCountry('XX'), null); // Cloudflare unknown
+  assert.equal(cleanCountry('T1'), null); // Tor
+  assert.equal(cleanCountry('USA'), null); // not 2-letter
+  assert.equal(cleanCountry(''), null);
+  assert.equal(cleanCountry(undefined), null);
+});

--- a/tests/Zeus.Server.Tests/SupportAgentTests.cs
+++ b/tests/Zeus.Server.Tests/SupportAgentTests.cs
@@ -466,7 +466,7 @@ public class HttpSupportBrokerClientIdentityTests
     public void BlankSeed_IsNotConfigured()
     {
         using var http = new HttpClient();
-        var broker = new HttpSupportBrokerClient(http, Endpoints(), "", "");
+        var broker = new HttpSupportBrokerClient(http, Endpoints(), "", "", "test-platform", "1.0");
         Assert.False(broker.IsConfigured);
     }
 
@@ -474,7 +474,7 @@ public class HttpSupportBrokerClientIdentityTests
     public void UpdateIdentity_RequiresBothCallsignAndKey()
     {
         using var http = new HttpClient();
-        var broker = new HttpSupportBrokerClient(http, Endpoints(), "", "");
+        var broker = new HttpSupportBrokerClient(http, Endpoints(), "", "", "test-platform", "1.0");
 
         broker.UpdateIdentity("N9WAR", null);
         Assert.False(broker.IsConfigured); // callsign without key
@@ -487,6 +487,81 @@ public class HttpSupportBrokerClientIdentityTests
 
         broker.UpdateIdentity("N9WAR", "");
         Assert.False(broker.IsConfigured); // key cleared (sign-out)
+    }
+
+    [Fact]
+    public async Task RegisterAndHeartbeat_EmitMetadataJsonBody()
+    {
+        var handler = new RecordingHandler();
+        using var http = new HttpClient(handler);
+        var broker = new HttpSupportBrokerClient(
+            http, Endpoints(), "N9WAR", "KEY", "win32-test", "9.9");
+        broker.UpdateMetadata("ANAN-G2", "G2", radioConnected: true);
+
+        Assert.True(await broker.RegisterAsync(CancellationToken.None));
+        Assert.NotNull(handler.LastBody);
+        using (var doc = JsonDocument.Parse(handler.LastBody!))
+        {
+            var root = doc.RootElement;
+            Assert.Equal("win32-test", root.GetProperty("platform").GetString());
+            Assert.Equal("9.9", root.GetProperty("appVersion").GetString());
+            Assert.Equal("ANAN-G2", root.GetProperty("radioBoard").GetString());
+            Assert.Equal("G2", root.GetProperty("radioModel").GetString());
+            Assert.True(root.GetProperty("radioConnected").GetBoolean());
+        }
+        Assert.EndsWith("/presence/register", handler.LastUri!.AbsolutePath);
+
+        Assert.True(await broker.HeartbeatAsync(CancellationToken.None));
+        Assert.EndsWith("/presence/heartbeat", handler.LastUri!.AbsolutePath);
+        Assert.NotNull(handler.LastBody);
+    }
+
+    [Fact]
+    public async Task Register_NullRadio_EmitsJsonNulls()
+    {
+        var handler = new RecordingHandler();
+        using var http = new HttpClient(handler);
+        var broker = new HttpSupportBrokerClient(
+            http, Endpoints(), "N9WAR", "KEY", "win32-test", "9.9");
+        // No radio connected: board/model null, connected false.
+        broker.UpdateMetadata(null, null, radioConnected: false);
+
+        Assert.True(await broker.RegisterAsync(CancellationToken.None));
+        using var doc = JsonDocument.Parse(handler.LastBody!);
+        var root = doc.RootElement;
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("radioBoard").ValueKind);
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("radioModel").ValueKind);
+        Assert.False(root.GetProperty("radioConnected").GetBoolean());
+    }
+
+    [Fact]
+    public async Task Drop_StaysBodyless()
+    {
+        var handler = new RecordingHandler();
+        using var http = new HttpClient(handler);
+        var broker = new HttpSupportBrokerClient(
+            http, Endpoints(), "N9WAR", "KEY", "win32-test", "9.9");
+
+        Assert.True(await broker.DropAsync(CancellationToken.None));
+        Assert.EndsWith("/presence/drop", handler.LastUri!.AbsolutePath);
+        Assert.Null(handler.LastBody); // drop carries no body
+    }
+
+    /// <summary>Captures the URI + request body of the last POST, replies 200 OK.</summary>
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        public Uri? LastUri;
+        public string? LastBody;
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastUri = request.RequestUri;
+            LastBody = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+            return new HttpResponseMessage(System.Net.HttpStatusCode.OK);
+        }
     }
 }
 
@@ -502,7 +577,8 @@ public class PresenceCoordinatorTests
     {
         var http = new HttpClient();
         var broker = new HttpSupportBrokerClient(
-            http, BrokerEndpoints.FromBrokerUrl("wss://remote.openhpsdrzeus.com/signal")!, "", "");
+            http, BrokerEndpoints.FromBrokerUrl("wss://remote.openhpsdrzeus.com/signal")!, "", "",
+            "test-platform", "1.0");
         var presence = new PresenceClient(broker, initiallyAvailable: false);
         var coord = new PresenceCoordinator(broker, presence, initialAutoShare);
         return (broker, presence, coord);
@@ -568,6 +644,36 @@ public class PresenceCoordinatorTests
         coord.Apply(State(remoteDiag: true, callsign: "N9WAR", key: "K", autoShare: true));
         Assert.True(coord.AutoShareOnCrash);
     }
+
+    [Fact]
+    public void Apply_ForwardsRadioMetadataToBroker()
+    {
+        var broker = new FakeMutableBroker();
+        var presence = new PresenceClient(broker, initiallyAvailable: false);
+        var coord = new PresenceCoordinator(broker, presence);
+
+        // A connected radio: board + variant model + connected flag must reach the broker.
+        coord.Apply(new SupportIpcListener.SupportState(
+            QrzCallsign: "N9WAR", RemoteDiagnosticsEnabled: true, AutoShareOnCrash: false,
+            QrzSessionKey: "K",
+            RadioBoard: "ANAN-G2", RadioModel: "G2", RadioConnected: true));
+
+        Assert.Equal("ANAN-G2", broker.LastRadioBoard);
+        Assert.Equal("G2", broker.LastRadioModel);
+        Assert.True(broker.LastRadioConnected);
+        Assert.Equal(1, broker.MetadataUpdates);
+
+        // Disconnect: nulls + false propagate so the broker clears the radio.
+        coord.Apply(new SupportIpcListener.SupportState(
+            QrzCallsign: "N9WAR", RemoteDiagnosticsEnabled: true, AutoShareOnCrash: false,
+            QrzSessionKey: "K",
+            RadioBoard: null, RadioModel: null, RadioConnected: false));
+
+        Assert.Null(broker.LastRadioBoard);
+        Assert.Null(broker.LastRadioModel);
+        Assert.False(broker.LastRadioConnected);
+        Assert.Equal(2, broker.MetadataUpdates);
+    }
 }
 
 /// <summary>A mutable-identity fake broker for coordinator/pipe tests; counts calls thread-safely.</summary>
@@ -581,6 +687,13 @@ internal sealed class FakeMutableBroker : IMutableSupportBrokerClient
     public int Registers => Volatile.Read(ref _registers);
     public int Drops => Volatile.Read(ref _drops);
 
+    // Last radio metadata forwarded via UpdateMetadata, captured for assertions.
+    public string? LastRadioBoard;
+    public string? LastRadioModel;
+    public bool LastRadioConnected;
+    private int _metadataUpdates;
+    public int MetadataUpdates => Volatile.Read(ref _metadataUpdates);
+
     public bool IsConfigured =>
         !string.IsNullOrWhiteSpace(_callsign) && !string.IsNullOrWhiteSpace(_sessionKey);
 
@@ -588,6 +701,14 @@ internal sealed class FakeMutableBroker : IMutableSupportBrokerClient
     {
         _callsign = callsign ?? "";
         _sessionKey = sessionKey ?? "";
+    }
+
+    public void UpdateMetadata(string? radioBoard, string? radioModel, bool radioConnected)
+    {
+        LastRadioBoard = radioBoard;
+        LastRadioModel = radioModel;
+        LastRadioConnected = radioConnected;
+        Interlocked.Increment(ref _metadataUpdates);
     }
 
     public Task<bool> RegisterAsync(CancellationToken ct) { Interlocked.Increment(ref _registers); return Task.FromResult(true); }

--- a/tests/Zeus.Server.Tests/SupportIpcFramingTests.cs
+++ b/tests/Zeus.Server.Tests/SupportIpcFramingTests.cs
@@ -86,6 +86,68 @@ public class SupportIpcFramingTests
             "v2 added QrzSessionKey to the identity messages; version must not regress.");
 
     [Fact]
+    public void ProtocolVersion_IsAtLeastV3_ForRadioMetadataOverIpc()
+        => Assert.True(SupportIpc.ProtocolVersion >= 3,
+            "v3 added RadioBoard/RadioModel/RadioConnected to the identity messages; version must not regress.");
+
+    [Fact]
+    public async Task Hello_WithRadioMetadata_RoundTrips()
+    {
+        // v3 radio metadata: board / model / connected must survive the round-trip
+        // so the sidecar can publish the operator's hardware in its presence body.
+        var hello = new SupportHello(
+            ProtocolVersion: SupportIpc.ProtocolVersion,
+            BackendPid: 1, AppVersion: "v", Platform: "p",
+            QrzCallsign: "N9WAR",
+            RemoteDiagnosticsEnabled: true,
+            AutoShareOnCrash: false,
+            AppLogPath: "a", StartupLogPath: "s",
+            QrzSessionKey: "sess",
+            RadioBoard: "ANAN-G2", RadioModel: "G2", RadioConnected: true);
+
+        var result = Assert.IsType<SupportHello>(await RoundTripAsync(hello));
+        Assert.Equal(hello, result);
+        Assert.Equal("ANAN-G2", result.RadioBoard);
+        Assert.Equal("G2", result.RadioModel);
+        Assert.True(result.RadioConnected);
+    }
+
+    [Fact]
+    public async Task StateChanged_WithRadioMetadata_RoundTrips()
+    {
+        var state = new SupportStateChanged(
+            QrzCallsign: "N9WAR",
+            RemoteDiagnosticsEnabled: true,
+            AutoShareOnCrash: true,
+            QrzSessionKey: "sess",
+            RadioBoard: "Hermes-Lite 2", RadioModel: null, RadioConnected: true);
+
+        var result = Assert.IsType<SupportStateChanged>(await RoundTripAsync(state));
+        Assert.Equal(state, result);
+        Assert.Equal("Hermes-Lite 2", result.RadioBoard);
+        Assert.Null(result.RadioModel);
+        Assert.True(result.RadioConnected);
+    }
+
+    [Fact]
+    public async Task Hello_WithoutRadioMetadata_DefaultsToDisconnected()
+    {
+        // Omitting the v3 params (older-style construction) must default to "no radio".
+        var hello = new SupportHello(
+            ProtocolVersion: SupportIpc.ProtocolVersion,
+            BackendPid: 1, AppVersion: "v", Platform: "p",
+            QrzCallsign: "N9WAR",
+            RemoteDiagnosticsEnabled: true,
+            AutoShareOnCrash: false,
+            AppLogPath: "a", StartupLogPath: "s");
+
+        var result = Assert.IsType<SupportHello>(await RoundTripAsync(hello));
+        Assert.Null(result.RadioBoard);
+        Assert.Null(result.RadioModel);
+        Assert.False(result.RadioConnected);
+    }
+
+    [Fact]
     public async Task PromptResult_PreservesEnumDecision()
     {
         var msg = new SupportPromptResult("req-1", SupportPromptDecision.Timeout);

--- a/zeus-web/src/components/ServerUrlPanel.tsx
+++ b/zeus-web/src/components/ServerUrlPanel.tsx
@@ -275,6 +275,12 @@ function RemoteDiagnosticsSection() {
   const [autoShare, setAutoShare] = useState(false);
   const [busy, setBusy] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
+  // Presence (appearing in the maintainer's "online operators" list) is
+  // QRZ-authenticated: the sidecar can only register/heartbeat with a verified
+  // callsign + session key. So "available" is necessary but NOT sufficient — if
+  // QRZ is not signed in, the operator silently never appears. Surface that.
+  const qrzConnected = useQrzStore((s) => s.connected);
+  const qrzCallsign = useQrzStore((s) => s.home?.callsign ?? null);
 
   useEffect(() => {
     const ctrl = new AbortController();
@@ -391,6 +397,32 @@ function RemoteDiagnosticsSection() {
           re-creating it.
         </span>
       </label>
+
+      {isOn && !qrzConnected && (
+        <div
+          style={{
+            marginTop: 12,
+            padding: '8px 10px',
+            fontSize: 11,
+            lineHeight: 1.5,
+            color: 'var(--tx)',
+            border: '1px solid var(--tx)',
+            borderRadius: 4,
+            background: 'rgba(230, 58, 43, 0.08)',
+          }}
+        >
+          <strong>Not visible to maintainers yet.</strong> Appearing in the
+          maintainer dashboard requires you to be <strong>signed in to QRZ</strong>{' '}
+          (your verified callsign is how you are listed). Sign in under QRZ
+          settings and you will show as online here.
+        </div>
+      )}
+      {isOn && qrzConnected && qrzCallsign && (
+        <div style={{ marginTop: 12, fontSize: 11, color: 'var(--fg-2)' }}>
+          Visible to maintainers as <strong>{qrzCallsign}</strong> while Zeus is
+          running.
+        </div>
+      )}
 
       {notice && (
         <div style={{ marginTop: 12, fontSize: 11, color: 'var(--tx)' }}>{notice}</div>


### PR DESCRIPTION
## What

Makes the maintainer remote-diagnostics admin portal actually useful for debugging **any** operator, addressing "I only see myself / no IP / no crash table" feedback. Backend + broker half of a vertical slice (the dashboard UI is [zeus-webpage#PR](https://github.com/OpenHPSDR-Zeus-org/zeus-webpage)).

### Broker (`cloud/zeus-remote-broker`)
- **Presence enriched**: `PresenceRoom` now stores edge **IP + country** and a sanitised metadata snapshot (**platform, app version, connected radio board/model**); `GET /admin/presence` returns them. `/presence/register|heartbeat` accept a JSON body; `index.ts` stamps the verified callsign + `cf-connecting-ip`/`cf.country` server-side (operator can't spoof its own IP/callsign).
- **New `presence-meta.ts`**: pure, node-tested sanitiser (length-clamp, control-char scrub, strict typing, country-code normalisation) so untrusted sidecar metadata is safe to render.
- **Crash IP + index**: `/crash` captures upload IP/country at the edge; `CrashStore` stores them. New `index` action + `GET /admin/crashes` (no callsign) lists every crash-bearing operator so the dashboard can browse without knowing callsigns.

### Backend + sidecar
- **IPC contract → ProtocolVersion 3**: `SupportHello`/`SupportStateChanged` append optional `RadioBoard`/`RadioModel`/`RadioConnected` (v2 peers still deserialize). `SupportSidecarBridge` resolves them from `RadioService` (`ConnectedBoardKind` + `EffectiveOrionMkIIVariant`, null-safe).
- `HttpSupportBrokerClient` sends the metadata body on register/heartbeat (platform + app version seeded at launch, radio via IPC); `PresenceCoordinator` forwards it.

### Frontend
- Remote-diagnostics opt-in panel now **warns when the switch is on but QRZ is not signed in** — presence is QRZ-authenticated, so "available" alone never makes an operator appear. This is the silent gap behind operators checking both boxes yet not showing up.

## Why "only seeing myself"
Two real causes, both addressed/surfaced here: (1) the presence send-side only landed on develop in #1127 (yesterday) — other operators must rebuild; (2) presence requires QRZ sign-in, which the opt-in UI never said — now it does.

## Tests
- Broker: `presence-meta` unit tests (32 total green) + `tsc` clean.
- Server: IPC v3 round-trip + presence-body tests; `dotnet build Zeus.slnx` clean, 40 support/presence tests pass.
- Frontend `tsc -b` clean.
- Dashboard verified end-to-end against these shapes via a mocked-fetch render (rich presence table + crash records with IP/exit-code/log-tails).

No PureSignal surface touched. Presence/crash remain QRZ-gated (operator) and admin-Bearer-gated (maintainer); remote-session auth unchanged.