### PR TITLE
fix(vst): anti-denormal conditioning on the TX VST-engine feed (zeus-umt6)

### DIFF
--- a/Zeus.Server.Hosting/AudioPluginBridge.cs
+++ b/Zeus.Server.Hosting/AudioPluginBridge.cs
@@ -611,8 +611,23 @@ public sealed class AudioPluginBridge : IHostedService, IAsyncDisposable
                 RecordEngineMeters(input, output[..sampleCount]);
             return true;
         }
+        // Anti-denormal input conditioning (zeus-umt6): floor exact-silence and
+        // any denormal-range input to a sub-audible ±AntiDenormalMag alternating
+        // excitation before it reaches the out-of-process engine. Without it the
+        // engine's plugin IIR / gate states can decay into the float32 denormal
+        // range over a long over and rot to silence/NaN (which the sanitize pass
+        // below turns into dead air). The engine stays responsive, so neither the
+        // crash nor the hang watchdog fires and the operator transmits silence
+        // until a manual profile change forces a fresh load_chain. The floor is
+        // ~-300 dBFS and alternates sign (energy at Nyquist), so it is inaudible
+        // and rejected by the SSB TX bandpass — the on-air signal is unchanged,
+        // and real-level samples are returned bit-identical. Preventive; it
+        // complements the reactive liveness auto-recovery below. sampleCount is a
+        // fixed engine block size (<= 1024), so the stackalloc is bounded.
+        Span<float> conditioned = stackalloc float[sampleCount];
+        ApplyAntiDenormalFloor(input[..sampleCount], conditioned);
         bool processed;
-        try { processed = vst.TryProcess(input, output, ctx); }
+        try { processed = vst.TryProcess(conditioned, output, ctx); }
         finally { Volatile.Write(ref _engineGate, 0); }
         // Sample master IN/OUT peaks so the Audio Suite meters stay live in VST
         // mode (the native chain's own metering path didn't run). Tap the OUT
@@ -749,6 +764,29 @@ public sealed class AudioPluginBridge : IHostedService, IAsyncDisposable
             }
         }
         catch { /* diagnostics must never throw on the timer thread */ }
+    }
+
+    // Sub-audible anti-denormal floor (~-300 dBFS, well above the float32
+    // smallest-normal of ~1.2e-38 and ~200 dB below full scale). See zeus-umt6
+    // and ApplyAntiDenormalFloor.
+    private const float AntiDenormalMag = 1e-15f;
+
+    /// <summary>
+    /// Copy <paramref name="src"/> into <paramref name="dst"/>, adding a tiny
+    /// alternating ±<see cref="AntiDenormalMag"/> excitation so the downstream
+    /// out-of-process engine never sees an exact-zero or denormal-range input
+    /// block. This keeps its plugin IIR / gate state from decaying into the
+    /// float32 denormal range over a long over — the zeus-umt6 dead-output wedge.
+    /// Audible-level samples are returned bit-identical (the floor is far below
+    /// float32 epsilon relative to any real signal); the alternating sign puts
+    /// the injected energy at Nyquist, which the SSB TX bandpass rejects, so the
+    /// on-air signal is unchanged. Realtime-safe: no allocation, no branches on
+    /// data. Caller guarantees <c>dst.Length &gt;= src.Length</c>.
+    /// </summary>
+    internal static void ApplyAntiDenormalFloor(ReadOnlySpan<float> src, Span<float> dst)
+    {
+        for (int i = 0; i < src.Length; i++)
+            dst[i] = src[i] + ((i & 1) == 0 ? AntiDenormalMag : -AntiDenormalMag);
     }
 
     /// <summary>Instantaneous block abs-peak — mirrors AudioChain.BlockPeak so the

--- a/tests/Zeus.Server.Tests/AudioPluginBridgeAntiDenormalTests.cs
+++ b/tests/Zeus.Server.Tests/AudioPluginBridgeAntiDenormalTests.cs
@@ -1,0 +1,86 @@
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+/// <summary>
+/// Unit coverage for <see cref="AudioPluginBridge.ApplyAntiDenormalFloor"/>, the
+/// anti-denormal input conditioning that feeds the out-of-process VST engine
+/// (zeus-umt6). The contract is: audible-level samples pass through bit-identical,
+/// exact-zero / denormal-range inputs are lifted out of the float32 denormal
+/// range, the perturbation is sub-audible, and the result is always finite.
+/// </summary>
+public class AudioPluginBridgeAntiDenormalTests
+{
+    // ~-300 dBFS — far below the -96 dBFS 16-bit wire floor, so it can never be
+    // heard, yet ~23 orders of magnitude above the float32 smallest-normal.
+    private const float MaxPerturbation = 1e-15f;
+    private const float SmallestNormal = 1.17549435e-38f; // float.Epsilon is the smallest *denormal*, not this.
+
+    [Fact]
+    public void Silence_Is_Lifted_Out_Of_Denormal_Range_And_Alternates_Sign()
+    {
+        var src = new float[8]; // all exact zero
+        var dst = new float[8];
+
+        AudioPluginBridge.ApplyAntiDenormalFloor(src, dst);
+
+        for (int i = 0; i < dst.Length; i++)
+        {
+            Assert.True(float.IsFinite(dst[i]));
+            // Out of the denormal range (|x| >= smallest normal) so downstream
+            // IIR/gate state can't rot to a denormal.
+            Assert.True(MathF.Abs(dst[i]) >= SmallestNormal, $"index {i} still denormal: {dst[i]}");
+            // Alternating sign: even +, odd -.
+            Assert.Equal(i % 2 == 0 ? MaxPerturbation : -MaxPerturbation, dst[i]);
+        }
+    }
+
+    [Fact]
+    public void AudibleLevel_Samples_Are_BitIdentical()
+    {
+        // Any real-level sample: the 1e-15 floor is below float32 epsilon
+        // relative to these magnitudes, so the add rounds away to a no-op.
+        var src = new[] { 0.5f, -0.3f, 1.0f, -1.0f, 0.001f, -0.001f, 0.123456f, -0.999f };
+        var dst = new float[src.Length];
+
+        AudioPluginBridge.ApplyAntiDenormalFloor(src, dst);
+
+        for (int i = 0; i < src.Length; i++)
+            Assert.Equal(src[i], dst[i]); // exact float equality
+    }
+
+    [Fact]
+    public void Denormal_Inputs_Are_Floored_To_Normal_Range()
+    {
+        // float.Epsilon is the smallest positive denormal; a handful of
+        // denormal-range values that an un-conditioned engine could latch on.
+        var src = new[] { float.Epsilon, -float.Epsilon, 1e-40f, -1e-42f, 1e-30f, -1e-30f, 0f, 0f };
+        var dst = new float[src.Length];
+
+        AudioPluginBridge.ApplyAntiDenormalFloor(src, dst);
+
+        foreach (var v in dst)
+        {
+            Assert.True(float.IsFinite(v));
+            Assert.True(MathF.Abs(v) >= SmallestNormal, $"value still denormal: {v}");
+        }
+    }
+
+    [Fact]
+    public void Perturbation_Is_SubAudible_For_Arbitrary_Signal()
+    {
+        var src = new float[256];
+        for (int i = 0; i < src.Length; i++)
+            src[i] = MathF.Sin(i * 0.17f) * 0.8f;
+        var dst = new float[src.Length];
+
+        AudioPluginBridge.ApplyAntiDenormalFloor(src, dst);
+
+        for (int i = 0; i < src.Length; i++)
+        {
+            Assert.True(float.IsFinite(dst[i]));
+            Assert.True(MathF.Abs(dst[i] - src[i]) <= MaxPerturbation,
+                $"index {i} moved more than the anti-denormal floor");
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Intermittently, after a sustained over in **VST processing mode**, TX audio goes
silent (drive byte set, IQ peak zero → ~0 W on air) and stays silent until the
operator switches the TX audio profile, which fires `load_chain` and restores it.

This is the open part of **zeus-umt6**. The out-of-process VST engine enters an
*alive-but-dead-output* state: it keeps answering every block promptly
(`outSeq==inSeq`), so `DegradedBlocks` never climbs and neither the crash nor the
hang watchdog fires — but it returns silence/NaN, which the sanitize pass turns
into dead air. The documented likely source is the engine's plugin IIR / gate
state decaying into the **float32 denormal range** over a long over.

## What this does

Adds preventive **anti-denormal input conditioning** at the single engine-feed
funnel (`AudioPluginBridge.TryProcessThroughEngine`): each block handed to the
engine is floored to a sub-audible alternating ±`1e-15` (~-300 dBFS) excitation,
so the plugins never see an exact-zero or denormal-range input and their filter
state can't rot into denormals.

This **complements** (does not replace) the existing reactive liveness
auto-recovery (Tier-1 `load_chain` reload / Tier-2 recycle) — it attacks the
likely cause at the source so the wedge is prevented rather than recovered from
after ~6 s of dead air.

## Why it's safe

- **On-air signal unchanged.** Real-level samples are returned bit-identical —
  the floor is far below float32 epsilon relative to any audible signal, so the
  add rounds away. Only exact-zero / denormal inputs are lifted.
- **Inaudible & rejected by the bandpass.** The floor is ~200 dB below full
  scale (the 16-bit wire floor is -96 dBFS), and the alternating sign puts its
  energy at Nyquist, which the SSB TX bandpass rejects.
- **No PureSignal interaction**, no protocol/wire change, pure managed code
  (cross-platform safe).
- Realtime-safe: bounded `stackalloc` (engine block size ≤ 1024), no heap alloc,
  no managed lock, no branches on data.

## Scope / limitations

- Targets the **denormal** failure class. The zeus-umt6 root cause is documented
  as "denormals **or** a latched gate" and is still unconfirmed on hardware; a
  pure gate-latch variant would not be covered by this and still relies on the
  auto-recovery + the new liveness logs to identify the offending plugin.
- **Bench confirmation still needed** — pairs with the zeus-umt6 "REMAINING:
  real-hardware confirmation of the wedging plugin via the new logs" item.

## Testing

- New unit test `AudioPluginBridgeAntiDenormalTests` (4 cases): silence is lifted
  out of the denormal range with alternating sign; audible-level samples are
  bit-identical; denormal inputs are floored to the normal range; the
  perturbation is sub-audible (≤ `1e-15`) for an arbitrary signal. All pass.
- `Zeus.Server.Hosting` + `Zeus.Server.Tests` build clean. Full cross-platform
  suite runs in CI.

Target: develop
Beads: zeus-umt6

🤖 Generated with [Claude Code](https://claude.com/claude-code)