### PR TITLE
fix(dsp): guard DspPipelineService.Tick against concurrent runs during sink attach/detach (#1167)

### DIFF
--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -1095,6 +1095,16 @@ public class DspPipelineService : BackgroundService,
     // disposed-check guards cover engine-swap-mid-call); engine swaps
     // serialise through _engineLock (writer side only).
     private volatile bool _rxSinkAttached;
+    // issue #1167: during the RX-sink attach/detach window the timer thread and
+    // the RX inline-tick thread can both be live, so Tick can run on two threads
+    // at once. FloatSpscRing's producer side is strict single-thread; this gate
+    // makes Tick mutually exclusive so the producer stays single-threaded.
+    private readonly SingleEntryGate _tickGate = new();
+    private long _tickReentrySkips;
+    /// <summary>Count of Tick calls skipped because another thread held the
+    /// gate — non-zero only during the sink attach/detach window (issue #1167).
+    /// Telemetry/test seam.</summary>
+    internal long TickReentrySkips => Interlocked.Read(ref _tickReentrySkips);
     // Reference to the protocol client this pipeline is currently sinking RX
     // packets from. Cached so we can explicitly DetachRxSink on disconnect —
     // RadioService nulls its ActiveClient before raising Disconnected, so the
@@ -5354,6 +5364,14 @@ public class DspPipelineService : BackgroundService,
 
     private void Tick(float[] panBuf, float[] wfBuf, float[] audioBuf)
     {
+        // issue #1167: the timer thread and the RX inline-tick thread can both
+        // be live during the sink attach/detach window. FloatSpscRing is strict
+        // single-producer; this gate guarantees only one Tick runs at a time so
+        // the producer side stays single-threaded. ~30 Hz, so the CompareExchange
+        // is free. A skipped tick is harmless — the holder is ticking ~now.
+        if (!_tickGate.TryEnter()) { Interlocked.Increment(ref _tickReentrySkips); return; }
+        try
+        {
         // iter5 pass-2: lock-free hot path. Tick runs inline on the RX OS
         // thread when a sink is attached (paced via Stopwatch elapsed in
         // OnIqFrame), and on the PeriodicTimer thread otherwise. Volatile
@@ -6015,6 +6033,8 @@ public class DspPipelineService : BackgroundService,
             _hub.Broadcast(v2);
             RxMetersV2Updated?.Invoke(channel, v2);
         }
+        }
+        finally { _tickGate.Exit(); }
     }
 
     /// <summary>

--- a/Zeus.Server.Hosting/SingleEntryGate.cs
+++ b/Zeus.Server.Hosting/SingleEntryGate.cs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2026 Brian Keating (EI6LF), Christian Suarez (N9WAR), and contributors.
+
+using System.Threading;
+
+namespace Zeus.Server;
+
+/// <summary>
+/// Non-blocking single-entry gate. Exactly one caller at a time may hold the
+/// gate; concurrent callers are rejected (they get <c>false</c>) rather than
+/// blocked. Used to make <see cref="DspPipelineService"/>'s <c>Tick</c> mutually
+/// exclusive across the timer thread and the RX inline-tick thread during the
+/// sink attach/detach window (issue #1167), keeping the strict
+/// single-producer <see cref="FloatSpscRing"/> producer side single-threaded.
+///
+/// <para>
+/// This deliberately does NOT re-add a per-sink lock (that reintroduced the
+/// #1148 hot-path contention) and does NOT block. A rejected caller simply
+/// skips its critical section — the holder is already executing it ~now.
+/// </para>
+/// </summary>
+internal sealed class SingleEntryGate
+{
+    private int _busy; // 0 = free, 1 = entered
+
+    /// <summary>Returns true to exactly one caller at a time. Concurrent
+    /// callers get false and MUST skip their critical section. Full
+    /// Interlocked fence orders the protected body across threads.</summary>
+    public bool TryEnter() => Interlocked.CompareExchange(ref _busy, 1, 0) == 0;
+
+    /// <summary>Releases the gate. Idempotent and safe to call from the same
+    /// thread that entered. Volatile write publishes the protected body's
+    /// effects before the next entrant acquires.</summary>
+    public void Exit() => Volatile.Write(ref _busy, 0);
+}

--- a/tests/Zeus.Server.Tests/SingleEntryGateTests.cs
+++ b/tests/Zeus.Server.Tests/SingleEntryGateTests.cs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2026 Brian Keating (EI6LF), Christian Suarez (N9WAR), and contributors.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Behaviour and concurrent-correctness tests for <see cref="SingleEntryGate"/>,
+/// the gate that keeps <c>DspPipelineService.Tick</c> single-threaded across the
+/// RX-sink attach/detach window (issue #1167). The deterministic sequencing test
+/// is the must-have; the stress test asserts mutual exclusion under contention.
+/// </summary>
+public class SingleEntryGateTests
+{
+    [Fact]
+    public void TryEnter_Admits_Exactly_One_Until_Exit()
+    {
+        var gate = new SingleEntryGate();
+
+        // Fresh gate → first caller is admitted.
+        Assert.True(gate.TryEnter());
+
+        // While held, a second TryEnter is rejected (no blocking).
+        Assert.False(gate.TryEnter());
+        Assert.False(gate.TryEnter());
+
+        // After Exit, the gate is free again.
+        gate.Exit();
+        Assert.True(gate.TryEnter());
+
+        // Exit is idempotent / safe to call repeatedly.
+        gate.Exit();
+        gate.Exit();
+        Assert.True(gate.TryEnter());
+        gate.Exit();
+    }
+
+    [Fact]
+    public void Concurrent_Callers_Never_Overlap_In_Critical_Section()
+    {
+        var gate = new SingleEntryGate();
+
+        const int threads = 8;
+        const int iterations = 100_000;
+
+        int sentinel = 0;        // plain int: only the holder may touch it
+        long admitted = 0;       // total successful entries
+        long rejected = 0;       // total rejected entries (contention proof)
+        bool violation = false;  // set if two callers were ever inside at once
+
+        Parallel.For(0, threads, _ =>
+        {
+            long localRejects = 0;
+            for (int i = 0; i < iterations; i++)
+            {
+                if (!gate.TryEnter())
+                {
+                    localRejects++;
+                    continue;
+                }
+
+                // Critical section. If the gate is correct, no other thread is
+                // here, so the sentinel must read 0 on entry.
+                if (Volatile.Read(ref sentinel) != 0)
+                {
+                    violation = true;
+                }
+                Volatile.Write(ref sentinel, 1);
+
+                // A touch of work to widen the overlap window.
+                Thread.SpinWait(4);
+
+                Volatile.Write(ref sentinel, 0);
+                Interlocked.Increment(ref admitted);
+                gate.Exit();
+            }
+            Interlocked.Add(ref rejected, localRejects);
+        });
+
+        Assert.False(violation, "two callers were inside the gate at the same time");
+        // Every thread did 'iterations' attempts; admitted + rejected must equal
+        // the total, and under real contention some attempts must be rejected.
+        Assert.Equal((long)threads * iterations, admitted + rejected);
+        Assert.True(rejected > 0, "expected some rejected entries under contention");
+
+        // Gate ends free.
+        Assert.True(gate.TryEnter());
+        gate.Exit();
+    }
+}


### PR DESCRIPTION
## Issue #1167 — `DspPipelineService.Tick` SPSC-ring concurrency hazard (RED-LIGHT, WDSP hot path)

### Root cause
`FloatSpscRing` is strict single-producer / single-consumer (documented at `FloatSpscRing.cs:39-41`). Its producer is `DspPipelineService.Tick` (via `PublishAudio → sink.Publish → ring.Write`), so Tick must never run on two threads at once.

In steady state that invariant holds: with a radio connected `_rxSinkAttached == true` makes the `PeriodicTimer` loop `continue` instead of ticking, and Tick runs only inline on the RX OS thread (`OnIqFrame → MaybeTickInline → Tick`).

The hazard is in the attach/detach **transitions**:

- **Attach** (`AttachRxSinkP1`/`AttachRxSinkP2`) calls `client.AttachRxSink(this)` and only **then** sets `_rxSinkAttached = true`. Between those two lines the RX thread can already fire `OnIqFrame → Tick` while the timer thread is still ticking → two producers on the ring.
- **Detach** (`DetachRxSinkP1`/`DetachRxSinkP2`) sets `_rxSinkAttached = false` **before** `client?.DetachRxSink()`. The timer can resume Tick while one last inline Tick is still in flight.

Reordering the flag alone is insufficient: the timer's check-then-Tick (`if (_rxSinkAttached) continue;` → `Tick(...)`) is itself non-atomic.

### Fix
A non-blocking single-entry gate (`SingleEntryGate`, `Interlocked.CompareExchange`) wraps the **whole** Tick body via `try/finally`. Exactly one Tick runs at a time, so the producer side stays single-threaded across **both** the attach and detach windows with a single, symmetric change.

- Does **not** re-add the per-sink hot-path lock removed in #1148 (no contention reintroduced).
- Does **not** block — a concurrent caller gets `false` and skips; harmless because the holder is ticking ~now.
- Tick runs ~30 Hz (per `TickPeriod`, not per IQ frame), so one `CompareExchange` per tick is negligible.
- Attach/detach ordering, the timer loop, `MaybeTickInline`, and `PublishAudio` are **unchanged**.
- `TickReentrySkips` exposes the skip count as a telemetry / test seam (non-zero only inside the attach/detach window).

### Tests
`tests/Zeus.Server.Tests/SingleEntryGateTests.cs` (modeled on `SpscRingTests.cs`):
- Deterministic sequencing: fresh gate admits one; second `TryEnter` while held is rejected; `Exit` frees it; `Exit` is idempotent.
- Threaded mutual-exclusion stress: 8 threads × 100k iterations, shared sentinel must never be seen as already-held inside the gate, and some entries are rejected under contention. No sockets, no network I/O.

### Scope / guardrails
- **Backend-only C#** (`Zeus.Server.Hosting` + tests). No frontend, no `tokens.css`, no wire bytes.
- **No drive / PA / TX / board math, no protocol change** → the per-board firmware mirror and `RadioDriveProfile`/`PaDefaults` seams are **N/A** here. This is host-side thread-ownership only.
- **PureSignal untouched** (no `PsEnabled`/`PsSettingsStore`/`/api/tx/ps`).
- **LiteDB N/A** (no store changes).
- Cross-platform safe: `Interlocked` + `Volatile` are platform-agnostic (macOS / Windows / Linux x64+arm64 / Pi).

### RED-LIGHT — needs bench sign-off
This touches **WDSP single-thread ownership on the DSP hot path**. It is **correct-by-construction** — no behavior change in steady state, and a tick dropped during the attach/detach window is harmless — but per repo policy it needs **KB2UKA G2 bench sign-off before merge** (the G2 is the only bench).

### Gates
- `dotnet build Zeus.slnx` → Build succeeded, 0 Warnings, 0 Errors.
- `dotnet test ... --filter "FullyQualifiedName~SingleEntryGate"` → Passed: 2, Failed: 0, Skipped: 0.

Closes #1167
