### PR TITLE
test(freedv): objective RADE fidelity harness (resampler response + e2e gate/clip)

### DIFF
--- a/docs/lessons/freedv-fidelity.md
+++ b/docs/lessons/freedv-fidelity.md
@@ -140,6 +140,36 @@ Validate: key RADE/700D into a dummy load with a second station decoding; confir
 no R2D2 tail when you unkey, and no garble when you pause mid-over. Confirm soft
 speech and word onsets are not clipped.
 
+## Objective fidelity testing (RADE methodology)
+
+RADE's upstream (drowe67/radae, "Testing RADE") insists results be **reproducible
+via CLI/objective metrics, not GUI/on-air listening** — calibrated stored-file
+channel sims scored by feature distortion (`loss.py`) and Whisper ASR WER, with
+documented SNR thresholds (V1 ≈ −2 dB AWGN, ~0 dB MPP). We adopt that discipline
+at the managed boundary so "nasal/artifacts" become measurable, not subjective:
+
+- **`RadeResamplerFidelityTests`** (deterministic, no native lib): single-bin DFT
+  magnitude response of the RADE 16↔48 kHz resampler. Asserts the passband is flat
+  through the **6 kHz presence band** (guards the 96-tap widening), images are
+  rejected (anti-imaging on RX), and out-of-band mic content doesn't alias
+  (anti-aliasing on the TX decimation). A hard regression guard on the filter.
+- **`RadeFidelityTests`** (native, skippable): end-to-end through the real
+  zeus_rade + FARGAN decoder. (1) decoded output carries energy and **does not
+  clip** — the objective answer to the "is the ×32768 shim scaling clipping?"
+  question (it is not, in practice; matches lpcnet_demo). (2) **the stop-talk gate
+  validated through the real decoder**: after a synced decode, pure band-noise
+  drives the decoded output to silence instead of an R2D2 tail.
+
+Gotcha encountered: `rade_sync()` is a debounced acquisition STATE, not a per-
+frame flag (RADE re-primes FARGAN on each loss — `zeus_rade.c`), and it
+deliberately drops sync on an **out-of-distribution** signal. A synthetic
+harmonic excitation triggers that mid-stream, and the gate (correctly) mutes
+there — so score "voice present" only over blocks where sync is actually held,
+never a fixed time window. For fully deterministic clean-channel scoring,
+`rade_api.h` exposes `rade_set_disable_unsync(seconds)` (radae's own test hook) —
+not yet surfaced through the shim; wire it through if a no-unsync fidelity sweep
+is wanted.
+
 ## Not yet changed (deliberately)
 
 - **Fixed RX AGC headroom** — instrumented, not auto-adjusted. Needs the clipping

--- a/tests/Zeus.Dsp.FreeDv.Tests/RadeFidelityTests.cs
+++ b/tests/Zeus.Dsp.FreeDv.Tests/RadeFidelityTests.cs
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using Zeus.Dsp.FreeDv;
+
+namespace Zeus.Dsp.FreeDv.Tests;
+
+/// <summary>
+/// Objective, native end-to-end RADE fidelity tests — the "next level" beyond the
+/// sync-only loopback in <see cref="RadeModemTests"/>. Inspired by RADE's own
+/// validation discipline (drowe67/radae "Testing RADE"): measure decoded-audio
+/// quality and behaviour with calibrated, reproducible signals rather than
+/// listening on air. Each runs the REAL native modem (zeus_rade + FARGAN) through
+/// the full Zeus hot path, so they also guard the artifact-gate + resampler
+/// changes against regressions in the actual decoder.
+///
+/// SkippableFact: requires the zeus_rade native library for this RID.
+/// </summary>
+public class RadeFidelityTests
+{
+    private const int Fs = 48000;
+    private const int Block = 1920; // 40 ms @ 48 kHz
+
+    /// <summary>
+    /// Clean loopback: the decoded speech must carry real energy AND must not clip.
+    /// FARGAN's float output is scaled by 32768 in the shim (matching upstream
+    /// lpcnet_demo); this asserts that scaling leaves headroom in practice — the
+    /// objective check behind the "is the decoder output clipping?" question from
+    /// the radae playback-scaling note. A high clip rate here would manifest on air
+    /// as harsh/"pinched" audio.
+    /// </summary>
+    [SkippableFact]
+    public void Loopback_DecodedOutput_HasEnergy_AndDoesNotClip()
+    {
+        using var modem = new RadeModem();
+        Skip.IfNot(modem.RadeAvailable, "zeus_rade native library not present for this RID.");
+        modem.SetTxText("N9WAR");
+        modem.Activate();
+
+        var modemAudio = Encode(modem, seconds: 7);
+
+        double sumSq = 0; long count = 0, clips = 0; double peak = 0;
+        bool synced = false;
+        var seg = new float[Block];
+        for (int off = 0; off + Block <= modemAudio.Length; off += Block)
+        {
+            Array.Copy(modemAudio, off, seg, 0, Block);
+            modem.ProcessRxInPlace(seg);
+            if (modem.Synced) synced = true;
+            if (!synced) continue; // only score the decoded (post-acquisition) region
+            foreach (var s in seg)
+            {
+                float a = MathF.Abs(s);
+                sumSq += (double)s * s; count++;
+                if (a > peak) peak = a;
+                if (a >= 0.999f) clips++;
+            }
+        }
+
+        Assert.True(synced, "RADE never synced — cannot score decoded fidelity.");
+        Assert.True(count > 0, "no decoded samples scored.");
+        double rms = Math.Sqrt(sumSq / count);
+        double clipRate = clips / (double)count;
+        Assert.True(rms > 1e-3, $"decoded speech essentially silent (rms={rms:E2}) — decode/level path broken.");
+        Assert.True(clipRate < 0.005,
+            $"decoded speech clips {clipRate:P2} of samples (peak={peak:F3}) — output scaling has no headroom.");
+    }
+
+    /// <summary>
+    /// THE headline artifact fix, validated through the real decoder: once a signal
+    /// has been decoded (gate open, audible), feeding pure band-noise (the far
+    /// station having unkeyed) must drive the decoded output to silence — the sync
+    /// squelch closes and flushes, instead of the FARGAN decoder warbling on noise
+    /// ("R2D2 tail"). Also a false-sync guard: noise must not be turned into audio.
+    /// </summary>
+    [SkippableFact]
+    public void SyncGate_SilencesDecodedOutput_AfterSignalStops()
+    {
+        using var modem = new RadeModem();
+        Skip.IfNot(modem.RadeAvailable, "zeus_rade native library not present for this RID.");
+        modem.SetTxText("N9WAR");
+        modem.Activate();
+
+        var modemAudio = Encode(modem, seconds: 7);
+
+        // Phase A: decode the real signal; measure the "voice present" decoded RMS
+        // over blocks where sync is actually HELD (and so the gate is open). RADE's
+        // acquisition state machine deliberately drops sync on a poor/out-of-
+        // distribution signal — on a synthetic excitation that happens mid-stream,
+        // and the gate correctly mutes there — so a fixed time window would wrongly
+        // average in those (correctly) muted stretches. Scoring only synced blocks
+        // gives the true open-gate voice level to compare the noise tail against.
+        bool everSynced = false;
+        double syncedSumSq = 0; long syncedCount = 0; int syncedBlocks = 0;
+        var seg = new float[Block];
+        int total = modemAudio.Length;
+        for (int off = 0; off + Block <= total; off += Block)
+        {
+            Array.Copy(modemAudio, off, seg, 0, Block);
+            modem.ProcessRxInPlace(seg);
+            if (!modem.Synced) continue;
+            everSynced = true;
+            syncedBlocks++;
+            foreach (var s in seg) { syncedSumSq += (double)s * s; syncedCount++; }
+        }
+        Assert.True(everSynced && syncedCount > 0, "RADE never synced — cannot validate the stop-talk gate.");
+        double syncedRms = Math.Sqrt(syncedSumSq / syncedCount);
+        Assert.True(syncedRms > 1e-3,
+            $"no audible decoded voice while synced (rms={syncedRms:E2} over {syncedBlocks} synced blocks).");
+
+        // Phase B: the far station stops — feed pure noise for ~3 s. The gate must
+        // ride its hold, lose sync, then mute + flush. Score only the last ~0.7 s.
+        var rng = new Random(20260629);
+        int noiseBlocks = (3 * Fs) / Block;
+        int scoreFrom = noiseBlocks - (int)(0.7 * Fs / Block);
+        double tailSumSq = 0; long tailCount = 0; double tailPeak = 0;
+        for (int b = 0; b < noiseBlocks; b++)
+        {
+            for (int i = 0; i < Block; i++) seg[i] = (float)((rng.NextDouble() * 2 - 1) * 0.2);
+            modem.ProcessRxInPlace(seg);
+            if (b >= scoreFrom)
+                foreach (var s in seg)
+                {
+                    tailSumSq += (double)s * s; tailCount++;
+                    float a = MathF.Abs(s); if (a > tailPeak) tailPeak = a;
+                }
+        }
+        double tailRms = Math.Sqrt(tailSumSq / tailCount);
+
+        Assert.True(tailRms < 0.1 * syncedRms,
+            $"decoded output not muted after the signal stopped: tailRms={tailRms:E2} vs voiceRms={syncedRms:E2} " +
+            $"(ratio={tailRms / syncedRms:P1}, peak={tailPeak:F3}) — the sync squelch is not killing the noise tail.");
+    }
+
+    // Encode `seconds` of wideband voiced-speech-like audio through the TX hot path,
+    // returning the 48 kHz modem waveform.
+    private static float[] Encode(RadeModem modem, int seconds)
+    {
+        int blocks = (seconds * Fs) / Block;
+        var modemAudio = new List<float>(blocks * Block);
+        double phase = 0;
+        var buf = new float[Block];
+        for (int b = 0; b < blocks; b++)
+        {
+            MakeSpeech(buf, ref phase);
+            modem.ProcessTxInPlace(buf);
+            modemAudio.AddRange(buf);
+        }
+        return modemAudio.ToArray();
+    }
+
+    // Voiced-ish speech at 48 kHz with content out to a few kHz: a low pitch with
+    // harmonics + slow tremolo, plus a light fricative-band noise so the LPCNet
+    // analyser sees broadband structure. Content is irrelevant to modem sync.
+    private static void MakeSpeech(float[] b, ref double phase)
+    {
+        const double f0 = 130.0, fs = 48000.0;
+        var rng = _speechNoise;
+        for (int i = 0; i < b.Length; i++)
+        {
+            double t = (phase += 1.0 / fs);
+            double trem = 0.6 + 0.4 * Math.Sin(2 * Math.PI * 3.0 * t);
+            double s = 0;
+            for (int h = 1; h <= 10; h++) s += (1.0 / h) * Math.Sin(2 * Math.PI * f0 * h * t);
+            s += 0.05 * (rng.NextDouble() * 2 - 1); // light broadband fricative energy
+            b[i] = (float)(trem * s * 0.16);
+        }
+    }
+
+    private static readonly Random _speechNoise = new(424242);
+}

--- a/tests/Zeus.Dsp.FreeDv.Tests/RadeResamplerFidelityTests.cs
+++ b/tests/Zeus.Dsp.FreeDv.Tests/RadeResamplerFidelityTests.cs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using Zeus.Dsp.FreeDv;
+
+namespace Zeus.Dsp.FreeDv.Tests;
+
+/// <summary>
+/// Objective magnitude-response tests for the RADE speech resampler (16↔48 kHz).
+/// RADE decodes WIDEBAND 16 kHz speech, so this resampler — not the codec2 one —
+/// sets the brightness/presence of decoded audio (RX, interpolator) and the
+/// fidelity of the mic feed into the LPCNet analyzer (TX, decimator). These are
+/// deterministic, native-free DSP measurements (a Goertzel-style single-bin DFT),
+/// so they run everywhere and act as a hard regression guard on the prototype
+/// filter: they fail if the passband narrows, the presence band rolls off, or the
+/// stopband stops rejecting images/aliases.
+///
+/// Inspired by RADE's own validation discipline (drowe67/radae "Testing RADE"):
+/// objective, reproducible metrics rather than subjective on-air listening.
+/// </summary>
+public class RadeResamplerFidelityTests
+{
+    // Single-frequency DFT magnitude (peak amplitude of a unit sine reads ~1.0).
+    private static double BinAmplitude(ReadOnlySpan<float> x, double freqHz, double fsHz)
+    {
+        double w = 2.0 * Math.PI * freqHz / fsHz;
+        double re = 0, im = 0;
+        for (int n = 0; n < x.Length; n++)
+        {
+            re += x[n] * Math.Cos(w * n);
+            im += x[n] * Math.Sin(w * n);
+        }
+        return 2.0 * Math.Sqrt(re * re + im * im) / x.Length;
+    }
+
+    private static float[] Sine(int n, double freqHz, double fsHz)
+    {
+        var b = new float[n];
+        for (int i = 0; i < n; i++) b[i] = (float)Math.Sin(2.0 * Math.PI * freqHz * i / fsHz);
+        return b;
+    }
+
+    // ---- Interpolator: 16 kHz -> 48 kHz (the RX decoded-speech up-sampler) ----
+
+    [Theory]
+    [InlineData(300, 0.93, 1.06)]   // low end — flat
+    [InlineData(1000, 0.93, 1.06)]  // core voice — flat
+    [InlineData(3000, 0.90, 1.06)]  // upper voice — flat
+    [InlineData(6000, 0.70, 1.06)]  // PRESENCE band — must survive (the 96-tap win)
+    public void Interpolator_Passband_IsFlatThroughPresenceBand(double freqHz, double lo, double hi)
+    {
+        var interp = RadeResampler.NewInterpolator();
+        var input = Sine(16000, freqHz, 16000);      // 1 s @ 16 kHz
+        var output = new float[input.Length * 3];     // 48 kHz
+        int n = interp.Process(input, output);
+
+        double mag = BinAmplitude(output.AsSpan(0, n), freqHz, 48000);
+        Assert.True(mag >= lo && mag <= hi,
+            $"interp |H({freqHz} Hz)| = {mag:F3}, expected [{lo},{hi}] — presence/passband regressed");
+    }
+
+    [Fact]
+    public void Interpolator_RejectsImages_NoAliasingArtifacts()
+    {
+        // A 5 kHz tone at 16 kHz produces an image at 16000-5000 = 11000 after
+        // up-sampling; the prototype low-pass must crush it (else the listener
+        // hears spurious HF "edge"). Wanted tone passes; image is gone.
+        var interp = RadeResampler.NewInterpolator();
+        var input = Sine(16000, 5000, 16000);
+        var output = new float[input.Length * 3];
+        int n = interp.Process(input, output);
+        var span = output.AsSpan(0, n);
+
+        double wanted = BinAmplitude(span, 5000, 48000);
+        double image = BinAmplitude(span, 11000, 48000);
+        Assert.True(wanted > 0.85, $"wanted 5 kHz tone attenuated: {wanted:F3}");
+        Assert.True(image < 0.05, $"image at 11 kHz not rejected: {image:F3} (>{0.05}) — stopband too weak");
+    }
+
+    // ---- Decimator: 48 kHz -> 16 kHz (the TX mic anti-alias into LPCNet) ----
+
+    [Theory]
+    [InlineData(300)]
+    [InlineData(1000)]
+    [InlineData(3000)]
+    public void Decimator_Passband_PassesVoice(double freqHz)
+    {
+        var dec = RadeResampler.NewDecimator();
+        var input = Sine(48000, freqHz, 48000);          // 1 s @ 48 kHz
+        var output = new float[input.Length / 3 + 8];
+        int n = dec.Process(input, output);
+
+        double mag = BinAmplitude(output.AsSpan(0, n), freqHz, 16000);
+        Assert.True(mag > 0.90, $"dec |H({freqHz} Hz)| = {mag:F3} — mic passband regressed");
+    }
+
+    [Fact]
+    public void Decimator_RejectsAliases_CleanMicFeed()
+    {
+        // A 9 kHz mic component is ABOVE the 8 kHz (16 kHz-rate) Nyquist; without
+        // a proper anti-alias filter it folds to 16000-9000 = 7000 Hz and colours
+        // the speech the vocoder analyses. The decimator must reject it pre-decimate.
+        var dec = RadeResampler.NewDecimator();
+        var input = Sine(48000, 9000, 48000);
+        var output = new float[input.Length / 3 + 8];
+        int n = dec.Process(input, output);
+
+        double alias = BinAmplitude(output.AsSpan(0, n), 7000, 16000);
+        Assert.True(alias < 0.05,
+            $"9 kHz mic tone aliased to 7 kHz at amplitude {alias:F3} (>{0.05}) — anti-alias too weak");
+
+        // Sanity: a legitimate 7 kHz tone is NOT what we just rejected — it passes
+        // (near the cutoff, so attenuated but clearly present), proving we rejected
+        // the alias specifically and didn't just gut the top of the band.
+        var legit = Sine(48000, 7000, 48000);
+        var lout = new float[legit.Length / 3 + 8];
+        int ln = RadeResampler.NewDecimator().Process(legit, lout);
+        double legitMag = BinAmplitude(lout.AsSpan(0, ln), 7000, 16000);
+        Assert.True(legitMag > 0.40, $"legit 7 kHz tone over-attenuated: {legitMag:F3}");
+    }
+}


### PR DESCRIPTION
Follow-up to #1195 (merged). Adds the objective test harness that #1195's quality changes were validated against — adopting RADE upstream's discipline (drowe67/radae "Testing RADE"): measure fidelity with reproducible metrics, not on-air listening.

## What

**`RadeResamplerFidelityTests`** (deterministic, no native lib) — single-bin DFT magnitude response of the RADE 16↔48 kHz speech resampler. Hard regression guard on the 96-tap widening from #1195:
- passband flat through the **6 kHz presence band** (the anti-"nasal" claim);
- **image rejection** on RX up-sampling (5 kHz tone → 11 kHz image crushed < −26 dB);
- **alias rejection** on the TX mic decimation (9 kHz → would fold to 7 kHz, rejected).

**`RadeFidelityTests`** (native, skippable) — end-to-end through the real `zeus_rade` + FARGAN decoder:
- decoded output carries energy and **does not clip** — the objective answer to "is the shim's ×32768 scaling clipping?" (it has headroom in practice, matching `lpcnet_demo`);
- **the stop-talk sync squelch validated through the real decoder**: after a synced decode, pure band-noise is muted to silence instead of an R2D2 tail.

## Notes
- `rade_sync()` is a debounced acquisition **state** (RADE re-primes FARGAN on each loss and deliberately drops sync on an out-of-distribution signal), so the gate test scores "voice present" only over held-sync blocks — documented in `docs/lessons/freedv-fidelity.md` along with `rade_api.h`'s `rade_set_disable_unsync()` hook for a future fully-deterministic clean-channel sweep.

## Tests
`dotnet test Zeus.Dsp.FreeDv.Tests` → **73 passed, 0 failed** (2 native-missing skips), incl. the 11 new fidelity tests run against the real codec2/zeus_rade libs.