### PR TITLE
fix(freedv): remove stop-talk artifacts + widen RADE speech resampler

### DIFF
--- a/Zeus.Dsp.FreeDv/FreeDvGates.cs
+++ b/Zeus.Dsp.FreeDv/FreeDvGates.cs
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Two small, allocation-free, lock-free dynamics blocks that kill the "random
+// artifacts when a user stops talking" on FreeDV — one per direction. Both are
+// owned exclusively by a modem hot path (RX tick / mic ingest) and are reset
+// only while that path is gated out during reconfigure, so they need no
+// synchronisation. Pure span math, no allocation — matching the realtime
+// discipline of the rest of the Zeus audio bus (FreeDvResampler, FreeDvModem).
+//
+//   RxSquelchGate — gates DECODED speech by the modem's sync flag with a smooth
+//   attack/release ramp and a short hold. When the far station unkeys, the
+//   decoder keeps turning band-noise into speech-shaped output (codec2's SNR
+//   squelch is per-frame and twitchy; RADE has NO squelch at all), so without a
+//   sync gate you hear an R2D2/warble tail. The hold rides brief mid-over sync
+//   flickers so good copy is never chopped; the ramp removes the click a hard
+//   mute would make. Reports "fully closed" so the modem can flush its output
+//   FIFO and start the next over clean (no stale-noise backlog plays on resync).
+//
+//   MicNoiseGate — gates the MIC by an envelope follower with hysteresis + hang
+//   BEFORE the vocoder. When the operator pauses mid-over, background hiss fed
+//   into freedv_tx / rade_tx encodes into vocoder garble at the far end. Gating
+//   the mic to digital silence during pauses makes the encoder emit clean
+//   silence frames instead (still valid modem frames, so far-end sync holds).
+//   Opens fast so word onsets are never clipped; the hang holds it open through
+//   inter-word gaps so speech isn't chopped.
+//
+// All time constants are bench-tunable; the defaults are deliberately
+// conservative (long hold/hang, gentle thresholds) so the gates only ever act
+// on genuine silence/noise, never on speech. See docs/lessons/freedv-fidelity.md.
+
+namespace Zeus.Dsp.FreeDv;
+
+/// <summary>
+/// Sync-driven output squelch for decoded FreeDV/RADE speech. Applies a smooth
+/// per-sample attack/release gain ramp toward open (synced) / closed (unsynced),
+/// with a hold window that rides brief sync dropouts so marginal copy isn't
+/// chopped. Single-threaded by contract (the RX hot path owns it).
+/// </summary>
+internal sealed class RxSquelchGate
+{
+    private readonly int _holdSamples;     // ride-through window after sync is lost
+    private readonly float _attackCoef;    // per-sample slew when opening
+    private readonly float _releaseCoef;   // per-sample slew when closing
+    private readonly float _closedEps;     // gain below this counts as fully closed
+
+    private float _gain;                   // current applied gain, 0..1
+    private long _samplesSinceSync;        // 48 kHz samples since the last synced block
+    private bool _open;
+
+    /// <summary>Default RX squelch gate at the given output rate (48 kHz).</summary>
+    internal static RxSquelchGate Default(int sampleRateHz) =>
+        new(sampleRateHz, holdMs: 250.0, attackMs: 5.0, releaseMs: 60.0);
+
+    internal RxSquelchGate(int sampleRateHz, double holdMs, double attackMs, double releaseMs)
+    {
+        _holdSamples = MsToSamples(sampleRateHz, holdMs);
+        _attackCoef = OnePoleCoef(sampleRateHz, attackMs);
+        _releaseCoef = OnePoleCoef(sampleRateHz, releaseMs);
+        _closedEps = 1e-3f;
+        Reset();
+    }
+
+    /// <summary>Current gain (0 closed .. 1 open). Telemetry/tests.</summary>
+    internal float Gain => _gain;
+
+    /// <summary>True while the gate is letting audio through (synced or within hold).</summary>
+    internal bool IsOpen => _open;
+
+    /// <summary>
+    /// Apply the gate to a block of decoded 48 kHz speech in place, given the
+    /// modem's live sync flag. Returns true when the gate is FULLY closed (gain
+    /// has reached zero and the hold has expired) so the caller may flush its
+    /// decoded-output FIFO — preventing a stale-noise backlog from playing when
+    /// sync next returns.
+    /// </summary>
+    internal bool Process(Span<float> block, bool synced)
+    {
+        if (synced) _samplesSinceSync = 0;
+        bool open = synced || _samplesSinceSync < _holdSamples;
+        if (!synced) _samplesSinceSync += block.Length;
+        _open = open;
+
+        float target = open ? 1f : 0f;
+        float g = _gain;
+        for (int i = 0; i < block.Length; i++)
+        {
+            float coef = target > g ? _attackCoef : _releaseCoef;
+            g += (target - g) * coef;
+            block[i] *= g;
+        }
+        _gain = g;
+
+        return !open && g < _closedEps;
+    }
+
+    /// <summary>Reset to a closed gate (next over fades in cleanly).</summary>
+    internal void Reset()
+    {
+        _gain = 0f;
+        _samplesSinceSync = long.MaxValue / 2;
+        _open = false;
+    }
+
+    private static int MsToSamples(int fs, double ms) => (int)Math.Max(1, Math.Round(fs * ms / 1000.0));
+
+    // One-pole smoothing coefficient for a target "reach" time constant in ms.
+    private static float OnePoleCoef(int fs, double ms)
+    {
+        double tau = Math.Max(1e-4, ms / 1000.0) * fs; // time constant in samples
+        return (float)(1.0 - Math.Exp(-1.0 / tau));
+    }
+}
+
+/// <summary>
+/// Pre-vocoder mic noise gate that ADAPTS to the mic level. The raw mic at this
+/// tap is pre-mic-gain, so its absolute level (and noise floor) varies wildly by
+/// interface — a fixed dBFS threshold would clip a quiet mic's speech or fail to
+/// gate a hot mic's hiss. Instead it tracks the noise floor with an asymmetric
+/// follower (falls toward quiet quickly, rises toward loud very slowly, so speech
+/// bursts don't drag the floor up) and gates relative to it: open at floor +
+/// openMargin dB, close at floor + closeMargin dB. Opens fast (word onsets never
+/// clipped) and holds open through inter-word gaps via the hang. Single-threaded
+/// by contract (the mic-ingest hot path owns it).
+/// </summary>
+internal sealed class MicNoiseGate
+{
+    private readonly float _openMargin;     // linear ratio above the noise floor to open
+    private readonly float _closeMargin;    // linear ratio above the noise floor to close
+    private readonly float _envAttackCoef;  // envelope follower rise
+    private readonly float _envReleaseCoef; // envelope follower fall
+    private readonly float _floorDownCoef;  // noise-floor tracks DOWN toward quiet (fast)
+    private readonly float _floorUpCoef;    // noise-floor tracks UP toward loud (very slow)
+    private readonly float _gateAttackCoef; // gain slew opening
+    private readonly float _gateReleaseCoef;// gain slew closing
+    private readonly int _hangSamples;      // hold-open after level drops below close
+    private readonly float _minFloor;       // absolute floor so digital silence can't collapse thresholds
+
+    private float _env;                     // smoothed |x| envelope
+    private float _floor;                   // tracked noise floor
+    private float _gain;                    // applied gate gain, 0..1
+    private int _hang;                      // samples remaining of hold-open
+    private bool _openState;
+
+    /// <summary>Default adaptive mic gate at the given mic rate (48 kHz).</summary>
+    internal static MicNoiseGate Default(int sampleRateHz) =>
+        new(sampleRateHz, openMarginDb: 14.0, closeMarginDb: 8.0,
+            envAttackMs: 2.0, envReleaseMs: 40.0,
+            floorDownMs: 50.0, floorUpMs: 3000.0, hangMs: 250.0,
+            gateAttackMs: 3.0, gateReleaseMs: 80.0, minFloorDb: -75.0);
+
+    internal MicNoiseGate(
+        int sampleRateHz, double openMarginDb, double closeMarginDb,
+        double envAttackMs, double envReleaseMs,
+        double floorDownMs, double floorUpMs, double hangMs,
+        double gateAttackMs, double gateReleaseMs, double minFloorDb)
+    {
+        _openMargin = DbToLinear(openMarginDb);
+        _closeMargin = DbToLinear(closeMarginDb);
+        _envAttackCoef = OnePoleCoef(sampleRateHz, envAttackMs);
+        _envReleaseCoef = OnePoleCoef(sampleRateHz, envReleaseMs);
+        _floorDownCoef = OnePoleCoef(sampleRateHz, floorDownMs);
+        _floorUpCoef = OnePoleCoef(sampleRateHz, floorUpMs);
+        _gateAttackCoef = OnePoleCoef(sampleRateHz, gateAttackMs);
+        _gateReleaseCoef = OnePoleCoef(sampleRateHz, gateReleaseMs);
+        _hangSamples = MsToSamples(sampleRateHz, hangMs);
+        _minFloor = DbToLinear(minFloorDb);
+        Reset();
+    }
+
+    /// <summary>Current gate gain (0 closed .. 1 open). Telemetry/tests.</summary>
+    internal float Gain => _gain;
+
+    /// <summary>True while the gate is passing the mic (speech detected or within hang).</summary>
+    internal bool IsOpen => _openState;
+
+    /// <summary>
+    /// Gate a block of 48 kHz mic audio in place. The noise floor is tracked
+    /// adaptively; speech (envelope well above the floor) opens the gate fast,
+    /// and a pause that decays back to the floor closes it after the hang.
+    /// Returns the end-of-block gain.
+    /// </summary>
+    internal float Process(Span<float> block)
+    {
+        float env = _env, floor = _floor, gain = _gain;
+        int hang = _hang;
+        bool open = _openState;
+        for (int i = 0; i < block.Length; i++)
+        {
+            float a = block[i];
+            if (a < 0f) a = -a;
+            float envCoef = a > env ? _envAttackCoef : _envReleaseCoef;
+            env += (a - env) * envCoef;
+
+            // Asymmetric noise-floor tracker: chase the envelope down quickly,
+            // creep up slowly — so transient speech never pulls the floor up.
+            float floorCoef = env < floor ? _floorDownCoef : _floorUpCoef;
+            floor += (env - floor) * floorCoef;
+            if (floor < _minFloor) floor = _minFloor;
+
+            float openThresh = floor * _openMargin;
+            float closeThresh = floor * _closeMargin;
+            if (env >= openThresh) { open = true; hang = _hangSamples; }
+            else if (env < closeThresh)
+            {
+                if (hang > 0) hang--;
+                else open = false;
+            }
+            // Between the two thresholds: hold the current state (hysteresis).
+
+            float target = open ? 1f : 0f;
+            float gCoef = target > gain ? _gateAttackCoef : _gateReleaseCoef;
+            gain += (target - gain) * gCoef;
+            block[i] *= gain;
+        }
+        _env = env;
+        _floor = floor;
+        _gain = gain;
+        _hang = hang;
+        _openState = open;
+        return gain;
+    }
+
+    /// <summary>Reset to an OPEN gate so the first syllable of an over is never clipped.</summary>
+    internal void Reset()
+    {
+        _env = 0f;
+        _floor = _minFloor;
+        _gain = 1f;
+        _hang = _hangSamples;
+        _openState = true;
+    }
+
+    private static int MsToSamples(int fs, double ms) => (int)Math.Max(1, Math.Round(fs * ms / 1000.0));
+
+    private static float DbToLinear(double db) => (float)Math.Pow(10.0, db / 20.0);
+
+    private static float OnePoleCoef(int fs, double ms)
+    {
+        double tau = Math.Max(1e-4, ms / 1000.0) * fs;
+        return (float)(1.0 - Math.Exp(-1.0 / tau));
+    }
+}

--- a/Zeus.Dsp.FreeDv/FreeDvModem.cs
+++ b/Zeus.Dsp.FreeDv/FreeDvModem.cs
@@ -65,6 +65,10 @@ public sealed class FreeDvModem : IDisposable
     private short[] _rxSpeechShort = new short[256];
     private float[] _rxSpeechFloat = new float[256];
     private float[] _rxInterp = new float[256];
+    // Sync-driven output squelch: mutes decoded speech (with a hold + smooth
+    // ramp) when the modem loses sync, so the far station unkeying doesn't leave
+    // an R2D2/warble tail. Owned by the RX hot path; reset in RetireRx.
+    private readonly RxSquelchGate _rxGate = RxSquelchGate.Default(FreeDvResampler.FsHigh);
 
     // TX chain
     private readonly FreeDvResampler.Decimator _txDown = FreeDvResampler.NewDecimator();
@@ -77,6 +81,10 @@ public sealed class FreeDvModem : IDisposable
     private short[] _txModemShort = new short[256];
     private float[] _txModemFloat = new float[256];
     private float[] _txInterp = new float[256];
+    // Pre-vocoder mic noise gate: drives the mic to digital silence during
+    // pauses so freedv_tx emits clean silence frames instead of vocoded
+    // background hiss. Owned by the TX hot path; reset in RetireTx / FlushTx.
+    private readonly MicNoiseGate _micGate = MicNoiseGate.Default(FreeDvResampler.FsHigh);
     private int _txNSpeech;                            // cached at open
     private int _txNNomModem;
 
@@ -327,6 +335,7 @@ public sealed class FreeDvModem : IDisposable
             SpinUntilIdle(ref _txBusy);
             _tx8In.Clear(); _txOut48.Clear();
             _txDown.Reset(); _txUp.Reset();
+            _micGate.Reset();
             Volatile.Write(ref _txFreedv, fd);
         }
     }
@@ -455,6 +464,13 @@ public sealed class FreeDvModem : IDisposable
 
             int filled = _rxOut48.Read(block48k);
             if (filled < block48k.Length) block48k.Slice(filled).Clear();
+
+            // Sync-gate the decoded speech: smooth fade-out on loss of sync kills
+            // the end-of-over warble tail (codec2's per-frame SNR squelch alone is
+            // twitchy). When fully closed, flush the decoded FIFO so a stale-noise
+            // backlog can't play at the head of the next over.
+            if (_rxGate.Process(block48k, _synced))
+                _rxOut48.Clear();
         }
         finally
         {
@@ -476,6 +492,10 @@ public sealed class FreeDvModem : IDisposable
 
             int nspeech = _txNSpeech, nmodem = _txNNomModem;
             if (nspeech <= 0 || nmodem <= 0) { block48k.Clear(); return; }
+
+            // Gate the mic to silence during pauses so freedv_tx encodes clean
+            // silence frames instead of vocoding background hiss into garble.
+            _micGate.Process(block48k);
 
             int n8 = _txDown.Process(block48k, _txDecScratch);
             _tx8In.Write(_txDecScratch.AsSpan(0, n8));
@@ -622,6 +642,7 @@ public sealed class FreeDvModem : IDisposable
         if (old != IntPtr.Zero) FreeDvNativeMethods.freedv_close(old);
         _rx8In.Clear(); _rxOut48.Clear();
         _rxDown.Reset(); _rxUp.Reset();
+        _rxGate.Reset();
         _rxTextRing.Clear(); // drop stale decoded chars across a resync/close
         Volatile.Write(ref _rxFreedv, replacement);
     }
@@ -635,6 +656,7 @@ public sealed class FreeDvModem : IDisposable
         if (old != IntPtr.Zero) FreeDvNativeMethods.freedv_close(old);
         _tx8In.Clear(); _txOut48.Clear();
         _txDown.Reset(); _txUp.Reset();
+        _micGate.Reset();
         Volatile.Write(ref _txFreedv, replacement);
     }
 

--- a/Zeus.Dsp.FreeDv/RadeModem.cs
+++ b/Zeus.Dsp.FreeDv/RadeModem.cs
@@ -67,6 +67,11 @@ public sealed class RadeModem : IDisposable
     private short[] _rxPcm = new short[256];           // int16 PCM @16k from the decoder
     private float[] _rxSpeechFloat = new float[256];   // PCM as float
     private float[] _rxInterp = new float[256];        // 48k after wideband interpolation
+    // Sync-driven output squelch. RADE has NO codec2-style SNR squelch, so this
+    // is the ONLY thing that mutes the FARGAN decoder's noise-driven output when
+    // the far station unkeys — without it you hear an R2D2 tail every un-key.
+    // Owned by the RX hot path; reset in RetireRx.
+    private readonly RxSquelchGate _rxGate = RxSquelchGate.Default(RadeResampler.FsHigh);
     private int _ninMax;                               // cached at open
     private readonly byte[] _eooScratch = new byte[CallsignMax + 1]; // hot-path EOO fetch buffer
 
@@ -82,6 +87,9 @@ public sealed class RadeModem : IDisposable
     private float[] _txIqOut = new float[2 * 1024];     // interleaved complex modem IQ from the encoder
     private float[] _txModemReal = new float[1024];     // the real lane (transmitted SSB audio @8k)
     private float[] _txInterp = new float[2048];        // 48k after interpolation
+    // Pre-vocoder mic noise gate: drives the mic to silence during pauses so
+    // rade_tx emits clean silence frames, not vocoded hiss. Reset in RetireTx/FlushTx.
+    private readonly MicNoiseGate _micGate = MicNoiseGate.Default(RadeResampler.FsHigh);
     private int _txNSpeech;                             // cached at open: int16 @16k per tx call
     private int _txNTxOut;                              // cached at open: modem samples per tx call
     private int _txNEooOut;                             // cached at open: modem samples in the EOO frame
@@ -277,6 +285,12 @@ public sealed class RadeModem : IDisposable
             // (decoded speech replaces the demod audio, exactly like FreeDvModem).
             int filled = _rxOut48.Read(block48k);
             if (filled < block48k.Length) block48k.Slice(filled).Clear();
+
+            // Sync-gate the decoded speech (RADE's only squelch): smooth fade-out
+            // on loss of sync kills the end-of-over tail; flush the FIFO when fully
+            // closed so no stale-noise backlog plays at the head of the next over.
+            if (_rxGate.Process(block48k, _synced))
+                _rxOut48.Clear();
         }
         finally
         {
@@ -301,6 +315,10 @@ public sealed class RadeModem : IDisposable
 
             int nspeech = _txNSpeech, ntx = _txNTxOut;
             if (nspeech <= 0 || ntx <= 0) { block48k.Clear(); return; }
+
+            // Gate the mic to silence during pauses so rade_tx encodes clean
+            // silence frames instead of vocoding background hiss into garble.
+            _micGate.Process(block48k);
 
             // 1. decimate mic 48k -> 16k speech into the speech ring.
             int n16 = _txDown.Process(block48k, _txDecScratch);
@@ -367,6 +385,7 @@ public sealed class RadeModem : IDisposable
             SpinUntilIdle(ref _txBusy);
             _tx16In.Clear(); _txOut48.Clear();
             _txDown.Reset(); _txUp.Reset();
+            _micGate.Reset();
             Volatile.Write(ref _txRade, tx);
         }
     }
@@ -528,6 +547,7 @@ public sealed class RadeModem : IDisposable
         if (old != IntPtr.Zero) RadeNativeMethods.zeus_rade_close(old);
         _rx8In.Clear(); _rxOut48.Clear();
         _rxDown.Reset(); _rxUp.Reset();
+        _rxGate.Reset();
         Volatile.Write(ref _rade, replacement);
     }
 
@@ -540,6 +560,7 @@ public sealed class RadeModem : IDisposable
         if (old != IntPtr.Zero) RadeNativeMethods.zeus_rade_close(old);
         _tx16In.Clear(); _txOut48.Clear();
         _txDown.Reset(); _txUp.Reset();
+        _micGate.Reset();
         Volatile.Write(ref _txRade, replacement);
     }
 

--- a/Zeus.Dsp.FreeDv/RadeResampler.cs
+++ b/Zeus.Dsp.FreeDv/RadeResampler.cs
@@ -30,7 +30,14 @@ internal static class RadeResampler
     internal const int Factor = 3;            // 48000 / 16000
     internal const int FsHigh = 48000;
     internal const int FsLow = 16000;
-    private const int TapsPerPhase = 20;      // -> 60-tap prototype (divisible by 3)
+    // 32 taps/phase -> 96-tap prototype (divisible by 3). The 60-tap version had a
+    // ~2.6 kHz Hamming transition band: it was only flat to ~5.5 kHz (rolling off
+    // FARGAN's brilliance band → dull/"nasal" decoded speech on RX) AND its skirt
+    // spilled past the 8 kHz Nyquist, aliasing on the 48→16 kHz mic decimation.
+    // 96 taps tightens the transition to ~1.6 kHz: passband flat to ~6.5 kHz with
+    // the stopband reached below 8 kHz, so more presence survives and the mic
+    // anti-alias is clean. Cost is ~36 extra MACs per output sample — trivial.
+    private const int TapsPerPhase = 32;      // -> 96-tap prototype (divisible by 3)
     private const double CutoffHz = 7200.0;   // wideband: below 8 kHz output Nyquist, keep FARGAN HF
 
     // Prototype low-pass, normalized so DC gain == 1.

--- a/docs/lessons/freedv-fidelity.md
+++ b/docs/lessons/freedv-fidelity.md
@@ -69,6 +69,77 @@ Validation steps:
    appear on strong signals, add headroom to the Fixed RX AGC seed (red-light:
    that's a level an operator feels — change with bench data, not blind).
 
+## Stop-talk artifacts — sync squelch (RX) + mic noise gate (TX)
+
+A second operator pass targeted "random artifacts when a user stops talking,"
+reported on **both** directions and primarily on **RADE V1**. Two new
+allocation-free, lock-free dynamics blocks in `Zeus.Dsp.FreeDv/FreeDvGates.cs`,
+wired into both `FreeDvModem` and `RadeModem`:
+
+- **`RxSquelchGate` (RX).** When the far station unkeys, the decoder keeps
+  turning band-noise into speech-shaped output. codec2's per-frame SNR squelch is
+  twitchy, and **RADE has no squelch at all** (`RadeModem.SetSquelch` is inert),
+  so you hear an R2D2/warble tail every un-key. The gate mutes decoded speech via
+  a smooth attack/release ramp driven by the modem sync flag, with a **hold**
+  window that rides brief mid-over sync dropouts so good copy is never chopped.
+  When it goes fully closed it flushes the decode FIFO (`_rxOut48.Clear()`) so a
+  stale-noise backlog can't play at the head of the next over. Applied at the end
+  of `ProcessRxInPlace` in both modems.
+- **`MicNoiseGate` (TX).** When the operator pauses mid-over, mic background hiss
+  fed into `freedv_tx` / `rade_tx` vocodes into garble at the far end. The gate
+  drives the mic to digital silence during pauses (the encoder then emits clean
+  silence frames — still valid modem frames, so far-end sync holds). It is
+  **adaptive**: the raw mic at this tap is pre-mic-gain, so its level varies
+  wildly by interface; a fixed dBFS threshold would clip a quiet mic or miss a hot
+  mic's hiss. Instead it tracks the noise floor (fast-down / slow-up follower so
+  speech bursts don't drag the floor up) and gates relative to it (`openMargin` /
+  `closeMargin` dB above floor) with hysteresis + hang. Resets to **open** each
+  over so the first syllable is never clipped. Applied at the start of
+  `ProcessTxInPlace` in both modems (before the mic decimation/encode).
+
+Both gates reset whenever the modem quiesces (`RetireRx`/`RetireTx`/`FlushTx`),
+so each over starts clean. Unit-tested in `FreeDvGatesTests.cs` (pure math, no
+native lib); the native loopback/perf/zero-alloc tests still pass with the gates
+inline.
+
+### "Pinched / nasal" RADE speech — widen the RADE speech resampler
+
+RADE decodes **wideband 16 kHz** speech (FARGAN synthesizes energy up to ~8 kHz)
+and that path uses `RadeResampler` (16↔48 kHz, ×3), which is SEPARATE from the
+codec2 `FreeDvResampler` widened earlier. Its prototype was a 60-tap Hamming
+sinc at 7.2 kHz cutoff — a ~2.6 kHz transition band that was only flat to
+~5.5 kHz (rolling off FARGAN's presence/brilliance → dull, "nasal" decode) and
+whose skirt spilled past the 8 kHz Nyquist, **aliasing on the 48→16 kHz mic
+decimation** (so what we TRANSMIT was coloured too). Bumped to a 96-tap prototype
+(32 taps/phase, cutoff unchanged at 7.2 kHz): transition ~1.6 kHz, flat to
+~6.5 kHz, stopband below Nyquist. More presence survives on RX and the mic
+anti-alias is clean on TX.
+
+**This is the only code-level lever for RADE decoded-speech timbre.** Remaining
+"nasal/underwater" quality on RADE is usually **low SNR** (the autoencoder
+degrades characteristically near threshold) or, on TX, the operator's mic itself
+— FreeDV deliberately bypasses the TX voice EQ/compressor (the vocoder wants flat
+speech), so a thin mic sounds thin. Those are not Zeus DSP bugs; confirm SNR via
+`/api/freedv/status` and compare against another FreeDV client on the same
+signal before changing DSP.
+
+### Bench-tuning the gates on the G2 (open knobs)
+
+Both are always-on with conservative defaults in `MicNoiseGate.Default` /
+`RxSquelchGate.Default`. If they ever over- or under-act, tune the `Default(...)`
+arguments:
+
+- **RX warble still audible after un-key** → shorten `holdMs` (250) or `releaseMs`
+  (60). **RX chops the start/end of weak-but-good copy** → lengthen `holdMs`.
+- **TX still passes background hiss during pauses** → lower `openMarginDb` (14) /
+  `closeMarginDb` (8). **TX swallows soft speech / first words** → raise the
+  margins or lengthen `hangMs` (250). If a very quiet shack lets the floor track
+  too low, raise `minFloorDb` (−75).
+
+Validate: key RADE/700D into a dummy load with a second station decoding; confirm
+no R2D2 tail when you unkey, and no garble when you pause mid-over. Confirm soft
+speech and word onsets are not clipped.
+
 ## Not yet changed (deliberately)
 
 - **Fixed RX AGC headroom** — instrumented, not auto-adjusted. Needs the clipping

--- a/tests/Zeus.Dsp.FreeDv.Tests/FreeDvGatesTests.cs
+++ b/tests/Zeus.Dsp.FreeDv.Tests/FreeDvGatesTests.cs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using Zeus.Dsp.FreeDv;
+
+namespace Zeus.Dsp.FreeDv.Tests;
+
+// Pure-math dynamics blocks — no native library needed. These verify the
+// "artifacts when a user stops talking" fixes: the RX sync squelch and the
+// pre-vocoder mic noise gate.
+public class FreeDvGatesTests
+{
+    private const int Fs = 48000;
+
+    private static float[] Const(int n, float v)
+    {
+        var b = new float[n];
+        for (int i = 0; i < n; i++) b[i] = v;
+        return b;
+    }
+
+    private static float PeakAbs(ReadOnlySpan<float> b)
+    {
+        float p = 0f;
+        foreach (var x in b) { float a = x < 0 ? -x : x; if (a > p) p = a; }
+        return p;
+    }
+
+    // ---------------- RxSquelchGate ----------------
+
+    [Fact]
+    public void RxGate_StartsClosed_FadesInWhenSynced()
+    {
+        var gate = new RxSquelchGate(Fs, holdMs: 10, attackMs: 1, releaseMs: 5);
+        // First synced block fades up from the closed (reset) state.
+        var first = Const(480, 1f);
+        gate.Process(first, synced: true);
+        Assert.True(gate.Gain > 0f && gate.Gain < 1f, $"expected partial open, got {gate.Gain}");
+
+        // After enough synced audio the gate is fully open and transparent.
+        for (int i = 0; i < 20; i++) gate.Process(Const(480, 1f), synced: true);
+        Assert.True(gate.Gain > 0.99f);
+        var blk = Const(480, 0.5f);
+        gate.Process(blk, synced: true);
+        Assert.True(PeakAbs(blk) > 0.49f); // passed through essentially unchanged
+    }
+
+    [Fact]
+    public void RxGate_MutesAfterSyncLoss_AndReportsFullyClosed()
+    {
+        var gate = new RxSquelchGate(Fs, holdMs: 10, attackMs: 1, releaseMs: 5);
+        for (int i = 0; i < 40; i++) gate.Process(Const(480, 1f), synced: true);
+        Assert.True(gate.Gain > 0.99f);
+
+        // Lose sync: within the hold the gate stays open (good copy isn't chopped).
+        gate.Process(Const(480, 1f), synced: false); // 10ms of samples = 480; hold=10ms=480
+        Assert.True(gate.IsOpen, "gate should ride the hold window before closing");
+
+        // Past the hold the gate closes; eventually reports fully closed and mutes.
+        bool fullyClosed = false;
+        for (int i = 0; i < 200 && !fullyClosed; i++)
+            fullyClosed = gate.Process(Const(480, 1f), synced: false);
+        Assert.True(fullyClosed, "gate never reported fully closed after sustained sync loss");
+
+        var blk = Const(480, 1f);
+        gate.Process(blk, synced: false);
+        Assert.True(PeakAbs(blk) < 1e-3f, $"muted block should be ~silent, peak={PeakAbs(blk)}");
+    }
+
+    [Fact]
+    public void RxGate_Reset_ReturnsToClosed()
+    {
+        var gate = new RxSquelchGate(Fs, holdMs: 10, attackMs: 1, releaseMs: 5);
+        for (int i = 0; i < 40; i++) gate.Process(Const(480, 1f), synced: true);
+        gate.Reset();
+        Assert.Equal(0f, gate.Gain);
+        Assert.False(gate.IsOpen);
+    }
+
+    // ---------------- MicNoiseGate ----------------
+
+    private static MicNoiseGate NewMicGate() => new(
+        Fs, openMarginDb: 14, closeMarginDb: 8, envAttackMs: 2, envReleaseMs: 40,
+        floorDownMs: 20, floorUpMs: 2000, hangMs: 30, gateAttackMs: 3, gateReleaseMs: 20,
+        minFloorDb: -90);
+
+    [Fact]
+    public void MicGate_PassesSpeechAboveNoiseFloor()
+    {
+        var gate = NewMicGate();
+        // Establish a low noise floor first (gate adapts + closes on it).
+        for (int i = 0; i < 80; i++) gate.Process(Const(480, 0.002f));
+        // Then speech well above the floor opens the gate and passes.
+        float gain = 0f;
+        for (int i = 0; i < 30; i++) { var b = Const(480, 0.2f); gain = gate.Process(b); }
+        Assert.True(gain > 0.99f, $"speech well above the floor should be fully open, gain={gain}");
+        Assert.True(gate.IsOpen);
+    }
+
+    [Fact]
+    public void MicGate_SilencesBackgroundNoiseAfterHang()
+    {
+        var gate = NewMicGate();
+        // Sustained low-level noise: the floor converges to it, so the envelope
+        // sits below the (relative) close threshold and the gate shuts.
+        const float noise = 0.002f;
+        float gain = 1f;
+        for (int i = 0; i < 200; i++) gain = gate.Process(Const(480, noise));
+        Assert.True(gain < 0.05f, $"steady background noise should be gated to silence, gain={gain}");
+
+        var blk = Const(480, noise);
+        gate.Process(blk);
+        Assert.True(PeakAbs(blk) < noise, "gated block should be attenuated below the input noise level");
+    }
+
+    [Fact]
+    public void MicGate_StartsOpen_FirstSyllableNotClipped()
+    {
+        var gate = NewMicGate();
+        // The very first block of an over should pass at (near) unity — the reset
+        // state is open, so a word onset at t=0 isn't swallowed.
+        var blk = Const(480, 0.3f);
+        gate.Process(blk);
+        Assert.True(PeakAbs(blk) > 0.29f, $"first block should pass through, peak={PeakAbs(blk)}");
+    }
+}


### PR DESCRIPTION
## Why

Operator reports of **random artifacts when a user stops talking** and **pinched/nasal** FreeDV audio — on **both RX and TX**, primarily on **RADE V1**.

## What

Three targeted, allocation-free/lock-free changes in `Zeus.Dsp.FreeDv`, wired into both `FreeDvModem` (codec2) and `RadeModem` (RADE):

### RX — sync-driven output squelch (`RxSquelchGate`)
When the far station unkeys, the decoder keeps turning band-noise into speech-shaped output. codec2's per-frame SNR squelch is twitchy, and **RADE has no squelch at all** (`RadeModem.SetSquelch` was inert) — so an R2D2/warble tail played on every un-key. The gate mutes decoded speech via a smooth attack/release ramp keyed on the modem sync flag, with:
- a **hold** window that rides brief mid-over sync dropouts so good copy is never chopped, and
- a **FIFO flush** when fully closed so no stale-noise backlog plays at the head of the next over.

### TX — adaptive mic noise gate (`MicNoiseGate`)
When the operator pauses, mic background hiss was fed into `freedv_tx`/`rade_tx` and vocoded into garble at the far end. The gate drives the mic to digital silence during pauses (the encoder then emits clean silence frames — still valid modem frames, so far-end sync holds). It's **adaptive** (the tap is pre-mic-gain and varies wildly by interface, so a fixed dBFS threshold is wrong): it tracks the noise floor and gates relative to it, opens fast so word onsets aren't clipped, and starts open each over.

Both gates reset on `RetireRx`/`RetireTx`/`FlushTx` so every over starts clean.

### Pinched/nasal — widen the RADE speech resampler
RADE decodes **wideband 16 kHz** speech (FARGAN up to ~8 kHz), and that path uses `RadeResampler` — separate from the codec2 `FreeDvResampler` widened earlier (PR #1008). It was a 60-tap Hamming with a ~2.6 kHz transition: flat only to ~5.5 kHz (dull/"nasal" HF) and its skirt spilled past the 8 kHz Nyquist, **aliasing on the 48→16 kHz mic decimation**. Bumped to a 96-tap prototype: flat to ~6.5 kHz, stopband below Nyquist. Cost ~36 extra MACs/sample.

## Tests
- New `FreeDvGatesTests` (pure math, no native lib): RX gate fade-in/hold/mute/flush; adaptive mic gate pass-speech/silence-noise/start-open.
- `dotnet test Zeus.Dsp.FreeDv.Tests` → **62 passed, 0 failed** (incl. native codec2/zeus_rade loopback + perf/zero-alloc, run with the gates inline).

## Notes / bench-tuning
The gates are always-on with conservative defaults; `RxSquelchGate.Default` / `MicNoiseGate.Default` / `RadeResampler` taps are the knobs (documented in `docs/lessons/freedv-fidelity.md`). Residual "nasal/underwater" RADE audio beyond this is typically **low SNR** (autoencoder degrades near threshold) or, on TX, the operator's mic (FreeDV deliberately bypasses TX EQ/compressor for the vocoder) — not a Zeus DSP bug. Bench validation on the G2 is recommended.