### PR TITLE
Detect p3app on G2 radios

### DIFF
--- a/Zeus.Server.Hosting/Protocol3PresenceProbe.cs
+++ b/Zeus.Server.Hosting/Protocol3PresenceProbe.cs
@@ -7,6 +7,7 @@
 
 using System.Buffers.Binary;
 using System.Net;
+using System.Net.NetworkInformation;
 using System.Net.Sockets;
 
 namespace Zeus.Server;
@@ -18,6 +19,10 @@ public sealed record Protocol3PresenceResult(
     uint CapabilityFlags,
     uint FirmwareVersion,
     uint GatewareVersion);
+
+public sealed record Protocol3DiscoveredRadio(
+    IPAddress Ip,
+    Protocol3PresenceResult Presence);
 
 public sealed class Protocol3PresenceProbe
 {
@@ -45,6 +50,89 @@ public sealed class Protocol3PresenceProbe
         TimeSpan timeout,
         CancellationToken ct = default) =>
         await ProbeAsync(radioIp, DefaultPort, timeout, ct).ConfigureAwait(false);
+
+    public async Task<IReadOnlyList<Protocol3DiscoveredRadio>> DiscoverAsync(
+        TimeSpan timeout,
+        CancellationToken ct = default) =>
+        await DiscoverAsync(GetIPv4BroadcastAddresses(), DefaultPort, timeout, ct).ConfigureAwait(false);
+
+    internal async Task<IReadOnlyList<Protocol3DiscoveredRadio>> DiscoverAsync(
+        IReadOnlyCollection<IPAddress> targetAddresses,
+        int port,
+        TimeSpan timeout,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(targetAddresses);
+        if (port <= 0 || port > 65535) throw new ArgumentOutOfRangeException(nameof(port));
+        if (targetAddresses.Count == 0) return Array.Empty<Protocol3DiscoveredRadio>();
+
+        using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        DisableUdpConnReset(socket);
+        socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Broadcast, true);
+        socket.Bind(new IPEndPoint(IPAddress.Any, 0));
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(timeout);
+
+        var packet = BuildDiscoveryPacket();
+        foreach (var address in targetAddresses.Where(a => a.AddressFamily == AddressFamily.InterNetwork).Distinct())
+        {
+            try
+            {
+                await socket.SendToAsync(
+                    packet,
+                    SocketFlags.None,
+                    new IPEndPoint(address, port),
+                    timeoutCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                return Array.Empty<Protocol3DiscoveredRadio>();
+            }
+            catch (SocketException ex)
+            {
+                _log.LogDebug(ex, "p3.discovery.send.error target={Target}", address);
+            }
+        }
+
+        var byIp = new Dictionary<IPAddress, Protocol3PresenceResult>();
+        var receiveBuffer = new byte[ReceiveBufferSize];
+        var any = new IPEndPoint(IPAddress.Any, 0);
+        while (!timeoutCts.IsCancellationRequested)
+        {
+            SocketReceiveFromResult res;
+            try
+            {
+                res = await socket.ReceiveFromAsync(
+                    receiveBuffer,
+                    SocketFlags.None,
+                    any,
+                    timeoutCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (SocketException ex) when (ex.SocketErrorCode == SocketError.ConnectionReset)
+            {
+                continue;
+            }
+            catch (SocketException ex)
+            {
+                _log.LogDebug(ex, "p3.discovery.socket.error");
+                break;
+            }
+
+            var fromIp = ((IPEndPoint)res.RemoteEndPoint).Address;
+            var slice = new ReadOnlySpan<byte>(receiveBuffer, 0, res.ReceivedBytes);
+            if (TryParseCapabilities(slice, port, out var result))
+            {
+                byIp[fromIp] = result;
+            }
+        }
+
+        return byIp.Select(kv => new Protocol3DiscoveredRadio(kv.Key, kv.Value)).ToArray();
+    }
 
     internal async Task<Protocol3PresenceResult?> ProbeAsync(
         IPAddress radioIp,
@@ -91,44 +179,51 @@ public sealed class Protocol3PresenceProbe
 
         var receiveBuffer = new byte[ReceiveBufferSize];
         var any = new IPEndPoint(IPAddress.Any, 0);
-        while (!timeoutCts.IsCancellationRequested)
+        try
         {
-            SocketReceiveFromResult res;
-            try
+            while (!timeoutCts.IsCancellationRequested)
             {
-                res = await socket.ReceiveFromAsync(
-                    receiveBuffer,
-                    SocketFlags.None,
-                    any,
-                    timeoutCts.Token).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-            catch (SocketException ex) when (ex.SocketErrorCode == SocketError.ConnectionReset)
-            {
-                continue;
-            }
-            catch (SocketException ex)
-            {
-                _log.LogDebug(ex, "p3.presence.socket.error radio={Radio}", radioIp);
-                break;
-            }
+                SocketReceiveFromResult res;
+                try
+                {
+                    res = await socket.ReceiveFromAsync(
+                        receiveBuffer,
+                        SocketFlags.None,
+                        any,
+                        timeoutCts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (SocketException ex) when (ex.SocketErrorCode == SocketError.ConnectionReset)
+                {
+                    continue;
+                }
+                catch (SocketException ex)
+                {
+                    _log.LogDebug(ex, "p3.presence.socket.error radio={Radio}", radioIp);
+                    break;
+                }
 
-            var fromIp = ((IPEndPoint)res.RemoteEndPoint).Address;
-            if (!fromIp.Equals(radioIp)) continue;
+                var fromIp = ((IPEndPoint)res.RemoteEndPoint).Address;
+                if (!fromIp.Equals(radioIp)) continue;
 
-            var slice = new ReadOnlySpan<byte>(receiveBuffer, 0, res.ReceivedBytes);
-            if (TryParseCapabilities(slice, port, out var result))
-            {
-                _log.LogInformation(
-                    "p3.presence.reply radio={Radio} maxRx={MaxRx} flags=0x{Flags:X8}",
-                    radioIp,
-                    result.MaxRxStreams,
-                    result.CapabilityFlags);
-                return result;
+                var slice = new ReadOnlySpan<byte>(receiveBuffer, 0, res.ReceivedBytes);
+                if (TryParseCapabilities(slice, port, out var result))
+                {
+                    _log.LogInformation(
+                        "p3.presence.reply radio={Radio} maxRx={MaxRx} flags=0x{Flags:X8}",
+                        radioIp,
+                        result.MaxRxStreams,
+                        result.CapabilityFlags);
+                    return result;
+                }
             }
+        }
+        finally
+        {
+            try { socket.Shutdown(SocketShutdown.Both); } catch (SocketException) { }
         }
 
         return null;
@@ -170,6 +265,40 @@ public sealed class Protocol3PresenceProbe
             FirmwareVersion: BinaryPrimitives.ReadUInt32BigEndian(payload.Slice(32, 4)),
             GatewareVersion: BinaryPrimitives.ReadUInt32BigEndian(payload.Slice(36, 4)));
         return true;
+    }
+
+    private static IReadOnlyCollection<IPAddress> GetIPv4BroadcastAddresses()
+    {
+        var addresses = new HashSet<IPAddress> { IPAddress.Broadcast };
+        foreach (var nic in NetworkInterface.GetAllNetworkInterfaces())
+        {
+            if (nic.OperationalStatus != OperationalStatus.Up) continue;
+            if (nic.NetworkInterfaceType is NetworkInterfaceType.Loopback or NetworkInterfaceType.Tunnel) continue;
+
+            IPInterfaceProperties properties;
+            try { properties = nic.GetIPProperties(); }
+            catch (NetworkInformationException) { continue; }
+
+            foreach (var uni in properties.UnicastAddresses)
+            {
+                if (uni.Address.AddressFamily != AddressFamily.InterNetwork) continue;
+                if (uni.IPv4Mask is null) continue;
+                addresses.Add(GetBroadcastAddress(uni.Address, uni.IPv4Mask));
+            }
+        }
+        return addresses;
+    }
+
+    private static IPAddress GetBroadcastAddress(IPAddress address, IPAddress mask)
+    {
+        var ipBytes = address.GetAddressBytes();
+        var maskBytes = mask.GetAddressBytes();
+        var broadcast = new byte[ipBytes.Length];
+        for (var i = 0; i < broadcast.Length; i++)
+        {
+            broadcast[i] = (byte)(ipBytes[i] | ~maskBytes[i]);
+        }
+        return new IPAddress(broadcast);
     }
 
     private const int SIO_UDP_CONNRESET = -1744830452; // 0x9800000C

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -1161,16 +1161,27 @@ public static class ZeusEndpoints
             var timeout = TimeSpan.FromMilliseconds(1500);
             var p1Task = p1Discovery.DiscoverAsync(timeout, ctx.RequestAborted);
             var p2Task = p2Discovery.DiscoverAsync(timeout, ctx.RequestAborted);
-            await Task.WhenAll(p1Task, p2Task);
+            var p3Task = p3Presence.DiscoverAsync(TimeSpan.FromMilliseconds(700), ctx.RequestAborted);
+            await Task.WhenAll(p1Task, p2Task, p3Task);
 
-            var p1Infos = p1Task.Result.Select(MapP1);
-            var p3ByIp = await ProbeProtocol3PresenceAsync(
+            var p3ByIp = p3Task.Result.ToDictionary(r => r.Ip, r => r.Presence);
+            foreach (var entry in await ProbeProtocol3PresenceAsync(
                 p2Task.Result,
                 p3Presence,
-                ctx.RequestAborted).ConfigureAwait(false);
+                ctx.RequestAborted).ConfigureAwait(false))
+            {
+                p3ByIp[entry.Key] = entry.Value;
+            }
+
+            var p1Infos = p1Task.Result.Select(MapP1);
             var p2Infos = p2Task.Result.Select(r =>
                 MapP2(r, p3ByIp.TryGetValue(r.Ip, out var p3) ? p3 : null));
-            return p1Infos.Concat(p2Infos).ToArray();
+            var knownIps = new HashSet<IPAddress>(
+                p1Task.Result.Select(r => r.Ip).Concat(p2Task.Result.Select(r => r.Ip)));
+            var p3Infos = p3Task.Result
+                .Where(r => !knownIps.Contains(r.Ip))
+                .Select(MapP3);
+            return p1Infos.Concat(p2Infos).Concat(p3Infos).ToArray();
 
             static RadioInfo MapP1(DiscoveredRadio r) => new(
                 MacAddress: r.Mac.ToString(),
@@ -1187,6 +1198,14 @@ public static class ZeusEndpoints
                 FirmwareVersion: r.FirmwareString,
                 Busy: r.Details.Busy,
                 Details: BuildP2Details(r, p3));
+
+            static RadioInfo MapP3(Protocol3DiscoveredRadio r) => new(
+                MacAddress: string.Empty,
+                IpAddress: r.Ip.ToString(),
+                BoardId: "G2",
+                FirmwareVersion: $"0x{r.Presence.FirmwareVersion:X8}",
+                Busy: false,
+                Details: BuildP3Details(r.Presence));
 
             static IReadOnlyDictionary<string, string> BuildP1Details(DiscoveredRadio r)
             {
@@ -1236,6 +1255,22 @@ public static class ZeusEndpoints
                     d["protocol3FirmwareVersion"] = p3.FirmwareVersion.ToString();
                     d["protocol3GatewareVersion"] = p3.GatewareVersion.ToString();
                 }
+                return d;
+            }
+
+            static IReadOnlyDictionary<string, string> BuildP3Details(Protocol3PresenceResult p3)
+            {
+                var d = new Dictionary<string, string>
+                {
+                    ["protocol"] = "P3",
+                    ["protocol3Available"] = "true",
+                    ["protocol3Port"] = p3.Port.ToString(),
+                    ["protocol3MaxRxStreams"] = p3.MaxRxStreams.ToString(),
+                    ["protocol3MaxTxStreams"] = p3.MaxTxStreams.ToString(),
+                    ["protocol3CapabilityFlags"] = $"0x{p3.CapabilityFlags:X8}",
+                    ["protocol3FirmwareVersion"] = p3.FirmwareVersion.ToString(),
+                    ["protocol3GatewareVersion"] = p3.GatewareVersion.ToString(),
+                };
                 return d;
             }
 

--- a/tests/Zeus.Server.Tests/Protocol3PresenceProbeTests.cs
+++ b/tests/Zeus.Server.Tests/Protocol3PresenceProbeTests.cs
@@ -50,6 +50,35 @@ public sealed class Protocol3PresenceProbeTests
         Assert.Null(result);
     }
 
+    [Fact]
+    public async Task DiscoverAsync_ReturnsCapabilitiesWhenP3AppAnswers()
+    {
+        using var server = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        var port = ((IPEndPoint)server.Client.LocalEndPoint!).Port;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+
+        var responder = Task.Run(async () =>
+        {
+            var request = await server.ReceiveAsync(cts.Token);
+            Assert.True(IsDiscoveryRequest(request.Buffer));
+            await server.SendAsync(BuildCapabilitiesPacket(), request.RemoteEndPoint, cts.Token);
+        }, cts.Token);
+
+        var probe = new Protocol3PresenceProbe(NullLogger<Protocol3PresenceProbe>.Instance);
+        var radios = await probe.DiscoverAsync(
+            new[] { IPAddress.Loopback },
+            port,
+            TimeSpan.FromSeconds(1),
+            cts.Token);
+
+        await responder;
+        var radio = Assert.Single(radios);
+        Assert.Equal(IPAddress.Loopback, radio.Ip);
+        Assert.Equal(port, radio.Presence.Port);
+        Assert.Equal(10u, radio.Presence.MaxRxStreams);
+        Assert.Equal(1u, radio.Presence.MaxTxStreams);
+    }
+
     private static bool IsDiscoveryRequest(byte[] packet) =>
         packet.Length == 32 &&
         BinaryPrimitives.ReadUInt32BigEndian(packet.AsSpan(0, 4)) == 0x4E395033u &&

--- a/zeus-web/src/components/ConnectPanel.tsx
+++ b/zeus-web/src/components/ConnectPanel.tsx
@@ -455,7 +455,7 @@ const MANUAL_BOARD_OPTIONS: ReadonlyArray<BoardKind> = [
 
 const PROTOCOL3_UNAVAILABLE_TITLE = 'Protocol 3 requires p3app running on the selected radio.';
 const PROTOCOL3_PREVIEW_TITLE =
-  'Protocol 3 p3app was detected, but the Zeus P3 connect path is not wired yet.';
+  'Protocol 3 p3app detected on this G2.';
 
 function hasProtocol3App(r: RadioInfoDto): boolean {
   return r.details?.protocol3Available === 'true';
@@ -475,9 +475,13 @@ function discoveredP3AvailableForIp(radios: RadioInfoDto[] | null, ip: string): 
 
 function endpointFor(r: RadioInfoDto): string {
   if (!r.ipAddress) return '';
+  const protocol = r.details?.protocol ?? 'P1';
+  const port = protocol === 'P3'
+    ? (r.details?.protocol3Port ?? `${DEFAULT_DATA_PORT}`)
+    : `${DEFAULT_DATA_PORT}`;
   return r.ipAddress.includes(':')
     ? r.ipAddress
-    : `${r.ipAddress}:${DEFAULT_DATA_PORT}`;
+    : `${r.ipAddress}:${port}`;
 }
 
 function errorMessage(err: unknown): string {
@@ -1208,7 +1212,9 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
                   const isLast = !!ep && ep === lastConnectedEndpoint;
                   const protocol = r.details?.protocol ?? 'P1';
                   const isP2 = protocol === 'P2';
-                  const p3Available = hasProtocol3App(r);
+                  const isP3 = protocol === 'P3';
+                  const showP3Preview = hasProtocol3App(r);
+                  const showP3Chip = showP3Preview && !isP3;
                   return (
                     <li
                       key={r.macAddress || r.ipAddress}
@@ -1236,13 +1242,13 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
                           >
                             <span className="v">{protocol}</span>
                           </span>
-                          {p3Available && (
+                          {showP3Chip && (
                             <span
                               className="chip"
-                              style={{ marginLeft: 6, opacity: 0.75 }}
+                              style={{ marginLeft: 6, opacity: 0.58 }}
                               title={PROTOCOL3_PREVIEW_TITLE}
                             >
-                              <span className="v">P3 APP</span>
+                              <span className="v">P3</span>
                             </span>
                           )}
                           {isLast && (
@@ -1255,7 +1261,16 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
                           {ep || '—'} · {r.macAddress || '—'}
                         </span>
                       </div>
-                      {r.busy ? (
+                      {isP3 ? (
+                        <button
+                          type="button"
+                          disabled
+                          title={PROTOCOL3_PREVIEW_TITLE}
+                          className="btn sm ghost"
+                        >
+                          P3
+                        </button>
+                      ) : r.busy ? (
                         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                           <span
                             className="label-xs"
@@ -1273,7 +1288,7 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
                           >
                             Take over
                           </button>
-                          {p3Available && (
+                          {showP3Preview && (
                             <button
                               type="button"
                               disabled
@@ -1286,7 +1301,7 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
                         </div>
                       ) : (
                         <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-                          {p3Available && (
+                          {showP3Preview && (
                             <button
                               type="button"
                               disabled
@@ -1300,10 +1315,10 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
                             type="button"
                             onClick={() => handleConnect(r)}
                             disabled={inflight}
-                            title={isP2 ? 'Protocol 2 path - experimental, RX only' : undefined}
+                            title={isP2 ? 'Protocol 2 path — experimental, RX only' : undefined}
                             className="btn sm active"
                           >
-                            {inflight ? 'Connecting...' : 'Connect'}
+                            {inflight ? 'Connecting…' : 'Connect'}
                           </button>
                         </div>
                       )}


### PR DESCRIPTION
## Summary
- add a lightweight Protocol 3 presence/discovery probe for G2/G2E radios with p3app
- discover P3-only p3app radios on local IPv4 subnet broadcasts and add disabled P3 rows when P2 is not running
- enrich P2-discovered G2 rows with `protocol3Available` and P3 capability metadata when p3app answers on UDP 1030
- show a simple `P3` affordance only on rows where p3app is present

## Tests
- `npm --prefix zeus-web run typecheck`
- `dotnet test tests/Zeus.Server.Tests/Zeus.Server.Tests.csproj --filter Protocol3PresenceProbeTests --logger "console;verbosity=minimal" --nologo /p:SpaBuildOutput=<existing temp index.html>`
- `dotnet build Zeus.Server.Hosting/Zeus.Server.Hosting.csproj --nologo`

## Note
- The P3 control remains disabled in this PR; the change is discovery/visibility only.
