### PR TITLE
fix(web): round LO frequency to integer at the wire seam (#1191)

### DIFF
--- a/zeus-web/src/api/client.test.ts
+++ b/zeus-web/src/api/client.test.ts
@@ -107,10 +107,13 @@ import {
   setMode,
   setNr,
   setPreamp,
+  setRadioLo,
+  setReceiverLo,
   setSampleRate,
   setTun,
   setTxVfo,
   setZoom,
+  toWireHz,
 } from './client';
 
 describe('normalizeStatus', () => {
@@ -500,6 +503,72 @@ describe('POST helpers', () => {
     expect(url).toBe('/api/rx/zoom');
     expect(init?.method).toBe('POST');
     expect(JSON.parse((init?.body ?? '') as string)).toEqual({ level: 4 });
+  });
+
+  // Regression (#1191): the CTUN zoom/recenter path computes a fractional LO
+  // and used to POST it raw; the Int64 RadioLoSetRequest/ReceiverLoSetRequest
+  // rejected the decimal with HTTP 400, the hardware LO never moved, and the
+  // panadapter/waterfall blanked under CTUN. toWireHz rounds + clamps at the
+  // wire seam so no caller can emit a non-integer or out-of-range Hz.
+  describe('toWireHz', () => {
+    it('rounds a fractional Hz to the nearest integer', () => {
+      expect(toWireHz(3_853_999.9999)).toBe(3_854_000);
+      expect(toWireHz(7_100_000.4)).toBe(7_100_000);
+      expect(toWireHz(7_100_000.5)).toBe(7_100_001);
+    });
+    it('clamps to the supported radio range', () => {
+      expect(toWireHz(-5)).toBe(0);
+      expect(toWireHz(99_000_000)).toBe(60_000_000);
+    });
+    it('coerces non-finite values to 0 (never NaN/Infinity on the wire)', () => {
+      expect(toWireHz(Number.NaN)).toBe(0);
+      expect(toWireHz(Number.POSITIVE_INFINITY)).toBe(0);
+      expect(toWireHz(Number.NEGATIVE_INFINITY)).toBe(0);
+    });
+    it('passes a clean integer through unchanged', () => {
+      expect(toWireHz(3_854_000)).toBe(3_854_000);
+    });
+  });
+
+  it('setRadioLo posts an integer hz to /api/radio/lo even when given a fraction', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(jsonResponse(okState));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await setRadioLo(3_853_999.9999);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('/api/radio/lo');
+    expect(init?.method).toBe('POST');
+    const body = JSON.parse((init?.body ?? '') as string);
+    expect(body).toEqual({ hz: 3_854_000 });
+    expect(Number.isInteger(body.hz)).toBe(true);
+  });
+
+  it('setReceiverLo posts an integer hz to /api/receivers/{i}/lo even when given a fraction', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(jsonResponse(okState));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await setReceiverLo(2, 14_204_300.75);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('/api/receivers/2/lo');
+    const body = JSON.parse((init?.body ?? '') as string);
+    expect(body).toEqual({ hz: 14_204_301 });
+    expect(Number.isInteger(body.hz)).toBe(true);
+  });
+
+  it('setReceiverLo(index<=0) delegates to /api/radio/lo, still rounding', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(jsonResponse(okState));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await setReceiverLo(0, 3_853_999.9999);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('/api/radio/lo');
+    expect(JSON.parse((init?.body ?? '') as string)).toEqual({ hz: 3_854_000 });
   });
 
   it('setAttenuator posts { db } to /api/attenuator', async () => {

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -5522,6 +5522,22 @@ export function disconnectP2(signal?: AbortSignal): Promise<unknown> {
 // the panadapter pan gesture (use-pan-tune-gesture.ts) when a drag releases
 // past the edge of the current IQ capture window. Server returns the full
 // updated StateDto; 400 if hz is out of range for the connected radio.
+// LO frequencies cross the wire as a 64-bit integer (`RadioLoSetRequest.Hz` /
+// `ReceiverLoSetRequest.Hz` are `long`). Several callers — chiefly the CTUN
+// zoom/recenter and keep-in-view autopan paths — compute the LO from
+// floating-point view-center math and can hand us a FRACTIONAL Hz (e.g.
+// 3_853_999.9999). System.Text.Json cannot parse a decimal into an Int64 and
+// rejects the whole request with HTTP 400, so the hardware LO never moves; under
+// CTUN that leaves the frozen DDC window pointed at the wrong place and the
+// panadapter/waterfall blank out (issue #1191). Round + clamp at this single
+// wire seam so NO caller can emit a non-integer or out-of-range LO. Rounding is
+// sub-Hz on the LO — far below the radio's tuning resolution, no audible effect.
+const MAX_LO_HZ = 60_000_000;
+export function toWireHz(hz: number): number {
+  if (!Number.isFinite(hz)) return 0;
+  return Math.min(MAX_LO_HZ, Math.max(0, Math.round(hz)));
+}
+
 export function setRadioLo(
   hz: number,
   signal?: AbortSignal,
@@ -5531,7 +5547,7 @@ export function setRadioLo(
     {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ hz }),
+      body: JSON.stringify({ hz: toWireHz(hz) }),
       signal,
     },
     normalizeState,
@@ -5553,7 +5569,7 @@ export function setReceiverLo(
     {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ hz }),
+      body: JSON.stringify({ hz: toWireHz(hz) }),
       signal,
     },
     normalizeState,


### PR DESCRIPTION
## Summary
Fixes #1191 — with **CTUN on** and zoomed in, the **panadapter + waterfall blank out** (intermittent; CTUN off restores them).

## Root cause (confirmed from the live backend log)
The CTUN zoom/recenter and keep-in-view autopan paths compute the local oscillator from floating-point view-center math and could hand `setRadioLo`/`setReceiverLo` a **fractional Hz** (e.g. `3853999.9999`). The backend request type carries Hz as a **64-bit integer** (`RadioLoSetRequest.Hz` / `ReceiverLoSetRequest.Hz` are `long`), so `System.Text.Json` rejects the decimal:

```
The JSON value could not be converted to RadioLoSetRequest. Path: $.hz
Either the JSON value is not in a supported format, or is out of bounds for an Int64.
```

→ HTTP 400 → the hardware LO never moves → under CTUN the frozen DDC window points at the wrong place → panadapter/waterfall blank. With CTUN off the display follows the dial directly, sidestepping the bad request — exactly the reported behavior. Reproduced live on the bench (the 400 fired repeatedly while zooming).

## Fix
Round + clamp to a valid integer Hz at the **single wire seam** — new `toWireHz`, used by both `setRadioLo` and `setReceiverLo` in `api/client.ts` — so **no caller** (zoom recenter, autopan, ruler pan) can emit a non-integer or out-of-range LO. Defensive against NaN/Infinity too (→ 0, never garbage on the wire).

**Rounding is sub-Hz on the LO**, far below the radio's NCO tuning resolution — no audible effect, no operator-felt change.

## Scope / safety
- **Frontend-only**, additive at the API boundary. No Contracts/wire-format change, no backend change, no new deps.
- Not a board/drive/PA/TX path — does not touch drive bytes or power.
- **Independent of PRs #1188 / #1187** (DSP tick guard / PA gain) — those can land on their own.

## Tests
7 regression tests in `client.test.ts`: `toWireHz` (fractional round, range clamp, NaN/Infinity → 0, integer passthrough) + `setRadioLo`/`setReceiverLo`/`setReceiverLo(index<=0)` posting an **integer** body when given a fraction. Full `client.test.ts` green (114), `tsc -b` clean, SPA build clean.

## Red-light
None — clean green-light bug fix (wire-format correctness). No defaults, visual, UX, or architecture surface.