### PR TITLE
fix(remote-diag): connect host signaling for support sessions + /admin/crashes CORS

### DIFF
--- a/Zeus.Server.Hosting/Remote/RemoteBrokerClient.cs
+++ b/Zeus.Server.Hosting/Remote/RemoteBrokerClient.cs
@@ -39,6 +39,7 @@ public sealed class RemoteBrokerClient : BackgroundService
     private readonly RemoteWebRtcService _rtc;
     private readonly SupportWebRtcService _support;
     private readonly SupportRequestCoordinator _coord;
+    private readonly SupportAvailabilityStore _availability;
     private readonly QrzService _qrz;
     private readonly ILogger<RemoteBrokerClient> _log;
     private readonly string _brokerUrl;
@@ -46,12 +47,14 @@ public sealed class RemoteBrokerClient : BackgroundService
     public RemoteBrokerClient(
         RemotePasswordStore passwords, RemoteWebRtcService rtc,
         SupportWebRtcService support, SupportRequestCoordinator coord,
+        SupportAvailabilityStore availability,
         QrzService qrz, ILogger<RemoteBrokerClient> log)
     {
         _passwords = passwords;
         _rtc = rtc;
         _support = support;
         _coord = coord;
+        _availability = availability;
         _qrz = qrz;
         _log = log;
         _brokerUrl = Environment.GetEnvironmentVariable("ZEUS_REMOTE_BROKER_URL")
@@ -63,8 +66,15 @@ public sealed class RemoteBrokerClient : BackgroundService
         var backoff = ReconnectMin;
         while (!stoppingToken.IsCancellationRequested)
         {
-            // Remote access off (no password) → stay disconnected.
-            if (!_passwords.HasPassword())
+            // Connect the host signaling socket when EITHER remote access is on
+            // (a session password is set) OR remote diagnostics is available (the
+            // L1 switch is on). The latter is what lets a maintainer's
+            // /admin/request reach this radio for a consent-gated support session
+            // without the operator also having to enable full remote access.
+            // Safe: remote-access *clients* are still deny-by-default (SPAKE2+) —
+            // with no password set, no client can authenticate, so opening the
+            // socket grants nothing but the support-request path (ADR-0008 intact).
+            if (!_passwords.HasPassword() && !_availability.IsAvailable)
             {
                 await Task.Delay(ReconnectMax, stoppingToken).ContinueWith(_ => { }, CancellationToken.None);
                 continue;

--- a/cloud/zeus-remote-broker/src/index.ts
+++ b/cloud/zeus-remote-broker/src/index.ts
@@ -1,7 +1,12 @@
 import type { Env } from './types';
 import { verifyQrzSessionCached } from './qrz';
 import { mintIceServers } from './turn';
-import { handleAdmin, verifyAdminToken, ensureAdminBootstrap } from './admin-api';
+import {
+  handleAdmin,
+  verifyAdminToken,
+  ensureAdminBootstrap,
+  corsHeaders as adminCorsHeaders,
+} from './admin-api';
 import { validateCrashBody } from './crash-validate';
 import { sanitizeOperatorMeta, cleanCountry } from './presence-meta';
 
@@ -221,7 +226,11 @@ async function handleAdminCrashes(
   env: Env,
   ctx: ExecutionContext,
 ): Promise<Response> {
-  const cors = adminCorsHeaders(env);
+  // Reuse the SAME origin-allowlist CORS as the rest of /admin (admin-api), which
+  // echoes the matching ADMIN_ORIGINS origin (the dashboard runs at the apex, NOT
+  // WEB_APP_ORIGIN). Using a WEB_APP_ORIGIN-pinned header here blocked the
+  // dashboard's /admin/crashes fetch with a CORS preflight failure.
+  const cors = adminCorsHeaders(env, request);
   if (request.method === 'OPTIONS') return new Response(null, { status: 204, headers: cors });
   if (request.method !== 'GET') {
     return Response.json({ error: 'method not allowed' }, { status: 405, headers: cors });
@@ -244,23 +253,6 @@ async function handleAdminCrashes(
   const res = await env.CRASH_STORE.get(id).fetch(internalUrl);
   const body = await res.json<unknown>();
   return Response.json(body, { status: res.status, headers: cors });
-}
-
-/**
- * CORS for the dashboard's cross-origin /admin/crashes fetch. Mirrors
- * admin-api's fail-closed policy: name exactly WEB_APP_ORIGIN, never '*', and
- * omit the header entirely if it is unset so a misconfigured deploy can't expose
- * the admin surface to every site.
- */
-function adminCorsHeaders(env: Env): Record<string, string> {
-  const headers: Record<string, string> = {
-    'Access-Control-Allow-Methods': 'GET, OPTIONS',
-    'Access-Control-Allow-Headers': 'content-type, authorization, x-qrz-session, x-qrz-callsign',
-    'Access-Control-Max-Age': '86400',
-    Vary: 'Origin',
-  };
-  if (env.WEB_APP_ORIGIN) headers['Access-Control-Allow-Origin'] = env.WEB_APP_ORIGIN;
-  return headers;
 }
 
 // CORS for the browser web client's cross-origin /turn fetch. Allow exactly the


### PR DESCRIPTION
Two fixes surfaced exercising the maintainer dashboard end-to-end.

## 1. 503 on "Request diagnostics" (the main one)
`RemoteBrokerClient` only opened the broker's `/signal?role=host` socket when a **remote-access session password** was set (`HasPassword()`). An operator who enabled **Remote Diagnostics** (the L1 switch) but never set a remote-access password therefore appeared in `/admin/presence` (sidecar heartbeat) yet had **no host socket**, so `/admin/request` → SignalRoom found no host → **503 "operator offline"**.

Fix: the host now also connects when **remote diagnostics is available** (`SupportAvailabilityStore.IsAvailable`), not only when a remote password is set.

**Safety (ADR-0008 intact):** remote-access *clients* are still deny-by-default (SPAKE2+). With no password set, no client can authenticate — opening the socket grants nothing except the consent-gated support-request path (operator still must Allow each session at the radio). This is purely additive to what the L1 switch already authorizes.

## 2. /admin/crashes CORS preflight failure
The crashes route (in `index.ts`) used a local `adminCorsHeaders` hardcoded to `WEB_APP_ORIGIN` (`app.openhpsdrzeus.com`), but the dashboard runs at the apex `openhpsdrzeus.com`, so the browser blocked it. Now reuses admin-api's `corsHeaders(env, request)` — the same `ADMIN_ORIGINS` allowlist every other `/admin` route uses. Dormant until the new Crashes tab first called the route. **Already deployed live** (broker version `f37d87df`); this lands it on develop so it doesn't regress.

## Verify
- Broker typecheck + 32 tests green; CORS preflight from `https://openhpsdrzeus.com` now returns the matching `Access-Control-Allow-Origin`.
- `Zeus.Server.Hosting` builds clean; DI auto-resolves the new `SupportAvailabilityStore` dependency (no direct construction).