### PR TITLE
fix(p2): RX-IQ/tick/speaker telemetry + paced radio-speaker egress (#1148)

### DIFF
--- a/Zeus.Protocol2/DiagStats.cs
+++ b/Zeus.Protocol2/DiagStats.cs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2026 Christian Suarez (N9WAR), and contributors.
+
+namespace Zeus.Protocol2;
+
+/// <summary>
+/// Allocation-light statistics helpers for the ~1 Hz diagnostic log lines added
+/// for issue #1148 (RX-IQ delivery jitter / inline-tick cadence / speaker-sink
+/// pacing). Shared across <c>Zeus.Protocol2</c> and <c>Zeus.Server.Hosting</c>
+/// (visible via <c>InternalsVisibleTo</c>) so the percentile math is written —
+/// and unit-tested — exactly once instead of being copy-pasted into every diag
+/// emit site.
+/// </summary>
+internal static class DiagStats
+{
+    /// <summary>
+    /// Nearest-rank percentile (<paramref name="q"/> in [0,1]) over the first
+    /// <paramref name="count"/> entries of <paramref name="values"/>. The
+    /// entries are copied into <paramref name="scratch"/> and sorted ascending
+    /// there, so the caller's ring buffer is left untouched. Returns 0 when
+    /// <paramref name="count"/> is zero.
+    /// </summary>
+    /// <param name="values">Sample buffer (only [0, count) is read).</param>
+    /// <param name="scratch">Scratch buffer; must be at least
+    /// <paramref name="count"/> long. Sorted in place.</param>
+    /// <param name="count">Number of valid samples in
+    /// <paramref name="values"/>.</param>
+    /// <param name="q">Quantile in [0,1], e.g. 0.99 for the 99th percentile.</param>
+    public static long Percentile(long[] values, long[] scratch, int count, double q)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        ArgumentNullException.ThrowIfNull(scratch);
+        if (count <= 0) return 0;
+        if (count > values.Length) count = values.Length;
+        if (count > scratch.Length) count = scratch.Length;
+
+        Array.Copy(values, scratch, count);
+        Array.Sort(scratch, 0, count);
+        return scratch[PercentileIndex(count, q)];
+    }
+
+    /// <summary>
+    /// Nearest-rank index into a length-<paramref name="count"/> ascending-sorted
+    /// array for quantile <paramref name="q"/>. Clamped to [0, count-1].
+    /// </summary>
+    public static int PercentileIndex(int count, double q)
+    {
+        if (count <= 0) return 0;
+        if (q < 0.0) q = 0.0;
+        if (q > 1.0) q = 1.0;
+        int idx = (int)Math.Ceiling(q * count) - 1;
+        if (idx < 0) idx = 0;
+        if (idx >= count) idx = count - 1;
+        return idx;
+    }
+}

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -2936,6 +2936,25 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         var portPkts = new long[MaxRxDdc];
         long lastPortRollMs = Environment.TickCount64;
 
+        // #1148 RX-IQ delivery telemetry. DDC0 datagram inter-arrival gap
+        // distribution + per-window sequence-gap count, emitted at ~1 Hz
+        // alongside the port-rate roll. The crux of the radio-speaker crackle
+        // investigation: an OFF-vs-ON capture shows whether inbound IQ arrives
+        // irregularly / under-rate (radio or physical clock coupling) versus
+        // with host socket loss (NIC / scheduling). All locals — RxLoop is a
+        // single dedicated thread. Allocation-light: one fixed gap ring + a
+        // reusable sort scratch, plus running min/max/sum; the only per-second
+        // work is a bounded Array.Sort in the emit branch.
+        const int GapRingSize = 512; // power of two for the cheap index wrap
+        var gapRingUs = new long[GapRingSize];
+        var gapSortScratch = new long[GapRingSize];
+        int gapRingPos = 0, gapRingFill = 0;
+        long gapCount = 0, gapSumUs = 0, gapMinUs = long.MaxValue, gapMaxUs = 0;
+        long lastDdc0ArrivalTicks = 0;
+        bool haveDdc0Arrival = false;
+        long lastDroppedSnapshot = Interlocked.Read(ref _droppedFrames);
+        double usPerTick = 1_000_000.0 / Stopwatch.Frequency;
+
         try
         {
             while (!ct.IsCancellationRequested)
@@ -2967,10 +2986,35 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
                 var srcPort = ((IPEndPoint)from).Port;
                 if (srcPort >= RxDataPortBase && srcPort < RxDataPortBase + MaxRxDdc)
                 {
-                    portPkts[srcPort - RxDataPortBase]++;
+                    int ddc = srcPort - RxDataPortBase;
+                    portPkts[ddc]++;
+
+                    // Measure inter-arrival on DDC0 only — the primary RX stream
+                    // that feeds the DSP tick (and the radio-speaker sink). Its
+                    // sequence-gap counter (_droppedFrames) is DDC0-specific too,
+                    // so the two correlate in one log line.
+                    if (ddc == 0)
+                    {
+                        long arr = Stopwatch.GetTimestamp();
+                        if (haveDdc0Arrival)
+                        {
+                            long gapUs = (long)((arr - lastDdc0ArrivalTicks) * usPerTick);
+                            gapCount++;
+                            gapSumUs += gapUs;
+                            if (gapUs < gapMinUs) gapMinUs = gapUs;
+                            if (gapUs > gapMaxUs) gapMaxUs = gapUs;
+                            gapRingUs[gapRingPos] = gapUs;
+                            gapRingPos = (gapRingPos + 1) & (GapRingSize - 1);
+                            if (gapRingFill < GapRingSize) gapRingFill++;
+                        }
+                        lastDdc0ArrivalTicks = arr;
+                        haveDdc0Arrival = true;
+                    }
+
                     long nowMs = Environment.TickCount64;
                     if (nowMs - lastPortRollMs >= 1000)
                     {
+                        long ddc0Pkts = portPkts[0];
                         lock (_rxPortRateLock)
                         {
                             Array.Copy(portPkts, _rxPortRateSnapshot, MaxRxDdc);
@@ -2978,6 +3022,30 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
                         }
                         Array.Clear(portPkts);
                         lastPortRollMs = nowMs;
+
+                        long droppedNow = Interlocked.Read(ref _droppedFrames);
+                        long seqGaps = droppedNow - lastDroppedSnapshot;
+                        lastDroppedSnapshot = droppedNow;
+
+                        long meanUs = gapCount > 0 ? gapSumUs / gapCount : 0;
+                        long minUs = gapCount > 0 ? gapMinUs : 0;
+                        long p99Us = DiagStats.Percentile(gapRingUs, gapSortScratch, gapRingFill, 0.99);
+
+                        // sockDrops=na: .NET's Socket exposes no portable
+                        // per-socket dropped-datagram counter, so OS recv-buffer
+                        // overflow is invisible from here. The discriminator the
+                        // reporter needs: seqGaps WITHOUT a matching host drop ⇒
+                        // the radio under-sent / streamed irregularly (radio or
+                        // physical clock coupling); seqGaps WITH host drops ⇒
+                        // NIC / scheduling. Reconcile seqGaps against the OS
+                        // (`ss -u` / `netstat -su` RcvbufErrors) when an
+                        // ON-vs-OFF radio-speaker capture diverges.
+                        _log.LogInformation(
+                            "p2.rxdiag ddc0pkts/s={Pps} seqGaps={SeqGaps} gapUs(min/mean/max/p99)={Min}/{Mean}/{Max}/{P99} sockDrops=na",
+                            ddc0Pkts, seqGaps, minUs, meanUs, gapMaxUs, p99Us);
+
+                        gapCount = 0; gapSumUs = 0; gapMinUs = long.MaxValue; gapMaxUs = 0;
+                        gapRingPos = 0; gapRingFill = 0;
                     }
                 }
                 if (srcPort >= RxDataPortBase && srcPort < RxDataPortBase + MaxRxDdc && n == BufLen)

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -1114,6 +1114,26 @@ public class DspPipelineService : BackgroundService,
     private long _lastTickStopwatchTicks;
     private static readonly long TickPeriodStopwatchTicks =
         (long)(Stopwatch.Frequency / 30.0);
+
+    // #1148 inline-tick cadence telemetry. The active RX packet thread drives
+    // Tick inline (one audio block per tick, nominally 30 Hz / 33.33 ms). If the
+    // radio-speaker UDP burst perturbs RX-IQ delivery, ticks slip from ~33 ms
+    // toward longer intervals and the host soundcard ring underruns (the #1148
+    // symptom). Emit mean / p99 / max interval + a count of intervals > 1.5×
+    // nominal (> 50 ms) at ~1 Hz. Single-threaded — only the active RX thread
+    // calls MaybeTickInline — so plain fields + a fixed ring suffice.
+    private long _tickDiagLastEmitTicks;
+    private long _tickDiagCount;
+    private long _tickDiagSumTicks;
+    private long _tickDiagMaxTicks;
+    private long _tickDiagSlowCount;
+    private readonly long[] _tickDiagRing = new long[256]; // power of two for the index wrap
+    private readonly long[] _tickDiagSortScratch = new long[256];
+    private int _tickDiagRingPos;
+    private int _tickDiagRingFill;
+    private static readonly long TickSlowThresholdTicks =
+        (long)(TickPeriodStopwatchTicks * 1.5);
+
     private readonly ConcurrentQueue<Action> _dspCommands = new();
 
     // DSP-thread-owned scratch buffers. Allocated once at construction so
@@ -5230,9 +5250,41 @@ public class DspPipelineService : BackgroundService,
         long last = _lastTickStopwatchTicks;
         if (last == 0 || (now - last) >= TickPeriodStopwatchTicks)
         {
+            if (last != 0) RecordTickInterval(now - last, now);
             _lastTickStopwatchTicks = now;
             Tick(_panBuf, _wfBuf, _audioBuf);
         }
+    }
+
+    // #1148: accumulate inline-tick interval stats and emit at ~1 Hz. Called
+    // only from MaybeTickInline (single active RX thread), so no synchronisation
+    // is needed and the buffers are plain instance fields.
+    private void RecordTickInterval(long intervalTicks, long now)
+    {
+        _tickDiagCount++;
+        _tickDiagSumTicks += intervalTicks;
+        if (intervalTicks > _tickDiagMaxTicks) _tickDiagMaxTicks = intervalTicks;
+        if (intervalTicks > TickSlowThresholdTicks) _tickDiagSlowCount++;
+        _tickDiagRing[_tickDiagRingPos] = intervalTicks;
+        _tickDiagRingPos = (_tickDiagRingPos + 1) & (_tickDiagRing.Length - 1);
+        if (_tickDiagRingFill < _tickDiagRing.Length) _tickDiagRingFill++;
+
+        if (_tickDiagLastEmitTicks == 0) { _tickDiagLastEmitTicks = now; return; }
+        if (now - _tickDiagLastEmitTicks < Stopwatch.Frequency) return;
+        _tickDiagLastEmitTicks = now;
+
+        double msPerTick = 1000.0 / Stopwatch.Frequency;
+        double mean = _tickDiagCount > 0 ? _tickDiagSumTicks * msPerTick / _tickDiagCount : 0;
+        double max = _tickDiagMaxTicks * msPerTick;
+        double p99 = Zeus.Protocol2.DiagStats.Percentile(
+            _tickDiagRing, _tickDiagSortScratch, _tickDiagRingFill, 0.99) * msPerTick;
+
+        _log.LogInformation(
+            "dsp.tickdiag mean={Mean:F1}ms p99={P99:F1}ms max={Max:F1}ms slow(>50ms)={Slow} n={N}",
+            mean, p99, max, _tickDiagSlowCount, _tickDiagCount);
+
+        _tickDiagCount = 0; _tickDiagSumTicks = 0; _tickDiagMaxTicks = 0;
+        _tickDiagSlowCount = 0; _tickDiagRingPos = 0; _tickDiagRingFill = 0;
     }
 
     /// <summary>

--- a/Zeus.Server.Hosting/SaturnSpeakerAudioSink.cs
+++ b/Zeus.Server.Hosting/SaturnSpeakerAudioSink.cs
@@ -13,6 +13,7 @@
 // instance is wired identically across the lineup (issue #1122).
 
 using System.Buffers.Binary;
+using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 using Zeus.Contracts;
@@ -55,11 +56,37 @@ internal sealed class SaturnSpeakerAudioSink : IRxAudioSink, IHostedService, IDi
     // stale audio queued for the radio's speaker jack.
     private const int RingCapacity = 8_192;
 
-    // Sender wake timeout — covers the (rare) case where a wake signal was
-    // missed across a flag toggle (settings/state change racing the wait). At
-    // 100 ms it's well below human-perceptible latency; the common path is
-    // wake-on-publish (~46 Hz) and never hits the timer.
-    private static readonly TimeSpan WorkerWakeTimeout = TimeSpan.FromMilliseconds(100);
+    // Sender wake timeout (ms) — covers the (rare) case where a wake signal was
+    // missed across a flag toggle (settings/state change racing the wait), and
+    // is the upper bound on the data-bound park (waiting for the next publish).
+    // At 100 ms it's well below human-perceptible latency; the common path is
+    // wake-on-publish (~30 Hz) and never hits this timer.
+    private const int WorkerWakeTimeoutMs = 100;
+
+    // #1148 candidate (bench-gated): pace the radio-speaker UDP egress at the
+    // codec's native 48 kHz cadence — one 64-sample packet per ~1333 µs ≈ 750
+    // pkt/s — instead of firing a whole DSP tick's worth of packets in one
+    // back-to-back burst (the one thing PR #1154 did NOT change). This mirrors
+    // deskHPSDR / Thetis, which pace audio to the radio at ~1333 µs spacing with
+    // 300-1000 µs adaptive waits (deskHPSDR new_protocol.c audio send loop). The
+    // ring is the jitter buffer; pacing only reshapes egress timing and never
+    // lowers AVERAGE throughput — catch-up (see DrainAndSend) keeps the long-run
+    // rate equal to the inbound rate. PENDING #1148 telemetry to confirm the
+    // burst is what perturbs inbound IQ; safe to ship because the worst case
+    // (coarse platform timer) degrades to small groups, never worse than the
+    // pre-existing single 16-burst.
+    private const int TargetPacketsPerSec = 750;
+    private static readonly long PacketIntervalTicks =
+        Math.Max(1, Stopwatch.Frequency / TargetPacketsPerSec);
+    // Bound how far the schedule may lag real time before we abandon the missed
+    // slots and realign to "now". This caps the catch-up burst after a scheduler
+    // stall so a stalled sender drains the ring at the paced rate rather than
+    // dumping it all at once — yet it is generous enough (≈48 packets ≈ 64 ms)
+    // that a coarse platform timer (Windows ~15 ms wake granularity) releases in
+    // small groups without ever throttling steady-state throughput.
+    private static readonly long MaxCatchupBehindTicks = PacketIntervalTicks * 48;
+    private static readonly double TicksPerMs = Math.Max(1.0, Stopwatch.Frequency / 1000.0);
+    private static readonly double UsPerTick = 1_000_000.0 / Stopwatch.Frequency;
 
     private readonly RadioService _radio;
     private readonly RadioSpeakerSettingsStore _settings;
@@ -83,6 +110,33 @@ internal sealed class SaturnSpeakerAudioSink : IRxAudioSink, IHostedService, IDi
     private bool _wasEligible;
     private ConnectionStatus _lastStatus = ConnectionStatus.Disconnected;
     private string? _lastEndpoint;
+
+    // #1148 pacing schedule (sender-thread-owned). _nextSendTicks is the
+    // monotonic Stopwatch deadline for the next packet (0 = realign to "now" on
+    // the next drain — set on fresh start, drain, disable, and socket loss).
+    // _pacingWaitTicks is how long the worker should park before the next due
+    // packet (0 = no pending deadline, park for data / the full wake timeout).
+    private long _nextSendTicks;
+    private long _pacingWaitTicks;
+
+    // Injectable clock + send observer for deterministic pacing tests — no
+    // sockets, no real time. Null/Stopwatch in production.
+    private Func<long> _clock = Stopwatch.GetTimestamp;
+    private Action<long>? _sentObserverForTest;
+
+    // #1148 sender-side telemetry (sender-thread-owned). Emitted at ~1 Hz so an
+    // OFF-vs-ON radio-speaker capture can be correlated with p2.rxdiag /
+    // dsp.tickdiag by timestamp: packets/sec, the MAX burst sent in a single
+    // DrainAndSend (proves pacing spreads egress), inter-send gap mean/max, and
+    // the running WouldBlock drop counters.
+    private long _diagLastEmitTicks;
+    private long _diagPacketsSent;
+    private int _diagBurstThisDrain;
+    private int _diagMaxBurst;
+    private long _diagSendGapSumUs;
+    private long _diagSendGapMaxUs;
+    private long _diagSendGapCount;
+    private long _diagLastSendTicks;
 
     // Cross-thread signals. Volatile reads/writes are sufficient — these are
     // single-bit flags, not data values; the worker re-snapshots radio/settings
@@ -202,7 +256,15 @@ internal sealed class SaturnSpeakerAudioSink : IRxAudioSink, IHostedService, IDi
         while (!ct.IsCancellationRequested)
         {
             _idle.Set();
-            try { _wake.Wait(WorkerWakeTimeout, ct); }
+            // Deadline-bound park when a paced packet is pending; otherwise wait
+            // for the next publish (or the safety timeout). Round the pacing wait
+            // UP to at least 1 ms so we never spin on a sub-millisecond timeout —
+            // on a coarse platform timer this simply releases packets in small
+            // groups, which is the documented graceful degradation.
+            int waitMs = _pacingWaitTicks > 0
+                ? Math.Clamp((int)Math.Ceiling(_pacingWaitTicks / TicksPerMs), 1, WorkerWakeTimeoutMs)
+                : WorkerWakeTimeoutMs;
+            try { _wake.Wait(waitMs, ct); }
             catch (OperationCanceledException) { break; }
             _wake.Reset();
             _idle.Reset();
@@ -220,6 +282,7 @@ internal sealed class SaturnSpeakerAudioSink : IRxAudioSink, IHostedService, IDi
                 _drainRequested = false;
                 _ring.Clear();
                 _packetFrames = 0;
+                _nextSendTicks = 0; // realign the pacing schedule on resume
             }
 
             if (_socket is null)
@@ -233,24 +296,64 @@ internal sealed class SaturnSpeakerAudioSink : IRxAudioSink, IHostedService, IDi
                     // a connection flap.
                     _ring.Clear();
                     _packetFrames = 0;
+                    _nextSendTicks = 0;
+                    _pacingWaitTicks = 0;
                     continue;
                 }
             }
 
             DrainAndSend(scratch);
+            if (_socket is not null) MaybeEmitDiag();
         }
 
         _idle.Set();
         CloseSocket();
     }
 
+    // Drain the ring into 64-sample packets and release them on a monotonic
+    // 750 pkt/s schedule (issue #1148). The ring itself is the jitter buffer;
+    // this loop never busy-spins — when the next packet is not yet due it parks
+    // the worker (via _pacingWaitTicks) until the deadline or the next publish.
+    // Average throughput is preserved: when the schedule falls behind real time
+    // (a scheduler hiccup, or a coarse platform timer waking late) packets are
+    // released back-to-back to catch up, bounded by MaxCatchupBehindTicks so a
+    // stalled sender can't dump the whole ring at once.
     private void DrainAndSend(Span<float> scratch)
     {
+        _diagBurstThisDrain = 0;
         while (true)
         {
+            long now = _clock();
+
+            // Fresh start / post-drain: anchor the schedule to "now" so the
+            // first packet of a new RX burst ships promptly (no backlog of
+            // "due" slots accumulated across an idle gap).
+            if (_nextSendTicks == 0) _nextSendTicks = now;
+
+            // Catch-up cap: never let the schedule lag real time by more than
+            // MaxCatchupBehindTicks. This bounds the burst after a stall while
+            // still letting the long-run rate equal the inbound rate.
+            long earliest = now - MaxCatchupBehindTicks;
+            if (_nextSendTicks < earliest) _nextSendTicks = earliest;
+
+            if (now < _nextSendTicks)
+            {
+                // Next packet not due yet — park until the deadline (or an
+                // earlier publish wake). Bounded; never busy-spins.
+                _pacingWaitTicks = _nextSendTicks - now;
+                return;
+            }
+
             int need = PacketFrames - _packetFrames;
             int read = _ring.Read(scratch[..need]);
-            if (read == 0) return;
+            if (read == 0)
+            {
+                // Nothing buffered: realign the schedule and wait for the
+                // producer to wake us with fresh audio.
+                _nextSendTicks = 0;
+                _pacingWaitTicks = 0;
+                return;
+            }
 
             for (int i = 0; i < read; i++)
             {
@@ -261,12 +364,78 @@ internal sealed class SaturnSpeakerAudioSink : IRxAudioSink, IHostedService, IDi
                 _packetFrames++;
             }
 
-            if (_packetFrames == PacketFrames)
+            if (_packetFrames < PacketFrames)
             {
-                SendPacket();
-                if (_socket is null) return;
+                // Partial packet — need more samples before this slot can ship.
+                // Wait for the next publish rather than the pacing deadline.
+                _pacingWaitTicks = 0;
+                return;
             }
+
+            if (!EmitPacket(now)) return; // socket died mid-drain
+            _nextSendTicks += PacketIntervalTicks;
         }
+    }
+
+    // Emit one full packet. Returns false only when the production socket went
+    // away (so the drain loop stops). The test observer simulates a successful
+    // send — advancing the sequence and recording the emit time — with no socket.
+    private bool EmitPacket(long now)
+    {
+        var obs = _sentObserverForTest;
+        if (obs is not null)
+        {
+            BinaryPrimitives.WriteUInt32BigEndian(_packet.AsSpan(0, sizeof(uint)), _sequence++);
+            _packetFrames = 0;
+            RecordSend(now);
+            obs(now);
+            return true;
+        }
+
+        SendPacket(); // resets _packetFrames in its finally
+        RecordSend(now);
+        return _socket is not null;
+    }
+
+    private void RecordSend(long now)
+    {
+        _diagPacketsSent++;
+        _diagBurstThisDrain++;
+        if (_diagBurstThisDrain > _diagMaxBurst) _diagMaxBurst = _diagBurstThisDrain;
+        if (_diagLastSendTicks != 0)
+        {
+            long gapUs = (long)((now - _diagLastSendTicks) * UsPerTick);
+            _diagSendGapSumUs += gapUs;
+            if (gapUs > _diagSendGapMaxUs) _diagSendGapMaxUs = gapUs;
+            _diagSendGapCount++;
+        }
+        _diagLastSendTicks = now;
+    }
+
+    // #1148 sender-side ~1 Hz diagnostic. Worker-thread-owned; called after each
+    // DrainAndSend while a socket is open.
+    private void MaybeEmitDiag()
+    {
+        long now = _clock();
+        if (_diagLastEmitTicks == 0) { _diagLastEmitTicks = now; return; }
+        long elapsed = now - _diagLastEmitTicks;
+        if (elapsed < Stopwatch.Frequency) return;
+        _diagLastEmitTicks = now;
+
+        double secs = elapsed / (double)Stopwatch.Frequency;
+        double pps = secs > 0 ? _diagPacketsSent / secs : 0;
+        long meanGapUs = _diagSendGapCount > 0 ? _diagSendGapSumUs / _diagSendGapCount : 0;
+
+        _log.LogInformation(
+            "audio.radio.speaker.p2.diag pkts/s={Pps:F0} maxBurst={MaxBurst} sendGapUs(mean/max)={Mean}/{Max} droppedPkts={DropPkts} droppedSamples={DropSamp}",
+            pps, _diagMaxBurst, meanGapUs, _diagSendGapMaxUs,
+            Interlocked.Read(ref _droppedPackets), Interlocked.Read(ref _droppedSamples));
+
+        _diagPacketsSent = 0;
+        _diagMaxBurst = 0;
+        _diagSendGapSumUs = 0;
+        _diagSendGapMaxUs = 0;
+        _diagSendGapCount = 0;
     }
 
     private void RefreshTargetIfDue()
@@ -393,6 +562,7 @@ internal sealed class SaturnSpeakerAudioSink : IRxAudioSink, IHostedService, IDi
         _socket = null;
         _target = null;
         _packetFrames = 0;
+        _nextSendTicks = 0; // realign the pacing schedule when a socket reopens
     }
 
     internal static short FloatToPcm16(float sample)
@@ -404,6 +574,42 @@ internal sealed class SaturnSpeakerAudioSink : IRxAudioSink, IHostedService, IDi
         float scale = sample < 0.0f ? 32768.0f : short.MaxValue;
         return (short)MathF.Round(sample * scale);
     }
+
+    // ---- Pacing test seams (#1148). No sockets, no real time: drive a virtual
+    // clock, feed the ring directly, observe simulated sends, and assert drain
+    // cadence + max-burst. None of these are used in production. ----
+
+    /// <summary>Test-only: override the monotonic clock the pacing schedule
+    /// reads (default <see cref="Stopwatch.GetTimestamp"/>).</summary>
+    internal Func<long> ClockForTest { set => _clock = value; }
+
+    /// <summary>Test-only: observe each simulated packet send (argument is the
+    /// virtual send time). Setting this routes <see cref="EmitPacket"/> through
+    /// the observer instead of the real socket.</summary>
+    internal Action<long>? SentObserverForTest { set => _sentObserverForTest = value; }
+
+    /// <summary>Test-only: write samples straight into the sender ring, as the
+    /// producer would, without going through <see cref="Publish"/>'s gates.
+    /// Returns the count actually written.</summary>
+    internal int WriteRingForTest(ReadOnlySpan<float> samples) => _ring.Write(samples);
+
+    /// <summary>Test-only: run one <see cref="DrainAndSend"/> pass on the
+    /// calling thread (the worker is not started in pacing tests).</summary>
+    internal void DrainForTest()
+    {
+        Span<float> scratch = stackalloc float[PacketFrames];
+        DrainAndSend(scratch);
+    }
+
+    /// <summary>Test-only: largest burst observed in a single
+    /// <see cref="DrainAndSend"/> since the last diag emit.</summary>
+    internal int MaxBurstForTest => _diagMaxBurst;
+
+    /// <summary>Test-only: the pacing packet interval in Stopwatch ticks.</summary>
+    internal static long PacketIntervalTicksForTest => PacketIntervalTicks;
+
+    /// <summary>Test-only: the catch-up clamp in Stopwatch ticks.</summary>
+    internal static long MaxCatchupBehindTicksForTest => MaxCatchupBehindTicks;
 
     /// <summary>Test-only: block until the worker has processed every signal
     /// posted before this call and is parked back in its wake-wait. Lets tests

--- a/tests/Zeus.Protocol2.Tests/DiagStatsTests.cs
+++ b/tests/Zeus.Protocol2.Tests/DiagStatsTests.cs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2026 Douglas J. Cerrato (KB2UKA), and contributors.
+
+using Zeus.Protocol2;
+
+namespace Zeus.Protocol2.Tests;
+
+// Issue #1148 — the ~1 Hz RX-IQ / tick / speaker diag log lines all compute a
+// p99 over a fixed ring via DiagStats. Lock down the nearest-rank math so the
+// numbers an operator (or a bench run) reads off those logs are trustworthy.
+public sealed class DiagStatsTests
+{
+    [Fact]
+    public void Percentile_EmptyCount_ReturnsZero()
+    {
+        var values = new long[] { 5, 9, 100 };
+        var scratch = new long[3];
+        Assert.Equal(0, DiagStats.Percentile(values, scratch, 0, 0.99));
+    }
+
+    [Fact]
+    public void Percentile_LeavesSourceUntouched_SortsOnlyScratch()
+    {
+        var values = new long[] { 30, 10, 20, 40 };
+        var snapshot = (long[])values.Clone();
+        var scratch = new long[4];
+
+        DiagStats.Percentile(values, scratch, 4, 0.5);
+
+        Assert.Equal(snapshot, values); // source ring must not be reordered
+    }
+
+    [Theory]
+    // 100 ascending samples 1..100. Nearest-rank index = ceil(q*n)-1.
+    [InlineData(0.99, 99)] // ceil(99)-1 = 98 -> value 99
+    [InlineData(0.50, 50)] // ceil(50)-1 = 49 -> value 50
+    [InlineData(1.00, 100)] // top
+    [InlineData(0.00, 1)] // clamps to index 0 -> value 1
+    public void Percentile_NearestRank_OnAscendingSamples(double q, long expected)
+    {
+        var values = new long[100];
+        for (int i = 0; i < 100; i++) values[i] = i + 1;
+        var scratch = new long[100];
+
+        // Pre-scramble to prove the helper sorts internally.
+        Array.Reverse(values);
+
+        Assert.Equal(expected, DiagStats.Percentile(values, scratch, 100, q));
+    }
+
+    [Fact]
+    public void Percentile_P99_IgnoresEntriesBeyondCount()
+    {
+        // Only the first 4 entries are valid; the trailing huge value must not
+        // leak into the percentile (simulates a partly-filled ring).
+        var values = new long[] { 1, 2, 3, 4, long.MaxValue };
+        var scratch = new long[5];
+        Assert.Equal(4, DiagStats.Percentile(values, scratch, 4, 0.99));
+    }
+
+    [Theory]
+    [InlineData(1, 0.99, 0)]
+    [InlineData(10, 0.99, 9)]
+    [InlineData(50, 0.99, 49)]
+    [InlineData(512, 0.99, 506)] // ceil(0.99*512)-1 = ceil(506.88)-1 = 506
+    public void PercentileIndex_ClampedNearestRank(int count, double q, int expected)
+    {
+        Assert.Equal(expected, DiagStats.PercentileIndex(count, q));
+    }
+
+    [Fact]
+    public void PercentileIndex_NonPositiveCount_ReturnsZero()
+    {
+        Assert.Equal(0, DiagStats.PercentileIndex(0, 0.99));
+        Assert.Equal(0, DiagStats.PercentileIndex(-5, 0.99));
+    }
+}

--- a/tests/Zeus.Server.Tests/SaturnSpeakerAudioSinkTests.cs
+++ b/tests/Zeus.Server.Tests/SaturnSpeakerAudioSinkTests.cs
@@ -245,6 +245,105 @@ public sealed class SaturnSpeakerAudioSinkTests : IDisposable
         Assert.Null(ex);
     }
 
+    // Issue #1148 pacing (Deliverable 2) — egress must be SPREAD at the codec's
+    // 750 pkt/s cadence, not fired in one burst per DSP tick. These drive a
+    // virtual clock + feed the ring directly: no worker thread, no sockets, no
+    // real time, fully deterministic.
+
+    [Fact]
+    public void Pacing_ReleasesOnePacketPerInterval_NeverBursts()
+    {
+        using var radio = NewRadio();
+        using var settings = new RadioSpeakerSettingsStore(
+            NullLogger<RadioSpeakerSettingsStore>.Instance, _dbPath + ".spk");
+        var sink = new SaturnSpeakerAudioSink(radio, settings, NullLogger<SaturnSpeakerAudioSink>.Instance);
+
+        long t = 1_000_000_000;
+        sink.ClockForTest = () => t;
+        int sent = 0;
+        sink.SentObserverForTest = _ => sent++;
+        long interval = SaturnSpeakerAudioSink.PacketIntervalTicksForTest;
+
+        // 100 packets of audio buffered up front (ring caps at 128 packets).
+        sink.WriteRingForTest(new float[64 * 100]);
+
+        // First drain anchors the schedule to "now": exactly one packet is due,
+        // even though 100 are buffered. A regression to the old behaviour would
+        // emit all 100 here.
+        sink.DrainForTest();
+        Assert.Equal(1, sent);
+
+        // Each interval that elapses yields exactly one more packet.
+        for (int i = 0; i < 50; i++)
+        {
+            t += interval;
+            sink.DrainForTest();
+        }
+
+        Assert.Equal(51, sent);
+        Assert.Equal(1, sink.MaxBurstForTest);
+    }
+
+    [Fact]
+    public void Pacing_CatchUpIsBounded_DoesNotDumpWholeRing()
+    {
+        using var radio = NewRadio();
+        using var settings = new RadioSpeakerSettingsStore(
+            NullLogger<RadioSpeakerSettingsStore>.Instance, _dbPath + ".spk");
+        var sink = new SaturnSpeakerAudioSink(radio, settings, NullLogger<SaturnSpeakerAudioSink>.Instance);
+
+        long t = 1_000_000_000;
+        sink.ClockForTest = () => t;
+        int sent = 0;
+        sink.SentObserverForTest = _ => sent++;
+        long interval = SaturnSpeakerAudioSink.PacketIntervalTicksForTest;
+        long maxBehind = SaturnSpeakerAudioSink.MaxCatchupBehindTicksForTest;
+
+        // Fill the ring to capacity (requesting far more than it holds).
+        sink.WriteRingForTest(new float[64 * 400]);
+
+        sink.DrainForTest();           // prime: schedule anchored, 1 packet out
+        int afterPrime = sent;
+        Assert.Equal(1, afterPrime);
+
+        // Simulate a long scheduler stall, then a single drain. The catch-up
+        // burst MUST be clamped to ~MaxCatchupBehindTicks / interval packets —
+        // it must not dump the whole 128-packet ring at once.
+        t += interval * 1000;
+        sink.DrainForTest();
+
+        int burst = sent - afterPrime;
+        long cap = maxBehind / interval;
+        Assert.InRange(burst, 1, (int)cap + 1);
+        Assert.True(afterPrime + burst < 128,
+            $"catch-up emitted {afterPrime + burst} packets — it dumped the whole ring");
+    }
+
+    [Fact]
+    public void Pacing_RealignsAfterIdle_NoStoredBacklog()
+    {
+        using var radio = NewRadio();
+        using var settings = new RadioSpeakerSettingsStore(
+            NullLogger<RadioSpeakerSettingsStore>.Instance, _dbPath + ".spk");
+        var sink = new SaturnSpeakerAudioSink(radio, settings, NullLogger<SaturnSpeakerAudioSink>.Instance);
+
+        long t = 1_000_000_000;
+        sink.ClockForTest = () => t;
+        int sent = 0;
+        sink.SentObserverForTest = _ => sent++;
+
+        // Drain with an empty ring (idle), then let a long gap pass.
+        sink.DrainForTest();
+        Assert.Equal(0, sent);
+        t += SaturnSpeakerAudioSink.PacketIntervalTicksForTest * 5000;
+
+        // One packet of fresh audio must ship on the very next drain — the idle
+        // gap must not have accrued a backlog of "due" slots (which would burst).
+        sink.WriteRingForTest(new float[64]);
+        sink.DrainForTest();
+        Assert.Equal(1, sent);
+    }
+
     private static uint SequenceOf(SaturnSpeakerAudioSink sink)
     {
         var f = typeof(SaturnSpeakerAudioSink)


### PR DESCRIPTION
## Issue #1148 — P2 radio-speaker host-audio underrun (REOPENED; prior fix #1154 disproven in the field)

**Draft / DO NOT MERGE without a bench or field confirmation — see "Status" below.**

### Why the last fix didn't work
PR #1154 (`ae9b04ec`, shipped in **v0.10.6**) moved the 16 speaker UDP sends off the DSP tick thread onto a worker, on the theory that the syscalls were starving the host audio ring. The reporter ran v0.10.6 (which provably contains that fix) plus a clean reinstall and got **zero change**. So that theory is disproven.

### What the evidence actually says
- Audio output rate **≡ DSP tick rate** — `Tick` runs inline on the P2 RX packet thread (`OnIqFrame → MaybeTickInline`, ~30 Hz, one audio block per tick).
- `NativeAudioSink` shows `overrun=0` with ~37 % underrun and `out ≈ in + underrun` → it is fed **good data too rarely**, i.e. **inbound IQ is arriving under-rate / bursty** when the radio speaker is on (`wdsp.rxdiag framesIn` varies ±20 %).
- The **one thing #1154 never changed is the on-wire shape**: `SaturnSpeakerAudioSink` fires *all 16* packets back-to-back per ~21 ms wake. The reference (deskHPSDR `new_protocol.c`) deliberately **paces** ~1 packet / 1333 µs (750 pkt/s).
- Refuted along the way: lock contention (too small, and not speaker-gated), pipeline reconfigure on toggle (the toggle only flips a flag), and the reporter's "Thetis single-streams" theory (Thetis `audio.cs` `VAC*ExclusiveOut` are *optional* — dual output is supported by design).
- Firmware mirror (`Hermes.v`): **no gateware coupling** between codec audio-in (port 1028) and RX-IQ egress (independent FIFOs/clocks, no backpressure). Only an unprovable PCB-level clock/power coupling remains possible.

### What this PR does
**1) Instrumentation (primary, always-on, ~1 Hz, allocation-light)** — so the next field report / bench run is *conclusive* instead of another guess:
- `p2.rxdiag` (Protocol2Client): DDC0 datagram inter-arrival gap **min/mean/max/p99 µs**, `ddc0pkts/s`, and a per-window **sequence-gap count** (reuses the existing DDC0-specific `_droppedFrames`). **Discriminator:** seq-gaps *without* host socket loss ⇒ the radio under-sent/streamed irregularly (radio or physical clock coupling); seq-gaps *with* host loss ⇒ NIC/scheduling. (`sockDrops=na` — .NET exposes no portable per-socket drop counter; reconcile against OS `ss -u` / `netstat -su`.)
- `dsp.tickdiag` (DspPipelineService): inline-tick interval **mean/p99/max** + count of intervals > 1.5× nominal (>50 ms) — proves/refutes whether ticks slip from ~30 Hz when the speaker is on.
- `audio.radio.speaker.p2.diag` (SaturnSpeakerAudioSink): pkts/s, **max burst per drain**, inter-send gap mean/max, WouldBlock drop counters.

All three are timestamp-correlatable, so a single **speaker-OFF-then-ON** capture pins the cause.

**2) Sender pacing (candidate, bench-gated)** — `DrainAndSend` now releases packets on a monotonic 750 pkt/s Stopwatch schedule (deskHPSDR cadence) instead of bursting, with a bounded ~48-packet catch-up so a scheduler stall can't dump the ring. The ring stays the jitter buffer; long-run throughput = inbound rate (radio codec stays fed). No busy-spin (bounded 1–100 ms parks), no process-wide timer change, graceful degradation to small groups on coarse timers (never worse than today's 16-burst).

### Status / what needs confirmation
- **Not bench-tested this session** — the G2 was powered down (0 P2 discovery replies), so I could not reproduce or confirm locally. Needs either the reporter to run a build of this branch and paste a new diagnostic report, **or** a P2 codec-board bench (ANAN-10E / HermesII).
- **Honest caveat on pacing:** fine pacing needs sub-ms timer granularity; Windows' default ~15.6 ms timer makes pacing **marginal on Windows** (where the reporter is). It should help Linux/macOS/Pi and is strictly no-worse on Windows — **the instrumentation is what will tell us if the burst is even the cause.** Treat pacing as a hypothesis test, not a declared fix.

### Red-light — needs KB2UKA sign-off (NOT done here)
- The reporter's **mutual-exclusivity** idea (auto-mute host soundcard when radio speaker is on) — an operator-felt UX/architecture change; Thetis supports dual output, so this diverges from the reference. Parked for your call.
- Enlarging the host audio **cushion/latency** (`PlaybackPrebufferSamples` / 120 ms) — operator-felt, and it would only mask a sustained deficit, not fix it. Not touched.

### Safety / guardrails
PureSignal untouched. No TX path touched (RX audio only; MOX mute preserved). No real sockets in the new tests (injected clock + send-observer seam). No operator-felt default changed. Cross-platform (monotonic Stopwatch, bounded waits).

### Tests
New: `DiagStatsTests` (12 percentile cases), 3 `SaturnSpeakerAudioSink` pacing tests (injected clock, no sockets/real time — assert single-packet release, bounded catch-up, idle realign). Local: backend build 0/0; Zeus.Protocol2 266 passed, Server.Tests (Speaker|AudioSink|Tick|Native|DspPipeline) 141 passed. Full 5-platform CI is the gate.
