### PR TITLE
fix: prepare Protocol 3 receiver capacity

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -909,26 +909,37 @@ public static class WireContract
     /// <see cref="StateDto.WireVersion"/>.</summary>
     public const int Version = 2;
 
-    /// <summary>Maximum concurrent DDC receivers. Protocol 2's DDC-enable
-    /// command is a single byte (8 bits ⇒ DDC0..DDC7), so the ceiling is 8.
-    /// <see cref="Zeus.Contracts"/> owns the canonical value;
-    /// <c>Zeus.Protocol2.Protocol2Client.MaxRxDdc</c> references it so the wire
-    /// foundation and the contract can never drift apart.</summary>
-    public const int MaxReceivers = 8;
+    /// <summary>Maximum hardware receiver/DDC count the state contract can
+    /// represent. Protocol 2 is lower on some boards because its DDC-enable byte
+    /// addresses only DDC0..DDC7; <see cref="StateDto.MaxReceivers"/> carries the
+    /// active protocol/board ceiling to the frontend. The shared contract keeps
+    /// ten hardware slots so Protocol 3-capable G2/Saturn firmware can expose
+    /// RX1..RX10 without colliding with software receiver slots.</summary>
+    public const int MaxReceivers = 10;
+
+    /// <summary>Protocol 2 DDC-enable wire ceiling. The P2 command is still a
+    /// single byte, so DDC0..DDC7 is the hard P2 limit even though the shared
+    /// receiver state contract can represent more for Protocol 3.</summary>
+    public const int Protocol2MaxDdc = 8;
 
     /// <summary>Reserved receiver index for the non-hardware KiwiSDR slice. It
-    /// sits at the very top of the DDC range so it never collides with the
-    /// contiguous hardware run (RX1..RX6, practical max 6 on a G2/Saturn).
-    /// Frames for the Kiwi receiver are broadcast with this value as their
-    /// <c>RxId</c>; the frontend routes them through the same per-RX render path
-    /// as a hardware DDC and labels the entry from <see cref="ReceiverDto.Name"/>
-    /// ("Kiwi") instead of "RX{Index+1}".</summary>
-    public const int KiwiReceiverIndex = MaxReceivers - 1;
+    /// sits just above the hardware receiver range so RX10 remains available to
+    /// Protocol 3-capable radios. Frames for the Kiwi receiver are broadcast with
+    /// this value as their <c>RxId</c>; the frontend routes them through the same
+    /// per-RX render path as a hardware DDC and labels the entry from
+    /// <see cref="ReceiverDto.Name"/> ("Kiwi") instead of "RX{Index+1}".</summary>
+    public const int KiwiReceiverIndex = MaxReceivers;
+
+    /// <summary>Total receiver-index slots on the wire, including the optional
+    /// Kiwi software receiver at <see cref="KiwiReceiverIndex"/>.</summary>
+    public const int MaxReceiverSlots = KiwiReceiverIndex + 1;
 }
 
 /// <summary>Per-receiver (per-DDC) state for the multi-DDC model. Index 0 is
 /// RX1, index 1 is RX2, and indices ≥ 2 are additional DDCs (up to
-/// <see cref="WireContract.MaxReceivers"/> − 1).
+/// <see cref="WireContract.MaxReceivers"/> − 1). The optional Kiwi software
+/// receiver uses <see cref="WireContract.KiwiReceiverIndex"/> outside that
+/// hardware range.
 /// <para>The first usable dual-receive path mirrors the <see cref="StateDto"/>
 /// flat RX1 fields (<see cref="StateDto.VfoHz"/> etc.) into index 0 and the
 /// RX2 / VFO-B fields (<see cref="StateDto.VfoBHz"/> etc.) into index 1;
@@ -1256,8 +1267,8 @@ public sealed record StateDto(
     // pre-multi-DDC baseline; v2 = Receivers[] present.
     int WireVersion = WireContract.Version,
 
-    // DDC / receiver ceiling for this build (WireContract.MaxReceivers). The
-    // multi-DDC UI gates the "exposed receivers" control against this.
+    // Active hardware DDC / receiver ceiling for this connection. Protocol 2 G2
+    // reports 6; Protocol 3-capable G2 firmware can report the full 10.
     int MaxReceivers = WireContract.MaxReceivers,
 
     // ---- VFO lock (Thetis chkVFOLock) ----

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -110,12 +110,10 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // both already use only byte[7]). There is no second enable byte — "10
     // DDCs" is not representable in standard P2. On Orion-family boards DDC0/1
     // are reserved for the PureSignal feedback pair when PS is armed, leaving 6
-    // user receivers; with PS off, all 8. The N-receiver pipeline keys off this
-    // constant so the ceiling is a single-line change if firmware ever extends
-    // the enable field. Sourced from Zeus.Contracts.WireContract.MaxReceivers
-    // so the wire foundation and the StateDto Receivers[] contract can never
-    // drift apart.
-    public const int MaxRxDdc = Zeus.Contracts.WireContract.MaxReceivers;
+    // user receivers; with PS off, all 8. Keep this P2 wire ceiling separate
+    // from WireContract.MaxReceivers, which is the shared state capacity for
+    // newer protocols such as P3.
+    public const int MaxRxDdc = Zeus.Contracts.WireContract.Protocol2MaxDdc;
 
     // RX IQ data arrives on UDP source ports RxDataPortBase + ddcIndex, i.e.
     // 1035 (DDC0) .. 1035 + MaxRxDdc - 1 (DDC7).

--- a/Zeus.Server.Hosting/DspPipelineService.cs
+++ b/Zeus.Server.Hosting/DspPipelineService.cs
@@ -704,8 +704,10 @@ public class DspPipelineService : BackgroundService,
     // every DDC once B3/B4 wire the per-receiver state + UI. Today only slot 1 is
     // ever activated (Rx2Enabled), so behaviour is identical to the previous
     // hardcoded RX1/RX2 pair. ChannelId is read/written via Volatile on the hot
-    // path exactly as the old _rx2ChannelId was.
-    internal const int MaxReceivers = Zeus.Protocol2.Protocol2Client.MaxRxDdc;
+    // path exactly as the old _rx2ChannelId was. Size to the shared hardware
+    // receiver contract (10) rather than the P2 wire ceiling (8) so Protocol 3
+    // can expose every G2 receiver without another DSP array refactor.
+    internal const int MaxReceivers = Zeus.Contracts.WireContract.MaxReceivers;
     private sealed class SecondaryRx
     {
         public int ChannelId = -1; // -1 = inactive; Volatile.Read/Write(ref ChannelId)
@@ -5824,7 +5826,7 @@ public class DspPipelineService : BackgroundService,
             _mixSlices[mixSliceCount++] = new RxAudioSlice(sec.AudioBuf, n);
         }
 
-        // Kiwi slice (RxId 7): an INDEPENDENT remote receiver that rides the same
+        // Kiwi slice: an INDEPENDENT remote receiver that rides the same
         // RX1-clocked mix bus as the hardware secondaries. Drain at most
         // audioSampleCount samples so it's fed at exactly the RX rate (its own
         // clock differs from the radio ADC; IKiwiAudioBus.ReadAudio caps buffered

--- a/Zeus.Server.Hosting/Kiwi/KiwiSdrService.cs
+++ b/Zeus.Server.Hosting/Kiwi/KiwiSdrService.cs
@@ -64,7 +64,7 @@ public interface IKiwiAudioBus
 /// waterfall into the same <see cref="DisplayFrame"/> / <see cref="AudioFrame"/>
 /// wire frames a hardware DDC produces (tagged with
 /// <see cref="WireContract.KiwiReceiverIndex"/> so the frontend renders it as
-/// "Kiwi" beside RX1..RX6), and pushes Zeus tuning down to the Kiwi as SET
+/// "Kiwi" beside the hardware receivers), and pushes Zeus tuning down to the Kiwi as SET
 /// commands. The Kiwi demodulates server-side, so this is a remote front-end —
 /// no WDSP channel is involved.
 /// </summary>

--- a/Zeus.Server.Hosting/Protocol3PresenceProbe.cs
+++ b/Zeus.Server.Hosting/Protocol3PresenceProbe.cs
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus - OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Zeus.Server;
+
+public sealed record Protocol3PresenceResult(
+    int Port,
+    uint MaxRxStreams,
+    uint MaxTxStreams,
+    uint CapabilityFlags,
+    uint FirmwareVersion,
+    uint GatewareVersion);
+
+public sealed class Protocol3PresenceProbe
+{
+    public const int DefaultPort = 1030;
+    private const uint Magic = 0x4E395033u; // "N9P3"
+    private const byte VersionMajor = 1;
+    private const byte VersionMinor = 0;
+    private const byte DiscoveryRequest = 1;
+    private const byte Capabilities = 2;
+    private const int HeaderBytes = 32;
+    private const int CapabilitiesBytes = 40;
+    private const int ReceiveBufferSize = 2048;
+    private const int SendAttempts = 2;
+    private static readonly TimeSpan SendGap = TimeSpan.FromMilliseconds(40);
+
+    private readonly ILogger<Protocol3PresenceProbe> _log;
+
+    public Protocol3PresenceProbe(ILogger<Protocol3PresenceProbe> log)
+    {
+        _log = log;
+    }
+
+    public async Task<Protocol3PresenceResult?> ProbeAsync(
+        IPAddress radioIp,
+        TimeSpan timeout,
+        CancellationToken ct = default) =>
+        await ProbeAsync(radioIp, DefaultPort, timeout, ct).ConfigureAwait(false);
+
+    internal async Task<Protocol3PresenceResult?> ProbeAsync(
+        IPAddress radioIp,
+        int port,
+        TimeSpan timeout,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(radioIp);
+        if (port <= 0 || port > 65535) throw new ArgumentOutOfRangeException(nameof(port));
+        if (radioIp.AddressFamily != AddressFamily.InterNetwork) return null;
+
+        var endpoint = new IPEndPoint(radioIp, port);
+        using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        DisableUdpConnReset(socket);
+        socket.Bind(new IPEndPoint(IPAddress.Any, 0));
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(timeout);
+
+        var packet = BuildDiscoveryPacket();
+        for (var attempt = 0; attempt < SendAttempts; attempt++)
+        {
+            try
+            {
+                await socket.SendToAsync(packet, SocketFlags.None, endpoint, timeoutCts.Token)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                return null;
+            }
+            catch (SocketException ex)
+            {
+                _log.LogDebug(ex, "p3.presence.send.error radio={Radio}", radioIp);
+                return null;
+            }
+
+            if (attempt + 1 < SendAttempts)
+            {
+                try { await Task.Delay(SendGap, timeoutCts.Token).ConfigureAwait(false); }
+                catch (OperationCanceledException) { return null; }
+            }
+        }
+
+        var receiveBuffer = new byte[ReceiveBufferSize];
+        var any = new IPEndPoint(IPAddress.Any, 0);
+        while (!timeoutCts.IsCancellationRequested)
+        {
+            SocketReceiveFromResult res;
+            try
+            {
+                res = await socket.ReceiveFromAsync(
+                    receiveBuffer,
+                    SocketFlags.None,
+                    any,
+                    timeoutCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (SocketException ex) when (ex.SocketErrorCode == SocketError.ConnectionReset)
+            {
+                continue;
+            }
+            catch (SocketException ex)
+            {
+                _log.LogDebug(ex, "p3.presence.socket.error radio={Radio}", radioIp);
+                break;
+            }
+
+            var fromIp = ((IPEndPoint)res.RemoteEndPoint).Address;
+            if (!fromIp.Equals(radioIp)) continue;
+
+            var slice = new ReadOnlySpan<byte>(receiveBuffer, 0, res.ReceivedBytes);
+            if (TryParseCapabilities(slice, port, out var result))
+            {
+                _log.LogInformation(
+                    "p3.presence.reply radio={Radio} maxRx={MaxRx} flags=0x{Flags:X8}",
+                    radioIp,
+                    result.MaxRxStreams,
+                    result.CapabilityFlags);
+                return result;
+            }
+        }
+
+        return null;
+    }
+
+    private static byte[] BuildDiscoveryPacket()
+    {
+        var packet = new byte[HeaderBytes];
+        BinaryPrimitives.WriteUInt32BigEndian(packet.AsSpan(0, 4), Magic);
+        packet[4] = VersionMajor;
+        packet[5] = VersionMinor;
+        packet[6] = DiscoveryRequest;
+        packet[7] = 0;
+        BinaryPrimitives.WriteUInt16BigEndian(packet.AsSpan(8, 2), HeaderBytes);
+        BinaryPrimitives.WriteUInt16BigEndian(packet.AsSpan(10, 2), 0);
+        BinaryPrimitives.WriteUInt32BigEndian(packet.AsSpan(12, 4), 1);
+        return packet;
+    }
+
+    private static bool TryParseCapabilities(ReadOnlySpan<byte> packet, int port, out Protocol3PresenceResult result)
+    {
+        result = default!;
+        if (packet.Length < HeaderBytes + CapabilitiesBytes) return false;
+        if (BinaryPrimitives.ReadUInt32BigEndian(packet[..4]) != Magic) return false;
+        if (packet[4] != VersionMajor || packet[5] != VersionMinor) return false;
+        if (packet[6] != Capabilities) return false;
+
+        var headerBytes = BinaryPrimitives.ReadUInt16BigEndian(packet.Slice(8, 2));
+        var payloadBytes = BinaryPrimitives.ReadUInt16BigEndian(packet.Slice(10, 2));
+        if (headerBytes != HeaderBytes || payloadBytes < CapabilitiesBytes) return false;
+        if (packet.Length < headerBytes + payloadBytes) return false;
+
+        var payload = packet.Slice(headerBytes, CapabilitiesBytes);
+        result = new Protocol3PresenceResult(
+            Port: port,
+            MaxRxStreams: BinaryPrimitives.ReadUInt32BigEndian(payload.Slice(0, 4)),
+            MaxTxStreams: BinaryPrimitives.ReadUInt32BigEndian(payload.Slice(4, 4)),
+            CapabilityFlags: BinaryPrimitives.ReadUInt32BigEndian(payload.Slice(28, 4)),
+            FirmwareVersion: BinaryPrimitives.ReadUInt32BigEndian(payload.Slice(32, 4)),
+            GatewareVersion: BinaryPrimitives.ReadUInt32BigEndian(payload.Slice(36, 4)));
+        return true;
+    }
+
+    private const int SIO_UDP_CONNRESET = -1744830452; // 0x9800000C
+
+    private static void DisableUdpConnReset(Socket s)
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        try { s.IOControl(SIO_UDP_CONNRESET, new byte[4], null); }
+        catch (SocketException) { }
+    }
+}

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -1155,6 +1155,7 @@ public static class ZeusEndpoints
         app.MapGet("/api/radios", async (
             IRadioDiscovery p1Discovery,
             Zeus.Protocol2.Discovery.IRadioDiscovery p2Discovery,
+            Protocol3PresenceProbe p3Presence,
             HttpContext ctx) =>
         {
             var timeout = TimeSpan.FromMilliseconds(1500);
@@ -1163,7 +1164,12 @@ public static class ZeusEndpoints
             await Task.WhenAll(p1Task, p2Task);
 
             var p1Infos = p1Task.Result.Select(MapP1);
-            var p2Infos = p2Task.Result.Select(MapP2);
+            var p3ByIp = await ProbeProtocol3PresenceAsync(
+                p2Task.Result,
+                p3Presence,
+                ctx.RequestAborted).ConfigureAwait(false);
+            var p2Infos = p2Task.Result.Select(r =>
+                MapP2(r, p3ByIp.TryGetValue(r.Ip, out var p3) ? p3 : null));
             return p1Infos.Concat(p2Infos).ToArray();
 
             static RadioInfo MapP1(DiscoveredRadio r) => new(
@@ -1174,13 +1180,13 @@ public static class ZeusEndpoints
                 Busy: r.Details.Busy,
                 Details: BuildP1Details(r));
 
-            static RadioInfo MapP2(Zeus.Protocol2.Discovery.DiscoveredRadio r) => new(
+            static RadioInfo MapP2(Zeus.Protocol2.Discovery.DiscoveredRadio r, Protocol3PresenceResult? p3) => new(
                 MacAddress: r.Mac.ToString(),
                 IpAddress: r.Ip.ToString(),
                 BoardId: r.Board.ToString(),
                 FirmwareVersion: r.FirmwareString,
                 Busy: r.Details.Busy,
-                Details: BuildP2Details(r));
+                Details: BuildP2Details(r, p3));
 
             static IReadOnlyDictionary<string, string> BuildP1Details(DiscoveredRadio r)
             {
@@ -1200,7 +1206,9 @@ public static class ZeusEndpoints
                 return d;
             }
 
-            static IReadOnlyDictionary<string, string> BuildP2Details(Zeus.Protocol2.Discovery.DiscoveredRadio r)
+            static IReadOnlyDictionary<string, string> BuildP2Details(
+                Zeus.Protocol2.Discovery.DiscoveredRadio r,
+                Protocol3PresenceResult? p3)
             {
                 var d = new Dictionary<string, string>
                 {
@@ -1218,8 +1226,67 @@ public static class ZeusEndpoints
                     ["rawReplyHex"] = Convert.ToHexString(r.Details.RawReply),
                 };
                 if (r.Details.BetaVersion != 0) d["betaVersion"] = r.Details.BetaVersion.ToString();
+                if (p3 is not null)
+                {
+                    d["protocol3Available"] = "true";
+                    d["protocol3Port"] = p3.Port.ToString();
+                    d["protocol3MaxRxStreams"] = p3.MaxRxStreams.ToString();
+                    d["protocol3MaxTxStreams"] = p3.MaxTxStreams.ToString();
+                    d["protocol3CapabilityFlags"] = $"0x{p3.CapabilityFlags:X8}";
+                    d["protocol3FirmwareVersion"] = p3.FirmwareVersion.ToString();
+                    d["protocol3GatewareVersion"] = p3.GatewareVersion.ToString();
+                }
                 return d;
             }
+
+            static async Task<Dictionary<IPAddress, Protocol3PresenceResult>> ProbeProtocol3PresenceAsync(
+                IReadOnlyList<Zeus.Protocol2.Discovery.DiscoveredRadio> radios,
+                Protocol3PresenceProbe p3Presence,
+                CancellationToken ct)
+            {
+                var candidates = radios.Where(IsProtocol3Candidate).ToArray();
+                if (candidates.Length == 0) return new Dictionary<IPAddress, Protocol3PresenceResult>();
+
+                var timeout = TimeSpan.FromMilliseconds(300);
+                var tasks = candidates.Select(async r =>
+                    (r.Ip, Result: await p3Presence.ProbeAsync(r.Ip, timeout, ct).ConfigureAwait(false))).ToArray();
+                await Task.WhenAll(tasks).ConfigureAwait(false);
+
+                var byIp = new Dictionary<IPAddress, Protocol3PresenceResult>();
+                foreach (var task in tasks)
+                {
+                    var (ip, result) = task.Result;
+                    if (result is not null) byIp[ip] = result;
+                }
+                return byIp;
+            }
+
+            static bool IsProtocol3Candidate(Zeus.Protocol2.Discovery.DiscoveredRadio r) =>
+                r.Details.RawBoardId is 0x0A or 0x14;
+        });
+
+        app.MapGet("/api/protocol3/presence", async (
+            string? ip,
+            Protocol3PresenceProbe p3Presence,
+            HttpContext ctx) =>
+        {
+            if (!IPAddress.TryParse(ip ?? string.Empty, out var radioIp) ||
+                radioIp.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
+                return Results.BadRequest(new { error = $"Invalid IPv4 address '{ip}'." });
+
+            var p3 = await p3Presence
+                .ProbeAsync(radioIp, TimeSpan.FromMilliseconds(500), ctx.RequestAborted)
+                .ConfigureAwait(false);
+            return Results.Ok(new
+            {
+                available = p3 is not null,
+                port = p3?.Port,
+                maxRxStreams = p3?.MaxRxStreams,
+                maxTxStreams = p3?.MaxTxStreams,
+                capabilityFlags = p3 is null ? null : $"0x{p3.CapabilityFlags:X8}",
+                firmwareVersion = p3?.FirmwareVersion,
+                gatewareVersion = p3?.GatewareVersion,
+            });
         });
 
         // Take over a Busy radio. Discovery reports status 0x03 when another
@@ -1448,8 +1515,8 @@ public static class ZeusEndpoints
         // an extra hardware DDC. Only supplied fields change.
         app.MapPost("/api/receivers/{index:int}", (int index, ReceiverSetRequest req, RadioService r, KiwiSdrService kiwi) =>
         {
-            if (index < 0 || index >= Zeus.Contracts.WireContract.MaxReceivers)
-                return Results.BadRequest(new { error = $"receiver index out of range (0..{Zeus.Contracts.WireContract.MaxReceivers - 1})" });
+            if (index < 0 || index > Zeus.Contracts.WireContract.KiwiReceiverIndex)
+                return Results.BadRequest(new { error = $"receiver index out of range (0..{Zeus.Contracts.WireContract.KiwiReceiverIndex})" });
             // The reserved Kiwi slot is a remote receiver, not a hardware DDC:
             // route tuning/mode/filter to the Kiwi service (enable/disable + URL
             // live on /api/kiwi). Returns the same StateDto so the projected Kiwi
@@ -1482,8 +1549,8 @@ public static class ZeusEndpoints
         // chkRX2Mute — silences only this receiver's contribution to the mix.
         app.MapPost("/api/receivers/{index:int}/mute", (int index, MuteSetRequest req, RadioService r, KiwiSdrService kiwi) =>
         {
-            if (index < 0 || index >= Zeus.Contracts.WireContract.MaxReceivers)
-                return Results.BadRequest(new { error = $"receiver index out of range (0..{Zeus.Contracts.WireContract.MaxReceivers - 1})" });
+            if (index < 0 || index > Zeus.Contracts.WireContract.KiwiReceiverIndex)
+                return Results.BadRequest(new { error = $"receiver index out of range (0..{Zeus.Contracts.WireContract.KiwiReceiverIndex})" });
             log.LogInformation("api.receivers.mute index={Index} muted={Muted}", index, req.Muted);
             if (index == Zeus.Contracts.WireContract.KiwiReceiverIndex)
             {
@@ -1594,6 +1661,8 @@ public static class ZeusEndpoints
         // secondaries (shared NCO) / CTUN-off / disabled — see RequestSecondaryLo.
         app.MapPost("/api/receivers/{index:int}/lo", (int index, RadioLoSetRequest req, RadioService r, DspPipelineService pipe, KiwiSdrService kiwi) =>
         {
+            if (index < 0 || index > Zeus.Contracts.WireContract.KiwiReceiverIndex)
+                return Results.BadRequest(new { error = $"receiver index out of range (0..{Zeus.Contracts.WireContract.KiwiReceiverIndex})" });
             if (req.Hz < 0 || req.Hz > 60_000_000)
             {
                 log.LogInformation("api.receivers.lo rejected index={Index} hz={Hz}", index, req.Hz);

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -323,6 +323,7 @@ public static class ZeusHost
         builder.Services.AddSingleton<
             Zeus.Protocol2.Discovery.IRadioDiscovery,
             Zeus.Protocol2.Discovery.RadioDiscoveryService>();
+        builder.Services.AddSingleton<Protocol3PresenceProbe>();
         // TxIqRing is shared: TxAudioIngest writes modulated IQ into it, Protocol1Client
         // (constructed inside RadioService) reads from it for the EP2 payload.
         builder.Services.AddSingleton<Zeus.Protocol1.TxIqRing>();

--- a/tests/Zeus.Server.Tests/Protocol3PresenceProbeTests.cs
+++ b/tests/Zeus.Server.Tests/Protocol3PresenceProbeTests.cs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Server;
+using Xunit;
+
+namespace Zeus.Server.Tests;
+
+public sealed class Protocol3PresenceProbeTests
+{
+    [Fact]
+    public async Task ProbeAsync_ReturnsCapabilitiesWhenP3AppAnswers()
+    {
+        using var server = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        var port = ((IPEndPoint)server.Client.LocalEndPoint!).Port;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+
+        var responder = Task.Run(async () =>
+        {
+            var request = await server.ReceiveAsync(cts.Token);
+            Assert.True(IsDiscoveryRequest(request.Buffer));
+            await server.SendAsync(BuildCapabilitiesPacket(), request.RemoteEndPoint, cts.Token);
+        }, cts.Token);
+
+        var probe = new Protocol3PresenceProbe(NullLogger<Protocol3PresenceProbe>.Instance);
+        var result = await probe.ProbeAsync(IPAddress.Loopback, port, TimeSpan.FromSeconds(1), cts.Token);
+
+        await responder;
+        Assert.NotNull(result);
+        Assert.Equal(port, result.Port);
+        Assert.Equal(10u, result.MaxRxStreams);
+        Assert.Equal(1u, result.MaxTxStreams);
+        Assert.Equal(0x00004000u, result.CapabilityFlags);
+        Assert.Equal(0x20260629u, result.FirmwareVersion);
+        Assert.Equal(0x00000001u, result.GatewareVersion);
+    }
+
+    [Fact]
+    public async Task ProbeAsync_ReturnsNullWhenNoP3AppAnswers()
+    {
+        using var server = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        var port = ((IPEndPoint)server.Client.LocalEndPoint!).Port;
+        var probe = new Protocol3PresenceProbe(NullLogger<Protocol3PresenceProbe>.Instance);
+
+        var result = await probe.ProbeAsync(IPAddress.Loopback, port, TimeSpan.FromMilliseconds(120));
+
+        Assert.Null(result);
+    }
+
+    private static bool IsDiscoveryRequest(byte[] packet) =>
+        packet.Length == 32 &&
+        BinaryPrimitives.ReadUInt32BigEndian(packet.AsSpan(0, 4)) == 0x4E395033u &&
+        packet[4] == 1 &&
+        packet[5] == 0 &&
+        packet[6] == 1 &&
+        BinaryPrimitives.ReadUInt16BigEndian(packet.AsSpan(8, 2)) == 32 &&
+        BinaryPrimitives.ReadUInt16BigEndian(packet.AsSpan(10, 2)) == 0;
+
+    private static byte[] BuildCapabilitiesPacket()
+    {
+        var packet = new byte[72];
+        BinaryPrimitives.WriteUInt32BigEndian(packet.AsSpan(0, 4), 0x4E395033u);
+        packet[4] = 1;
+        packet[5] = 0;
+        packet[6] = 2;
+        BinaryPrimitives.WriteUInt16BigEndian(packet.AsSpan(8, 2), 32);
+        BinaryPrimitives.WriteUInt16BigEndian(packet.AsSpan(10, 2), 40);
+        BinaryPrimitives.WriteUInt32BigEndian(packet.AsSpan(12, 4), 2);
+
+        var payload = packet.AsSpan(32, 40);
+        BinaryPrimitives.WriteUInt32BigEndian(payload.Slice(0, 4), 10);
+        BinaryPrimitives.WriteUInt32BigEndian(payload.Slice(4, 4), 1);
+        BinaryPrimitives.WriteUInt32BigEndian(payload.Slice(8, 4), 0x3f);
+        BinaryPrimitives.WriteUInt32BigEndian(payload.Slice(12, 4), 0x04);
+        BinaryPrimitives.WriteUInt32BigEndian(payload.Slice(16, 4), 0x01);
+        BinaryPrimitives.WriteUInt32BigEndian(payload.Slice(20, 4), 0x01);
+        BinaryPrimitives.WriteUInt32BigEndian(payload.Slice(24, 4), 1440);
+        BinaryPrimitives.WriteUInt32BigEndian(payload.Slice(28, 4), 0x00004000u);
+        BinaryPrimitives.WriteUInt32BigEndian(payload.Slice(32, 4), 0x20260629u);
+        BinaryPrimitives.WriteUInt32BigEndian(payload.Slice(36, 4), 0x00000001u);
+        return packet;
+    }
+}

--- a/tests/Zeus.Server.Tests/RadioServiceUnifiedReceiverWriteTests.cs
+++ b/tests/Zeus.Server.Tests/RadioServiceUnifiedReceiverWriteTests.cs
@@ -64,6 +64,33 @@ public sealed class RadioServiceUnifiedReceiverWriteTests : IDisposable
     }
 
     [Fact]
+    public void Snapshot_DisconnectedState_CanRepresentTenHardwareReceivers()
+    {
+        using var radio = BuildRadio();
+
+        var s = radio.SetReceiver(9, enabled: true, vfoHz: 28_074_000);
+
+        Assert.Equal(WireContract.MaxReceivers, s.MaxReceivers);
+        Assert.Equal(10, s.Receivers!.Where(r => r.Index < WireContract.MaxReceivers).Count());
+        Assert.Contains(s.Receivers!, r => r.Index == 9 && r.Enabled && r.VfoHz == 28_074_000);
+        Assert.Equal(WireContract.MaxReceivers, WireContract.KiwiReceiverIndex);
+    }
+
+    [Fact]
+    public void Snapshot_Protocol2G2_AdvertisesSixReceivers()
+    {
+        using var radio = BuildRadio();
+
+        radio.MarkProtocol2Connected(
+            "127.0.0.1:1024",
+            192_000,
+            client: null,
+            boardKind: HpsdrBoardKind.OrionMkII);
+
+        Assert.Equal(6, radio.Snapshot().MaxReceivers);
+    }
+
+    [Fact]
     public void SetReceiver_Rx2_RoutesEnableVfoModeFilterAndAf()
     {
         using var radio = BuildRadio();

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -449,7 +449,7 @@ export type RadioStateDto = {
   receivers?: ReceiverDto[];
   // Wire contract version (WireContract.Version). v2 = receivers[] present.
   wireVersion?: number;
-  // DDC / receiver ceiling for this build (WireContract.MaxReceivers).
+  // Active hardware DDC / receiver ceiling for this connection.
   maxReceivers?: number;
 };
 
@@ -461,8 +461,8 @@ export type ReceiverDto = {
   index: number;
   enabled: boolean;
   // Operator-facing display name. Hardware DDCs leave this null and fall back to
-  // an "RX{n}" label; the reserved KiwiSDR slice receiver (index
-  // WireContract.KiwiReceiverIndex) carries "Kiwi". See receiverLabel().
+  // an "RX{n}" label; the reserved KiwiSDR slice receiver carries "Kiwi". See
+  // receiverLabel().
   name?: string | null;
   // Which phase-synchronous 16-bit ADC feeds this DDC (0 or 1).
   adcSource: number;
@@ -644,6 +644,16 @@ export type RadioInfoDto = {
   firmwareVersion: string;
   busy: boolean;
   details: Record<string, string> | null;
+};
+
+export type Protocol3PresenceDto = {
+  available: boolean;
+  port: number | null;
+  maxRxStreams: number | null;
+  maxTxStreams: number | null;
+  capabilityFlags: string | null;
+  firmwareVersion: number | null;
+  gatewareVersion: number | null;
 };
 
 export type HardwareDiagnosticItemDto = {
@@ -2734,6 +2744,19 @@ function normalizeRadios(raw: unknown): RadioInfoDto[] {
           : null,
     };
   });
+}
+
+function normalizeProtocol3Presence(raw: unknown): Protocol3PresenceDto {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  return {
+    available: Boolean(r.available),
+    port: typeof r.port === 'number' ? r.port : null,
+    maxRxStreams: typeof r.maxRxStreams === 'number' ? r.maxRxStreams : null,
+    maxTxStreams: typeof r.maxTxStreams === 'number' ? r.maxTxStreams : null,
+    capabilityFlags: typeof r.capabilityFlags === 'string' ? r.capabilityFlags : null,
+    firmwareVersion: typeof r.firmwareVersion === 'number' ? r.firmwareVersion : null,
+    gatewareVersion: typeof r.gatewareVersion === 'number' ? r.gatewareVersion : null,
+  };
 }
 
 function asDiagRecord(raw: unknown): Record<string, unknown> {
@@ -4845,6 +4868,17 @@ export function fetchRadios(signal?: AbortSignal): Promise<RadioInfoDto[]> {
   return jsonFetch('/api/radios', { signal }, normalizeRadios);
 }
 
+export function fetchProtocol3Presence(
+  ip: string,
+  signal?: AbortSignal,
+): Promise<Protocol3PresenceDto> {
+  return jsonFetch(
+    `/api/protocol3/presence?ip=${encodeURIComponent(ip)}`,
+    { signal },
+    normalizeProtocol3Presence,
+  );
+}
+
 /** A POTA / SOTA / DX activation spot from GET /api/spots/activations. `freqHz`
  *  is absolute Hz (server normalizes POTA kHz / SOTA MHz / DX kHz). `mode` is
  *  the raw upstream string (SSB/CW/FT8/…) — map it to an RxMode at tune time. */
@@ -6050,7 +6084,7 @@ export function setFavoriteFilterSlots(
   );
 }
 
-// 768/1536 kHz are Protocol-2 only (ANAN G2); Protocol 1 caps at 384 kHz.
+// 768/1536 kHz need a wide DDC transport (P2/P3); Protocol 1 caps at 384 kHz.
 // ConnectPanel gates the higher rungs to P2, and the backend rejects them on
 // a P1 connect.
 export type SampleRate = 48_000 | 96_000 | 192_000 | 384_000 | 768_000 | 1_536_000;

--- a/zeus-web/src/components/BandwidthSettingsSection.test.tsx
+++ b/zeus-web/src/components/BandwidthSettingsSection.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 //
-// The live bandwidth control must not offer wide P2 DDC rates unless both the
+// The live bandwidth control must not offer wide DDC rates unless both the
 // protocol and board capability fingerprint allow them.
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -81,6 +81,19 @@ describe('BandwidthSettingsSection', () => {
     expect(container.textContent).toContain('max 1536 kHz');
   });
 
+  it('unlocks the full P3 ladder for a G2-class 1536 kHz board', () => {
+    seedRadioCaps({ maxRxSampleRateHz: 1_536_000 });
+    useConnectionStore.setState({ connectedProtocol: 'P3' });
+    act(() => {
+      root.render(<BandwidthSettingsSection />);
+    });
+
+    const wide = rateButton(container, '1536');
+    expect(wide.disabled).toBe(false);
+    expect(wide.title).toBe('Set DDC bandwidth to 1536 kHz');
+    expect(container.textContent).toContain('max 1536 kHz');
+  });
+
   it('keeps 768/1536 locked on Protocol 1 even when the board is wideband-capable', () => {
     seedRadioCaps({ maxRxSampleRateHz: 1_536_000 });
     useConnectionStore.setState({ connectedProtocol: 'P1' });
@@ -90,7 +103,7 @@ describe('BandwidthSettingsSection', () => {
 
     const wide = rateButton(container, '1536');
     expect(wide.disabled).toBe(true);
-    expect(wide.title).toBe('1536 kHz needs a Protocol-2 connection');
+    expect(wide.title).toBe('1536 kHz needs a Protocol-2 or Protocol-3 connection');
     expect(container.textContent).toContain('max 384 kHz');
   });
 });

--- a/zeus-web/src/components/BandwidthSettingsSection.tsx
+++ b/zeus-web/src/components/BandwidthSettingsSection.tsx
@@ -19,10 +19,9 @@
 // ladder as a live control so an operator can widen/narrow the spectrum without
 // reconnecting. Mirrors Thetis's Setup ▸ General ▸ "Sample Rate" selector.
 //
-// The 768/1536 kHz rungs are Protocol-2 only: Protocol-1's control frame carries
-// the rate in 2 bits (max 384 kHz), so they are gated to a P2 connection both
-// here and in the backend (RadioService.SetSampleRate clamps, the connect path
-// rejects). Sends are optimistic + applyState-reconciled like every other
+// The 768/1536 kHz rungs need a wide DDC transport: Protocol-1's control frame
+// carries the rate in 2 bits (max 384 kHz), so they are gated to P2/P3 here and
+// in the backend. Sends are optimistic + applyState-reconciled like every other
 // section, so the toolbar/connect view and this control stay in sync.
 
 import { useCallback, useEffect, useRef } from 'react';
@@ -57,10 +56,12 @@ export function BandwidthSettingsSection() {
     [applyState],
   );
 
-  // 768/1536 are P2-only and board-capability gated. Treat unknown protocol
+  // 768/1536 are P2/P3-only and board-capability gated. Treat unknown protocol
   // (null, e.g. after reload) conservatively as the P1 cap so we never offer
   // a rung the radio rejects.
-  const protocolMaxRateHz = protocol === 'P2' ? boardMaxRateHz : P1_MAX_SAMPLE_RATE;
+  const protocolMaxRateHz = protocol === 'P2' || protocol === 'P3'
+    ? boardMaxRateHz
+    : P1_MAX_SAMPLE_RATE;
 
   return (
     <div className="dsp-cfg">
@@ -71,7 +72,7 @@ export function BandwidthSettingsSection() {
         </span>
         <div className="dsp-cfg-btns">
           {RATES.map((r) => {
-            const protocolLocked = r > P1_MAX_SAMPLE_RATE && protocol !== 'P2';
+            const protocolLocked = r > P1_MAX_SAMPLE_RATE && protocol !== 'P2' && protocol !== 'P3';
             const capabilityLocked = r > protocolMaxRateHz;
             const locked = protocolLocked || capabilityLocked;
             const isActive = sampleRate === r;
@@ -85,7 +86,7 @@ export function BandwidthSettingsSection() {
                 className={`btn sm ${isActive ? 'active' : ''}`}
                 title={
                   protocolLocked
-                    ? `${r / 1000} kHz needs a Protocol-2 connection`
+                    ? `${r / 1000} kHz needs a Protocol-2 or Protocol-3 connection`
                     : capabilityLocked
                       ? `${r / 1000} kHz exceeds this radio's ${protocolMaxRateHz / 1000} kHz RX/DDC capability`
                     : `Set DDC bandwidth to ${r / 1000} kHz`

--- a/zeus-web/src/components/ConnectPanel.tsx
+++ b/zeus-web/src/components/ConnectPanel.tsx
@@ -51,6 +51,7 @@ import {
   disconnectP2 as apiDisconnectP2,
   reclaimRadio,
   fetchRadios,
+  fetchProtocol3Presence,
   fetchState,
   listPrefsDatabases,
   setActivePrefsDatabase,
@@ -87,15 +88,13 @@ const DEFAULT_DATA_PORT = 1024;
 const DEFAULT_SAMPLE_RATE = 192_000;
 const RETRY_THRESHOLD = 2;
 const IPV4_RE = /^(?:(?:25[0-5]|2[0-4]\d|[01]?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d?\d)$/;
-// 768/1536 kHz are Protocol-2 only (ANAN G2 supports the full ladder); the
-// select below filters them out when Protocol 1 is selected.
+// 768/1536 kHz need a wide DDC transport (P2/P3); the select below filters
+// them out when Protocol 1 is selected.
 const SAMPLE_RATES: SampleRate[] = [48_000, 96_000, 192_000, 384_000, 768_000, 1_536_000];
 const P1_MAX_SAMPLE_RATE = 384_000;
 
 function sampleRateCeiling(protocol: ProtocolChoice, boardMaxRateHz: number): number {
-  return protocol === 'P2'
-    ? boardMaxRateHz
-    : P1_MAX_SAMPLE_RATE;
+  return protocol === 'P1' ? P1_MAX_SAMPLE_RATE : boardMaxRateHz;
 }
 
 function highestAllowedSampleRate(maxHz: number): SampleRate {
@@ -454,6 +453,26 @@ const MANUAL_BOARD_OPTIONS: ReadonlyArray<BoardKind> = [
   'Metis',
 ];
 
+const PROTOCOL3_UNAVAILABLE_TITLE = 'Protocol 3 requires p3app running on the selected radio.';
+const PROTOCOL3_PREVIEW_TITLE =
+  'Protocol 3 p3app was detected, but the Zeus P3 connect path is not wired yet.';
+
+function hasProtocol3App(r: RadioInfoDto): boolean {
+  return r.details?.protocol3Available === 'true';
+}
+
+function protocolDisplayName(protocol: string): string {
+  if (protocol === 'P3') return 'Protocol 3';
+  if (protocol === 'P2') return 'Protocol 2';
+  return 'Protocol 1';
+}
+
+function discoveredP3AvailableForIp(radios: RadioInfoDto[] | null, ip: string): boolean {
+  const needle = ip.trim();
+  if (!needle || radios === null) return false;
+  return radios.some((r) => r.ipAddress === needle && hasProtocol3App(r));
+}
+
 function endpointFor(r: RadioInfoDto): string {
   if (!r.ipAddress) return '';
   return r.ipAddress.includes(':')
@@ -560,12 +579,51 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
   const [manualBoard, setManualBoard] = useState<BoardKind>(manualFormDefaults.board ?? 'Auto');
   const [manualSave, setManualSave] = useState(true);
   const [manualError, setManualError] = useState<string | null>(null);
+  const [manualP3ProbeAvailable, setManualP3ProbeAvailable] = useState(false);
+  const [manualP3Checking, setManualP3Checking] = useState(false);
   const manualMaxRateHz = sampleRateCeiling(manualProtocol, boardMaxRateHz);
+  const manualP3Available =
+    discoveredP3AvailableForIp(radios, manualIp) || manualP3ProbeAvailable;
 
   useEffect(() => {
     if (manualSampleRate <= manualMaxRateHz) return;
     setManualSampleRate(highestAllowedSampleRate(manualMaxRateHz));
   }, [manualMaxRateHz, manualSampleRate]);
+
+  useEffect(() => {
+    const ip = manualIp.trim();
+    setManualP3ProbeAvailable(false);
+    if (!IPV4_RE.test(ip)) {
+      setManualP3Checking(false);
+      return;
+    }
+
+    const ctrl = new AbortController();
+    setManualP3Checking(true);
+    const timer = window.setTimeout(() => {
+      fetchProtocol3Presence(ip, ctrl.signal)
+        .then((p3) => setManualP3ProbeAvailable(p3.available))
+        .catch((err) => {
+          if ((err as { name?: string })?.name !== 'AbortError') {
+            setManualP3ProbeAvailable(false);
+          }
+        })
+        .finally(() => {
+          if (!ctrl.signal.aborted) setManualP3Checking(false);
+        });
+    }, 250);
+
+    return () => {
+      window.clearTimeout(timer);
+      ctrl.abort();
+    };
+  }, [manualIp]);
+
+  useEffect(() => {
+    if (manualProtocol === 'P3' && !manualP3Available) {
+      setManualProtocol('P2');
+    }
+  }, [manualP3Available, manualProtocol]);
 
   useEffect(() => {
     inflightRef.current = inflight;
@@ -628,7 +686,11 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
   const performConnect = useCallback(
     async (r: RadioInfoDto, force = false) => {
       const ep = endpointFor(r);
-      const isP2 = (r.details?.protocol ?? 'P1') === 'P2';
+      const protocol = r.details?.protocol ?? 'P1';
+      if (protocol === 'P3') {
+        throw new Error(PROTOCOL3_PREVIEW_TITLE);
+      }
+      const isP2 = protocol === 'P2';
       if (isP2) {
         // Pass the discovered board byte (e.g. 0x01 = Hermes for Brick2).
         // Without this the server falls back to OrionMkII for every P2
@@ -691,7 +753,12 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
     async (r: RadioInfoDto) => {
       if (inflightRef.current) return;
       const ep = endpointFor(r);
-      const isP2 = (r.details?.protocol ?? 'P1') === 'P2';
+      const protocol = r.details?.protocol ?? 'P1';
+      if (protocol === 'P3') {
+        setError(PROTOCOL3_PREVIEW_TITLE);
+        return;
+      }
+      const isP2 = protocol === 'P2';
       setInflight(true);
       setError(null);
       try {
@@ -723,6 +790,10 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
       }
       if (!Number.isInteger(port) || port < 1 || port > 65535) {
         setManualError('Port must be between 1 and 65535');
+        return;
+      }
+      if (protocol === 'P3') {
+        setManualError(PROTOCOL3_PREVIEW_TITLE);
         return;
       }
 
@@ -764,7 +835,7 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
         }
         setManualFormDefaults({ ip, port, protocol, sampleRate, board, label: '' });
       } catch (err) {
-        // Busy radio (relay-chatter guard, P2 only): the server refuses a
+        // Busy radio (relay-chatter guard, P2 path): the server refuses a
         // second-master connect with a 409 { reclaimable: true }. Offer the
         // same Reclaim-then-connect takeover the Discover path exposes instead
         // of dead-ending on the error text. `force` is already set on a retry
@@ -793,6 +864,10 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
   const handleManualForceConnect = useCallback(
     async (snap: NonNullable<typeof pendingManualTakeover>) => {
       if (inflightRef.current) return;
+      if (snap.protocol === 'P3') {
+        setManualError(PROTOCOL3_PREVIEW_TITLE);
+        return;
+      }
       const ep = `${snap.ip}:${snap.port}`;
       // Latch the ref directly (the effect that mirrors `inflight` only runs on
       // the next render) so the reclaim shows as inflight and a stray click
@@ -1021,7 +1096,7 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
               textShadow: '0 1px 2px rgba(0,0,0,0.8)',
             }}
           >
-            OpenHPSDR · Protocol 1 / 2
+            OpenHPSDR · Protocol 1 / 2 / 3
           </span>
         </div>
         <button
@@ -1133,6 +1208,7 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
                   const isLast = !!ep && ep === lastConnectedEndpoint;
                   const protocol = r.details?.protocol ?? 'P1';
                   const isP2 = protocol === 'P2';
+                  const p3Available = hasProtocol3App(r);
                   return (
                     <li
                       key={r.macAddress || r.ipAddress}
@@ -1156,10 +1232,19 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
                           <span
                             className="chip"
                             style={{ marginLeft: 6 }}
-                            title={`Discovered via Protocol ${protocol === 'P2' ? '2' : '1'}`}
+                            title={`Discovered via ${protocolDisplayName(protocol)}`}
                           >
                             <span className="v">{protocol}</span>
                           </span>
+                          {p3Available && (
+                            <span
+                              className="chip"
+                              style={{ marginLeft: 6, opacity: 0.75 }}
+                              title={PROTOCOL3_PREVIEW_TITLE}
+                            >
+                              <span className="v">P3 APP</span>
+                            </span>
+                          )}
                           {isLast && (
                             <span className="chip accent" style={{ marginLeft: 6 }} title="Last connected radio">
                               <span className="v">LAST</span>
@@ -1188,17 +1273,39 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
                           >
                             Take over
                           </button>
+                          {p3Available && (
+                            <button
+                              type="button"
+                              disabled
+                              title={PROTOCOL3_PREVIEW_TITLE}
+                              className="btn sm ghost"
+                            >
+                              P3
+                            </button>
+                          )}
                         </div>
                       ) : (
-                        <button
-                          type="button"
-                          onClick={() => handleConnect(r)}
-                          disabled={inflight}
-                          title={isP2 ? 'Protocol 2 path — experimental, RX only' : undefined}
-                          className="btn sm active"
-                        >
-                          {inflight ? 'Connecting…' : 'Connect'}
-                        </button>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                          {p3Available && (
+                            <button
+                              type="button"
+                              disabled
+                              title={PROTOCOL3_PREVIEW_TITLE}
+                              className="btn sm ghost"
+                            >
+                              P3
+                            </button>
+                          )}
+                          <button
+                            type="button"
+                            onClick={() => handleConnect(r)}
+                            disabled={inflight}
+                            title={isP2 ? 'Protocol 2 path - experimental, RX only' : undefined}
+                            className="btn sm active"
+                          >
+                            {inflight ? 'Connecting...' : 'Connect'}
+                          </button>
+                        </div>
                       )}
                     </li>
                   );
@@ -1214,6 +1321,8 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
             setPort={setManualPort}
             protocol={manualProtocol}
             setProtocol={setManualProtocol}
+            p3Available={manualP3Available}
+            p3Checking={manualP3Checking}
             sampleRate={manualSampleRate}
             setSampleRate={setManualSampleRate}
             maxSampleRateHz={manualMaxRateHz}
@@ -1391,6 +1500,8 @@ interface ManualModeProps {
   ip: string; setIp: (v: string) => void;
   port: number; setPort: (v: number) => void;
   protocol: ProtocolChoice; setProtocol: (v: ProtocolChoice) => void;
+  p3Available: boolean;
+  p3Checking: boolean;
   sampleRate: SampleRate; setSampleRate: (v: SampleRate) => void;
   maxSampleRateHz: number;
   board: BoardKind; setBoard: (v: BoardKind) => void;
@@ -1423,7 +1534,8 @@ const fieldLabelStyle: React.CSSProperties = {
 };
 
 function ManualMode(p: ManualModeProps) {
-  const canConnect = !p.inflight;
+  const p3Disabled = !p.p3Available || p.p3Checking || p.inflight;
+  const canConnect = !p.inflight && p.protocol !== 'P3';
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
       <div
@@ -1484,6 +1596,28 @@ function ManualMode(p: ManualModeProps) {
               title="Protocol 2 — experimental, RX only"
             >
               P2
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                if (!p3Disabled) p.setProtocol('P3');
+              }}
+              disabled={p3Disabled}
+              className={`btn sm ${p.protocol === 'P3' ? 'active' : 'ghost'}`}
+              style={{
+                flex: 1,
+                opacity: p3Disabled ? 0.45 : 1,
+                cursor: p3Disabled ? 'not-allowed' : 'pointer',
+              }}
+              title={
+                p.p3Checking
+                  ? 'Checking for p3app on this radio...'
+                  : p.p3Available
+                    ? PROTOCOL3_PREVIEW_TITLE
+                    : PROTOCOL3_UNAVAILABLE_TITLE
+              }
+            >
+              P3
             </button>
           </div>
         </div>
@@ -1568,10 +1702,11 @@ function ManualMode(p: ManualModeProps) {
         type="button"
         onClick={p.onConnect}
         disabled={!canConnect}
+        title={p.protocol === 'P3' ? PROTOCOL3_PREVIEW_TITLE : undefined}
         className={`btn lg ${canConnect ? 'active' : ''}`}
         style={{ alignSelf: 'stretch' }}
       >
-        {p.inflight ? 'Connecting…' : 'Connect'}
+        {p.inflight ? 'Connecting...' : 'Connect'}
       </button>
 
       <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginTop: 4 }}>
@@ -1597,6 +1732,7 @@ function ManualMode(p: ManualModeProps) {
           <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: 4 }}>
             {p.savedEndpoints.map((e) => {
               const isLast = e.id === p.lastConnectedId;
+              const p3Saved = e.protocol === 'P3';
               return (
                 <li
                   key={e.id}
@@ -1644,8 +1780,9 @@ function ManualMode(p: ManualModeProps) {
                     <button
                       type="button"
                       onClick={() => p.onReconnect(e)}
-                      disabled={p.inflight}
-                      className={`btn sm ${p.inflight ? '' : 'active'}`}
+                      disabled={p.inflight || p3Saved}
+                      className={`btn sm ${p.inflight || p3Saved ? '' : 'active'}`}
+                      title={p3Saved ? PROTOCOL3_PREVIEW_TITLE : undefined}
                     >
                       Connect
                     </button>

--- a/zeus-web/src/components/ReceiversPanel.test.tsx
+++ b/zeus-web/src/components/ReceiversPanel.test.tsx
@@ -37,14 +37,15 @@ function rx(index: number, enabled: boolean, adcSource = 0): ReceiverDto {
 }
 
 function setup(opts: {
-  protocol?: 'P1' | 'P2' | null;
+  protocol?: 'P1' | 'P2' | 'P3' | null;
   receivers?: ReceiverDto[];
+  maxReceivers?: number;
 }) {
   useConnectionStore.setState({
     status: 'Connected',
     connectedProtocol: opts.protocol ?? 'P2',
     receivers: opts.receivers ?? [rx(0, true)],
-    maxReceivers: 8,
+    maxReceivers: opts.maxReceivers ?? 6,
   });
 }
 
@@ -53,11 +54,11 @@ describe('ReceiversPanel', () => {
     vi.clearAllMocks();
   });
 
-  it('gates multi-DDC on a Protocol-2 connection', () => {
+  it('gates multi-DDC on a wide-DDC protocol connection', () => {
     setup({ protocol: 'P1' });
     const { container, unmount } = render(createElement(ReceiversPanel));
-    expect(container.textContent).toContain('Protocol 2 only');
-    // No exposed-count buttons on a non-P2 radio.
+    expect(container.textContent).toContain('Protocol 2 / 3 only');
+    // No exposed-count buttons on a non-P2/P3 radio.
     expect(container.querySelector('[aria-label="Exposed receiver count"]')).toBeNull();
     unmount();
   });
@@ -77,6 +78,18 @@ describe('ReceiversPanel', () => {
 
     // Exposing 3 enables index 2 (server contiguity turns on RX2..RX3).
     expect(setReceiver).toHaveBeenCalledWith(2, { enabled: true });
+    unmount();
+  });
+
+  it('exposes all ten receiver choices on Protocol 3', () => {
+    setup({ protocol: 'P3', receivers: [rx(0, true)], maxReceivers: 10 });
+    const { container, unmount } = render(createElement(ReceiversPanel));
+
+    const buttons = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[aria-label="Exposed receiver count"] button'),
+    ).map((b) => b.textContent);
+
+    expect(buttons).toEqual(['1', '2', '3', '4', '5', '6', '7', '8', '9', '10']);
     unmount();
   });
 

--- a/zeus-web/src/components/ReceiversPanel.tsx
+++ b/zeus-web/src/components/ReceiversPanel.tsx
@@ -8,8 +8,8 @@
 // RECEIVERS (multi-DDC) settings tab. Lets the operator choose how many
 // hardware DDC receivers to expose and which phase-synchronous ADC each one
 // reads — the front end for the B4-server N-receiver path (POST
-// /api/receivers/{index}, StateDto.Receivers[]). Multi-DDC is a Protocol-2
-// feature (ANAN G2 / Saturn class); the panel gates on a live P2 connection.
+// /api/receivers/{index}, StateDto.Receivers[]). Multi-DDC is a Protocol-2/3
+// feature (ANAN G2 / Saturn class); the panel gates on a live P2/P3 connection.
 //
 // Receivers are contiguous (the radio's DDC run has no gaps): exposing N means
 // RX1..RXN are active. The "exposed" button row composes the per-index calls;
@@ -21,7 +21,7 @@ import { setReceiver } from '../api/client';
 import { useConnectionStore } from '../state/connection-store';
 import {
   KIWI_RECEIVER_INDEX,
-  PRACTICAL_MAX_RECEIVERS,
+  MAX_HARDWARE_RECEIVERS,
   receiverLabel,
   setExposedReceiverCount,
 } from '../state/receiver-state';
@@ -46,11 +46,11 @@ export function ReceiversPanel() {
   const applyState = useConnectionStore((s) => s.applyState);
 
   const connected = status === 'Connected';
-  const isP2 = connectedProtocol === 'P2';
+  const supportsMultiDdc = connectedProtocol === 'P2' || connectedProtocol === 'P3';
 
-  // Effective ceiling = whatever the build/wire allows, clamped to the count
-  // that actually streams on hardware (see PRACTICAL_MAX_RECEIVERS).
-  const effectiveMax = Math.min(maxReceivers, PRACTICAL_MAX_RECEIVERS);
+  // Effective ceiling = the active protocol/board count from the server,
+  // bounded by the client contract's hardware receiver capacity.
+  const effectiveMax = Math.min(maxReceivers, MAX_HARDWARE_RECEIVERS);
 
   // Number of contiguous active receivers (RX1 always counts).
   const exposedCount = Math.max(1, receivers.filter((r) => r.enabled).length);
@@ -87,13 +87,14 @@ export function ReceiversPanel() {
               <em>Connect a radio to configure its DDC receivers.</em>
             </div>
           </div>
-        ) : !isP2 ? (
+        ) : !supportsMultiDdc ? (
           <div className="ps-field">
             <div className="ps-name">
-              Protocol 2 only
+              Protocol 2 / 3 only
               <em>
-                Multiple independent DDC receivers require a Protocol-2 radio
-                (ANAN G2 / Saturn class). RX1/RX2 remain available on this radio.
+                Multiple independent DDC receivers require a Protocol-2 or
+                Protocol-3 radio (ANAN G2 / Saturn class). RX1/RX2 remain
+                available on this radio.
               </em>
             </div>
           </div>

--- a/zeus-web/src/dsp/floor-normalization.test.ts
+++ b/zeus-web/src/dsp/floor-normalization.test.ts
@@ -98,31 +98,31 @@ describe('floorNormalizationOffsetDb', () => {
   });
 });
 
-describe('Kiwi slice (index 7) is a foreign RX — aligns to, but never defines, the anchor', () => {
+describe('Kiwi slice (index 10) is a foreign RX - aligns to, but never defines, the anchor', () => {
   it('is excluded from the reference median', () => {
     reportReceiverFloorDb(0, -135); // hardware RX1
-    reportReceiverFloorDb(7, -100); // Kiwi — must not move the anchor
+    reportReceiverFloorDb(10, -100); // Kiwi - must not move the anchor
     expect(referenceFloorDb()).toBe(-135);
   });
 
   it('aligns the Kiwi fully to the hardware anchor (not half-way)', () => {
     reportReceiverFloorDb(0, -140); // quiet hardware RX
-    reportReceiverFloorDb(7, -100); // noisier remote Kiwi
+    reportReceiverFloorDb(10, -100); // noisier remote Kiwi
     // Kiwi shifts its whole window up by the full floor delta so its floor lands
-    // at the hardware floor's colour — NOT the half-shift a shared median gives.
-    expect(floorNormalizationOffsetDb(7)).toBeCloseTo(40, 1);
+    // at the hardware floor's colour - NOT the half-shift a shared median gives.
+    expect(floorNormalizationOffsetDb(10)).toBeCloseTo(40, 1);
   });
 
   it('does not pull the hardware panes (RX1 offset stays 0 with only the Kiwi alongside)', () => {
     reportReceiverFloorDb(0, -140);
-    reportReceiverFloorDb(7, -100);
+    reportReceiverFloorDb(10, -100);
     expect(floorNormalizationOffsetDb(0)).toBe(0);
   });
 
   it('falls back to no shift when no hardware floor has reported yet', () => {
-    reportReceiverFloorDb(7, -100); // Kiwi alone → anchor null → raw window
+    reportReceiverFloorDb(10, -100); // Kiwi alone -> anchor null -> raw window
     expect(referenceFloorDb()).toBeNull();
-    expect(floorNormalizationOffsetDb(7)).toBe(0);
+    expect(floorNormalizationOffsetDb(10)).toBe(0);
   });
 });
 

--- a/zeus-web/src/dsp/floor-normalization.ts
+++ b/zeus-web/src/dsp/floor-normalization.ts
@@ -43,9 +43,9 @@ const floorByRx = new Map<number, number>();
 // must NOT help DEFINE it — co-anchoring drags the hardware panes toward the
 // Kiwi's (often very different) floor and, with just RX1 + Kiwi, leaves BOTH only
 // half-aligned, so the Kiwi pane washes out bright instead of matching RX1's dark
-// floor (operator report). Held as a local literal to avoid a dsp→state import
+// floor (operator report). Held as a local literal to avoid a dsp->state import
 // cycle.
-const KIWI_RX_INDEX = 7;
+const KIWI_RX_INDEX = 10;
 
 // EMA smoothing for the per-receiver floor — fast enough to settle on a band
 // change within a couple of seconds, slow enough that the colours don't jitter

--- a/zeus-web/src/state/__tests__/receiver-state.test.ts
+++ b/zeus-web/src/state/__tests__/receiver-state.test.ts
@@ -1,7 +1,14 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { describe, expect, it } from 'vitest';
-import { KIWI_RECEIVER_INDEX, receiverLabel } from '../receiver-state';
+import { KIWI_RECEIVER_INDEX, MAX_HARDWARE_RECEIVERS, receiverLabel } from '../receiver-state';
+
+describe('receiver constants', () => {
+  it('keeps Kiwi outside the ten hardware receiver slots', () => {
+    expect(MAX_HARDWARE_RECEIVERS).toBe(10);
+    expect(KIWI_RECEIVER_INDEX).toBe(MAX_HARDWARE_RECEIVERS);
+  });
+});
 
 describe('receiverLabel', () => {
   it('falls back to a 1-based RX{n} label when name is null', () => {

--- a/zeus-web/src/state/connect-store.ts
+++ b/zeus-web/src/state/connect-store.ts
@@ -18,7 +18,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { BoardKind } from '../api/radio';
 
-export type ProtocolChoice = 'P1' | 'P2';
+export type ProtocolChoice = 'P1' | 'P2' | 'P3';
 export type SampleRate = 48_000 | 96_000 | 192_000 | 384_000 | 768_000 | 1_536_000;
 export type ConnectMode = 'discover' | 'manual';
 

--- a/zeus-web/src/state/connection-store.ts
+++ b/zeus-web/src/state/connection-store.ts
@@ -65,6 +65,8 @@ import {
   type ReceiverDto,
 } from '../api/client';
 
+export type ConnectedProtocol = 'P1' | 'P2' | 'P3' | null;
+
 // WDSP wisdom bootstrap phase, mirroring the server's WisdomPhase enum.
 // 'idle' = initializer hasn't started yet (first ms after boot),
 // 'building' = WDSPwisdom is running (up to ~2 min on a fresh machine),
@@ -120,19 +122,19 @@ export type ConnectionState = {
   // 0 = RX1, 1 = RX2, >= 2 = extra hardware DDCs. Empty until the first state
   // frame. The RECEIVERS settings panel reads this to render per-DDC controls.
   receivers: ReceiverDto[];
-  // DDC / receiver ceiling for this build (WireContract.MaxReceivers); the
-  // RECEIVERS panel caps the exposed-count control against it.
+  // Active hardware DDC / receiver ceiling for this connection. P2 G2 reports
+  // 6; P3-capable G2 firmware can report all 10.
   maxReceivers: number;
   // Board kind only known from the discovery list at connect time — StateDto
   // doesn't echo it. Null after a page reload while already connected; the
   // preamp guard treats null as "show", which is the safe default (an HL2
   // preamp toggle does nothing harmful, just nothing useful).
   boardId: string | null;
-  // Connected protocol — 'P1' or 'P2', or null when disconnected. Set by
-  // ConnectPanel on a successful /api/connect or /api/connect/p2 call so
+  // Connected protocol — 'P1', 'P2', or 'P3', or null when disconnected. Set by
+  // ConnectPanel on a successful connect call so
   // protocol-gated features can disable their controls cleanly without
   // round-tripping the discovery list.
-  connectedProtocol: 'P1' | 'P2' | null;
+  connectedProtocol: ConnectedProtocol;
   preampOn: boolean;
   // CTUN (click-tune / centred tuning). When true, a panadapter click tunes
   // the dial off-centre with the hardware NCO frozen; the pan-tune gesture
@@ -175,7 +177,7 @@ export type ConnectionState = {
   applyState: (s: RadioStateDto, opts?: { trustVfo?: boolean }) => void;
   setInflight: (v: boolean) => void;
   setBoardId: (id: string | null) => void;
-  setConnectedProtocol: (p: 'P1' | 'P2' | null) => void;
+  setConnectedProtocol: (p: ConnectedProtocol) => void;
   setPreampOn: (on: boolean) => void;
   setNr: (nr: NrConfigDto) => void;
   setAgc: (agc: AgcConfigDto) => void;
@@ -219,7 +221,7 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
   vfoHz: 14_200_000,
   rx2Enabled: false,
   receivers: [],
-  maxReceivers: 8,
+  maxReceivers: 10,
   txVfo: 'A',
   txReceiverIndex: 0,
   rxFocus: 'A',

--- a/zeus-web/src/state/receiver-state.ts
+++ b/zeus-web/src/state/receiver-state.ts
@@ -58,11 +58,16 @@ import {
  *  RX3+); `'A'`/`'B'` are legacy aliases for 0/1. */
 export type ReceiverKey = 'A' | 'B' | number;
 
+/** Maximum hardware receiver count the frontend contract can represent. The
+ *  server's state.maxReceivers carries the active protocol/board ceiling: P2 G2
+ *  reports 6, while P3-capable G2 firmware can report all 10. */
+export const MAX_HARDWARE_RECEIVERS = 10;
+
 /** Reserved high index for the KiwiSDR slice receiver (mirrors
- *  WireContract.KiwiReceiverIndex = MaxReceivers-1 = 7). It is a software
- *  receiver, not a hardware DDC — it never counts toward the multi-RX count
- *  stepper or the ADC-source list. */
-export const KIWI_RECEIVER_INDEX = 7;
+ *  WireContract.KiwiReceiverIndex = 10). It is a software receiver, not a
+ *  hardware DDC — it never counts toward the multi-RX count stepper or the
+ *  ADC-source list. */
+export const KIWI_RECEIVER_INDEX = 10;
 
 /** Operator-facing label for a receiver. Hardware DDCs carry no name and fall
  *  back to "RX{n}" (1-based); the Kiwi slice receiver carries "Kiwi". */
@@ -352,16 +357,10 @@ export function gangedReceiverAction(opts: {
 // the MULTI-RX toolbar toggle so both compose the same per-index endpoint calls
 // and honour the same practical ceiling.
 
-// Protocol ceiling is WireContract.MaxReceivers (8 DDCs), but the count that
-// actually streams on a G2/Saturn at the wide multi-DDC sample rates
-// (768/1536 kHz) is 6 — beyond that the radio's DDC throughput budget is
-// exceeded and the extra DDCs come up dead. Cap the operator-facing count here.
-export const PRACTICAL_MAX_RECEIVERS = 6;
-
 const DESIRED_COUNT_KEY = 'zeus.multiRx.desiredCount';
 
 function clampDesired(n: number): number {
-  return Math.min(Math.max(Math.round(n), 2), PRACTICAL_MAX_RECEIVERS);
+  return Math.min(Math.max(Math.round(n), 2), MAX_HARDWARE_RECEIVERS);
 }
 
 /** The operator's chosen multi-RX count, remembered across an off toggle and
@@ -395,7 +394,7 @@ export function setDesiredReceiverCount(n: number): void {
  */
 export async function setExposedReceiverCount(target: number): Promise<void> {
   const st = useConnectionStore.getState();
-  const effectiveMax = Math.min(st.maxReceivers, PRACTICAL_MAX_RECEIVERS);
+  const effectiveMax = Math.min(st.maxReceivers, MAX_HARDWARE_RECEIVERS);
   const n = Math.min(Math.max(Math.round(target), 1), effectiveMax);
   const applyState = st.applyState;
   if (n >= 2) setDesiredReceiverCount(n);

--- a/zeus-web/src/state/view-zoom.ts
+++ b/zeus-web/src/state/view-zoom.ts
@@ -144,7 +144,7 @@ export function getDisplayedHzPerPixel(): number {
 /** The displayed hzPerPixel a given receiver's spectrum surfaces should scale
  *  their trace/history against.
  *
- *  Hardware DDCs (RX1..RX6) share the radio's one Hz/pixel scale and follow the
+ *  Hardware DDCs share the radio's one Hz/pixel scale and follow the
  *  global zoom tween, so they get `getDisplayedHzPerPixel()`. The Kiwi slice
  *  receiver (KIWI_RECEIVER_INDEX) is a remote KiwiSDR with its OWN independent
  *  Hz/pixel (its native ~29 kHz span over its own bin count), which the shared


### PR DESCRIPTION
## Summary
- expands the shared hardware receiver contract to 10 slots while keeping Protocol 2's wire DDC ceiling at 8 and G2's active P2 ceiling at 6
- moves Kiwi to the reserved receiver index above the hardware RX10 slot
- adds Protocol 3 p3app presence probing and exposes protocol3Available/stream details in discovery plus a direct manual-IP presence endpoint
- adds P3 to the connect protocol selector, greyed out until p3app responds, and gates P3 connect until the backend P3 transport exists

Beads: zeus-kzfw

## Verification
- dotnet test tests\\Zeus.Server.Tests\\Zeus.Server.Tests.csproj --filter "FullyQualifiedName~Protocol3PresenceProbeTests|FullyQualifiedName~RadioServiceUnifiedReceiverWriteTests|FullyQualifiedName~KiwiSdrTests"
- dotnet test tests\\Zeus.Protocol2.Tests\\Zeus.Protocol2.Tests.csproj --filter "FullyQualifiedName~ComposeCmdRxBufferForReceiversTests|FullyQualifiedName~Rx2DdcTests"
- npm --prefix zeus-web run test -- src/state/__tests__/receiver-state.test.ts src/dsp/floor-normalization.test.ts src/components/ReceiversPanel.test.tsx src/components/BandwidthSettingsSection.test.tsx
- npm --prefix zeus-web run build

Note: scripts/finish-work.ps1 created the commit, then timed out while running full `dotnet test Zeus.slnx`; the process tree was idle and was stopped before manually pushing the already-verified branch and beads data.