### PR TITLE
feat(vradio): virtual HPSDR radio emulator — P1 + P2 engine

### DIFF
--- a/Zeus.Protocol1/AssemblyInfo.cs
+++ b/Zeus.Protocol1/AssemblyInfo.cs
@@ -50,3 +50,17 @@ using System.Runtime.CompilerServices;
 // delegates to ControlFrame's pure antenna-bit helpers so the firewall and the
 // wire path share one copy of the math — byte-identical by construction.
 [assembly: InternalsVisibleTo("Zeus.Server.Hosting")]
+// The virtual-radio emulator is the MIRROR side of these wire codecs: it
+// decodes EP2 (ControlFrame) and encodes EP6 (PacketParser). It consumes the
+// framing CONSTANTS / byte offsets / CcRegister + CcState shapes directly so
+// the emulator and the real parsers can never drift — any wire-format change
+// breaks the emulator's compile or its round-trip tests. See the Virtual HPSDR
+// Radio plan (Phase 0/1).
+[assembly: InternalsVisibleTo("Zeus.VirtualRadio")]
+// The emulator's anti-drift round-trip tests live in Zeus.VirtualRadio.Tests and
+// must call the REAL parsers (PacketParser.TryParsePacket) and encoders
+// (ControlFrame.BuildDataPacket / WriteCcBytes) directly to prove the emulator's
+// EP6 encode / EP2 decode invert them byte-for-byte. Without this the round-trip
+// guarantee can only be self-consistent, not validated against Zeus's own wire
+// code. INTEGRATOR: added by the wire-codec implementer; confirm placement.
+[assembly: InternalsVisibleTo("Zeus.VirtualRadio.Tests")]

--- a/Zeus.Protocol2/AssemblyInfo.cs
+++ b/Zeus.Protocol2/AssemblyInfo.cs
@@ -46,6 +46,17 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Zeus.Protocol2.Tests")]
+// The virtual-radio emulator (Zeus.VirtualRadio) mirrors the Protocol-2 wire
+// format from the radio's side. It consumes Protocol2Client internals — the
+// canonical paired-feedback de-interleave (DecodePsPairForTest), the CmdRx
+// composer (ComposeCmdRxBuffer), and the single-ADC time-mux flag
+// (Hermes10ePsTimeMuxOnAir / G2ePsTimeMuxOnAir) — so the emulator and the
+// client share ONE definition of every byte offset and a wire-format change
+// breaks the build or a round-trip test rather than drifting silently. The
+// Tests assembly gets the same access so the socketless round-trip tests can
+// feed the emulator's frames through the real client decode path.
+[assembly: InternalsVisibleTo("Zeus.VirtualRadio")]
+[assembly: InternalsVisibleTo("Zeus.VirtualRadio.Tests")]
 // The external-port encoder seam (Zeus.Server.Hosting.IExternalPortEncoder)
 // delegates to Protocol2Client's pure antenna-bit helpers so the firewall and
 // the wire path share one copy of the math — byte-identical by construction.

--- a/Zeus.Server.Hosting/Zeus.Server.Hosting.csproj
+++ b/Zeus.Server.Hosting/Zeus.Server.Hosting.csproj
@@ -47,6 +47,11 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Zeus.Contracts.Tests" />
     <InternalsVisibleTo Include="Zeus.Server.Tests" />
+    <!-- Virtual-radio emulator consumes the per-board calibration / PA /
+         capability tables (RadioCalibrations, PaDefaults, BoardCapabilitiesTable)
+         to invert Zeus's own forward-power math, so its UNMODIFIED meter path
+         reads back the watts the emulator intends. Zero new public surface. -->
+    <InternalsVisibleTo Include="Zeus.VirtualRadio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Zeus.VirtualRadio.Host/Program.cs
+++ b/Zeus.VirtualRadio.Host/Program.cs
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Globalization;
+using System.Net;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Zeus.Contracts;
+using Zeus.VirtualRadio;
+using Zeus.VirtualRadio.Observation;
+using Zeus.VirtualRadio.P1;
+
+[assembly: InternalsVisibleTo("Zeus.VirtualRadio.Tests")]
+
+namespace Zeus.VirtualRadio.Host;
+
+/// <summary>
+/// Console host for the virtual HPSDR radio ("zeus-vradio"). Parses the CLI,
+/// builds a <see cref="VirtualRadioProfile"/>, and runs the matching engine
+/// under <see cref="Microsoft.Extensions.Hosting"/> (logging / config / lifetime
+/// for free). No Photino / WDSP / native deps — runs anywhere Zeus does.
+///
+/// Usage:
+///   zeus-vradio [--board HermesII] [--protocol P1] [--variant G2]
+///               [--bind 127.0.0.1] [--rate 48]
+///               [--tone 14074000:-73 [--tone …]] [--noise -110]
+///               [--status-port 8073]
+/// </summary>
+internal static class Program
+{
+    private static async Task<int> Main(string[] args)
+    {
+        HostConfig config;
+        try
+        {
+            config = ParseArgs(args);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"zeus-vradio: {ex.Message}");
+            Console.Error.WriteLine(
+                "usage: zeus-vradio [--board HermesII] [--protocol P1] [--variant G2] " +
+                "[--bind 127.0.0.1] [--rate 48] [--tone 14074000:-73] [--noise -110] [--status-port 8073]");
+            return 2;
+        }
+
+        var builder = Microsoft.Extensions.Hosting.Host.CreateApplicationBuilder(args);
+        builder.Services.AddSingleton(config);
+        builder.Services.AddSingleton(config.Profile);
+        builder.Services.AddSingleton<IVirtualRadio>(sp =>
+            // P1-only for Phase 1. When the P2 engine exists, branch on
+            // config.Profile.Protocol in this lambda.
+            new Protocol1Engine(config.Profile, sp.GetService<ILogger<Protocol1Engine>>()));
+        builder.Services.AddHostedService<VirtualRadioHostedService>();
+
+        using var host = builder.Build();
+        await host.RunAsync().ConfigureAwait(false);
+        return 0;
+    }
+
+    /// <summary>
+    /// Parse the CLI into a validated <see cref="HostConfig"/>.
+    /// Defaults: board HermesII, protocol P1, variant G2, bind 127.0.0.1,
+    /// rate 48 kHz, noise floor -110 dBc, no tones, status port
+    /// <see cref="StatusJsonServer.DefaultPort"/>.
+    /// </summary>
+    internal static HostConfig ParseArgs(string[] args)
+    {
+        var board = HpsdrBoardKind.HermesII;
+        var protocol = ProtocolVersion.P1;
+        var variant = OrionMkIIVariant.G2;
+        var bind = IPAddress.Loopback;
+        int rateKhz = 48;
+        double noise = -110.0;
+        int statusPort = StatusJsonServer.DefaultPort;
+        var tones = new List<ToneSpec>();
+
+        for (int i = 0; i < args.Length; i++)
+        {
+            string arg = args[i];
+            string Next(string name) =>
+                i + 1 < args.Length ? args[++i] : throw new ArgumentException($"{name} requires a value");
+
+            switch (arg)
+            {
+                case "--board":
+                    board = Enum.Parse<HpsdrBoardKind>(Next(arg), ignoreCase: true);
+                    break;
+                case "--protocol":
+                    protocol = Enum.Parse<ProtocolVersion>(Next(arg), ignoreCase: true);
+                    break;
+                case "--variant":
+                    variant = Enum.Parse<OrionMkIIVariant>(Next(arg), ignoreCase: true);
+                    break;
+                case "--bind":
+                    bind = IPAddress.Parse(Next(arg));
+                    break;
+                case "--rate":
+                    rateKhz = int.Parse(Next(arg), CultureInfo.InvariantCulture);
+                    break;
+                case "--noise":
+                    noise = double.Parse(Next(arg), CultureInfo.InvariantCulture);
+                    break;
+                case "--tone":
+                    tones.Add(ParseTone(Next(arg)));
+                    break;
+                case "--status-port":
+                    statusPort = int.Parse(Next(arg), CultureInfo.InvariantCulture);
+                    if (statusPort is < 1 or > 65535)
+                        throw new ArgumentException($"--status-port out of range: {statusPort}");
+                    break;
+                default:
+                    throw new ArgumentException($"unknown argument '{arg}'");
+            }
+        }
+
+        var profile = VirtualRadioProfile.Create(board, protocol, variant) with
+        {
+            BindAddress = bind,
+            SampleRateKhz = rateKhz,
+            NoiseFloorDbc = noise,
+            Tones = tones,
+        };
+        return new HostConfig(profile, statusPort);
+    }
+
+    /// <summary>Parse a "freqHz:dBc" tone spec, e.g. "14074000:-73".</summary>
+    internal static ToneSpec ParseTone(string spec)
+    {
+        int colon = spec.IndexOf(':');
+        if (colon <= 0)
+            throw new ArgumentException($"--tone expects freqHz:dBc, got '{spec}'");
+        long freq = long.Parse(spec[..colon], CultureInfo.InvariantCulture);
+        double dbc = double.Parse(spec[(colon + 1)..], CultureInfo.InvariantCulture);
+        return new ToneSpec(freq, dbc);
+    }
+}
+
+/// <summary>Parsed CLI: the validated radio profile plus host-only options.</summary>
+internal sealed record HostConfig(VirtualRadioProfile Profile, int StatusPort);
+
+/// <summary>
+/// Drives the engine's <see cref="IVirtualRadio.RunAsync"/> for the process
+/// lifetime, alongside the read-only <see cref="StatusJsonServer"/>. Also wires
+/// the structured command log: every decoded host command is logged edge-
+/// triggered, and a ~1 Hz summary line mirrors Zeus's own <c>p1.tx.rate</c>
+/// cadence.
+/// </summary>
+internal sealed class VirtualRadioHostedService : BackgroundService
+{
+    private readonly IVirtualRadio _radio;
+    private readonly HostConfig _config;
+    private readonly ILogger<VirtualRadioHostedService> _logger;
+    private readonly StatusJsonServer _status;
+
+    public VirtualRadioHostedService(
+        IVirtualRadio radio,
+        HostConfig config,
+        ILoggerFactory loggerFactory)
+    {
+        _radio = radio;
+        _config = config;
+        _logger = loggerFactory.CreateLogger<VirtualRadioHostedService>();
+        _status = new StatusJsonServer(
+            _radio.Snapshot,
+            config.StatusPort,
+            loggerFactory.CreateLogger<StatusJsonServer>());
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation(
+            "vradio starting: board {Board} variant {Variant} protocol {Protocol} bind {Bind} rate {Rate}kHz tones {Tones} status :{StatusPort}",
+            _config.Profile.Board, _config.Profile.Variant, _config.Profile.Protocol,
+            _config.Profile.BindAddress, _config.Profile.SampleRateKhz,
+            _config.Profile.Tones.Count, _config.StatusPort);
+
+        _radio.CommandDecoded += OnCommandDecoded;
+        try
+        {
+            await Task.WhenAll(
+                _radio.RunAsync(stoppingToken),
+                _status.RunAsync(stoppingToken),
+                SummaryLoopAsync(stoppingToken)).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // normal shutdown
+        }
+        finally
+        {
+            _radio.CommandDecoded -= OnCommandDecoded;
+        }
+    }
+
+    private void OnCommandDecoded(DecodedHostCommand cmd) =>
+        // Edge-triggered: one line per decoded host command, fully decoded.
+        _logger.LogInformation("vradio.cmd {Kind}: {Summary}", cmd.CommandKind, cmd.Summary);
+
+    private async Task SummaryLoopAsync(CancellationToken ct)
+    {
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1), ct).ConfigureAwait(false);
+                VirtualRadioStatus s = _radio.Snapshot();
+                _logger.LogInformation(
+                    "vradio.status host={Host} mox={Mox} fwd={Fwd:F1}W ref={Ref:F1}W swr={Swr:F2} ep6={Ep6} ep2={Ep2} gaps={Gaps}",
+                    s.ConnectedHost ?? "-", s.Mox, s.FwdWatts, s.RefWatts, s.Swr,
+                    s.Ep6PacketsSent, s.Ep2PacketsReceived, s.SeqGaps);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // normal shutdown
+        }
+    }
+}

--- a/Zeus.VirtualRadio.Host/Program.cs
+++ b/Zeus.VirtualRadio.Host/Program.cs
@@ -18,6 +18,7 @@ using Zeus.Contracts;
 using Zeus.VirtualRadio;
 using Zeus.VirtualRadio.Observation;
 using Zeus.VirtualRadio.P1;
+using Zeus.VirtualRadio.P2;
 
 [assembly: InternalsVisibleTo("Zeus.VirtualRadio.Tests")]
 
@@ -48,8 +49,9 @@ internal static class Program
         {
             Console.Error.WriteLine($"zeus-vradio: {ex.Message}");
             Console.Error.WriteLine(
-                "usage: zeus-vradio [--board HermesII] [--protocol P1] [--variant G2] " +
-                "[--bind 127.0.0.1] [--rate 48] [--tone 14074000:-73] [--noise -110] [--status-port 8073]");
+                "usage: zeus-vradio [--board HermesII] [--protocol P1|P2] [--variant G2] " +
+                "[--bind 127.0.0.1] [--rate 48] [--tone 14074000:-73] [--noise -110] " +
+                "[--status-port 8073] [--ps-distortion]");
             return 2;
         }
 
@@ -57,9 +59,12 @@ internal static class Program
         builder.Services.AddSingleton(config);
         builder.Services.AddSingleton(config.Profile);
         builder.Services.AddSingleton<IVirtualRadio>(sp =>
-            // P1-only for Phase 1. When the P2 engine exists, branch on
-            // config.Profile.Protocol in this lambda.
-            new Protocol1Engine(config.Profile, sp.GetService<ILogger<Protocol1Engine>>()));
+            // Branch on the configured wire stack: the P2 engine for Protocol 2
+            // (multi-port + PureSignal single-ADC time-mux feedback), the P1
+            // engine otherwise.
+            config.Profile.Protocol == ProtocolVersion.P2
+                ? (IVirtualRadio)new Protocol2Engine(config.Profile, sp.GetService<ILogger<Protocol2Engine>>(), config.PsDistortion)
+                : new Protocol1Engine(config.Profile, sp.GetService<ILogger<Protocol1Engine>>()));
         builder.Services.AddHostedService<VirtualRadioHostedService>();
 
         using var host = builder.Build();
@@ -82,6 +87,7 @@ internal static class Program
         int rateKhz = 48;
         double noise = -110.0;
         int statusPort = StatusJsonServer.DefaultPort;
+        bool psDistortion = false;
         var tones = new List<ToneSpec>();
 
         for (int i = 0; i < args.Length; i++)
@@ -118,6 +124,11 @@ internal static class Program
                     if (statusPort is < 1 or > 65535)
                         throw new ArgumentException($"--status-port out of range: {statusPort}");
                     break;
+                case "--ps-distortion":
+                    // Shape the PS coupler through a mild PA model so WDSP calcc
+                    // has a non-trivial curve to converge against (P2 only).
+                    psDistortion = true;
+                    break;
                 default:
                     throw new ArgumentException($"unknown argument '{arg}'");
             }
@@ -130,7 +141,7 @@ internal static class Program
             NoiseFloorDbc = noise,
             Tones = tones,
         };
-        return new HostConfig(profile, statusPort);
+        return new HostConfig(profile, statusPort, psDistortion);
     }
 
     /// <summary>Parse a "freqHz:dBc" tone spec, e.g. "14074000:-73".</summary>
@@ -146,7 +157,7 @@ internal static class Program
 }
 
 /// <summary>Parsed CLI: the validated radio profile plus host-only options.</summary>
-internal sealed record HostConfig(VirtualRadioProfile Profile, int StatusPort);
+internal sealed record HostConfig(VirtualRadioProfile Profile, int StatusPort, bool PsDistortion = false);
 
 /// <summary>
 /// Drives the engine's <see cref="IVirtualRadio.RunAsync"/> for the process

--- a/Zeus.VirtualRadio.Host/Zeus.VirtualRadio.Host.csproj
+++ b/Zeus.VirtualRadio.Host/Zeus.VirtualRadio.Host.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+    <!-- The standalone emulator binary is invoked as `zeus-vradio` by the
+         manual-verification workflow in the plan; pin the output filename so
+         the launch instructions don't depend on the project name. -->
+    <AssemblyName>zeus-vradio</AssemblyName>
+    <RootNamespace>Zeus.VirtualRadio.Host</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Zeus.VirtualRadio\Zeus.VirtualRadio.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/Zeus.VirtualRadio/BoardProtocolSupport.cs
+++ b/Zeus.VirtualRadio/BoardProtocolSupport.cs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Zeus.Contracts;
+
+namespace Zeus.VirtualRadio;
+
+/// <summary>
+/// Bit flags for the set of protocols a board can speak.
+/// </summary>
+[Flags]
+public enum ProtocolSupport : byte
+{
+    None = 0,
+    P1 = 1,
+    P2 = 2,
+    Both = P1 | P2,
+}
+
+/// <summary>
+/// Per-board "which protocols does this board actually speak" fact. This does
+/// NOT exist in Zeus's <c>BoardCapabilitiesTable</c> — Zeus-the-client never
+/// needed it (it just connects to whatever answers discovery). The emulator
+/// needs it to reject illegal <c>{Board, Protocol}</c> startup combinations
+/// (e.g. HL2 + P2, Metis + P2). Kept local to the emulator on purpose: do NOT
+/// promote it into the operator-felt <c>BoardCapabilities</c> table — that is a
+/// separate, red-light decision.
+///
+/// Seed (per the Virtual HPSDR Radio plan):
+/// <list type="bullet">
+/// <item>Metis (0x00), Hermes (0x01), Hermes-Lite 2 (0x06) → P1 only.</item>
+/// <item>HermesII (0x02), Angelia (0x04), Orion (0x05), OrionMkII (0x0A),
+///       HermesC10 (0x14) → both protocols.</item>
+/// </list>
+/// </summary>
+public static class BoardProtocolSupport
+{
+    /// <summary>The set of protocols <paramref name="board"/> can speak.</summary>
+    public static ProtocolSupport For(HpsdrBoardKind board) => board switch
+    {
+        HpsdrBoardKind.Metis       => ProtocolSupport.P1,
+        HpsdrBoardKind.Hermes      => ProtocolSupport.P1,
+        HpsdrBoardKind.HermesLite2 => ProtocolSupport.P1,
+        HpsdrBoardKind.HermesII    => ProtocolSupport.Both,
+        HpsdrBoardKind.Angelia     => ProtocolSupport.Both,
+        HpsdrBoardKind.Orion       => ProtocolSupport.Both,
+        HpsdrBoardKind.OrionMkII   => ProtocolSupport.Both,
+        HpsdrBoardKind.HermesC10   => ProtocolSupport.Both,
+        _                          => ProtocolSupport.None,
+    };
+
+    /// <summary>True when <paramref name="board"/> can speak <paramref name="protocol"/>.</summary>
+    public static bool Supports(HpsdrBoardKind board, ProtocolVersion protocol)
+    {
+        ProtocolSupport flag = protocol == ProtocolVersion.P1 ? ProtocolSupport.P1 : ProtocolSupport.P2;
+        return (For(board) & flag) != 0;
+    }
+}

--- a/Zeus.VirtualRadio/DecodedHostCommand.cs
+++ b/Zeus.VirtualRadio/DecodedHostCommand.cs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.VirtualRadio;
+
+/// <summary>
+/// One decoded host-command event, emitted for the structured command log and
+/// the <c>IVirtualRadio.CommandDecoded</c> event. This is the inverse of
+/// <c>ControlFrame.WriteCcBytes</c> — it reports exactly what Zeus put on the
+/// wire, with every field already decoded into <see cref="Summary"/>.
+/// </summary>
+/// <param name="Timestamp">When the command was decoded (wall clock).</param>
+/// <param name="Protocol">Which wire stack the command arrived on.</param>
+/// <param name="CommandKind">The frame / register name, e.g. "Config",
+/// "TxFreq", "RxFreq", "DriveFilter", "Start", "Stop".</param>
+/// <param name="Summary">Human-readable fully-decoded field dump — the line
+/// written to the command log (mirrors the <c>p1.tx.rate</c> cadence).</param>
+public sealed record DecodedHostCommand(
+    DateTimeOffset Timestamp,
+    ProtocolVersion Protocol,
+    string CommandKind,
+    string Summary);

--- a/Zeus.VirtualRadio/Discovery/DiscoveryResponder.cs
+++ b/Zeus.VirtualRadio/Discovery/DiscoveryResponder.cs
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Zeus.VirtualRadio.Discovery;
+
+/// <summary>
+/// Listens on the radio port for Protocol-1 discovery requests
+/// (<c>0xEF 0xFE 0x02 …</c>) and replies to the SENDER (an ephemeral host port,
+/// not a fixed port) with a <see cref="P1DiscoveryReply"/> for the configured
+/// board. Discovery skips loopback, so a profile bound to <c>127.0.0.1</c> is
+/// direct-connect only and this responder never fires; bind a LAN IP to appear
+/// in Zeus's discovery panel.
+///
+/// The wire-format work lives in the pure, socketless <see cref="TryBuildReply"/>
+/// helper so it is unit-testable; <see cref="RunAsync"/> is the thin socket loop
+/// around it. The Protocol-1 engine may instead call <see cref="TryBuildReply"/>
+/// directly on its own shared port-1024 socket to avoid a second bind.
+/// </summary>
+public sealed class DiscoveryResponder
+{
+    /// <summary>The well-known HPSDR Protocol-1 discovery / command UDP port.</summary>
+    public const int DiscoveryPort = 1024;
+
+    /// <summary>
+    /// Default gateware/code version advertised in the reply (firmware "7.3").
+    /// For board byte 0x02 (HermesII / ANAN-10E) the value is informational and
+    /// never affects board classification.
+    /// </summary>
+    public const byte DefaultCodeVersion = 73;
+
+    // Locally-administered MAC (bit 0x02 set in the first octet) so the emulator
+    // can never collide with a real HPSDR unit's burned-in OUI on the LAN.
+    private static readonly byte[] DefaultMacBytes = { 0x02, 0x00, 0x00, 0x5A, 0xC0, 0x01 };
+
+    /// <summary>The MAC the emulator advertises by default in discovery replies.</summary>
+    public static PhysicalAddress DefaultMac => new(DefaultMacBytes);
+
+    private readonly VirtualRadioProfile _profile;
+    private readonly ILogger<DiscoveryResponder> _logger;
+    private readonly PhysicalAddress _mac;
+    private readonly byte _codeVersion;
+
+    public DiscoveryResponder(VirtualRadioProfile profile, ILogger<DiscoveryResponder>? logger = null)
+        : this(profile, DefaultMac, DefaultCodeVersion, logger)
+    {
+    }
+
+    public DiscoveryResponder(
+        VirtualRadioProfile profile,
+        PhysicalAddress mac,
+        byte codeVersion,
+        ILogger<DiscoveryResponder>? logger = null)
+    {
+        _profile = profile ?? throw new ArgumentNullException(nameof(profile));
+        _mac = mac ?? throw new ArgumentNullException(nameof(mac));
+        _codeVersion = codeVersion;
+        _logger = logger ?? NullLogger<DiscoveryResponder>.Instance;
+    }
+
+    /// <summary>
+    /// Pure, socketless reply builder. Given the bytes of a received datagram,
+    /// returns <see langword="true"/> and the discovery reply to send back to the
+    /// sender when the datagram is a Protocol-1 discovery probe
+    /// (<c>0xEF 0xFE 0x02 …</c>); otherwise returns <see langword="false"/>
+    /// (e.g. an EP2 command frame or junk). The engine can call this on its own
+    /// socket; tests call it directly with byte buffers.
+    /// </summary>
+    public bool TryBuildReply(ReadOnlySpan<byte> probe, out byte[] reply)
+    {
+        reply = Array.Empty<byte>();
+        if (!IsDiscoveryProbe(probe))
+            return false;
+
+        var buffer = new byte[P1DiscoveryReply.ReplyLength];
+        int written = P1DiscoveryReply.Build(buffer, _profile, _mac, _codeVersion, busy: false);
+        reply = written == buffer.Length ? buffer : buffer[..written];
+        return true;
+    }
+
+    /// <summary>
+    /// True when <paramref name="datagram"/> is a Protocol-1 discovery probe:
+    /// the <c>0xEF 0xFE</c> preamble followed by the <c>0x02</c> discovery
+    /// command byte. A connect/start frame uses <c>0xEF 0xFE 0x04</c>, so the
+    /// third byte discriminates discovery from a command.
+    /// </summary>
+    public static bool IsDiscoveryProbe(ReadOnlySpan<byte> datagram) =>
+        datagram.Length >= 3 && datagram[0] == 0xEF && datagram[1] == 0xFE && datagram[2] == 0x02;
+
+    /// <summary>
+    /// Bind the discovery socket and serve replies until cancelled. Returns
+    /// immediately (after logging) when the profile is bound to a loopback
+    /// address, because Zeus's discovery never probes loopback — a loopback
+    /// profile is direct-connect only and the engine owns port 1024 there.
+    /// </summary>
+    public async Task RunAsync(CancellationToken ct)
+    {
+        if (IPAddress.IsLoopback(_profile.BindAddress))
+        {
+            _logger.LogInformation(
+                "vradio.discovery skipped: bind {Bind} is loopback (direct-connect only; discovery does not probe loopback).",
+                _profile.BindAddress);
+            return;
+        }
+
+        using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        try
+        {
+            socket.EnableBroadcast = true;
+            socket.Bind(new IPEndPoint(_profile.BindAddress, DiscoveryPort));
+        }
+        catch (SocketException ex)
+        {
+            _logger.LogError(ex,
+                "vradio.discovery bind failed on {Bind}:{Port} — another HPSDR app may be running.",
+                _profile.BindAddress, DiscoveryPort);
+            return;
+        }
+
+        _logger.LogInformation(
+            "vradio.discovery listening on {Bind}:{Port} as board {Board} (mac {Mac}, ver {Ver}).",
+            _profile.BindAddress, DiscoveryPort, _profile.Board, _mac, _codeVersion);
+
+        var buffer = new byte[2048];
+        var any = new IPEndPoint(IPAddress.Any, 0);
+
+        while (!ct.IsCancellationRequested)
+        {
+            SocketReceiveFromResult rx;
+            try
+            {
+                rx = await socket.ReceiveFromAsync(buffer, SocketFlags.None, any, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (SocketException ex)
+            {
+                _logger.LogDebug(ex, "vradio.discovery receive error (continuing).");
+                continue;
+            }
+
+            if (!TryBuildReply(buffer.AsSpan(0, rx.ReceivedBytes), out byte[] reply))
+                continue; // not a discovery probe (e.g. a command frame) — ignore here.
+
+            try
+            {
+                // Reply to the SENDER's ephemeral port, never a fixed port.
+                await socket.SendToAsync(reply, SocketFlags.None, rx.RemoteEndPoint, ct).ConfigureAwait(false);
+                _logger.LogInformation("vradio.discovery replied to {Peer} as {Board}.",
+                    rx.RemoteEndPoint, _profile.Board);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (SocketException ex)
+            {
+                _logger.LogDebug(ex, "vradio.discovery send error to {Peer} (continuing).", rx.RemoteEndPoint);
+            }
+        }
+    }
+}

--- a/Zeus.VirtualRadio/Discovery/P1DiscoveryReply.cs
+++ b/Zeus.VirtualRadio/Discovery/P1DiscoveryReply.cs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Net.NetworkInformation;
+using Zeus.Contracts;
+using Zeus.Protocol1.Discovery;
+
+namespace Zeus.VirtualRadio.Discovery;
+
+/// <summary>
+/// Builds a Protocol-1 discovery reply — the inverse of
+/// <c>Zeus.Protocol1.Discovery.ReplyParser.TryParse</c>. Encodes the 0xEF 0xFE
+/// header, idle/busy status, MAC, code version, and the board byte for the
+/// profile's <see cref="HpsdrBoardKind"/> (e.g. HermesII → 0x02), so the real
+/// <c>ReplyParser</c> round-trips it back to the same board.
+/// </summary>
+internal static class P1DiscoveryReply
+{
+    /// <summary>
+    /// Map a board kind to its Protocol-1 discovery wire byte (inverse of
+    /// <c>ReplyParser.MapBoard</c>). NOTE: ANAN-10E (<see cref="HpsdrBoardKind.HermesII"/>)
+    /// reports wire byte 0x02 directly; the 0x06-with-low-version reclassification
+    /// path in <c>ReplyParser</c> is a separate HL2-vs-10E disambiguation the
+    /// emulator does not need to reproduce for the 0x02 board.
+    /// </summary>
+    /// <returns>The discovery board byte for <paramref name="board"/>.</returns>
+    public static byte BoardByte(HpsdrBoardKind board) => board switch
+    {
+        HpsdrBoardKind.Metis       => 0x00,
+        HpsdrBoardKind.Hermes      => 0x01,
+        HpsdrBoardKind.HermesII    => 0x02,
+        HpsdrBoardKind.Angelia     => 0x04,
+        HpsdrBoardKind.Orion       => 0x05,
+        HpsdrBoardKind.HermesLite2 => 0x06,
+        HpsdrBoardKind.OrionMkII   => 0x0A,
+        HpsdrBoardKind.HermesC10   => 0x14,
+        _ => throw new ArgumentOutOfRangeException(
+            nameof(board), board, "No Protocol-1 discovery board byte for this board kind."),
+    };
+
+    /// <summary>
+    /// Write a Protocol-1 discovery reply into <paramref name="dest"/>.
+    /// </summary>
+    /// <param name="dest">Destination buffer (≥ 60 bytes; the canonical reply is
+    /// 60 bytes, of which <c>ReplyParser.MinimumReplyLength</c>=24 are parsed).</param>
+    /// <param name="profile">The radio being impersonated.</param>
+    /// <param name="mac">The MAC address to advertise.</param>
+    /// <param name="codeVersion">Gateware code version byte to advertise.</param>
+    /// <param name="busy">Whether to report the busy status (0x03) rather than idle (0x02).</param>
+    /// <returns>The number of bytes written.</returns>
+    public static int Build(
+        Span<byte> dest,
+        VirtualRadioProfile profile,
+        PhysicalAddress mac,
+        byte codeVersion,
+        bool busy)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+        ArgumentNullException.ThrowIfNull(mac);
+        if (dest.Length < ReplyLength)
+        {
+            throw new ArgumentException(
+                $"Discovery reply needs at least {ReplyLength} bytes, got {dest.Length}.",
+                nameof(dest));
+        }
+
+        // Start from a clean slate so unused C&C / HL2 fields read as zero —
+        // ReplyParser only meaningfully reads bytes [0..21] for a non-HL2 board.
+        dest[..ReplyLength].Clear();
+
+        // [0:1] fixed 0xEF 0xFE preamble (ReplyParser rejects anything else).
+        dest[0] = 0xEF;
+        dest[1] = 0xFE;
+
+        // [2] status: 0x02 idle / 0x03 busy (ReplyParser.StatusIdle / StatusBusy).
+        dest[2] = busy ? ReplyParser.StatusBusy : ReplyParser.StatusIdle;
+
+        // [3:8] MAC (6 bytes). PhysicalAddress.GetAddressBytes is always 6 for EUI-48.
+        byte[] macBytes = mac.GetAddressBytes();
+        if (macBytes.Length != 6)
+        {
+            throw new ArgumentException(
+                $"Discovery MAC must be a 6-byte EUI-48, got {macBytes.Length} bytes.",
+                nameof(mac));
+        }
+        macBytes.CopyTo(dest.Slice(3, 6));
+
+        // [9] gateware/code version (FirmwareVersion). For a 0x02 board this is
+        // purely informational — it never triggers the HL2 reclassification path,
+        // which only fires for board byte 0x06.
+        dest[9] = codeVersion;
+
+        // [10] board id byte (0x02 for HermesII / ANAN-10E).
+        dest[10] = BoardByte(profile.Board);
+
+        // [11] HL2 flag byte — left zero; ReplyParser ignores it for non-HL2 boards.
+        // [19] gateware build — informational, left zero.
+        // [21] HL2 minor version — ignored for non-HL2 boards, left zero.
+
+        return ReplyLength;
+    }
+
+    /// <summary>
+    /// Canonical Protocol-1 discovery reply length. The real radio emits a
+    /// 60-byte datagram; <c>ReplyParser.MinimumReplyLength</c> (24) of those are
+    /// parsed. We always emit the full 60 so any future field a parser adds is
+    /// present and zeroed rather than truncated.
+    /// </summary>
+    public const int ReplyLength = 60;
+}

--- a/Zeus.VirtualRadio/HostCommandState.cs
+++ b/Zeus.VirtualRadio/HostCommandState.cs
@@ -65,6 +65,30 @@ public sealed class HostCommandState
     /// <summary>Codec mic/line-in select (DriveFilter frame C2[1]).</summary>
     public bool MicLineIn;
 
+    // ---- Protocol-2 specific (populated by the P2 decoder) ----------------
+
+    /// <summary>
+    /// PureSignal single-ADC time-mux armed for the current TX burst — the
+    /// <c>Mux</c> register, P2 CmdRx byte 1363 bit 1 (0x02). On the ANAN-10E
+    /// (HermesII) and ANAN-G2E (HermesC10) this swings DDC0's input to the
+    /// interleaved coupler/TX-DAC-reference pair (firmware Hermes.v:684-687,
+    /// :1080-1093). The emulator keys its feedback layout off this bit exactly
+    /// as the gateware does. Zero on Protocol 1.
+    /// </summary>
+    public bool PsArmedBurst;
+
+    /// <summary>
+    /// TX-time ADC step-attenuator in dB — P2 CmdTx byte 59
+    /// (<c>Angelia_atten_Tx0</c>, Tx_specific_C&amp;C.v:182-183). On a single-ADC
+    /// PS time-mux board the DAC feedback hits the only RX ADC during TX, so
+    /// this must reach the protective floor whenever PS is armed (the byte-59
+    /// safety seed). Surfaced for the safety assertion. Zero on Protocol 1.
+    /// </summary>
+    public byte TxStepAttnDb;
+
+    /// <summary>Number of active ADCs the host commanded (P2 CmdRx byte 4).</summary>
+    public byte NumAdc = 1;
+
     /// <summary>Return a deep copy for publishing an immutable status snapshot.</summary>
     public HostCommandState Clone() => (HostCommandState)MemberwiseClone();
 }

--- a/Zeus.VirtualRadio/HostCommandState.cs
+++ b/Zeus.VirtualRadio/HostCommandState.cs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.VirtualRadio;
+
+/// <summary>
+/// Mutable, running snapshot of everything the host (Zeus) has commanded the
+/// virtual radio to do, as decoded from inbound EP2 frames (and, later, P2
+/// command packets). The decoder mutates one shared instance in place; the
+/// engine reads it to drive RX/telemetry generation and clones it
+/// (<see cref="Clone"/>) when publishing an immutable status snapshot.
+///
+/// Fields are deliberately primitive (no coupling to Zeus's internal
+/// <c>CcState</c>) so the type is protocol-agnostic — the P1 decoder and the
+/// future P2 decoder both populate the same shape.
+/// </summary>
+public sealed class HostCommandState
+{
+    /// <summary>Raw transmit drive level byte (0..255) from the DriveFilter (0x12) frame C1.</summary>
+    public byte DriveByte;
+
+    /// <summary>MOX / transmit-enable as commanded on the C0 MOX bit.</summary>
+    public bool Mox;
+
+    /// <summary>Host PTT request (distinct from MOX where the wire distinguishes them).</summary>
+    public bool Ptt;
+
+    /// <summary>Commanded TX NCO frequency in Hz (TxFreq 0x02 frame).</summary>
+    public long TxFreqHz;
+
+    /// <summary>Commanded RX1 NCO frequency in Hz (RxFreq 0x04 frame).</summary>
+    public long RxFreqHz;
+
+    /// <summary>Negotiated IQ sample rate in kHz (Config frame C1[1:0] → 48/96/192/384).</summary>
+    public int SampleRateKhz = 48;
+
+    /// <summary>RX step-attenuator value in dB (extended Attenuator 0x14 frame).</summary>
+    public int AttenuatorDb;
+
+    /// <summary>RX preamp / LNA gain enable (Config frame C3[2] on LT2208 boards).</summary>
+    public bool PreampOn;
+
+    /// <summary>User open-collector TX pin mask (Config frame C2, while MOX).</summary>
+    public byte OcTxMask;
+
+    /// <summary>User open-collector RX pin mask (Config frame C2, while not MOX).</summary>
+    public byte OcRxMask;
+
+    /// <summary>Number of receivers minus one (Config frame C4[5:3]).</summary>
+    public byte NumReceiversMinusOne;
+
+    /// <summary>Whether the host has sent the EP2 start (0x04 type 0x01) command.</summary>
+    public bool Running;
+
+    /// <summary>Codec mic-boost (DriveFilter frame C2[0] on Hermes-class codec boards).</summary>
+    public bool MicBoost;
+
+    /// <summary>Codec mic/line-in select (DriveFilter frame C2[1]).</summary>
+    public bool MicLineIn;
+
+    /// <summary>Return a deep copy for publishing an immutable status snapshot.</summary>
+    public HostCommandState Clone() => (HostCommandState)MemberwiseClone();
+}

--- a/Zeus.VirtualRadio/IVirtualRadio.cs
+++ b/Zeus.VirtualRadio/IVirtualRadio.cs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.VirtualRadio;
+
+/// <summary>
+/// A running virtual radio engine. One implementation per protocol
+/// (<c>Protocol1Engine</c> now; <c>Protocol2Engine</c> later). The host process
+/// constructs the engine for the configured profile and drives it via
+/// <see cref="RunAsync"/>.
+/// </summary>
+public interface IVirtualRadio
+{
+    /// <summary>
+    /// Bind the radio sockets, answer discovery, accept a direct connection,
+    /// decode inbound host commands, and stream RX IQ + telemetry until
+    /// <paramref name="ct"/> is cancelled. Completes when cancelled.
+    /// </summary>
+    Task RunAsync(CancellationToken ct);
+
+    /// <summary>
+    /// Raised for every decoded host command (start/stop, drive, MOX, frequency,
+    /// config, …). Used by the command log and any external observer.
+    /// </summary>
+    event Action<DecodedHostCommand>? CommandDecoded;
+
+    /// <summary>Capture the current read-only state for <c>/status</c>.</summary>
+    VirtualRadioStatus Snapshot();
+}

--- a/Zeus.VirtualRadio/Observation/CommandLog.cs
+++ b/Zeus.VirtualRadio/Observation/CommandLog.cs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.VirtualRadio.Observation;
+
+/// <summary>
+/// Bounded ring of the most-recent decoded host commands, surfaced in the
+/// <c>/status</c> snapshot and the 1 Hz structured log. Thread-safe: written
+/// from the decode path, read from the status path.
+/// </summary>
+public sealed class CommandLog
+{
+    private readonly int _capacity;
+    private readonly object _gate = new();
+    // FIFO of retained commands. We cap the queue at _capacity and drop the
+    // oldest on overflow, so Snapshot() yields oldest-first newest-last.
+    private readonly Queue<DecodedHostCommand> _items;
+
+    /// <summary>Create a log holding at most <paramref name="capacity"/> commands.</summary>
+    public CommandLog(int capacity = 64)
+    {
+        if (capacity < 1)
+            throw new ArgumentOutOfRangeException(nameof(capacity), capacity, "Capacity must be at least 1.");
+        _capacity = capacity;
+        _items = new Queue<DecodedHostCommand>(capacity);
+    }
+
+    /// <summary>The configured ring capacity.</summary>
+    public int Capacity => _capacity;
+
+    /// <summary>Append a decoded command, evicting the oldest past capacity.</summary>
+    public void Add(DecodedHostCommand command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        lock (_gate)
+        {
+            _items.Enqueue(command);
+            while (_items.Count > _capacity)
+                _items.Dequeue();
+        }
+    }
+
+    /// <summary>Return the retained commands, oldest first.</summary>
+    public IReadOnlyList<DecodedHostCommand> Snapshot()
+    {
+        lock (_gate)
+        {
+            return _items.ToArray();
+        }
+    }
+}

--- a/Zeus.VirtualRadio/Observation/StatusJsonServer.cs
+++ b/Zeus.VirtualRadio/Observation/StatusJsonServer.cs
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Zeus.VirtualRadio.Observation;
+
+/// <summary>
+/// Minimal, read-only, localhost-only <c>GET /status</c> endpoint built on the
+/// BCL <see cref="System.Net.HttpListener"/> (no ASP.NET dependency — keeps the
+/// host binary lean and cross-platform). Serializes the engine's current
+/// <see cref="VirtualRadioStatus"/> as JSON so an agent can poll and diff it
+/// against Zeus's own <c>GET /api/state</c>.
+/// </summary>
+public sealed class StatusJsonServer
+{
+    private readonly Func<VirtualRadioStatus> _snapshot;
+    private readonly int _port;
+    private readonly ILogger<StatusJsonServer> _logger;
+
+    /// <summary>Default loopback port for the status endpoint.</summary>
+    public const int DefaultPort = 8073;
+
+    /// <param name="snapshot">Supplier of the current status (typically
+    /// <c>IVirtualRadio.Snapshot</c>).</param>
+    /// <param name="port">Loopback TCP port to listen on.</param>
+    /// <param name="logger">Optional logger.</param>
+    public StatusJsonServer(Func<VirtualRadioStatus> snapshot, int port = DefaultPort, ILogger<StatusJsonServer>? logger = null)
+    {
+        _snapshot = snapshot;
+        _port = port;
+        _logger = logger ?? NullLogger<StatusJsonServer>.Instance;
+    }
+
+    /// <summary>The port the server listens on.</summary>
+    public int Port => _port;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = false,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    /// <summary>
+    /// Serialize a <see cref="VirtualRadioStatus"/> into the <c>/status</c> JSON
+    /// body. Projects to a flat, primitive-only shape (enums and the bind
+    /// <c>IPAddress</c> as strings) so the output is stable and never depends on
+    /// <see cref="System.Net.IPAddress"/> reflection quirks. Public + static so
+    /// the shape can be asserted in a unit test without binding a socket.
+    /// </summary>
+    public static string Serialize(VirtualRadioStatus status)
+    {
+        ArgumentNullException.ThrowIfNull(status);
+        VirtualRadioProfile p = status.Profile;
+        var payload = new
+        {
+            profile = new
+            {
+                board = p.Board.ToString(),
+                variant = p.Variant.ToString(),
+                protocol = p.Protocol.ToString(),
+                tunedHz = p.TunedHz,
+                sampleRateKhz = p.SampleRateKhz,
+                bindAddress = p.BindAddress.ToString(),
+                noiseFloorDbc = p.NoiseFloorDbc,
+                pureSignalEnabled = p.PureSignalEnabled,
+                tones = p.Tones.Select(t => new { freqHz = t.FreqHz, dbc = t.Dbc }).ToArray(),
+            },
+            connectedHost = status.ConnectedHost,
+            mox = status.Mox,
+            fwdWatts = status.FwdWatts,
+            refWatts = status.RefWatts,
+            swr = status.Swr,
+            ep6PacketsSent = status.Ep6PacketsSent,
+            ep2PacketsReceived = status.Ep2PacketsReceived,
+            seqGaps = status.SeqGaps,
+            lastCommands = status.LastCommands.Select(c => new
+            {
+                timestamp = c.Timestamp,
+                protocol = c.Protocol.ToString(),
+                commandKind = c.CommandKind,
+                summary = c.Summary,
+            }).ToArray(),
+        };
+        return JsonSerializer.Serialize(payload, JsonOptions);
+    }
+
+    /// <summary>Start the listener and serve <c>/status</c> until cancelled.</summary>
+    public async Task RunAsync(CancellationToken ct)
+    {
+        if (!HttpListener.IsSupported)
+        {
+            _logger.LogWarning("vradio.status HttpListener is not supported on this platform; /status disabled.");
+            return;
+        }
+
+        var listener = new HttpListener();
+        // localhost-only: bind the loopback prefix so the read-only surface is
+        // never exposed off-box and no Windows URL ACL is required.
+        listener.Prefixes.Add($"http://localhost:{_port}/");
+        try
+        {
+            listener.Start();
+        }
+        catch (HttpListenerException ex)
+        {
+            // Port already taken (or ACL denied) — log and continue; the status
+            // surface is optional and must never take the emulator down.
+            _logger.LogWarning(ex, "vradio.status could not bind port {Port}; /status disabled.", _port);
+            return;
+        }
+
+        _logger.LogInformation("vradio.status serving GET /status on http://localhost:{Port}/status", _port);
+
+        // Unblocks the GetContextAsync await when cancellation fires.
+        using var reg = ct.Register(() =>
+        {
+            try { listener.Stop(); } catch { /* ignore: shutdown race */ }
+        });
+
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                HttpListenerContext context;
+                try
+                {
+                    context = await listener.GetContextAsync().ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (HttpListenerException)
+                {
+                    break; // listener stopped (cancellation)
+                }
+                catch (ObjectDisposedException)
+                {
+                    break; // listener closed (cancellation)
+                }
+
+                try
+                {
+                    HandleRequest(context);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    _logger.LogDebug(ex, "vradio.status request handling error.");
+                }
+            }
+        }
+        finally
+        {
+            try { listener.Close(); } catch { /* ignore: shutdown race */ }
+        }
+    }
+
+    private void HandleRequest(HttpListenerContext context)
+    {
+        HttpListenerRequest request = context.Request;
+        HttpListenerResponse response = context.Response;
+        try
+        {
+            string path = request.Url?.AbsolutePath ?? "/";
+            bool isStatus = path is "/status" or "/";
+
+            if (!isStatus)
+            {
+                response.StatusCode = (int)HttpStatusCode.NotFound;
+                return;
+            }
+
+            if (!string.Equals(request.HttpMethod, "GET", StringComparison.OrdinalIgnoreCase))
+            {
+                response.StatusCode = (int)HttpStatusCode.MethodNotAllowed;
+                return;
+            }
+
+            string json = Serialize(_snapshot());
+            byte[] body = Encoding.UTF8.GetBytes(json);
+            response.StatusCode = (int)HttpStatusCode.OK;
+            response.ContentType = "application/json";
+            response.ContentLength64 = body.Length;
+            response.OutputStream.Write(body, 0, body.Length);
+        }
+        finally
+        {
+            try { response.OutputStream.Close(); } catch { /* ignore */ }
+            try { response.Close(); } catch { /* ignore */ }
+        }
+    }
+}

--- a/Zeus.VirtualRadio/P1/Ep2Decoder.cs
+++ b/Zeus.VirtualRadio/P1/Ep2Decoder.cs
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Buffers.Binary;
+using Zeus.Protocol1; // internal ControlFrame / PacketParser, via InternalsVisibleTo
+
+namespace Zeus.VirtualRadio.P1;
+
+/// <summary>
+/// Decodes inbound Protocol-1 host packets — the inverse of
+/// <c>Zeus.Protocol1.ControlFrame</c>. Handles both the 64-byte start/stop
+/// command (<c>0xEF 0xFE 0x04 …</c>) and the 1032-byte EP2 data frame
+/// (<c>0xEF 0xFE 0x01 0x02 …</c>), reading the per-USB-frame C&amp;C round-robin
+/// (Config / TxFreq / RxFreq / DriveFilter / Attenuator …) into the shared
+/// <see cref="HostCommandState"/> and emitting a <see cref="DecodedHostCommand"/>
+/// per frame. Anti-drift: it consumes <c>ControlFrame.CcRegister</c> /
+/// <c>PacketParser</c> constants directly (via InternalsVisibleTo), so a wire-
+/// format change breaks the build or the round-trip test.
+/// </summary>
+internal sealed class Ep2Decoder
+{
+    // Reference the Protocol-1 framing constants directly so the decoder shares
+    // ONE definition with the encoder it inverts — these are also the
+    // compile-time proof that the emulator reaches Zeus.Protocol1 internals.
+    public const int Ep2PacketLength = ControlFrame.PacketLength; // 1032
+    public const int UsbFrameLength = ControlFrame.UsbFrameLength; // 512
+
+    private const int MetisHeaderLength = 8;     // 0xEF 0xFE 0x01 0x02 + BE seq
+    private const byte Sync = 0x7F;
+
+    private static readonly IReadOnlyList<DecodedHostCommand> Empty = Array.Empty<DecodedHostCommand>();
+
+    /// <summary>
+    /// Decode one inbound host packet, mutating <paramref name="state"/> in
+    /// place and returning the command event(s) it produced (one per decoded
+    /// C&amp;C frame; a start/stop yields a single event). Returns an empty list
+    /// for packets that are not recognised host frames.
+    /// </summary>
+    public IReadOnlyList<DecodedHostCommand> Decode(ReadOnlySpan<byte> packet, HostCommandState state)
+    {
+        // Start/stop command: 0xEF 0xFE 0x04 {0x01 start | 0x03 start+wideband |
+        // 0x00 stop}. ControlFrame.BuildStartStop produces a 64-byte packet; we
+        // only need the 4-byte preamble to classify it.
+        if (packet.Length >= 4 &&
+            packet[0] == 0xEF && packet[1] == 0xFE && packet[2] == 0x04)
+        {
+            byte cmd = packet[3];
+            bool start = cmd is 0x01 or 0x03;
+            bool wideband = cmd == 0x03;
+            state.Running = start;
+            return new[]
+            {
+                start
+                    ? Make("Start", $"running=1 wideband={(wideband ? 1 : 0)}")
+                    : Make("Stop", "running=0"),
+            };
+        }
+
+        // EP2 data frame: 0xEF 0xFE 0x01 0x02, exactly 1032 bytes, two USB frames
+        // each carrying one round-robin C&C register.
+        if (packet.Length == Ep2PacketLength &&
+            packet[0] == 0xEF && packet[1] == 0xFE &&
+            packet[2] == 0x01 && packet[3] == 0x02)
+        {
+            var events = new List<DecodedHostCommand>(2);
+            for (int frame = 0; frame < 2; frame++)
+            {
+                ReadOnlySpan<byte> usb = packet.Slice(MetisHeaderLength + frame * UsbFrameLength, UsbFrameLength);
+                if (usb[0] != Sync || usb[1] != Sync || usb[2] != Sync) continue;
+
+                ReadOnlySpan<byte> cc = usb.Slice(3, 5);
+                byte c0 = cc[0];
+                // MOX is bit 0 of every frame's C0 (ControlFrame ORs it onto the
+                // pre-shifted register byte). Set it BEFORE decoding the payload
+                // so the Config frame routes the OC mask to the right (TX/RX) slot.
+                state.Mox = (c0 & 0x01) != 0;
+                var register = (ControlFrame.CcRegister)(byte)(c0 & 0xFE);
+                events.Add(DecodeCcFrame(register, cc, state));
+            }
+            return events;
+        }
+
+        return Empty;
+    }
+
+    /// <summary>
+    /// Decode the 5 C&amp;C bytes of one USB frame into <paramref name="state"/>,
+    /// returning the decoded event. The <paramref name="register"/> is the
+    /// <c>ControlFrame.CcRegister</c> identified from C0 (address bits + MOX).
+    /// </summary>
+    public DecodedHostCommand DecodeCcFrame(
+        ControlFrame.CcRegister register,
+        ReadOnlySpan<byte> cc,
+        HostCommandState state)
+    {
+        byte c1 = cc[1], c2 = cc[2], c3 = cc[3], c4 = cc[4];
+
+        switch (register)
+        {
+            case ControlFrame.CcRegister.Config:
+            {
+                // C1[1:0] = sample-rate code (ControlFrame.WriteConfigPayload).
+                int rateCode = c1 & 0x03;
+                state.SampleRateKhz = rateCode switch
+                {
+                    0 => 48,
+                    1 => 96,
+                    2 => 192,
+                    3 => 384,
+                    _ => 48,
+                };
+                // C2 = ocPins << 1. MOX selects the TX vs RX mask source.
+                byte ocMask = (byte)((c2 >> 1) & 0x7F);
+                if (state.Mox) state.OcTxMask = ocMask;
+                else state.OcRxMask = ocMask;
+                // C3[2] = preamp / LNA gain on LT2208 boards.
+                state.PreampOn = (c3 & 0x04) != 0;
+                // C4[5:3] = number of receivers minus one.
+                state.NumReceiversMinusOne = (byte)((c4 >> 3) & 0x07);
+
+                return Make("Config",
+                    $"rate={state.SampleRateKhz}k oc{(state.Mox ? "Tx" : "Rx")}=0x{ocMask:X2} " +
+                    $"preamp={(state.PreampOn ? 1 : 0)} numRx={state.NumReceiversMinusOne + 1} " +
+                    $"mox={(state.Mox ? 1 : 0)}");
+            }
+
+            case ControlFrame.CcRegister.TxFreq:
+                state.TxFreqHz = BinaryPrimitives.ReadUInt32BigEndian(cc.Slice(1, 4));
+                return Make("TxFreq", $"txFreq={state.TxFreqHz}Hz mox={(state.Mox ? 1 : 0)}");
+
+            case ControlFrame.CcRegister.RxFreq:
+                state.RxFreqHz = BinaryPrimitives.ReadUInt32BigEndian(cc.Slice(1, 4));
+                return Make("RxFreq", $"rxFreq={state.RxFreqHz}Hz");
+
+            case ControlFrame.CcRegister.RxFreq2:
+            case ControlFrame.CcRegister.RxFreq3:
+            case ControlFrame.CcRegister.RxFreq4:
+            {
+                // Secondary DDC NCOs — logged for observability; Zeus has no
+                // split-VFO so these mirror VfoAHz. Not persisted into the
+                // single RxFreqHz state field.
+                long f = BinaryPrimitives.ReadUInt32BigEndian(cc.Slice(1, 4));
+                return Make(register.ToString(), $"{register}={f}Hz");
+            }
+
+            case ControlFrame.CcRegister.DriveFilter:
+            {
+                // C1 = raw drive level. C2[0]=mic_boost, C2[1]=mic_linein
+                // (Hermes-class codec boards), C2[3]=PA enable (HL2 while MOX),
+                // C2[4]=ATU tune request.
+                state.DriveByte = c1;
+                state.MicBoost = (c2 & 0x01) != 0;
+                state.MicLineIn = (c2 & 0x02) != 0;
+                bool paEnable = (c2 & 0x08) != 0;
+                bool atuTune = (c2 & 0x10) != 0;
+                return Make("DriveFilter",
+                    $"drive={c1} micBoost={(state.MicBoost ? 1 : 0)} " +
+                    $"micLineIn={(state.MicLineIn ? 1 : 0)} paEnable={(paEnable ? 1 : 0)} " +
+                    $"atuTune={(atuTune ? 1 : 0)}");
+            }
+
+            case ControlFrame.CcRegister.Attenuator:
+            {
+                // C4 carries the extended RX attenuator. Board-agnostic decode:
+                //   standard HPSDR (ANAN/Hermes): 0x20 | (db & 0x1F)
+                //   HL2:                          0x40 | (60 - db)
+                // Distinguish by the encoding-select bit so the decoder works for
+                // any P1 board without needing the board kind in HostCommandState.
+                int attenDb;
+                if ((c4 & 0x40) != 0)
+                    attenDb = 60 - (c4 & 0x3F);          // HL2 gain-reduction form
+                else
+                    attenDb = c4 & 0x1F;                 // standard step-attenuator
+                state.AttenuatorDb = attenDb;
+                // C2[4:0] = line-in gain (HL2 + ANAN-10E share this layout).
+                int lineInGain = c2 & 0x1F;
+                bool psRun = (c2 & 0x40) != 0;            // HL2 puresignal_run echo (observability only)
+                return Make("Attenuator",
+                    $"atten={attenDb}dB lineInGain={lineInGain} psRun={(psRun ? 1 : 0)}");
+            }
+
+            default:
+                return Make(register.ToString(),
+                    $"c1=0x{c1:X2} c2=0x{c2:X2} c3=0x{c3:X2} c4=0x{c4:X2}");
+        }
+    }
+
+    private static DecodedHostCommand Make(string kind, string summary) =>
+        new(DateTimeOffset.UtcNow, ProtocolVersion.P1, kind, summary);
+}

--- a/Zeus.VirtualRadio/P1/Ep6Encoder.cs
+++ b/Zeus.VirtualRadio/P1/Ep6Encoder.cs
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Buffers.Binary;
+using Zeus.Protocol1; // internal PacketParser, via InternalsVisibleTo
+using Zeus.VirtualRadio.Rf;
+
+namespace Zeus.VirtualRadio.P1;
+
+/// <summary>
+/// Encodes a Protocol-1 EP6 RX-IQ packet — the inverse of
+/// <c>Zeus.Protocol1.PacketParser.TryParsePacket</c>. Writes the 8-byte Metis
+/// header (<c>0xEF 0xFE 0x01 0x06</c> + BE seq), two USB frames each with the
+/// triple <c>0x7F</c> sync, the C&amp;C echo (round-robin address + ADC
+/// telemetry slots + overload bits), and 63 sample groups of int24-BE I/Q (+ the
+/// mic field). Anti-drift: shares <c>PacketParser</c>'s length / offset / scale
+/// constants directly (via InternalsVisibleTo) and is validated by feeding its
+/// output back into <c>PacketParser.TryParsePacket</c> in a round-trip test.
+/// </summary>
+internal sealed class Ep6Encoder
+{
+    // Share the Protocol-1 framing constants with the decoder it inverts — also
+    // the compile-time proof that the emulator reaches Zeus.Protocol1 internals.
+    public const int Ep6PacketLength = PacketParser.PacketLength;                 // 1032
+    public const int ComplexSamplesPerPacket = PacketParser.ComplexSamplesPerPacket; // 126
+
+    // The remaining geometry constants come straight from PacketParser so the
+    // encoder and decoder agree on the layout by construction.
+    private const int MetisHeaderLength = PacketParser.MetisHeaderLength;          // 8
+    private const int UsbFrameLength = PacketParser.UsbFrameLength;                // 512
+    private const int UsbHeaderLength = PacketParser.UsbHeaderLength;              // 8 (3 sync + 5 C&C)
+    private const int BytesPerSampleGroup = PacketParser.BytesPerSampleGroup;      // 8 (3 I + 3 Q + 2 mic)
+    private const int ComplexSamplesPerUsbFrame = PacketParser.ComplexSamplesPerUsbFrame; // 63
+
+    private const byte Sync = 0x7F;
+
+    // Inverse of PacketParser.ScaleInt24 — the same 2^23 full-scale constant.
+    private const double Int24FullScale = 8_388_608.0;   // 2^23
+    private const int Int24Max = 8_388_607;              // +2^23 - 1
+    private const int Int24Min = -8_388_608;             // -2^23
+
+    // C&C echo round-robin addresses Zeus reads back for the FWD/REF meter pair
+    // (TxMetersService.cs: C0AddrAlexFwd=0x08, C0AddrAlexRef=0x10). PacketParser
+    // recovers the address as (C0 >> 3) & 0x1F, so addr 1 → 0x08, addr 2 → 0x10.
+    //   addr=1 (C0=0x08): Ain0 = exciter/PA-temp (unused here, 0); Ain1 = FWD
+    //   addr=2 (C0=0x10): Ain0 = REF;                              Ain1 = 0
+    // Ain0 is the BE u16 at C1..C2 (usb[4..6]); Ain1 is the BE u16 at C3..C4
+    // (usb[6..8]).
+    private const byte AddrAlexFwd = 1;
+    private const byte AddrAlexRef = 2;
+
+    /// <summary>
+    /// Encode one EP6 RX-IQ packet into <paramref name="packet"/>.
+    /// </summary>
+    /// <param name="packet">Destination, exactly <see cref="Ep6PacketLength"/> bytes.</param>
+    /// <param name="sequence">Radio-assigned monotonic sequence number (BE u32 at bytes 4..7).</param>
+    /// <param name="interleavedIq">Source I/Q (<c>[I0,Q0,…]</c>), ≥
+    /// <c>2 × <see cref="ComplexSamplesPerPacket"/></c> doubles.</param>
+    /// <param name="telemetry">FWD/REF ADC counts to place in the C&amp;C echo
+    /// slots (PTT/MOX-gated upstream).</param>
+    /// <param name="pttEcho">Decoded host PTT/MOX state to echo back in the C0[0]
+    /// hardware-PTT bit. This mirrors the firmware's <c>clean_PTT_in</c> line,
+    /// which is the debounced PTT — asserted whenever keyed and wholly independent
+    /// of drive amplitude / forward power. Pass the decoded MOX flag, NOT a watts
+    /// threshold, or the echo drops on a keyed-with-zero-drive frame.</param>
+    /// <param name="micSamples">Optional mic / line-in samples for the mic field
+    /// (int16); pass an empty span to emit silence.</param>
+    public void Encode(
+        Span<byte> packet,
+        uint sequence,
+        ReadOnlySpan<double> interleavedIq,
+        in RfTelemetry telemetry,
+        bool pttEcho = false,
+        ReadOnlySpan<short> micSamples = default)
+    {
+        if (packet.Length != Ep6PacketLength)
+            throw new ArgumentException(
+                $"packet must be exactly {Ep6PacketLength} bytes", nameof(packet));
+
+        int needed = 2 * ComplexSamplesPerPacket; // interleaved I+Q for 126 samples = 252
+        if (interleavedIq.Length < needed)
+            throw new ArgumentException(
+                $"interleavedIq must hold at least {needed} doubles", nameof(interleavedIq));
+
+        packet.Clear();
+
+        // Metis header: 0xEF 0xFE 0x01 0x06 + BE uint32 seq. Endpoint 0x06 = RX IQ.
+        packet[0] = 0xEF;
+        packet[1] = 0xFE;
+        packet[2] = 0x01;
+        packet[3] = 0x06;
+        BinaryPrimitives.WriteUInt32BigEndian(packet.Slice(4, 4), sequence);
+
+        // C0[0] is the firmware's debounced PTT echo (clean_PTT_in in
+        // Hermes_Tx_fifo_ctrl.v: Tx_fifo_wdata = {8'h7F, tx_addr, clean_dot,
+        // clean_dash, clean_PTT_in}). It is asserted whenever the radio is keyed
+        // and is wholly independent of forward power / drive amplitude — so it is
+        // driven by the decoded host MOX flag passed in, NOT by a watts threshold
+        // (a watts threshold would drop the echo on a keyed-with-zero-drive
+        // frame). PacketParser.ExtractHardwarePtt reads exactly this bit; the
+        // meter slot match masks C0[0] off (C0 & 0x7E), so the meter is unaffected
+        // either way — this only drives the hardware-PTT echo.
+        int sampleIndex = 0;
+        for (int frame = 0; frame < 2; frame++)
+        {
+            Span<byte> usb = packet.Slice(MetisHeaderLength + frame * UsbFrameLength, UsbFrameLength);
+
+            // 3-byte sync.
+            usb[0] = Sync;
+            usb[1] = Sync;
+            usb[2] = Sync;
+
+            // C&C echo: frame 0 carries the FWD slot (addr 1), frame 1 the REF
+            // slot (addr 2). One packet therefore delivers both meter axes every
+            // tick (Zeus's PacketParser emits telemetry0/telemetry1 independently
+            // and TxMetersService.OnTelemetry routes each by C0 address).
+            byte addr = frame == 0 ? AddrAlexFwd : AddrAlexRef;
+            usb[3] = (byte)((addr << 3) | (pttEcho ? 0x01 : 0x00)); // C0
+            ushort ain0 = frame == 0 ? (ushort)0 : telemetry.RefAdc; // C1..C2
+            ushort ain1 = frame == 0 ? telemetry.FwdAdc : (ushort)0; // C3..C4
+            BinaryPrimitives.WriteUInt16BigEndian(usb.Slice(4, 2), ain0);
+            BinaryPrimitives.WriteUInt16BigEndian(usb.Slice(6, 2), ain1);
+            // ADC-overload bits (C1[0]/C2[0]) are left as they fall out of the
+            // telemetry bytes — faithful to the wire, where REF shares C1/C2 with
+            // those flag positions. See the implementer note in the handoff.
+
+            Span<byte> payload = usb.Slice(UsbHeaderLength); // 504 bytes
+            for (int g = 0; g < ComplexSamplesPerUsbFrame; g++)
+            {
+                double iVal = interleavedIq[2 * sampleIndex];
+                double qVal = interleavedIq[2 * sampleIndex + 1];
+
+                int off = g * BytesPerSampleGroup;
+                WriteInt24BigEndian(payload.Slice(off, 3), ToInt24(iVal));
+                WriteInt24BigEndian(payload.Slice(off + 3, 3), ToInt24(qVal));
+
+                // Mic / line-in field (int16 BE). Audio is a later phase — pass
+                // an empty span to emit silence; any shortfall is zero-filled.
+                short mic = sampleIndex < micSamples.Length ? micSamples[sampleIndex] : (short)0;
+                BinaryPrimitives.WriteInt16BigEndian(payload.Slice(off + 6, 2), mic);
+
+                sampleIndex++;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Quantise a [-1.0, +1.0] sample to signed int24, the exact inverse of
+    /// <c>PacketParser.ScaleInt24</c> (which multiplies by 1/2^23). Values are
+    /// clamped to the int24 range so a full-scale +1.0 maps to the largest
+    /// representable code rather than overflowing.
+    /// </summary>
+    private static int ToInt24(double value)
+    {
+        double scaled = Math.Round(value * Int24FullScale);
+        if (scaled > Int24Max) return Int24Max;
+        if (scaled < Int24Min) return Int24Min;
+        return (int)scaled;
+    }
+
+    /// <summary>
+    /// Write a signed 24-bit value big-endian — the inverse of
+    /// <c>PacketParser.ReadInt24BigEndian</c> (high byte first, sign-extended on
+    /// read).
+    /// </summary>
+    private static void WriteInt24BigEndian(Span<byte> dest, int value)
+    {
+        dest[0] = (byte)((value >> 16) & 0xFF);
+        dest[1] = (byte)((value >> 8) & 0xFF);
+        dest[2] = (byte)(value & 0xFF);
+    }
+}

--- a/Zeus.VirtualRadio/P1/Protocol1Engine.cs
+++ b/Zeus.VirtualRadio/P1/Protocol1Engine.cs
@@ -1,0 +1,372 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Buffers.Binary;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.VirtualRadio.Discovery;
+using Zeus.VirtualRadio.Observation;
+using Zeus.VirtualRadio.Rf;
+
+namespace Zeus.VirtualRadio.P1;
+
+/// <summary>
+/// The Protocol-1 virtual-radio engine: binds UDP 1024, answers discovery,
+/// accepts a direct connection, decodes inbound EP2 host commands
+/// (<see cref="Ep2Decoder"/>), and streams EP6 RX-IQ (<see cref="Ep6Encoder"/>)
+/// with synthetic signal (<see cref="SyntheticIqGenerator"/>) and calibration-
+/// inverted FWD/REF telemetry (<see cref="RfTelemetryModel"/>) at the true
+/// ~381 pkt/s cadence. This is the Phase-1 vertical slice (ANAN-10E / HermesII).
+///
+/// One UDP socket is owned by the engine: the receive loop classifies each
+/// datagram (discovery probe → reply; start/stop → begin/stop the RX stream;
+/// EP2 data frame → decode into <see cref="HostCommandState"/>), and the send
+/// loop streams EP6 to the host endpoint observed from inbound traffic, paced by
+/// a <see cref="Stopwatch"/> at the negotiated sample rate. Both loops are
+/// cancellable; the socket is disposed on shutdown.
+/// </summary>
+public sealed class Protocol1Engine : IVirtualRadio
+{
+    private readonly VirtualRadioProfile _profile;
+    private readonly ILogger<Protocol1Engine> _logger;
+    private readonly HostCommandState _state = new();
+    private readonly CommandLog _commandLog = new();
+
+    private readonly DiscoveryResponder _discovery;
+    private readonly Ep2Decoder _decoder = new();
+    private readonly Ep6Encoder _encoder = new();
+    private readonly SyntheticIqGenerator _iq;
+    private readonly RfTelemetryModel _rf;
+
+    // Guards _state mutation (receive loop) against reads (send loop / Snapshot).
+    private readonly object _stateGate = new();
+
+    // Host endpoint observed from inbound traffic; the send loop streams EP6
+    // here. Reference write/read is atomic; updated on every recognised frame.
+    private volatile IPEndPoint? _hostEndPoint;
+
+    // Last decoded RX NCO frequency (Hz). Falls back to the profile seed until
+    // the host commands an RxFreq. Read by the send loop for the IQ baseband
+    // offset; written under _stateGate.
+    private long _currentRxHz;
+
+    // UDP port the engine binds. Defaults to the well-known Protocol-1 radio
+    // port (1024); overridable only so the hermetic loopback test can bind a
+    // free ephemeral port instead of contending for 1024.
+    private readonly int _port;
+
+    // EP6 monotonic sequence (radio-assigned). Send loop only.
+    private uint _ep6Sequence;
+
+    // Inbound EP2 sequence-gap tracking (best-effort observability).
+    private uint _lastEp2Seq;
+    private bool _seenEp2Seq;
+
+    // Counters (cross-thread; Interlocked).
+    private long _ep6PacketsSent;
+    private long _ep2PacketsReceived;
+    private long _seqGaps;
+
+    // Edge-trigger de-dup for CommandDecoded: the round-robin re-sends the same
+    // Config/RxFreq/DriveFilter every few ms, so we only surface a command when
+    // its decoded summary changes (mirrors the p1.tx.rate "1 Hz + edge" idiom).
+    private readonly Dictionary<string, string> _lastSummaryByKind = new();
+
+    public Protocol1Engine(
+        VirtualRadioProfile profile,
+        ILogger<Protocol1Engine>? logger = null,
+        int port = DiscoveryResponder.DiscoveryPort)
+    {
+        _profile = profile ?? throw new ArgumentNullException(nameof(profile));
+        _logger = logger ?? NullLogger<Protocol1Engine>.Instance;
+        _port = port;
+        _discovery = new DiscoveryResponder(profile);
+        _iq = new SyntheticIqGenerator(profile);
+        _rf = new RfTelemetryModel(profile);
+        _currentRxHz = profile.TunedHz;
+        _state.SampleRateKhz = profile.SampleRateKhz;
+    }
+
+    /// <inheritdoc />
+    public event Action<DecodedHostCommand>? CommandDecoded;
+
+    /// <inheritdoc />
+    public async Task RunAsync(CancellationToken ct)
+    {
+        using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp)
+        {
+            ReceiveBufferSize = 256 * 1024,
+            SendBufferSize = 256 * 1024,
+        };
+        socket.EnableBroadcast = true;
+        socket.Bind(new IPEndPoint(_profile.BindAddress, _port));
+
+        _logger.LogInformation(
+            "vradio.p1 listening on {Bind}:{Port} as {Board} ({Protocol}), rate {Rate}kHz, tones {Tones}",
+            _profile.BindAddress, _port, _profile.Board, _profile.Protocol,
+            _profile.SampleRateKhz, _profile.Tones.Count);
+
+        // Cancel both loops together; either failing tears the engine down.
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        Task receive = ReceiveLoopAsync(socket, linked.Token);
+        Task send = Task.Run(() => SendLoopAsync(socket, linked.Token), CancellationToken.None);
+
+        try
+        {
+            await Task.WhenAny(receive, send).ConfigureAwait(false);
+        }
+        finally
+        {
+            linked.Cancel();
+            try { await Task.WhenAll(receive, send).ConfigureAwait(false); }
+            catch (OperationCanceledException) { /* expected on shutdown */ }
+            catch (Exception ex) { _logger.LogDebug(ex, "vradio.p1 loop teardown."); }
+        }
+    }
+
+    private async Task ReceiveLoopAsync(Socket socket, CancellationToken ct)
+    {
+        var buffer = new byte[2048];
+        var any = new IPEndPoint(IPAddress.Any, 0);
+
+        while (!ct.IsCancellationRequested)
+        {
+            SocketReceiveFromResult rx;
+            try
+            {
+                rx = await socket.ReceiveFromAsync(buffer, SocketFlags.None, any, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { break; }
+            catch (SocketException ex)
+            {
+                _logger.LogDebug(ex, "vradio.p1 receive error (continuing).");
+                continue;
+            }
+            catch (ObjectDisposedException) { break; }
+
+            var span = buffer.AsSpan(0, rx.ReceivedBytes);
+            var remote = (IPEndPoint)rx.RemoteEndPoint;
+
+            // Discovery probe (0xEF FE 02): reply to the sender, do not treat as
+            // a host connection. On loopback Zeus never probes (direct-connect),
+            // so this path is dormant there but ready for a LAN bind.
+            if (DiscoveryResponder.IsDiscoveryProbe(span))
+            {
+                if (_discovery.TryBuildReply(span, out byte[] reply))
+                {
+                    try
+                    {
+                        await socket.SendToAsync(reply, SocketFlags.None, remote, ct).ConfigureAwait(false);
+                        _logger.LogInformation("vradio.p1 discovery reply → {Peer} as {Board}.", remote, _profile.Board);
+                    }
+                    catch (OperationCanceledException) { break; }
+                    catch (SocketException ex) { _logger.LogDebug(ex, "vradio.p1 discovery send error."); }
+                }
+                continue;
+            }
+
+            // Any recognised host frame (start/stop or EP2 data) marks the host
+            // endpoint the RX stream is delivered to.
+            IReadOnlyList<DecodedHostCommand> events;
+            lock (_stateGate)
+            {
+                events = _decoder.Decode(span, _state);
+                if (events.Count > 0)
+                {
+                    _hostEndPoint = remote;
+                    _currentRxHz = _state.RxFreqHz != 0 ? _state.RxFreqHz : _currentRxHz;
+                }
+            }
+
+            if (events.Count == 0)
+                continue;
+
+            // EP2 data frame: count it and track inbound sequence gaps.
+            if (span.Length == Ep2Decoder.Ep2PacketLength)
+            {
+                Interlocked.Increment(ref _ep2PacketsReceived);
+                TrackEp2Sequence(BinaryPrimitives.ReadUInt32BigEndian(span.Slice(4, 4)));
+            }
+
+            foreach (DecodedHostCommand cmd in events)
+                PublishIfChanged(cmd);
+        }
+    }
+
+    private void TrackEp2Sequence(uint seq)
+    {
+        if (_seenEp2Seq && seq > _lastEp2Seq)
+        {
+            long gap = (long)seq - _lastEp2Seq - 1;
+            if (gap > 0) Interlocked.Add(ref _seqGaps, gap);
+        }
+        _seenEp2Seq = true;
+        _lastEp2Seq = seq;
+    }
+
+    /// <summary>
+    /// Edge-triggered publish: feed the command log + raise
+    /// <see cref="CommandDecoded"/> only when this kind's decoded summary
+    /// changed, so the round-robin's steady re-sends don't flood observers.
+    /// </summary>
+    private void PublishIfChanged(DecodedHostCommand cmd)
+    {
+        lock (_lastSummaryByKind)
+        {
+            if (_lastSummaryByKind.TryGetValue(cmd.CommandKind, out string? prev) && prev == cmd.Summary)
+                return;
+            _lastSummaryByKind[cmd.CommandKind] = cmd.Summary;
+        }
+
+        _commandLog.Add(cmd);
+        try { CommandDecoded?.Invoke(cmd); }
+        catch (Exception ex) { _logger.LogWarning(ex, "vradio.p1 CommandDecoded handler threw."); }
+    }
+
+    private async Task SendLoopAsync(Socket socket, CancellationToken ct)
+    {
+        // Reusable scratch: one EP6 packet, its IQ source buffer, an empty mic
+        // span (audio is a later phase).
+        var packet = new byte[Ep6Encoder.Ep6PacketLength];
+        var iq = new double[2 * Ep6Encoder.ComplexSamplesPerPacket];
+
+        var sw = Stopwatch.StartNew();
+        long nextTick = sw.ElapsedTicks;
+
+        while (!ct.IsCancellationRequested)
+        {
+            IPEndPoint? host = _hostEndPoint;
+            bool running;
+            byte driveByte;
+            bool mox;
+            long bandHz;
+            long tunedHz;
+            int rateKhz;
+            lock (_stateGate)
+            {
+                running = _state.Running;
+                driveByte = _state.DriveByte;
+                mox = _state.Mox;
+                bandHz = _state.TxFreqHz != 0 ? _state.TxFreqHz : _currentRxHz;
+                tunedHz = _currentRxHz;
+                rateKhz = _state.SampleRateKhz > 0 ? _state.SampleRateKhz : _profile.SampleRateKhz;
+            }
+
+            if (!running || host is null)
+            {
+                // Idle: nothing to stream yet. Sleep briefly and rebase the
+                // pacing clock so we don't burst on the first packet after start.
+                try { await Task.Delay(10, ct).ConfigureAwait(false); }
+                catch (OperationCanceledException) { break; }
+                nextTick = sw.ElapsedTicks;
+                continue;
+            }
+
+            double sampleRateHz = rateKhz * 1000.0;
+
+            _iq.Generate(iq, Ep6Encoder.ComplexSamplesPerPacket, tunedHz);
+            RfTelemetry tel = _rf.Compute(driveByte, bandHz, mox);
+            // C0[0] hardware-PTT echo follows the decoded host MOX (the firmware's
+            // debounced clean_PTT_in), independent of drive amplitude — so a
+            // keyed-with-zero-drive frame still echoes PTT. mic span omitted
+            // (audio is a later phase).
+            _encoder.Encode(packet, _ep6Sequence++, iq, tel, mox);
+
+            try
+            {
+                await socket.SendToAsync(packet, SocketFlags.None, host, ct).ConfigureAwait(false);
+                Interlocked.Increment(ref _ep6PacketsSent);
+            }
+            catch (OperationCanceledException) { break; }
+            catch (ObjectDisposedException) { break; }
+            catch (SocketException ex)
+            {
+                _logger.LogDebug(ex, "vradio.p1 EP6 send error to {Host}.", host);
+            }
+
+            // Pace at the true EP6 cadence: ComplexSamplesPerPacket / sampleRate
+            // seconds per packet (48k → 2.625 ms → ~381 pkt/s). Stopwatch-based
+            // so the host's own clock pacing (Zeus paces TX off received RX) sees
+            // a steady stream, not whatever Task.Delay rounds to.
+            long intervalTicks = (long)(Ep6Encoder.ComplexSamplesPerPacket / sampleRateHz * Stopwatch.Frequency);
+            nextTick += intervalTicks;
+            long now = sw.ElapsedTicks;
+            long remain = nextTick - now;
+            if (remain <= 0)
+            {
+                // Fell behind (or sub-ms cadence we can't sleep precisely): rebase
+                // and free-run; the kernel buffers absorb the small burst.
+                nextTick = now;
+                continue;
+            }
+
+            double remainMs = remain * 1000.0 / Stopwatch.Frequency;
+            if (remainMs > 1.5)
+            {
+                try { await Task.Delay((int)(remainMs - 1.0), ct).ConfigureAwait(false); }
+                catch (OperationCanceledException) { break; }
+            }
+            // Spin off the sub-millisecond remainder for cadence accuracy.
+            while (sw.ElapsedTicks < nextTick && !ct.IsCancellationRequested)
+                Thread.SpinWait(40);
+        }
+    }
+
+    /// <inheritdoc />
+    public VirtualRadioStatus Snapshot()
+    {
+        byte driveByte;
+        bool mox;
+        long bandHz;
+        long tunedHz;
+        lock (_stateGate)
+        {
+            driveByte = _state.DriveByte;
+            mox = _state.Mox;
+            bandHz = _state.TxFreqHz != 0 ? _state.TxFreqHz : _currentRxHz;
+            tunedHz = _currentRxHz;
+        }
+
+        RfTelemetry tel = _rf.Compute(driveByte, bandHz, mox);
+        VirtualRadioProfile profile = _profile with { TunedHz = tunedHz };
+
+        return new VirtualRadioStatus(
+            Profile: profile,
+            ConnectedHost: _hostEndPoint?.ToString(),
+            Mox: mox,
+            FwdWatts: tel.FwdWatts,
+            RefWatts: tel.RefWatts,
+            Swr: tel.Swr,
+            Ep6PacketsSent: Interlocked.Read(ref _ep6PacketsSent),
+            Ep2PacketsReceived: Interlocked.Read(ref _ep2PacketsReceived),
+            SeqGaps: Interlocked.Read(ref _seqGaps),
+            LastCommands: _commandLog.Snapshot());
+    }
+
+    // ---- Test observability (InternalsVisibleTo) --------------------------
+    // The loopback integration test asserts the engine decoded the host's drive
+    // byte / MOX without reaching into the wire. Snapshot() surfaces watts (a
+    // function of the drive byte) but not the raw byte, so expose it here.
+
+    /// <summary>The most-recently decoded transmit drive byte (test hook).</summary>
+    internal byte DecodedDriveByte
+    {
+        get { lock (_stateGate) { return _state.DriveByte; } }
+    }
+
+    /// <summary>The most-recently decoded MOX state (test hook).</summary>
+    internal bool DecodedMox
+    {
+        get { lock (_stateGate) { return _state.Mox; } }
+    }
+}

--- a/Zeus.VirtualRadio/P2/P2CmdDecoder.cs
+++ b/Zeus.VirtualRadio/P2/P2CmdDecoder.cs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Buffers.Binary;
+using Zeus.Contracts;
+using Zeus.Protocol2;
+
+namespace Zeus.VirtualRadio.P2;
+
+/// <summary>
+/// Decodes inbound Protocol-2 host command packets — the inverse of
+/// <c>Zeus.Protocol2.Protocol2Client</c>'s <c>SendCmdGeneral</c> /
+/// <c>SendCmdRx</c> / <c>SendCmdTx</c> / <c>SendCmdHighPriority</c> composers.
+/// The client sends each command kind to a distinct UDP port, so the engine
+/// classifies a datagram by the port it arrived on and this decoder reads the
+/// fields the emulator needs to drive RX / telemetry / PureSignal feedback:
+/// MOX, drive byte, the byte-1363 <c>Mux</c> PS-arm, and the byte-59 TX
+/// attenuator. Pure and socketless.
+/// </summary>
+internal sealed class P2CmdDecoder
+{
+    private static readonly IReadOnlyList<DecodedHostCommand> Empty = Array.Empty<DecodedHostCommand>();
+
+    // User-RX DDC config block offset for the rest-mode rate. The client lays
+    // DDC config blocks at 17 + ddc*6 with the BE u16 rate at +1
+    // (Protocol2Client.ComposeCmdRxBuffer); the user RX sits at RxBaseDdc(board).
+    private readonly int _userRxRateOffset;
+
+    /// <param name="board">The board the emulator impersonates — selects the
+    /// user-RX DDC slot for rest-mode rate decode (HermesII RX is DDC0).</param>
+    public P2CmdDecoder(HpsdrBoardKind board = HpsdrBoardKind.HermesII)
+    {
+        int rxDdc = Protocol2Client.RxBaseDdc(board);
+        _userRxRateOffset = 17 + rxDdc * 6 + 1;
+    }
+
+    /// <summary>
+    /// Decode one inbound command packet that arrived on <paramref name="destPort"/>
+    /// (the well-known radio port the host targeted), mutating
+    /// <paramref name="state"/> in place and returning the decoded event(s).
+    /// Returns an empty list for unrecognised packets (discovery probes are
+    /// handled by the engine before this is called).
+    /// </summary>
+    public IReadOnlyList<DecodedHostCommand> Decode(int destPort, ReadOnlySpan<byte> packet, HostCommandState state)
+    {
+        switch (destPort)
+        {
+            case P2Wire.CmdGeneralPort:
+                return DecodeGeneral(packet, state);
+            case P2Wire.CmdRxPort:
+                return DecodeRx(packet, state);
+            case P2Wire.CmdTxPort:
+                return DecodeTx(packet, state);
+            case P2Wire.CmdHighPriorityPort:
+                return DecodeHighPriority(packet, state);
+            default:
+                return Empty;
+        }
+    }
+
+    private static IReadOnlyList<DecodedHostCommand> DecodeGeneral(ReadOnlySpan<byte> p, HostCommandState state)
+    {
+        // CmdGeneral is a 60-byte packet with byte 4 = 0x00 (a discovery probe
+        // carries 0x02 there and never reaches this decoder). It carries the
+        // radio-side port map and PA-enable; we only need it to mark that the
+        // host has begun the connect handshake, which flips the RX stream on.
+        if (p.Length < P2Wire.CmdSmallLength || p[P2Wire.GeneralCmdByte] != P2Wire.GeneralConnect)
+            return Empty;
+        state.Running = true;
+        return One("CmdGeneral", "connect handshake — radio configured, RX stream armed");
+    }
+
+    private IReadOnlyList<DecodedHostCommand> DecodeRx(ReadOnlySpan<byte> p, HostCommandState state)
+    {
+        if (p.Length != P2Wire.BufLen)
+            return Empty;
+
+        state.NumAdc = p[P2Wire.RxNumAdcByte];
+        byte ddcEnable = p[P2Wire.RxDdcEnableByte];
+
+        // Byte 1363 (the Mux register on the 10E): bit 1 (0x02) arms the
+        // single-ADC PS time-mux for this TX burst. The gateware keys feedback
+        // off exactly this bit (Hermes.v:684-687), so the emulator does too.
+        bool psArmed = (p[P2Wire.RxMuxByte] & P2Wire.RxMuxPsBit) != 0;
+        state.PsArmedBurst = psArmed;
+
+        // Negotiated IQ rate: the burst descriptor pins DDC0 at 192k (offset 18);
+        // at rest read the user-RX DDC config block (RxBaseDdc-dependent offset).
+        int rateOffset = psArmed ? P2Wire.RxDdc0SampleRateOffset : _userRxRateOffset;
+        int rateKhz = BinaryPrimitives.ReadUInt16BigEndian(p.Slice(rateOffset, 2));
+        if (rateKhz > 0) state.SampleRateKhz = rateKhz;
+
+        return One("CmdRx",
+            $"numAdc={state.NumAdc} ddcEnable=0x{ddcEnable:X2} mux1363=0x{p[P2Wire.RxMuxByte]:X2} " +
+            $"psBurst={(psArmed ? 1 : 0)} rate={state.SampleRateKhz}k");
+    }
+
+    private static IReadOnlyList<DecodedHostCommand> DecodeTx(ReadOnlySpan<byte> p, HostCommandState state)
+    {
+        if (p.Length < P2Wire.CmdSmallLength)
+            return Empty;
+
+        state.MicBoost = (p[P2Wire.TxMicControlByte] & 0x02) != 0;
+        state.MicLineIn = (p[P2Wire.TxMicControlByte] & 0x01) != 0;
+        // Byte 59 = the TX-time ADC attenuator (Angelia_atten_Tx0). On a
+        // single-ADC PS time-mux this is the protective seed; surface it for the
+        // safety assertion.
+        state.TxStepAttnDb = p[P2Wire.TxStepAttnByte];
+
+        return One("CmdTx",
+            $"micCtrl=0x{p[P2Wire.TxMicControlByte]:X2} lineInGain={p[P2Wire.TxLineInGainByte]} " +
+            $"byte59={state.TxStepAttnDb}");
+    }
+
+    private static IReadOnlyList<DecodedHostCommand> DecodeHighPriority(ReadOnlySpan<byte> p, HostCommandState state)
+    {
+        if (p.Length != P2Wire.BufLen)
+            return Empty;
+
+        byte runMox = p[P2Wire.HpRunMoxByte];
+        state.Running |= (runMox & P2Wire.HpRunBit) != 0;
+        state.Mox = (runMox & P2Wire.HpMoxBit) != 0;
+        state.Ptt = state.Mox;
+        state.DriveByte = p[P2Wire.HpDriveByte];
+
+        // Decode the DDC0 RX NCO + TX-DUC phase words back to Hz for
+        // observability (the host writes phase = Hz * HzToPhase).
+        uint rxPhase = BinaryPrimitives.ReadUInt32BigEndian(p.Slice(P2Wire.HpDdc0PhaseOffset, 4));
+        uint txPhase = BinaryPrimitives.ReadUInt32BigEndian(p.Slice(P2Wire.HpTxDucPhaseOffset, 4));
+        state.RxFreqHz = (long)Math.Round(rxPhase / P2Wire.HzToPhase);
+        state.TxFreqHz = (long)Math.Round(txPhase / P2Wire.HzToPhase);
+
+        return One("CmdHighPriority",
+            $"run={(state.Running ? 1 : 0)} mox={(state.Mox ? 1 : 0)} drive={state.DriveByte} " +
+            $"rxFreq={state.RxFreqHz}Hz txFreq={state.TxFreqHz}Hz");
+    }
+
+    private static IReadOnlyList<DecodedHostCommand> One(string kind, string summary) =>
+        new[] { new DecodedHostCommand(DateTimeOffset.UtcNow, ProtocolVersion.P2, kind, summary) };
+}

--- a/Zeus.VirtualRadio/P2/P2DiscoveryReply.cs
+++ b/Zeus.VirtualRadio/P2/P2DiscoveryReply.cs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Net.NetworkInformation;
+using Zeus.Contracts;
+using Zeus.Protocol2.Discovery;
+
+namespace Zeus.VirtualRadio.P2;
+
+/// <summary>
+/// Builds a Protocol-2 discovery reply — the inverse of
+/// <c>Zeus.Protocol2.Discovery.ReplyParser.TryParse</c>. The P2 discovery wire
+/// differs from P1: the reply has a four-byte zero seq header, the status byte
+/// is at offset 4, the MAC at 5..10, and the board id at offset 11 (NOT 10 as
+/// in P1). The board-id numbering is also the NEW-protocol map (Angelia 0x03,
+/// Orion 0x04) — but HermesII / ANAN-10E is 0x02 in both, which is all the
+/// Phase-1 vertical slice needs. Feeding this reply back through the real
+/// <c>ReplyParser</c> round-trips it to the same board, the anti-drift guard.
+/// </summary>
+internal static class P2DiscoveryReply
+{
+    /// <summary>
+    /// Map a board kind to its Protocol-2 discovery wire byte (offset 11),
+    /// the inverse of <c>ReplyParser.MapBoard</c>. The 0x0A/0x05 OrionMkII
+    /// ambiguity in the parser means the inverse picks one canonical byte;
+    /// HermesII (0x02) — the emulator's vertical slice — is unambiguous.
+    /// </summary>
+    public static byte BoardByte(HpsdrBoardKind board) => board switch
+    {
+        HpsdrBoardKind.Metis       => 0x00,
+        HpsdrBoardKind.Hermes      => 0x01,
+        HpsdrBoardKind.HermesII    => 0x02,
+        HpsdrBoardKind.Angelia     => 0x03, // P2 numbering (P1 is 0x04)
+        HpsdrBoardKind.Orion       => 0x04, // P2 numbering (P1 is 0x05)
+        HpsdrBoardKind.OrionMkII   => 0x0A, // Saturn / ANAN-G2
+        HpsdrBoardKind.HermesLite2 => 0x06,
+        HpsdrBoardKind.HermesC10   => 0x14,
+        _ => throw new ArgumentOutOfRangeException(
+            nameof(board), board, "No Protocol-2 discovery board byte for this board kind."),
+    };
+
+    /// <summary>The canonical Protocol-2 discovery reply length.</summary>
+    public const int ReplyLength = 60;
+
+    /// <summary>
+    /// True when <paramref name="datagram"/> is a Protocol-2 discovery probe:
+    /// a 60-byte packet with a zero sequence header and the discovery command
+    /// byte 0x02 at offset 4 (<c>RadioDiscoveryService.BuildDiscoveryPacket</c>).
+    /// A <c>CmdGeneral</c> packet to the same port 1024 carries 0x00 there, so
+    /// byte 4 discriminates discovery from a connect/config command.
+    /// </summary>
+    public static bool IsDiscoveryProbe(ReadOnlySpan<byte> datagram) =>
+        datagram.Length >= 5
+        && datagram[0] == 0 && datagram[1] == 0 && datagram[2] == 0 && datagram[3] == 0
+        && datagram[P2Wire.GeneralCmdByte] == P2Wire.DiscoveryProbe;
+
+    /// <summary>
+    /// Write a Protocol-2 discovery reply into <paramref name="dest"/>.
+    /// </summary>
+    /// <param name="dest">Destination buffer (≥ 60 bytes).</param>
+    /// <param name="profile">The radio being impersonated.</param>
+    /// <param name="mac">The MAC address to advertise.</param>
+    /// <param name="codeVersion">Gateware code version (offset 13).</param>
+    /// <param name="numReceivers">Receiver count advertised at offset 20 (≥ 2).</param>
+    /// <param name="busy">Report busy (0x03) rather than idle (0x02) at offset 4.</param>
+    /// <returns>The number of bytes written.</returns>
+    public static int Build(
+        Span<byte> dest,
+        VirtualRadioProfile profile,
+        PhysicalAddress mac,
+        byte codeVersion,
+        byte numReceivers,
+        bool busy)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+        ArgumentNullException.ThrowIfNull(mac);
+        if (dest.Length < ReplyLength)
+        {
+            throw new ArgumentException(
+                $"P2 discovery reply needs at least {ReplyLength} bytes, got {dest.Length}.",
+                nameof(dest));
+        }
+
+        dest[..ReplyLength].Clear();
+
+        // [0..3] zero sequence header (ReplyParser rejects any non-zero here).
+        // [4] status: 0x02 idle / 0x03 busy.
+        dest[4] = busy ? ReplyParser.StatusBusy : ReplyParser.StatusIdle;
+
+        // [5..10] MAC (6 bytes).
+        byte[] macBytes = mac.GetAddressBytes();
+        if (macBytes.Length != 6)
+        {
+            throw new ArgumentException(
+                $"Discovery MAC must be a 6-byte EUI-48, got {macBytes.Length} bytes.",
+                nameof(mac));
+        }
+        macBytes.CopyTo(dest.Slice(5, 6));
+
+        // [11] board id (0x02 HermesII / ANAN-10E).
+        dest[11] = BoardByte(profile.Board);
+
+        // [12] protocols supported — advertise P2 (informational; ReplyParser
+        // surfaces it but does not gate on it).
+        dest[12] = 0x02;
+
+        // [13] gateware code version.
+        dest[13] = codeVersion;
+
+        // [20] number of receivers (≥ 2 so the host sees full DDC capability).
+        dest[20] = numReceivers < 2 ? (byte)2 : numReceivers;
+
+        // [14..19] mercury/penny/metis sub-versions and [23] beta — informational, left zero.
+        return ReplyLength;
+    }
+}

--- a/Zeus.VirtualRadio/P2/P2HiPriStatusEncoder.cs
+++ b/Zeus.VirtualRadio/P2/P2HiPriStatusEncoder.cs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Buffers.Binary;
+using Zeus.VirtualRadio.Rf;
+
+namespace Zeus.VirtualRadio.P2;
+
+/// <summary>
+/// Encodes the Protocol-2 hi-priority status packet (UDP source port 1025) —
+/// the inverse of <c>Protocol2Client.DecodeHiPriStatus</c>. A 4-byte BE u32
+/// sequence prefixes the packet; the status body begins at byte 4, so the
+/// decoder's payload-relative offsets map to absolute offsets as
+/// <c>absolute = 4 + payload</c>:
+/// <list type="bullet">
+///   <item>[4] status — bit 0 PTT, bit 4 PLL locked</item>
+///   <item>[5] ADC overload bits</item>
+///   <item>[6..7] exciter power ADC (BE u16)</item>
+///   <item>[14..15] PA forward power ADC (BE u16)</item>
+///   <item>[22..23] PA reverse power ADC (BE u16)</item>
+/// </list>
+/// FWD/REV are PTT-gated in the firmware, so the caller passes an all-zero
+/// telemetry reading at rest. Feeding this packet's body back through
+/// <c>DecodeHiPriStatus</c> recovers the same fields — the anti-drift guard.
+/// </summary>
+internal sealed class P2HiPriStatusEncoder
+{
+    /// <summary>
+    /// Build a hi-priority status packet into a freshly-allocated buffer of
+    /// <see cref="P2Wire.HiPriStatusPacketLength"/> bytes.
+    /// </summary>
+    /// <param name="sequence">Monotonic packet sequence (BE u32 at [0..3]).</param>
+    /// <param name="telemetry">FWD/REF ADC counts (PTT-gated upstream — all-zero at rest).</param>
+    /// <param name="ptt">Whether the radio is keyed (status bit 0).</param>
+    /// <param name="pllLocked">PLL-lock flag (status bit 4) — true on a healthy radio.</param>
+    /// <param name="adcOverloadBits">ADC overload byte ([5]); 0 = no overload.</param>
+    public byte[] Build(uint sequence, in RfTelemetry telemetry, bool ptt, bool pllLocked, byte adcOverloadBits)
+    {
+        var p = new byte[P2Wire.HiPriStatusPacketLength];
+        BinaryPrimitives.WriteUInt32BigEndian(p.AsSpan(0, 4), sequence);
+
+        // Status byte (absolute [4]): bit 0 PTT, bit 4 PLL locked.
+        byte status = 0;
+        if (ptt) status |= 0x01;
+        if (pllLocked) status |= 0x10;
+        p[4] = status;
+
+        // ADC overload (absolute [5]).
+        p[5] = adcOverloadBits;
+
+        // Exciter power ADC (absolute [6..7]) — mirror the forward count so an
+        // observer sees the exciter move with drive while keyed.
+        BinaryPrimitives.WriteUInt16BigEndian(p.AsSpan(6, 2), telemetry.FwdAdc);
+
+        // PA forward power ADC (absolute [14..15]).
+        BinaryPrimitives.WriteUInt16BigEndian(p.AsSpan(14, 2), telemetry.FwdAdc);
+
+        // PA reverse power ADC (absolute [22..23]).
+        BinaryPrimitives.WriteUInt16BigEndian(p.AsSpan(22, 2), telemetry.RefAdc);
+
+        return p;
+    }
+}

--- a/Zeus.VirtualRadio/P2/P2RxDdcEncoder.cs
+++ b/Zeus.VirtualRadio/P2/P2RxDdcEncoder.cs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Buffers.Binary;
+
+namespace Zeus.VirtualRadio.P2;
+
+/// <summary>
+/// Encodes the two shapes a DDC0 data packet (UDP source port 1035) takes — the
+/// inverse of <c>Protocol2Client.HandleDdcPacket</c> (plain user RX) and
+/// <c>Protocol2Client.HandlePsPairedPacket</c> (PureSignal single-ADC time-mux
+/// feedback). Both are 1444 bytes with a BE u32 sequence at [0..3].
+///
+/// Plain RX: 238 complex samples, interleaved int24-BE I/Q from byte 16.
+///
+/// PS feedback (only emitted while the host's CmdRx byte 1363 <c>Mux</c> bit is
+/// set, i.e. an armed TX burst): a samplesPerFrame=238 marker at [14..15] then
+/// 119 12-byte pairs from byte 16. Per pair, COUPLER FIRST (DDC0 → pscc's "rx",
+/// the post-PA feedback) then REFERENCE SECOND (DDC1 → pscc's "tx", the clean
+/// TX-DAC loopback) — the exact order <c>Protocol2Client.DecodePsPairForTest</c>
+/// expects, so the de-interleave is reused unchanged.
+/// </summary>
+internal sealed class P2RxDdcEncoder
+{
+    /// <summary>Plain user-RX samples per packet.</summary>
+    public const int RxSamplesPerPacket = P2Wire.RxSamplesPerPacket;   // 238
+
+    /// <summary>PS feedback sample-pairs per packet.</summary>
+    public const int PsPairsPerPacket = P2Wire.PsPairsPerPacket;       // 119
+
+    /// <summary>
+    /// Encode a plain user-RX DDC packet from <paramref name="interleavedIq"/>
+    /// (<c>[I0,Q0,…]</c>, full-scale units where 1.0 = 0 dBFS, ≥
+    /// <c>2 × <see cref="RxSamplesPerPacket"/></c> doubles).
+    /// </summary>
+    public void EncodeRxIq(Span<byte> packet, uint sequence, ReadOnlySpan<double> interleavedIq)
+    {
+        if (packet.Length != P2Wire.BufLen)
+            throw new ArgumentException($"packet must be exactly {P2Wire.BufLen} bytes", nameof(packet));
+        int needed = 2 * RxSamplesPerPacket;
+        if (interleavedIq.Length < needed)
+            throw new ArgumentException($"interleavedIq must hold at least {needed} doubles", nameof(interleavedIq));
+
+        packet.Clear();
+        BinaryPrimitives.WriteUInt32BigEndian(packet.Slice(0, 4), sequence);
+        // samplesPerFrame marker — the plain-RX decoder uses a fixed 238 and
+        // ignores this, but writing it keeps both packet shapes self-describing.
+        BinaryPrimitives.WriteUInt16BigEndian(
+            packet.Slice(P2Wire.PsSamplesPerFrameOffset, 2), P2Wire.RxSamplesPerPacket);
+
+        for (int s = 0; s < RxSamplesPerPacket; s++)
+        {
+            int off = P2Wire.RxPayloadOffset + s * P2Wire.RxSampleStride;
+            WriteInt24BigEndian(packet.Slice(off, 3), ToInt24(interleavedIq[2 * s]));
+            WriteInt24BigEndian(packet.Slice(off + 3, 3), ToInt24(interleavedIq[2 * s + 1]));
+        }
+    }
+
+    /// <summary>
+    /// Encode a PureSignal feedback packet. <paramref name="couplerIq"/> is the
+    /// post-PA feedback (becomes pscc's "rx"); <paramref name="referenceIq"/> is
+    /// the clean TX-DAC loopback (becomes pscc's "tx"). Both are interleaved
+    /// <c>[I0,Q0,…]</c> with ≥ <c>2 × <see cref="PsPairsPerPacket"/></c> doubles.
+    /// </summary>
+    public void EncodePsFeedback(
+        Span<byte> packet, uint sequence,
+        ReadOnlySpan<double> couplerIq, ReadOnlySpan<double> referenceIq)
+    {
+        if (packet.Length != P2Wire.BufLen)
+            throw new ArgumentException($"packet must be exactly {P2Wire.BufLen} bytes", nameof(packet));
+        int needed = 2 * PsPairsPerPacket;
+        if (couplerIq.Length < needed)
+            throw new ArgumentException($"couplerIq must hold at least {needed} doubles", nameof(couplerIq));
+        if (referenceIq.Length < needed)
+            throw new ArgumentException($"referenceIq must hold at least {needed} doubles", nameof(referenceIq));
+
+        packet.Clear();
+        BinaryPrimitives.WriteUInt32BigEndian(packet.Slice(0, 4), sequence);
+        // samplesPerFrame = 238 → 119 pairs (Protocol2Client.HandlePsPairedPacket
+        // reads this at [14..15] and computes pairs = 238/2).
+        BinaryPrimitives.WriteUInt16BigEndian(
+            packet.Slice(P2Wire.PsSamplesPerFrameOffset, 2), P2Wire.PsSamplesPerFrame);
+
+        for (int i = 0; i < PsPairsPerPacket; i++)
+        {
+            int off = P2Wire.PsPayloadOffset + i * P2Wire.PsPairStride;
+            // DDC0 (coupler → rx) first.
+            WriteInt24BigEndian(packet.Slice(off, 3), ToInt24(couplerIq[2 * i]));
+            WriteInt24BigEndian(packet.Slice(off + 3, 3), ToInt24(couplerIq[2 * i + 1]));
+            // DDC1 (reference → tx) second.
+            WriteInt24BigEndian(packet.Slice(off + 6, 3), ToInt24(referenceIq[2 * i]));
+            WriteInt24BigEndian(packet.Slice(off + 9, 3), ToInt24(referenceIq[2 * i + 1]));
+        }
+    }
+
+    private static int ToInt24(double value)
+    {
+        double scaled = Math.Round(value * P2Wire.Int24FullScale);
+        if (scaled > P2Wire.Int24Max) return P2Wire.Int24Max;
+        if (scaled < P2Wire.Int24Min) return P2Wire.Int24Min;
+        return (int)scaled;
+    }
+
+    private static void WriteInt24BigEndian(Span<byte> dest, int value)
+    {
+        dest[0] = (byte)((value >> 16) & 0xFF);
+        dest[1] = (byte)((value >> 8) & 0xFF);
+        dest[2] = (byte)(value & 0xFF);
+    }
+}

--- a/Zeus.VirtualRadio/P2/P2Wire.cs
+++ b/Zeus.VirtualRadio/P2/P2Wire.cs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.VirtualRadio.P2;
+
+/// <summary>
+/// Protocol-2 wire constants the emulator shares with the client it mirrors.
+///
+/// Zeus's <c>Protocol2Client</c> declares these same numbers as <c>private
+/// const</c> (BufLen, RxDataPortBase, HiPriSeqHeaderBytes, the 238/240 sample
+/// geometries), so <c>InternalsVisibleTo</c> cannot reach them — they are
+/// re-declared here with a precise source citation, and the anti-drift
+/// guarantee is the round-trip tests: every packet the emulator emits is fed
+/// back through the REAL client decode (<c>ReplyParser.TryParse</c>,
+/// <c>Protocol2Client.DecodeHiPriStatus</c>,
+/// <c>Protocol2Client.DecodePsPairForTest</c>) and every command the emulator
+/// decodes is produced by the REAL composer
+/// (<c>Protocol2Client.ComposeCmdRxBuffer</c> /
+/// <c>ComposeCmdTxBuffer</c>). A wire-format change in the client therefore
+/// reds a round-trip test rather than drifting silently.
+/// </summary>
+internal static class P2Wire
+{
+    // ---- UDP port map (Protocol2Client.cs:577-1591, SendCmdGeneral) -------
+    // Host → radio destination ports.
+    public const int CmdGeneralPort = 1024;       // discovery + general config
+    public const int CmdRxPort = 1025;            // receive-specific (DDC enable, byte 1363 Mux)
+    public const int CmdTxPort = 1026;            // transmit-specific (byte 59 TX attenuator)
+    public const int CmdHighPriorityPort = 1027;  // run/MOX, NCO phases, drive byte 345
+    public const int TxIqPort = 1029;             // TX-DUC IQ from the host
+
+    // Radio → host SOURCE ports (the client demuxes inbound by source port —
+    // Protocol2Client.RxLoop, the #1 thing to get wrong). The emulator MUST
+    // send each stream from the matching socket.
+    public const int HiPriStatusSrcPort = 1025;   // hi-priority status (FWD/REV/exciter/PTT)
+    public const int RxDataPortBase = 1035;       // DDC0 RX-IQ + PS feedback (Protocol2Client.cs:122)
+
+    // ---- Packet geometry --------------------------------------------------
+    public const int BufLen = 1444;                   // Protocol2Client.cs:82
+    public const int DiscoveryPacketLength = 60;      // RadioDiscoveryService.cs:58
+    public const int CmdSmallLength = 60;             // CmdGeneral / CmdTx length
+
+    // Plain RX DDC: 238 complex samples, int24 BE I+Q from byte 16
+    // (Protocol2Client.HandleDdcPacket, DiscoverySamplesPerPacket).
+    public const int RxSamplesPerPacket = 238;
+    public const int RxSampleStride = 6;              // 3B I + 3B Q
+    public const int RxPayloadOffset = 16;
+
+    // PS paired feedback: 16-byte header, samplesPerFrame BE u16 at [14..15]
+    // = 238 → 119 pairs of 12 bytes from byte 16 (Protocol2Client.HandlePsPairedPacket).
+    public const int PsSamplesPerFrame = 238;
+    public const int PsPairsPerPacket = 119;
+    public const int PsPairStride = 12;               // 6B coupler(DDC0=rx) + 6B reference(DDC1=tx)
+    public const int PsPayloadOffset = 16;
+    public const int PsSamplesPerFrameOffset = 14;
+
+    // TX-IQ ingest: BE u32 seq, then 240 complex int24 BE from byte 4
+    // (Protocol2Client.FlushTxIqLocked).
+    public const int TxIqSamplesPerPacket = 240;
+    public const int TxIqPayloadOffset = 4;
+    public const int TxIqSampleStride = 6;
+
+    // ---- Hi-priority status (Protocol2Client.DecodeHiPriStatus) -----------
+    // A 4-byte BE u32 sequence prefixes EVERY P2 UDP packet; the status body
+    // starts at byte 4. The min length the client requires is 4 + 20 = 24.
+    public const int HiPriSeqHeaderBytes = 4;         // Protocol2Client.cs:94
+    public const int HiPriStatusMinBody = 20;
+    public const int HiPriStatusPacketLength = 60;    // 4 seq + 56 body (Thetis memcpy 56)
+
+    // ---- Field offsets read/written on the wire ---------------------------
+    // CmdHighPriority (port 1027):
+    public const int HpRunMoxByte = 4;                // bit0 run, bit1 (0x02) PTT/MOX
+    public const byte HpRunBit = 0x01;
+    public const byte HpMoxBit = 0x02;
+    public const int HpDdc0PhaseOffset = 9;           // DDC0 RX NCO phase (Hermes-class RxBaseDdc=0)
+    public const int HpTxDucPhaseOffset = 329;        // TX DUC NCO phase
+    public const int HpDriveByte = 345;               // drive level 0..255
+
+    // CmdRx (port 1025):
+    public const int RxNumAdcByte = 4;
+    public const int RxDdcEnableByte = 7;
+    public const int RxMuxByte = 1363;                // the Mux register on the 10E
+    public const byte RxMuxPsBit = 0x02;              // Mux[1] — Rx PS time-mux select
+    public const int RxDdc0SampleRateOffset = 18;     // BE u16 kHz in the burst descriptor
+
+    // CmdTx (port 1026):
+    public const int TxMicControlByte = 50;
+    public const int TxLineInGainByte = 51;
+    public const int TxStepAttnByte = 59;             // Angelia_atten_Tx0 (byte-59 safety seed)
+
+    // CmdGeneral / discovery (port 1024): byte 4 discriminates.
+    public const int GeneralCmdByte = 4;
+    public const byte GeneralConnect = 0x00;          // CmdGeneral
+    public const byte DiscoveryProbe = 0x02;          // discovery request (RadioDiscoveryService)
+
+    // Hz → 32-bit phase increment (Protocol2Client.HzToPhase). Used only to
+    // decode the host's commanded RX/TX frequency back out for observability.
+    public const double HzToPhase = 34.952533333333333;
+
+    public const double Int24FullScale = 8_388_608.0; // 2^23
+    public const int Int24Max = 8_388_607;
+    public const int Int24Min = -8_388_608;
+}

--- a/Zeus.VirtualRadio/P2/Protocol2Engine.cs
+++ b/Zeus.VirtualRadio/P2/Protocol2Engine.cs
@@ -1,0 +1,436 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.VirtualRadio.Discovery;
+using Zeus.VirtualRadio.Observation;
+using Zeus.VirtualRadio.Rf;
+
+namespace Zeus.VirtualRadio.P2;
+
+/// <summary>
+/// The Protocol-2 virtual-radio engine (Phase-3 + the PureSignal single-ADC
+/// time-mux slice for the ANAN-10E / HermesII). Binds the P2 UDP port set
+/// (1024 CmdGeneral, 1025 CmdRx, 1026 CmdTx, 1027 CmdHighPriority, 1029 TX-IQ)
+/// and a DDC0 send socket (source port 1035), answers P2 discovery as a
+/// HermesII (board byte 0x02), decodes the host commands, streams synthetic
+/// DDC0 RX-IQ + PTT-gated FWD/REF hi-priority status, and — when the host arms
+/// the single-ADC PS time-mux (CmdRx byte 1363 <c>Mux</c> bit) during a keyed
+/// burst — flips DDC0 to the coupler/reference interleaved feedback layout the
+/// client decodes in <c>HandlePsPairedPacket</c>.
+///
+/// Each radio→host stream is sent from the matching SOURCE port (the client
+/// demuxes inbound by source port — the #1 thing to get wrong), so hi-priority
+/// status goes out of the 1025 socket and DDC0 IQ/feedback out of the 1035
+/// socket. The host endpoint is observed from inbound command traffic; on
+/// loopback Zeus direct-connects, so discovery is dormant there.
+/// </summary>
+public sealed class Protocol2Engine : IVirtualRadio
+{
+    private readonly VirtualRadioProfile _profile;
+    private readonly ILogger<Protocol2Engine> _logger;
+    private readonly HostCommandState _state = new();
+    private readonly CommandLog _commandLog = new();
+
+    private readonly P2CmdDecoder _decoder;
+    private readonly P2RxDdcEncoder _rxEncoder = new();
+    private readonly P2HiPriStatusEncoder _hiPriEncoder = new();
+    private readonly SyntheticIqGenerator _iq;
+    private readonly RfTelemetryModel _rf;
+    private readonly PaDistortionModel _distortion;
+    private readonly TxReferenceSource _txRef;
+
+    private readonly object _stateGate = new();
+    private volatile IPEndPoint? _hostEndPoint;
+
+    // The PS feedback burst runs DDC0 at 192 kHz (the burst descriptor rate).
+    private const double PsBurstRateHz = 192_000.0;
+
+    // Byte-59 protective floor the host MUST seed while the PS time-mux is
+    // armed (the DAC feedback hits the only RX ADC during TX). Below this the
+    // emulator asserts ADC-overload in the hi-priority status — the safety
+    // signal a real G2E/10E would raise on a first key-down with byte 59 = 0.
+    internal const byte TxAdcProtectFloorDb = 1;
+
+    // ~5 Hz hi-priority status. A few Hz is enough for the meter to render.
+    private static readonly TimeSpan HiPriPeriod = TimeSpan.FromMilliseconds(200);
+
+    private long _currentTunedHz;
+
+    private long _ddc0PacketsSent;
+    private long _cmdPacketsReceived;
+    private long _psFeedbackPacketsSent;
+
+    // De-dup edge-trigger for CommandDecoded (steady re-sends of the same
+    // command should not flood observers).
+    private readonly Dictionary<string, string> _lastSummaryByKind = new();
+
+    public Protocol2Engine(
+        VirtualRadioProfile profile,
+        ILogger<Protocol2Engine>? logger = null,
+        bool psDistortion = false)
+    {
+        _profile = profile ?? throw new ArgumentNullException(nameof(profile));
+        _logger = logger ?? NullLogger<Protocol2Engine>.Instance;
+        _decoder = new P2CmdDecoder(profile.Board);
+        _iq = new SyntheticIqGenerator(profile);
+        _rf = new RfTelemetryModel(profile);
+        _distortion = new PaDistortionModel(psDistortion);
+        _txRef = new TxReferenceSource(PsBurstRateHz);
+        _currentTunedHz = profile.TunedHz;
+        _state.SampleRateKhz = profile.SampleRateKhz;
+    }
+
+    /// <inheritdoc />
+    public event Action<DecodedHostCommand>? CommandDecoded;
+
+    /// <summary>True once the PA distortion model is shaping the PS coupler.</summary>
+    public bool PsDistortionEnabled => _distortion.Enabled;
+
+    /// <inheritdoc />
+    public async Task RunAsync(CancellationToken ct)
+    {
+        // One socket per port so each stream can be sent from its matching
+        // source port. The send-only DDC0 socket binds 1035.
+        using var sockGeneral = Bind(P2Wire.CmdGeneralPort);
+        using var sockRx = Bind(P2Wire.CmdRxPort);
+        using var sockTx = Bind(P2Wire.CmdTxPort);
+        using var sockHp = Bind(P2Wire.CmdHighPriorityPort);
+        using var sockTxIq = Bind(P2Wire.TxIqPort);
+        using var sockDdc0 = Bind(P2Wire.RxDataPortBase);
+
+        _logger.LogInformation(
+            "vradio.p2 listening on {Bind} ports {G}/{Rx}/{Tx}/{Hp}/{TxIq} (+DDC0 {Ddc0}) as {Board}, rate {Rate}kHz, tones {Tones}, psDistortion={Dist}",
+            _profile.BindAddress, P2Wire.CmdGeneralPort, P2Wire.CmdRxPort, P2Wire.CmdTxPort,
+            P2Wire.CmdHighPriorityPort, P2Wire.TxIqPort, P2Wire.RxDataPortBase, _profile.Board,
+            _profile.SampleRateKhz, _profile.Tones.Count, _distortion.Enabled);
+
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        var tasks = new[]
+        {
+            ReceiveLoopAsync(sockGeneral, P2Wire.CmdGeneralPort, linked.Token),
+            ReceiveLoopAsync(sockRx, P2Wire.CmdRxPort, linked.Token),
+            ReceiveLoopAsync(sockTx, P2Wire.CmdTxPort, linked.Token),
+            ReceiveLoopAsync(sockHp, P2Wire.CmdHighPriorityPort, linked.Token),
+            ReceiveLoopAsync(sockTxIq, P2Wire.TxIqPort, linked.Token),
+            Task.Run(() => Ddc0SendLoopAsync(sockDdc0, linked.Token), CancellationToken.None),
+            Task.Run(() => HiPriStatusLoopAsync(sockRx, linked.Token), CancellationToken.None),
+        };
+
+        try
+        {
+            await Task.WhenAny(tasks).ConfigureAwait(false);
+        }
+        finally
+        {
+            linked.Cancel();
+            try { await Task.WhenAll(tasks).ConfigureAwait(false); }
+            catch (OperationCanceledException) { }
+            catch (Exception ex) { _logger.LogDebug(ex, "vradio.p2 loop teardown."); }
+        }
+    }
+
+    private Socket Bind(int port)
+    {
+        var s = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp)
+        {
+            ReceiveBufferSize = 1 << 20,
+            SendBufferSize = 1 << 20,
+        };
+        s.EnableBroadcast = true;
+        s.Bind(new IPEndPoint(_profile.BindAddress, port));
+        return s;
+    }
+
+    private async Task ReceiveLoopAsync(Socket socket, int destPort, CancellationToken ct)
+    {
+        var buffer = new byte[2048];
+        var any = new IPEndPoint(IPAddress.Any, 0);
+
+        while (!ct.IsCancellationRequested)
+        {
+            SocketReceiveFromResult rx;
+            try
+            {
+                rx = await socket.ReceiveFromAsync(buffer, SocketFlags.None, any, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { break; }
+            catch (ObjectDisposedException) { break; }
+            catch (SocketException ex)
+            {
+                _logger.LogDebug(ex, "vradio.p2 receive error on {Port} (continuing).", destPort);
+                continue;
+            }
+
+            var span = buffer.AsSpan(0, rx.ReceivedBytes);
+            var remote = (IPEndPoint)rx.RemoteEndPoint;
+
+            // Discovery probe on port 1024 → reply to the sender. (Dormant on
+            // loopback: Zeus direct-connects and never probes loopback.)
+            if (destPort == P2Wire.CmdGeneralPort && P2DiscoveryReply.IsDiscoveryProbe(span))
+            {
+                await ReplyToDiscoveryAsync(socket, remote, ct).ConfigureAwait(false);
+                continue;
+            }
+
+            // TX-IQ stream (port 1029) → ingest as the PS reference. Not a
+            // command; never marks state but does mark the host endpoint.
+            if (destPort == P2Wire.TxIqPort)
+            {
+                _hostEndPoint = remote;
+                IngestTxIq(span);
+                continue;
+            }
+
+            IReadOnlyList<DecodedHostCommand> events;
+            lock (_stateGate)
+            {
+                events = _decoder.Decode(destPort, span, _state);
+                if (events.Count > 0)
+                {
+                    _hostEndPoint = remote;
+                    if (_state.RxFreqHz != 0) _currentTunedHz = _state.RxFreqHz;
+                }
+            }
+
+            if (events.Count == 0)
+                continue;
+
+            Interlocked.Increment(ref _cmdPacketsReceived);
+            foreach (DecodedHostCommand cmd in events)
+                PublishIfChanged(cmd);
+        }
+    }
+
+    private async Task ReplyToDiscoveryAsync(Socket socket, IPEndPoint sender, CancellationToken ct)
+    {
+        var reply = new byte[P2DiscoveryReply.ReplyLength];
+        P2DiscoveryReply.Build(
+            reply, _profile, DiscoveryResponder.DefaultMac,
+            codeVersion: DiscoveryResponder.DefaultCodeVersion, numReceivers: 2, busy: false);
+        try
+        {
+            await socket.SendToAsync(reply, SocketFlags.None, sender, ct).ConfigureAwait(false);
+            _logger.LogInformation("vradio.p2 discovery reply → {Peer} as {Board}.", sender, _profile.Board);
+        }
+        catch (OperationCanceledException) { }
+        catch (SocketException ex) { _logger.LogDebug(ex, "vradio.p2 discovery send error."); }
+    }
+
+    private void IngestTxIq(ReadOnlySpan<byte> packet)
+    {
+        // BE u32 seq, then 240 complex int24 BE from offset 4.
+        if (packet.Length < P2Wire.TxIqPayloadOffset + P2Wire.TxIqSamplesPerPacket * P2Wire.TxIqSampleStride)
+            return;
+        Span<float> iq = stackalloc float[P2Wire.TxIqSamplesPerPacket * 2];
+        const float scale = 1f / (float)P2Wire.Int24FullScale;
+        for (int i = 0; i < P2Wire.TxIqSamplesPerPacket; i++)
+        {
+            int off = P2Wire.TxIqPayloadOffset + i * P2Wire.TxIqSampleStride;
+            iq[2 * i] = SignExtend24((packet[off] << 16) | (packet[off + 1] << 8) | packet[off + 2]) * scale;
+            iq[2 * i + 1] = SignExtend24((packet[off + 3] << 16) | (packet[off + 4] << 8) | packet[off + 5]) * scale;
+        }
+        _txRef.Ingest(iq);
+    }
+
+    private static int SignExtend24(int raw)
+    {
+        if ((raw & 0x800000) != 0) raw |= unchecked((int)0xFF000000);
+        return raw;
+    }
+
+    private void PublishIfChanged(DecodedHostCommand cmd)
+    {
+        lock (_lastSummaryByKind)
+        {
+            if (_lastSummaryByKind.TryGetValue(cmd.CommandKind, out string? prev) && prev == cmd.Summary)
+                return;
+            _lastSummaryByKind[cmd.CommandKind] = cmd.Summary;
+        }
+        _commandLog.Add(cmd);
+        try { CommandDecoded?.Invoke(cmd); }
+        catch (Exception ex) { _logger.LogWarning(ex, "vradio.p2 CommandDecoded handler threw."); }
+    }
+
+    private async Task Ddc0SendLoopAsync(Socket socket, CancellationToken ct)
+    {
+        var packet = new byte[P2Wire.BufLen];
+        var rxIq = new double[2 * P2RxDdcEncoder.RxSamplesPerPacket];
+        var refBuf = new double[2 * P2RxDdcEncoder.PsPairsPerPacket];
+        var coupBuf = new double[2 * P2RxDdcEncoder.PsPairsPerPacket];
+        uint seq = 0;
+
+        var sw = Stopwatch.StartNew();
+        long nextTick = sw.ElapsedTicks;
+
+        while (!ct.IsCancellationRequested)
+        {
+            IPEndPoint? host = _hostEndPoint;
+            bool running, feedback;
+            int rateKhz;
+            long tunedHz;
+            lock (_stateGate)
+            {
+                running = _state.Running;
+                // The host only sets byte 1363 during an armed keyed burst, so
+                // the Mux bit alone is the gateware-faithful discriminator.
+                feedback = _state.PsArmedBurst;
+                rateKhz = _state.SampleRateKhz > 0 ? _state.SampleRateKhz : _profile.SampleRateKhz;
+                tunedHz = _currentTunedHz;
+            }
+
+            if (!running || host is null)
+            {
+                try { await Task.Delay(10, ct).ConfigureAwait(false); }
+                catch (OperationCanceledException) { break; }
+                nextTick = sw.ElapsedTicks;
+                continue;
+            }
+
+            double intervalSec;
+            if (feedback)
+            {
+                // Clean reference → coupler-through-PA (identity if distortion
+                // off). Coupler is DDC0 (pscc "rx"), reference is DDC1 (pscc "tx").
+                _txRef.Fill(refBuf, P2RxDdcEncoder.PsPairsPerPacket);
+                for (int i = 0; i < P2RxDdcEncoder.PsPairsPerPacket; i++)
+                {
+                    var (ci, cq) = _distortion.Apply(refBuf[2 * i], refBuf[2 * i + 1]);
+                    coupBuf[2 * i] = ci;
+                    coupBuf[2 * i + 1] = cq;
+                }
+                _rxEncoder.EncodePsFeedback(packet, seq++, coupBuf, refBuf);
+                Interlocked.Increment(ref _psFeedbackPacketsSent);
+                intervalSec = P2RxDdcEncoder.PsPairsPerPacket / PsBurstRateHz;
+            }
+            else
+            {
+                _iq.Generate(rxIq, P2RxDdcEncoder.RxSamplesPerPacket, tunedHz);
+                _rxEncoder.EncodeRxIq(packet, seq++, rxIq);
+                intervalSec = P2RxDdcEncoder.RxSamplesPerPacket / (rateKhz * 1000.0);
+            }
+
+            try
+            {
+                await socket.SendToAsync(packet, SocketFlags.None, host, ct).ConfigureAwait(false);
+                Interlocked.Increment(ref _ddc0PacketsSent);
+            }
+            catch (OperationCanceledException) { break; }
+            catch (ObjectDisposedException) { break; }
+            catch (SocketException ex) { _logger.LogDebug(ex, "vradio.p2 DDC0 send error."); }
+
+            long intervalTicks = (long)(intervalSec * Stopwatch.Frequency);
+            nextTick += intervalTicks;
+            long now = sw.ElapsedTicks;
+            long remain = nextTick - now;
+            if (remain <= 0) { nextTick = now; continue; }
+
+            double remainMs = remain * 1000.0 / Stopwatch.Frequency;
+            if (remainMs > 1.5)
+            {
+                try { await Task.Delay((int)(remainMs - 1.0), ct).ConfigureAwait(false); }
+                catch (OperationCanceledException) { break; }
+            }
+            while (sw.ElapsedTicks < nextTick && !ct.IsCancellationRequested)
+                Thread.SpinWait(40);
+        }
+    }
+
+    private async Task HiPriStatusLoopAsync(Socket socket, CancellationToken ct)
+    {
+        uint seq = 0;
+        while (!ct.IsCancellationRequested)
+        {
+            try { await Task.Delay(HiPriPeriod, ct).ConfigureAwait(false); }
+            catch (OperationCanceledException) { break; }
+
+            IPEndPoint? host = _hostEndPoint;
+            if (host is null) continue;
+
+            byte driveByte, txAttn;
+            bool mox, feedback;
+            long tunedHz;
+            lock (_stateGate)
+            {
+                driveByte = _state.DriveByte;
+                mox = _state.Mox;
+                feedback = _state.PsArmedBurst;
+                txAttn = _state.TxStepAttnDb;
+                tunedHz = _currentTunedHz;
+            }
+
+            RfTelemetry tel = _rf.Compute(driveByte, tunedHz, mox);
+            // Model the single-ADC PS hazard: with the time-mux armed and keyed,
+            // a missing byte-59 protective seed (txAttn below the floor) slams
+            // the DAC feedback into the only RX ADC at 0 dB → ADC overload. A
+            // correctly-seeded host clears it.
+            byte overload = (feedback && txAttn < TxAdcProtectFloorDb) ? (byte)0x01 : (byte)0x00;
+
+            byte[] packet = _hiPriEncoder.Build(seq++, tel, ptt: mox, pllLocked: true, overload);
+            try
+            {
+                await socket.SendToAsync(packet, SocketFlags.None, host, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { break; }
+            catch (ObjectDisposedException) { break; }
+            catch (SocketException ex) { _logger.LogDebug(ex, "vradio.p2 hi-pri send error."); }
+        }
+    }
+
+    /// <inheritdoc />
+    public VirtualRadioStatus Snapshot()
+    {
+        byte driveByte;
+        bool mox;
+        long tunedHz;
+        lock (_stateGate)
+        {
+            driveByte = _state.DriveByte;
+            mox = _state.Mox;
+            tunedHz = _currentTunedHz;
+        }
+
+        RfTelemetry tel = _rf.Compute(driveByte, tunedHz, mox);
+        VirtualRadioProfile profile = _profile with { TunedHz = tunedHz };
+
+        return new VirtualRadioStatus(
+            Profile: profile,
+            ConnectedHost: _hostEndPoint?.ToString(),
+            Mox: mox,
+            FwdWatts: tel.FwdWatts,
+            RefWatts: tel.RefWatts,
+            Swr: tel.Swr,
+            Ep6PacketsSent: Interlocked.Read(ref _ddc0PacketsSent),
+            Ep2PacketsReceived: Interlocked.Read(ref _cmdPacketsReceived),
+            SeqGaps: 0,
+            LastCommands: _commandLog.Snapshot());
+    }
+
+    // ---- Test observability (InternalsVisibleTo) --------------------------
+
+    /// <summary>Most-recently decoded MOX state (test hook).</summary>
+    internal bool DecodedMox { get { lock (_stateGate) return _state.Mox; } }
+
+    /// <summary>Most-recently decoded drive byte (test hook).</summary>
+    internal byte DecodedDriveByte { get { lock (_stateGate) return _state.DriveByte; } }
+
+    /// <summary>Whether the host has armed the PS time-mux burst (byte 1363).</summary>
+    internal bool PsBurstArmed { get { lock (_stateGate) return _state.PsArmedBurst; } }
+
+    /// <summary>Most-recently decoded CmdTx byte 59 (the TX-time ADC attenuator).</summary>
+    internal byte DecodedTxStepAttnDb { get { lock (_stateGate) return _state.TxStepAttnDb; } }
+
+    /// <summary>Count of PS feedback packets streamed on DDC0.</summary>
+    internal long PsFeedbackPacketsSent => Interlocked.Read(ref _psFeedbackPacketsSent);
+}

--- a/Zeus.VirtualRadio/ProtocolVersion.cs
+++ b/Zeus.VirtualRadio/ProtocolVersion.cs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.VirtualRadio;
+
+/// <summary>
+/// Which HPSDR wire stack the emulator (and the board it impersonates) speaks.
+/// Zeus.Contracts has no such enum today — Zeus-the-client never needed to name
+/// the protocol abstractly because each protocol lives in its own assembly
+/// (<c>Zeus.Protocol1</c> / <c>Zeus.Protocol2</c>). The emulator needs to choose
+/// at runtime which engine to spin, so the concept is introduced here, local to
+/// the virtual-radio projects. If Zeus.Contracts ever grows a canonical
+/// <c>ProtocolVersion</c>, collapse this into it.
+/// </summary>
+public enum ProtocolVersion : byte
+{
+    /// <summary>HPSDR original protocol (Protocol 1, "Metis"/EP2/EP6 over UDP 1024).</summary>
+    P1 = 1,
+
+    /// <summary>HPSDR Protocol 2 (ANAN-class / Orion, multi-port UDP 1024–1029+).</summary>
+    P2 = 2,
+}

--- a/Zeus.VirtualRadio/Rf/PaDistortionModel.cs
+++ b/Zeus.VirtualRadio/Rf/PaDistortionModel.cs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.VirtualRadio.Rf;
+
+/// <summary>
+/// A mild memoryless power-amplifier model — AM/AM compression plus AM/PM phase
+/// rotation — applied to the clean TX-DAC reference to synthesize the
+/// PureSignal feedback "coupler" sample. With distortion disabled the model is
+/// the identity, so PS converges to a unity correction (a useful smoke test);
+/// with it enabled WDSP <c>calcc</c> has a non-trivial curve to fit, exercising
+/// the full convergence path against a radio that will never saturate.
+///
+/// This is a SIMULATION of a PA for a software radio with no real RF — it is
+/// deliberately gentle and bounded so the feedback can never blow past full
+/// scale. It is NOT a calibration model and carries no operator-felt defaults.
+/// </summary>
+internal sealed class PaDistortionModel
+{
+    private readonly bool _enabled;
+
+    // AM/AM: third-order compression coefficient (gain droops as |x|² grows).
+    // AM/PM: phase rotates a few degrees at full envelope. Both small so the
+    // feedback stays inside [-1, 1] and the correction is well-conditioned.
+    private const double Am3 = 0.18;     // compression depth
+    private const double AmPmRad = 0.20; // radians of phase rotation at unit envelope
+
+    public PaDistortionModel(bool enabled) => _enabled = enabled;
+
+    /// <summary>Whether this model applies any distortion (false = identity).</summary>
+    public bool Enabled => _enabled;
+
+    /// <summary>
+    /// Map a clean reference sample (<paramref name="i"/>, <paramref name="q"/>)
+    /// to the coupler sample the radio would see through a real PA. Identity
+    /// when disabled.
+    /// </summary>
+    public (double I, double Q) Apply(double i, double q)
+    {
+        if (!_enabled)
+            return (i, q);
+
+        double mag2 = i * i + q * q;
+
+        // AM/AM: gain = 1 - Am3·|x|², clamped so it never inverts.
+        double gain = 1.0 - Am3 * mag2;
+        if (gain < 0.05) gain = 0.05;
+
+        // AM/PM: rotate by an envelope-dependent angle.
+        double theta = AmPmRad * mag2;
+        double c = Math.Cos(theta);
+        double s = Math.Sin(theta);
+
+        double di = gain * (i * c - q * s);
+        double dq = gain * (i * s + q * c);
+        return (di, dq);
+    }
+}

--- a/Zeus.VirtualRadio/Rf/RfTelemetryModel.cs
+++ b/Zeus.VirtualRadio/Rf/RfTelemetryModel.cs
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Zeus.Contracts;
+using Zeus.Server; // internal RadioCalibrations / PaDefaults / BoardCapabilitiesTable, via InternalsVisibleTo
+
+namespace Zeus.VirtualRadio.Rf;
+
+/// <summary>
+/// One computed RF telemetry reading: the synthesized ADC counts the host will
+/// read back, plus the watts/SWR they correspond to.
+/// </summary>
+/// <param name="FwdAdc">Forward-power ADC count (0..4095) for the EP6 C&amp;C echo / P2 hi-pri status.</param>
+/// <param name="RefAdc">Reflected-power ADC count (0..4095).</param>
+/// <param name="FwdWatts">Forward power in watts the reading represents.</param>
+/// <param name="RefWatts">Reflected power in watts.</param>
+/// <param name="Swr">SWR derived from FWD/REF.</param>
+public readonly record struct RfTelemetry(
+    ushort FwdAdc,
+    ushort RefAdc,
+    double FwdWatts,
+    double RefWatts,
+    double Swr);
+
+/// <summary>
+/// Inverts Zeus's own forward-power math so its UNMODIFIED <c>TxMetersService</c>
+/// reads back the watts the emulator intends:
+/// <c>targetW = f(driveByte, band, MaxWatts)</c> →
+/// <c>volts = sqrt(targetW · BridgeVolt)</c> →
+/// <c>fwdAdc = clamp(volts/RefVoltage·4095 + AdcCalOffset, 0..4095)</c>, with REF
+/// from the bridge identity at a chosen SWR. Constants come from
+/// <c>RadioCalibrations.For(Board, Variant)</c> and <c>PaDefaults</c> (consumed
+/// here via <c>InternalsVisibleTo</c>), so this is a genuine round-trip test of
+/// Zeus's calibration path. Telemetry is PTT/MOX-gated.
+/// </summary>
+internal sealed class RfTelemetryModel
+{
+    private readonly RadioCalibration _calibration;
+
+    // Rated PA output the meter lands on at full drive. We deliberately use the
+    // calibration record's MaxWatts (the meter-scaling ceiling tied to the SAME
+    // bridge constants we invert below) rather than PaDefaults.GetMaxPowerWatts:
+    // for the ANAN-10E / HermesII bridge that is 10 W — the board's real rated
+    // output — so "push 100 % drive" reads ~10 W, not the 100 W PA-gain-bracket
+    // reference. See the return note for the Integrator on the two distinct
+    // "max watts" numbers Zeus carries.
+    private readonly double _ratedWatts;
+
+    private const int AdcFullScale = 4095;
+
+    /// <summary>Default modelled SWR when no explicit reflection is requested (~1.1:1).</summary>
+    public const double DefaultSwr = 1.1;
+
+    public RfTelemetryModel(VirtualRadioProfile profile)
+    {
+        // RadioCalibrations.For is the calibration table we invert. The other two
+        // internal-table calls are the compile-time proof that the emulator can
+        // reach Zeus's per-board PA / capability tables through InternalsVisibleTo
+        // (discarded — the inversion only needs the bridge constants + rated W).
+        _calibration = RadioCalibrations.For(profile.Board, profile.Variant);
+        _ratedWatts = _calibration.MaxWatts;
+        _ = PaDefaults.GetMaxPowerWatts(profile.Board, profile.Variant);
+        _ = BoardCapabilitiesTable.For(profile.Board, profile.Variant);
+    }
+
+    /// <summary>
+    /// Compute the FWD/REF ADC counts (and the watts they represent) for the
+    /// given drive byte and band. Returns an all-zero reading when not keyed.
+    ///
+    /// Drive→power model: the Protocol-1 drive byte scales the exciter output
+    /// amplitude linearly, so RF power ∝ amplitude² ∝ (driveByte/255)². Full
+    /// drive lands on <see cref="_ratedWatts"/>. The forward inversion mirrors
+    /// <c>TxMetersService.ComputeMeters</c> exactly:
+    /// <c>volts = sqrt(W · BridgeVolt)</c> →
+    /// <c>adc = volts / RefVoltage · 4095 + AdcCalOffset</c>. REF is derived from
+    /// the requested SWR via the bridge identity <c>rho = (s−1)/(s+1)</c>,
+    /// <c>refW = fwdW · rho²</c>. The reported watts/SWR are then read BACK out of
+    /// the integer ADC counts through Zeus's own <c>ComputeMeters</c>, so
+    /// <c>/status</c> mirrors exactly what the client renders and the reading is a
+    /// genuine round-trip of the calibration path.
+    /// </summary>
+    /// <param name="driveByte">Commanded transmit drive level (0..255).</param>
+    /// <param name="bandHz">Operating frequency in Hz. Reserved for a future
+    /// per-band PA-gain refinement; the Phase-1 curve is band-flat (Zeus already
+    /// folds per-band gain into the drive byte it sends).</param>
+    /// <param name="mox">Whether the host has the radio keyed (telemetry gate —
+    /// FWD/REF are PTT-gated in the firmware, so an unkeyed reading is all-zero).</param>
+    /// <param name="swr">Modelled SWR for the reflected reading (default ~1.1:1).</param>
+    public RfTelemetry Compute(byte driveByte, long bandHz, bool mox, double swr = DefaultSwr)
+    {
+        _ = bandHz; // reserved for per-band PA-gain modelling (see remarks)
+
+        // Firmware gates FWD/REF on PTT: an unkeyed radio reports no power.
+        if (!mox)
+            return new RfTelemetry(0, 0, 0.0, 0.0, 1.0);
+
+        double drive = driveByte / 255.0;
+        double targetWatts = _ratedWatts * drive * drive;
+
+        double s = swr < 1.0 ? 1.0 : swr;
+        double rho = (s - 1.0) / (s + 1.0);
+        double refWatts = targetWatts * rho * rho;
+
+        ushort fwdAdc = WattsToAdc(targetWatts);
+        ushort refAdc = WattsToAdc(refWatts);
+
+        // Read the watts/SWR back out of the integer ADC counts using Zeus's own
+        // forward math — the reported figures then equal what the client will
+        // render, and the unit test that feeds these ADCs through ComputeMeters
+        // and recovers targetWatts IS the calibration round-trip guarantee.
+        var (fwdW, refW, swrOut) = TxMetersService.ComputeMeters(fwdAdc, refAdc, _calibration);
+        return new RfTelemetry(fwdAdc, refAdc, fwdW, refW, swrOut);
+    }
+
+    /// <summary>
+    /// Invert the forward-power formula to an ADC count. Zero (or negative) watts
+    /// map to the bridge baseline <c>AdcCalOffset</c>, which the forward math
+    /// subtracts back to exactly 0 W.
+    /// </summary>
+    private ushort WattsToAdc(double watts)
+    {
+        if (watts <= 0.0)
+            return (ushort)Math.Clamp(_calibration.AdcCalOffset, 0, AdcFullScale);
+
+        double volts = Math.Sqrt(watts * _calibration.BridgeVolt);
+        double adc = volts / _calibration.RefVoltage * AdcFullScale + _calibration.AdcCalOffset;
+        long rounded = (long)Math.Round(adc, MidpointRounding.AwayFromZero);
+        return (ushort)Math.Clamp(rounded, 0, AdcFullScale);
+    }
+}

--- a/Zeus.VirtualRadio/Rf/SyntheticIqGenerator.cs
+++ b/Zeus.VirtualRadio/Rf/SyntheticIqGenerator.cs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.VirtualRadio.Rf;
+
+/// <summary>
+/// Produces time-domain interleaved I/Q at the negotiated DDC rate: the
+/// profile's configured tones placed at baseband offset <c>(toneHz − tunedHz)</c>,
+/// plus a Gaussian noise floor so the S-meter / waterfall / AGC behave. Rate-
+/// aware (48/96/192/384k on P1). Models the <c>ChannelState</c> ideas in
+/// <c>Zeus.Dsp/SyntheticDspEngine.cs</c>; one generator feeds the per-protocol
+/// EP6 / DDC packers.
+/// </summary>
+internal sealed class SyntheticIqGenerator
+{
+    private const double TwoPi = 2.0 * Math.PI;
+
+    // A fixed seed makes the noise stream deterministic so round-trip / spectrum
+    // tests are reproducible across platforms. Phase-1 runs one radio at a time,
+    // so a shared constant is fine; a per-instance seed can be threaded later if
+    // multiple emulators must decorrelate.
+    private const int NoiseSeed = 0x5EED5EED;
+
+    private readonly double _sampleRateHz;
+    private readonly long[] _toneFreqHz;
+    private readonly double[] _toneAmp;
+    private readonly double[] _tonePhase;   // persisted → phase-continuous across Generate calls
+    private readonly double _noiseSigmaPerComponent;
+    private readonly Random _rng;
+
+    // Box–Muller produces two independent normals per draw; cache the spare.
+    private bool _haveSpareGaussian;
+    private double _spareGaussian;
+
+    public SyntheticIqGenerator(VirtualRadioProfile profile)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+
+        // Negotiated DDC rate (48/96/192/384 kHz on P1). Guard against 0 so a
+        // misconfigured profile can't divide-by-zero in the phase increment.
+        _sampleRateHz = Math.Max(1, profile.SampleRateKhz) * 1000.0;
+
+        var tones = profile.Tones ?? Array.Empty<ToneSpec>();
+        int n = tones.Count;
+        _toneFreqHz = new long[n];
+        _toneAmp = new double[n];
+        _tonePhase = new double[n];
+        for (int i = 0; i < n; i++)
+        {
+            _toneFreqHz[i] = tones[i].FreqHz;
+            _toneAmp[i] = DbToLinear(tones[i].Dbc);
+        }
+
+        // Total complex-noise RMS = 10^(dBc/20) of full scale. Split equally
+        // across I and Q so E[|z|²] = noiseRms²: each component σ = rms/√2.
+        double noiseRms = DbToLinear(profile.NoiseFloorDbc);
+        _noiseSigmaPerComponent = noiseRms / Math.Sqrt(2.0);
+
+        _rng = new Random(NoiseSeed);
+    }
+
+    /// <summary>
+    /// Fill <paramref name="interleavedOut"/> with <paramref name="complexSamples"/>
+    /// I/Q pairs (<c>[I0,Q0,I1,Q1,…]</c>) for a receiver tuned to
+    /// <paramref name="tunedHz"/>. Each tone is rendered at its baseband offset
+    /// <c>(FreqHz − tunedHz)</c>; a Gaussian noise floor is summed on top.
+    /// Amplitude is in full-scale units (1.0 = 0 dBFS, matching
+    /// <c>PacketParser.ScaleInt24</c>). Advances the per-tone phase so successive
+    /// calls are phase-continuous.
+    /// </summary>
+    public void Generate(Span<double> interleavedOut, int complexSamples, long tunedHz)
+    {
+        if (complexSamples < 0)
+            throw new ArgumentOutOfRangeException(nameof(complexSamples));
+        if (interleavedOut.Length < complexSamples * 2)
+            throw new ArgumentException(
+                $"interleavedOut needs {complexSamples * 2} doubles, got {interleavedOut.Length}.",
+                nameof(interleavedOut));
+
+        int toneCount = _toneFreqHz.Length;
+        double sigma = _noiseSigmaPerComponent;
+
+        for (int sample = 0; sample < complexSamples; sample++)
+        {
+            double iAcc = 0.0;
+            double qAcc = 0.0;
+
+            for (int t = 0; t < toneCount; t++)
+            {
+                double amp = _toneAmp[t];
+                double phase = _tonePhase[t];
+                iAcc += amp * Math.Cos(phase);
+                qAcc += amp * Math.Sin(phase);
+
+                double inc = TwoPi * (_toneFreqHz[t] - tunedHz) / _sampleRateHz;
+                // IEEERemainder keeps the accumulator bounded in [-π, π] for any
+                // increment (incl. aliasing past Nyquist) without unbounded drift.
+                _tonePhase[t] = Math.IEEERemainder(phase + inc, TwoPi);
+            }
+
+            if (sigma > 0.0)
+            {
+                iAcc += NextGaussian() * sigma;
+                qAcc += NextGaussian() * sigma;
+            }
+
+            interleavedOut[2 * sample] = iAcc;
+            interleavedOut[2 * sample + 1] = qAcc;
+        }
+    }
+
+    private static double DbToLinear(double db) => Math.Pow(10.0, db / 20.0);
+
+    /// <summary>Standard-normal draw via Box–Muller, caching the paired sample.</summary>
+    private double NextGaussian()
+    {
+        if (_haveSpareGaussian)
+        {
+            _haveSpareGaussian = false;
+            return _spareGaussian;
+        }
+
+        double u1;
+        do { u1 = _rng.NextDouble(); } while (u1 <= double.Epsilon);
+        double u2 = _rng.NextDouble();
+
+        double mag = Math.Sqrt(-2.0 * Math.Log(u1));
+        _spareGaussian = mag * Math.Sin(TwoPi * u2);
+        _haveSpareGaussian = true;
+        return mag * Math.Cos(TwoPi * u2);
+    }
+}

--- a/Zeus.VirtualRadio/Rf/TxReferenceSource.cs
+++ b/Zeus.VirtualRadio/Rf/TxReferenceSource.cs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.VirtualRadio.Rf;
+
+/// <summary>
+/// The clean TX-DAC "reference" the radio loops back as the PureSignal TX
+/// feedback. When the host streams TX-IQ on UDP 1029 (a transmitting Zeus) the
+/// real exciter samples drive it; when no TX-IQ has arrived — a bench test that
+/// keys without feeding IQ — it falls back to a synthesized clean carrier so PS
+/// always has a finite, well-conditioned reference. Thread-safe: the 1029
+/// receive loop ingests while the DDC0 send loop drains.
+/// </summary>
+internal sealed class TxReferenceSource
+{
+    private const double TwoPi = 2.0 * Math.PI;
+
+    private readonly object _gate = new();
+    private readonly double[] _ring;        // interleaved I/Q
+    private readonly int _capacityComplex;
+    private int _head;                      // next write (complex index)
+    private int _count;                     // available complex samples
+
+    // Synthesized fallback carrier: a clean tone at a small baseband offset so
+    // the reference is a genuine signal, not DC. Phase-continuous.
+    private readonly double _fallbackInc;
+    private readonly double _fallbackAmp;
+    private double _fallbackPhase;
+
+    /// <param name="sampleRateHz">DDC rate the feedback is clocked at (for the
+    /// synthesized fallback tone's baseband offset).</param>
+    /// <param name="fallbackToneHz">Baseband offset of the fallback carrier.</param>
+    /// <param name="fallbackAmp">Fallback carrier amplitude in full-scale units.</param>
+    /// <param name="capacityComplex">Ring capacity in complex samples.</param>
+    public TxReferenceSource(
+        double sampleRateHz,
+        double fallbackToneHz = 1_000.0,
+        double fallbackAmp = 0.5,
+        int capacityComplex = 8192)
+    {
+        _capacityComplex = Math.Max(256, capacityComplex);
+        _ring = new double[_capacityComplex * 2];
+        double rate = sampleRateHz <= 0 ? 192_000.0 : sampleRateHz;
+        _fallbackInc = TwoPi * fallbackToneHz / rate;
+        _fallbackAmp = fallbackAmp;
+    }
+
+    /// <summary>True once the host has streamed at least one TX-IQ packet.</summary>
+    public bool HasHostIq { get { lock (_gate) return _count > 0; } }
+
+    /// <summary>
+    /// Ingest interleaved float I/Q from a TX-IQ packet (UDP 1029). Overwrites
+    /// the oldest samples when the ring is full (a transmitting host outruns a
+    /// slow drain — the freshest reference is what PS wants).
+    /// </summary>
+    public void Ingest(ReadOnlySpan<float> interleaved)
+    {
+        int complex = interleaved.Length / 2;
+        if (complex <= 0) return;
+        lock (_gate)
+        {
+            for (int i = 0; i < complex; i++)
+            {
+                _ring[_head * 2] = interleaved[2 * i];
+                _ring[_head * 2 + 1] = interleaved[2 * i + 1];
+                _head = (_head + 1) % _capacityComplex;
+                if (_count < _capacityComplex) _count++;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Fill <paramref name="referenceInterleaved"/> with
+    /// <paramref name="complexCount"/> reference samples, draining the host ring
+    /// when available and synthesizing the fallback carrier otherwise.
+    /// </summary>
+    public void Fill(Span<double> referenceInterleaved, int complexCount)
+    {
+        if (referenceInterleaved.Length < complexCount * 2)
+            throw new ArgumentException("reference buffer too small", nameof(referenceInterleaved));
+
+        lock (_gate)
+        {
+            for (int i = 0; i < complexCount; i++)
+            {
+                if (_count > 0)
+                {
+                    // Oldest sample is (head - count) modulo capacity.
+                    int tail = (_head - _count + _capacityComplex) % _capacityComplex;
+                    referenceInterleaved[2 * i] = _ring[tail * 2];
+                    referenceInterleaved[2 * i + 1] = _ring[tail * 2 + 1];
+                    _count--;
+                }
+                else
+                {
+                    referenceInterleaved[2 * i] = _fallbackAmp * Math.Cos(_fallbackPhase);
+                    referenceInterleaved[2 * i + 1] = _fallbackAmp * Math.Sin(_fallbackPhase);
+                    _fallbackPhase += _fallbackInc;
+                    if (_fallbackPhase > TwoPi) _fallbackPhase -= TwoPi;
+                }
+            }
+        }
+    }
+}

--- a/Zeus.VirtualRadio/VirtualRadioProfile.cs
+++ b/Zeus.VirtualRadio/VirtualRadioProfile.cs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Net;
+using Zeus.Contracts;
+
+namespace Zeus.VirtualRadio;
+
+/// <summary>
+/// One synthetic RX tone: a carrier at <paramref name="FreqHz"/> placed at
+/// baseband offset <c>(FreqHz − tunedHz)</c>, at <paramref name="Dbc"/> relative
+/// to full scale (e.g. -73 dBc ≈ S9). Consumed by the synthetic IQ generator.
+/// </summary>
+public readonly record struct ToneSpec(long FreqHz, double Dbc);
+
+/// <summary>
+/// Immutable configuration of one virtual radio: the <c>{Board, Variant,
+/// Protocol}</c> triple plus the RX-signal / binding parameters. Construct via
+/// <see cref="Create"/>, which validates the triple against
+/// <see cref="BoardProtocolSupport"/> and throws on an illegal combination
+/// (e.g. HL2 + P2). The non-triple fields are <c>init</c> so callers compose
+/// with a <c>with</c> expression after <see cref="Create"/>.
+/// </summary>
+public sealed record VirtualRadioProfile
+{
+    /// <summary>The HPSDR board this radio impersonates (drives the discovery
+    /// board byte, calibration table, PA defaults, and capability fingerprint).</summary>
+    public HpsdrBoardKind Board { get; }
+
+    /// <summary>Disambiguates the 0x0A OrionMkII wire-byte alias family. Ignored
+    /// for every board kind other than <see cref="HpsdrBoardKind.OrionMkII"/>.</summary>
+    public OrionMkIIVariant Variant { get; }
+
+    /// <summary>The wire stack this radio speaks. Validated against the board.</summary>
+    public ProtocolVersion Protocol { get; }
+
+    /// <summary>Initial RX tuned frequency in Hz (informational seed; the live
+    /// tuned frequency tracks the host's decoded RxFreq commands once connected).</summary>
+    public long TunedHz { get; init; }
+
+    /// <summary>DDC / IQ sample rate in kHz (48 / 96 / 192 / 384 on P1).</summary>
+    public int SampleRateKhz { get; init; } = 48;
+
+    /// <summary>Synthetic RX tones to render into the IQ stream.</summary>
+    public IReadOnlyList<ToneSpec> Tones { get; init; } = Array.Empty<ToneSpec>();
+
+    /// <summary>Gaussian noise-floor level in dBc (e.g. -110) so the S-meter,
+    /// waterfall, and AGC have something to settle on.</summary>
+    public double NoiseFloorDbc { get; init; } = -110.0;
+
+    /// <summary>Local address the emulator binds its radio sockets to.
+    /// <c>127.0.0.1</c> is direct-connect only (Zeus discovery skips loopback);
+    /// bind a LAN IP to appear in Zeus's discovery panel.</summary>
+    public IPAddress BindAddress { get; init; } = IPAddress.Loopback;
+
+    /// <summary>PureSignal feedback emission. OFF by default — burn-zone, gated
+    /// to a later phase. Present here only so the type is ready; Phase 0/1 never
+    /// reads it.</summary>
+    public bool PureSignalEnabled { get; init; } = false;
+
+    private VirtualRadioProfile(HpsdrBoardKind board, OrionMkIIVariant variant, ProtocolVersion protocol)
+    {
+        Board = board;
+        Variant = variant;
+        Protocol = protocol;
+    }
+
+    /// <summary>
+    /// Validate and construct. Throws <see cref="ArgumentException"/> when
+    /// <paramref name="board"/> cannot speak <paramref name="protocol"/>
+    /// (per <see cref="BoardProtocolSupport"/>). The <paramref name="variant"/>
+    /// only matters for the 0x0A OrionMkII family; it is accepted (and ignored)
+    /// for other boards to keep call sites uniform.
+    /// </summary>
+    public static VirtualRadioProfile Create(
+        HpsdrBoardKind board,
+        ProtocolVersion protocol,
+        OrionMkIIVariant variant = OrionMkIIVariant.G2)
+    {
+        if (!BoardProtocolSupport.Supports(board, protocol))
+        {
+            throw new ArgumentException(
+                $"Board {board} does not support {protocol} " +
+                $"(supported: {BoardProtocolSupport.For(board)}).",
+                nameof(protocol));
+        }
+
+        return new VirtualRadioProfile(board, variant, protocol);
+    }
+}

--- a/Zeus.VirtualRadio/VirtualRadioStatus.cs
+++ b/Zeus.VirtualRadio/VirtualRadioStatus.cs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+namespace Zeus.VirtualRadio;
+
+/// <summary>
+/// Read-only snapshot of the virtual radio's live state, served by the
+/// <c>StatusJsonServer</c> at <c>GET /status</c> and returned by
+/// <c>IVirtualRadio.Snapshot()</c>. An agent (or KB2UKA) polls this and diffs
+/// it against Zeus's own <c>GET /api/state</c> — that diff IS the analysis
+/// workflow.
+/// </summary>
+/// <param name="Profile">The configured board / variant / protocol triple.</param>
+/// <param name="ConnectedHost">The host endpoint currently driving the radio
+/// (ip:port), or null when no host has connected.</param>
+/// <param name="Mox">Whether the host currently has the radio keyed.</param>
+/// <param name="FwdWatts">Synthesized forward power in watts (PTT/MOX-gated).</param>
+/// <param name="RefWatts">Synthesized reflected power in watts.</param>
+/// <param name="Swr">Synthesized SWR derived from FWD/REF.</param>
+/// <param name="Ep6PacketsSent">Count of RX-IQ packets sent to the host.</param>
+/// <param name="Ep2PacketsReceived">Count of host command/TX packets received.</param>
+/// <param name="SeqGaps">Count of detected inbound sequence gaps.</param>
+/// <param name="LastCommands">The most-recent decoded host commands (newest last).</param>
+public sealed record VirtualRadioStatus(
+    VirtualRadioProfile Profile,
+    string? ConnectedHost,
+    bool Mox,
+    double FwdWatts,
+    double RefWatts,
+    double Swr,
+    long Ep6PacketsSent,
+    long Ep2PacketsReceived,
+    long SeqGaps,
+    IReadOnlyList<DecodedHostCommand> LastCommands);

--- a/Zeus.VirtualRadio/Zeus.VirtualRadio.csproj
+++ b/Zeus.VirtualRadio/Zeus.VirtualRadio.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- The wire-codec round-trip / calibration-inversion unit tests construct
+         the emulator's internal types (Ep6Encoder, Ep2Decoder, RfTelemetryModel).
+         INTEGRATOR: if another implementer also added this line, dedupe. -->
+    <InternalsVisibleTo Include="Zeus.VirtualRadio.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Zeus.Contracts\Zeus.Contracts.csproj" />
+    <ProjectReference Include="..\Zeus.Protocol1\Zeus.Protocol1.csproj" />
+    <ProjectReference Include="..\Zeus.Server.Hosting\Zeus.Server.Hosting.csproj" />
+    <ProjectReference Include="..\Zeus.Dsp\Zeus.Dsp.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- 10.0.7 floor: this project references Zeus.Server.Hosting → SIPSorcery, which
+         requires Logging.Abstractions >= 10.0.7; pinning 10.0.0 here trips NU1605. -->
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+  </ItemGroup>
+
+</Project>

--- a/Zeus.VirtualRadio/Zeus.VirtualRadio.csproj
+++ b/Zeus.VirtualRadio/Zeus.VirtualRadio.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Zeus.Contracts\Zeus.Contracts.csproj" />
     <ProjectReference Include="..\Zeus.Protocol1\Zeus.Protocol1.csproj" />
+    <ProjectReference Include="..\Zeus.Protocol2\Zeus.Protocol2.csproj" />
     <ProjectReference Include="..\Zeus.Server.Hosting\Zeus.Server.Hosting.csproj" />
     <ProjectReference Include="..\Zeus.Dsp\Zeus.Dsp.csproj" />
   </ItemGroup>

--- a/Zeus.slnx
+++ b/Zeus.slnx
@@ -8,6 +8,7 @@
     <Project Path="tests/Zeus.Plugins.Host.Tests/Zeus.Plugins.Host.Tests.csproj" />
     <Project Path="tests/Zeus.Protocol1.Tests/Zeus.Protocol1.Tests.csproj" />
     <Project Path="tests/Zeus.Protocol2.Tests/Zeus.Protocol2.Tests.csproj" />
+    <Project Path="tests/Zeus.VirtualRadio.Tests/Zeus.VirtualRadio.Tests.csproj" />
     <Project Path="tests/Zeus.Server.Tests/Zeus.Server.Tests.csproj" />
   </Folder>
   <Project Path="Zeus.Contracts/Zeus.Contracts.csproj" />
@@ -22,6 +23,8 @@
   <Project Path="Zeus.Protocol1/Zeus.Protocol1.csproj" />
   <Project Path="Zeus.Protocol2/Zeus.Protocol2.csproj" />
   <Project Path="Zeus.Midi/Zeus.Midi.csproj" />
+  <Project Path="Zeus.VirtualRadio/Zeus.VirtualRadio.csproj" />
+  <Project Path="Zeus.VirtualRadio.Host/Zeus.VirtualRadio.Host.csproj" />
   <Project Path="OpenhpsdrZeus/OpenhpsdrZeus.csproj" />
   <Project Path="Zeus.Server.Hosting/Zeus.Server.Hosting.csproj" />
   <Project Path="Zeus.Diagnostics.TestGen/Zeus.Diagnostics.TestGen.csproj" />

--- a/tests/Zeus.VirtualRadio.Tests/DiscoveryObservationHostTests.cs
+++ b/tests/Zeus.VirtualRadio.Tests/DiscoveryObservationHostTests.cs
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Text.Json;
+using Zeus.Contracts;
+using Zeus.Protocol1.Discovery;
+using Zeus.VirtualRadio;
+using Zeus.VirtualRadio.Discovery;
+using Zeus.VirtualRadio.Host;
+using Zeus.VirtualRadio.Observation;
+
+namespace Zeus.VirtualRadio.Tests;
+
+/// <summary>
+/// Socketless unit tests for the discovery reply, observation surface, and host
+/// CLI. The discovery tests are the anti-drift guarantee: the emulator's reply
+/// is fed straight through the real <see cref="ReplyParser"/> and must round-trip
+/// back to the same board kind / MAC / status.
+/// </summary>
+public class DiscoveryReplyTests
+{
+    private static VirtualRadioProfile HermesII() =>
+        VirtualRadioProfile.Create(HpsdrBoardKind.HermesII, ProtocolVersion.P1);
+
+    [Fact]
+    public void Build_RoundTripsThroughReplyParser_AsHermesII()
+    {
+        var mac = DiscoveryResponder.DefaultMac;
+        Span<byte> buf = stackalloc byte[P1DiscoveryReply.ReplyLength];
+
+        int n = P1DiscoveryReply.Build(buf, HermesII(), mac, codeVersion: 73, busy: false);
+
+        Assert.Equal(P1DiscoveryReply.ReplyLength, n);
+        Assert.True(ReplyParser.TryParse(buf[..n].ToArray(), IPAddress.Parse("192.168.1.50"), out var radio));
+        Assert.NotNull(radio);
+        Assert.Equal(HpsdrBoardKind.HermesII, radio!.Board);
+        Assert.Equal(mac, radio.Mac);
+        Assert.Equal((byte)73, radio.FirmwareVersion);
+        Assert.False(radio.Details.Busy);
+        Assert.Equal((byte)0x02, radio.Details.RawBoardId);
+    }
+
+    [Fact]
+    public void Build_BusyFlag_IsReportedByParser()
+    {
+        Span<byte> buf = stackalloc byte[P1DiscoveryReply.ReplyLength];
+        P1DiscoveryReply.Build(buf, HermesII(), DiscoveryResponder.DefaultMac, 73, busy: true);
+
+        Assert.True(ReplyParser.TryParse(buf.ToArray(), IPAddress.Loopback, out var radio));
+        Assert.True(radio!.Details.Busy);
+    }
+
+    [Theory]
+    [InlineData(HpsdrBoardKind.Metis, 0x00)]
+    [InlineData(HpsdrBoardKind.Hermes, 0x01)]
+    [InlineData(HpsdrBoardKind.HermesII, 0x02)]
+    [InlineData(HpsdrBoardKind.Angelia, 0x04)]
+    [InlineData(HpsdrBoardKind.Orion, 0x05)]
+    [InlineData(HpsdrBoardKind.HermesLite2, 0x06)]
+    [InlineData(HpsdrBoardKind.OrionMkII, 0x0A)]
+    [InlineData(HpsdrBoardKind.HermesC10, 0x14)]
+    public void BoardByte_IsInverseOfReplyParserMap(HpsdrBoardKind board, int expected)
+    {
+        Assert.Equal((byte)expected, P1DiscoveryReply.BoardByte(board));
+    }
+
+    [Fact]
+    public void Build_PreservesMacBytes()
+    {
+        var mac = new PhysicalAddress(new byte[] { 0x02, 0x11, 0x22, 0x33, 0x44, 0x55 });
+        Span<byte> buf = stackalloc byte[P1DiscoveryReply.ReplyLength];
+        P1DiscoveryReply.Build(buf, HermesII(), mac, 73, busy: false);
+
+        ReplyParser.TryParse(buf.ToArray(), IPAddress.Loopback, out var radio);
+        Assert.Equal(mac, radio!.Mac);
+    }
+
+    [Fact]
+    public void Build_ThrowsOnTooSmallBuffer()
+    {
+        Assert.Throws<ArgumentException>(() =>
+        {
+            byte[] tiny = new byte[10];
+            P1DiscoveryReply.Build(tiny, HermesII(), DiscoveryResponder.DefaultMac, 73, false);
+        });
+    }
+}
+
+public class DiscoveryResponderTests
+{
+    private static DiscoveryResponder Responder() =>
+        new(VirtualRadioProfile.Create(HpsdrBoardKind.HermesII, ProtocolVersion.P1));
+
+    [Fact]
+    public void TryBuildReply_OnDiscoveryProbe_ProducesParseableReply()
+    {
+        byte[] probe = new byte[63];
+        probe[0] = 0xEF;
+        probe[1] = 0xFE;
+        probe[2] = 0x02;
+
+        Assert.True(Responder().TryBuildReply(probe, out byte[] reply));
+        Assert.True(ReplyParser.TryParse(reply, IPAddress.Loopback, out var radio));
+        Assert.Equal(HpsdrBoardKind.HermesII, radio!.Board);
+    }
+
+    [Theory]
+    [InlineData(new byte[] { 0xEF, 0xFE, 0x04, 0x00 })] // command/connect frame, not discovery
+    [InlineData(new byte[] { 0xEF, 0xFE })]             // too short
+    [InlineData(new byte[] { 0x00, 0x01, 0x02 })]       // wrong preamble
+    public void TryBuildReply_OnNonProbe_ReturnsFalse(byte[] datagram)
+    {
+        Assert.False(Responder().TryBuildReply(datagram, out byte[] reply));
+        Assert.Empty(reply);
+    }
+
+    [Fact]
+    public void IsDiscoveryProbe_DiscriminatesOnThirdByte()
+    {
+        Assert.True(DiscoveryResponder.IsDiscoveryProbe(new byte[] { 0xEF, 0xFE, 0x02 }));
+        Assert.False(DiscoveryResponder.IsDiscoveryProbe(new byte[] { 0xEF, 0xFE, 0x04 }));
+    }
+}
+
+public class CommandLogTests
+{
+    private static DecodedHostCommand Cmd(string kind) =>
+        new(DateTimeOffset.UnixEpoch, ProtocolVersion.P1, kind, $"summary {kind}");
+
+    [Fact]
+    public void Add_EvictsOldest_PastCapacity()
+    {
+        var log = new CommandLog(capacity: 3);
+        log.Add(Cmd("a"));
+        log.Add(Cmd("b"));
+        log.Add(Cmd("c"));
+        log.Add(Cmd("d")); // evicts "a"
+
+        var snap = log.Snapshot();
+        Assert.Equal(3, snap.Count);
+        Assert.Equal(new[] { "b", "c", "d" }, snap.Select(x => x.CommandKind).ToArray());
+    }
+
+    [Fact]
+    public void Snapshot_IsOldestFirst()
+    {
+        var log = new CommandLog();
+        log.Add(Cmd("first"));
+        log.Add(Cmd("second"));
+        var snap = log.Snapshot();
+        Assert.Equal("first", snap[0].CommandKind);
+        Assert.Equal("second", snap[1].CommandKind);
+    }
+
+    [Fact]
+    public void Snapshot_IsIsolatedFromLaterMutation()
+    {
+        var log = new CommandLog();
+        log.Add(Cmd("x"));
+        var snap = log.Snapshot();
+        log.Add(Cmd("y"));
+        Assert.Single(snap); // earlier snapshot unaffected
+    }
+
+    [Fact]
+    public void Constructor_RejectsNonPositiveCapacity()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new CommandLog(0));
+    }
+}
+
+public class StatusJsonServerSerializeTests
+{
+    private static VirtualRadioStatus SampleStatus()
+    {
+        var profile = VirtualRadioProfile.Create(HpsdrBoardKind.HermesII, ProtocolVersion.P1) with
+        {
+            TunedHz = 14_074_000,
+            SampleRateKhz = 96,
+            Tones = new[] { new ToneSpec(14_074_000, -73) },
+            BindAddress = IPAddress.Parse("192.168.1.50"),
+        };
+        var cmds = new[]
+        {
+            new DecodedHostCommand(DateTimeOffset.UnixEpoch, ProtocolVersion.P1, "TxFreq", "tx=14074000"),
+        };
+        return new VirtualRadioStatus(
+            profile, ConnectedHost: "192.168.1.10:51000", Mox: true,
+            FwdWatts: 5.0, RefWatts: 0.2, Swr: 1.1,
+            Ep6PacketsSent: 1234, Ep2PacketsReceived: 56, SeqGaps: 0, LastCommands: cmds);
+    }
+
+    [Fact]
+    public void Serialize_ProducesExpectedShape()
+    {
+        string json = StatusJsonServer.Serialize(SampleStatus());
+        using var doc = JsonDocument.Parse(json);
+        JsonElement root = doc.RootElement;
+
+        JsonElement profile = root.GetProperty("profile");
+        Assert.Equal("HermesII", profile.GetProperty("board").GetString());
+        Assert.Equal("P1", profile.GetProperty("protocol").GetString());
+        Assert.Equal("192.168.1.50", profile.GetProperty("bindAddress").GetString());
+        Assert.Equal(96, profile.GetProperty("sampleRateKhz").GetInt32());
+        Assert.Equal(14_074_000L, profile.GetProperty("tones")[0].GetProperty("freqHz").GetInt64());
+
+        Assert.Equal("192.168.1.10:51000", root.GetProperty("connectedHost").GetString());
+        Assert.True(root.GetProperty("mox").GetBoolean());
+        Assert.Equal(5.0, root.GetProperty("fwdWatts").GetDouble());
+        Assert.Equal(1234L, root.GetProperty("ep6PacketsSent").GetInt64());
+        Assert.Equal("TxFreq", root.GetProperty("lastCommands")[0].GetProperty("commandKind").GetString());
+    }
+
+    [Fact]
+    public void Serialize_NullConnectedHost_IsJsonNull()
+    {
+        var s = SampleStatus() with { ConnectedHost = null };
+        string json = StatusJsonServer.Serialize(s);
+        using var doc = JsonDocument.Parse(json);
+        Assert.Equal(JsonValueKind.Null, doc.RootElement.GetProperty("connectedHost").ValueKind);
+    }
+}
+
+public class HostCliParseTests
+{
+    [Fact]
+    public void ParseArgs_Defaults()
+    {
+        HostConfig c = Program.ParseArgs(Array.Empty<string>());
+        Assert.Equal(HpsdrBoardKind.HermesII, c.Profile.Board);
+        Assert.Equal(ProtocolVersion.P1, c.Profile.Protocol);
+        Assert.Equal(OrionMkIIVariant.G2, c.Profile.Variant);
+        Assert.Equal(IPAddress.Loopback, c.Profile.BindAddress);
+        Assert.Equal(48, c.Profile.SampleRateKhz);
+        Assert.Equal(-110.0, c.Profile.NoiseFloorDbc);
+        Assert.Empty(c.Profile.Tones);
+        Assert.Equal(StatusJsonServer.DefaultPort, c.StatusPort);
+    }
+
+    [Fact]
+    public void ParseArgs_FullCommandLine()
+    {
+        HostConfig c = Program.ParseArgs(new[]
+        {
+            "--board", "HermesII",
+            "--protocol", "P1",
+            "--variant", "G2",
+            "--bind", "192.168.1.77",
+            "--rate", "192",
+            "--tone", "14074000:-73",
+            "--tone", "7074000:-80",
+            "--noise", "-120",
+            "--status-port", "9000",
+        });
+
+        Assert.Equal(IPAddress.Parse("192.168.1.77"), c.Profile.BindAddress);
+        Assert.Equal(192, c.Profile.SampleRateKhz);
+        Assert.Equal(-120.0, c.Profile.NoiseFloorDbc);
+        Assert.Equal(2, c.Profile.Tones.Count);
+        Assert.Equal(14_074_000L, c.Profile.Tones[0].FreqHz);
+        Assert.Equal(-73.0, c.Profile.Tones[0].Dbc);
+        Assert.Equal(9000, c.StatusPort);
+    }
+
+    [Fact]
+    public void ParseArgs_UnknownArg_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => Program.ParseArgs(new[] { "--bogus" }));
+    }
+
+    [Fact]
+    public void ParseArgs_MissingValue_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => Program.ParseArgs(new[] { "--rate" }));
+    }
+
+    [Fact]
+    public void ParseArgs_IllegalTriple_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            Program.ParseArgs(new[] { "--board", "HermesLite2", "--protocol", "P2" }));
+    }
+
+    [Fact]
+    public void ParseArgs_StatusPortOutOfRange_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            Program.ParseArgs(new[] { "--status-port", "70000" }));
+    }
+
+    [Theory]
+    [InlineData("14074000:-73", 14_074_000L, -73.0)]
+    [InlineData("7074000:-80.5", 7_074_000L, -80.5)]
+    public void ParseTone_Valid(string spec, long freq, double dbc)
+    {
+        ToneSpec t = Program.ParseTone(spec);
+        Assert.Equal(freq, t.FreqHz);
+        Assert.Equal(dbc, t.Dbc);
+    }
+
+    [Theory]
+    [InlineData("14074000")]   // no colon
+    [InlineData(":-73")]       // no freq
+    public void ParseTone_Invalid_Throws(string spec)
+    {
+        Assert.Throws<ArgumentException>(() => Program.ParseTone(spec));
+    }
+}

--- a/tests/Zeus.VirtualRadio.Tests/Ep2DecoderRoundTripTests.cs
+++ b/tests/Zeus.VirtualRadio.Tests/Ep2DecoderRoundTripTests.cs
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Zeus.Contracts;
+using Zeus.Protocol1;            // internal ControlFrame, via InternalsVisibleTo
+using Zeus.VirtualRadio.P1;      // internal Ep2Decoder, via InternalsVisibleTo
+
+namespace Zeus.VirtualRadio.Tests;
+
+/// <summary>
+/// Anti-drift round-trip tests for <see cref="Ep2Decoder"/>: host packets are
+/// built with the REAL <c>Zeus.Protocol1.ControlFrame</c> encoder — the encoder
+/// the emulator inverts — then decoded, and the recovered
+/// <see cref="HostCommandState"/> fields are asserted to match what was encoded.
+/// Socketless: pure byte buffers. If the EP2 wire format changes in Zeus, these
+/// break.
+/// </summary>
+public class Ep2DecoderRoundTripTests
+{
+    // The ANAN-10E vertical-slice board.
+    private const HpsdrBoardKind Board = HpsdrBoardKind.HermesII;
+
+    private static ControlFrame.CcState BaseState(
+        long vfoHz = 14_074_000,
+        HpsdrSampleRate rate = HpsdrSampleRate.Rate48k,
+        bool preamp = false,
+        int attenDb = 0,
+        bool mox = false,
+        byte drive = 0,
+        byte ocTx = 0,
+        byte ocRx = 0,
+        byte numRxMinus1 = 0,
+        bool micBoost = false,
+        bool micLineIn = false) =>
+        new ControlFrame.CcState(
+            VfoAHz: vfoHz,
+            Rate: rate,
+            PreampOn: preamp,
+            Atten: new HpsdrAtten(attenDb),
+            RxAntenna: HpsdrAntenna.Ant1,
+            Mox: mox,
+            EnableHl2BandVolts: false,
+            Board: Board,
+            DriveLevel: drive,
+            UserOcTxMask: ocTx,
+            UserOcRxMask: ocRx,
+            NumReceiversMinusOne: numRxMinus1,
+            MicBoost: micBoost,
+            MicLineIn: micLineIn);
+
+    private static byte[] BuildPacket(ControlFrame.CcRegister even, ControlFrame.CcRegister odd, in ControlFrame.CcState state)
+    {
+        var packet = new byte[ControlFrame.PacketLength];
+        ControlFrame.BuildDataPacket(packet, sendSequence: 1, even, odd, in state);
+        return packet;
+    }
+
+    [Fact]
+    public void Decode_ConfigFrame_RecoversRateOcPreampNumRx()
+    {
+        var state = BaseState(
+            rate: HpsdrSampleRate.Rate96k,
+            preamp: true,
+            ocRx: 0x05,
+            numRxMinus1: 1,
+            mox: false);
+        var packet = BuildPacket(ControlFrame.CcRegister.Config, ControlFrame.CcRegister.RxFreq, in state);
+
+        var dec = new Ep2Decoder();
+        var host = new HostCommandState();
+        var events = dec.Decode(packet, host);
+
+        Assert.Equal(2, events.Count);
+        Assert.Equal("Config", events[0].CommandKind);
+        Assert.Equal(96, host.SampleRateKhz);
+        Assert.True(host.PreampOn);
+        Assert.Equal((byte)0x05, host.OcRxMask);   // !MOX → RX mask
+        Assert.Equal((byte)1, host.NumReceiversMinusOne);
+        Assert.False(host.Mox);
+    }
+
+    [Fact]
+    public void Decode_Config_RoutesOcMaskByMox()
+    {
+        // MOX engaged → the OC mask Zeus sends is the TX mask, and the decoder
+        // must store it as OcTxMask (Config C2 = ocPins << 1, ocPins selected by
+        // MOX in ControlFrame.WriteConfigPayload).
+        var state = BaseState(mox: true, ocTx: 0x12, ocRx: 0x7F);
+        var packet = BuildPacket(ControlFrame.CcRegister.Config, ControlFrame.CcRegister.TxFreq, in state);
+
+        var dec = new Ep2Decoder();
+        var host = new HostCommandState();
+        dec.Decode(packet, host);
+
+        Assert.True(host.Mox);
+        Assert.Equal((byte)0x12, host.OcTxMask);
+        Assert.Equal((byte)0x00, host.OcRxMask); // untouched while keyed
+    }
+
+    [Theory]
+    [InlineData(HpsdrSampleRate.Rate48k, 48)]
+    [InlineData(HpsdrSampleRate.Rate96k, 96)]
+    [InlineData(HpsdrSampleRate.Rate192k, 192)]
+    [InlineData(HpsdrSampleRate.Rate384k, 384)]
+    public void Decode_Config_AllSampleRates(HpsdrSampleRate rate, int expectedKhz)
+    {
+        var state = BaseState(rate: rate);
+        var packet = BuildPacket(ControlFrame.CcRegister.Config, ControlFrame.CcRegister.RxFreq, in state);
+
+        var dec = new Ep2Decoder();
+        var host = new HostCommandState();
+        dec.Decode(packet, host);
+
+        Assert.Equal(expectedKhz, host.SampleRateKhz);
+    }
+
+    [Fact]
+    public void Decode_FrequencyFrames_RecoverTxAndRxHz()
+    {
+        const long freq = 7_074_000;
+        var state = BaseState(vfoHz: freq);
+        // TxFreq + RxFreq both carry VfoAHz in ControlFrame (no split VFO).
+        var packet = BuildPacket(ControlFrame.CcRegister.TxFreq, ControlFrame.CcRegister.RxFreq, in state);
+
+        var dec = new Ep2Decoder();
+        var host = new HostCommandState();
+        var events = dec.Decode(packet, host);
+
+        Assert.Equal("TxFreq", events[0].CommandKind);
+        Assert.Equal("RxFreq", events[1].CommandKind);
+        Assert.Equal(freq, host.TxFreqHz);
+        Assert.Equal(freq, host.RxFreqHz);
+    }
+
+    [Fact]
+    public void Decode_DriveFilter_RecoversDriveMoxAndMicBits()
+    {
+        var state = BaseState(mox: true, drive: 200, micBoost: true, micLineIn: true);
+        var packet = BuildPacket(ControlFrame.CcRegister.DriveFilter, ControlFrame.CcRegister.RxFreq, in state);
+
+        var dec = new Ep2Decoder();
+        var host = new HostCommandState();
+        var events = dec.Decode(packet, host);
+
+        Assert.Equal("DriveFilter", events[0].CommandKind);
+        Assert.Equal((byte)200, host.DriveByte);
+        Assert.True(host.Mox);
+        Assert.True(host.MicBoost);
+        Assert.True(host.MicLineIn);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(12)]
+    [InlineData(31)]
+    public void Decode_Attenuator_RecoversStepDb(int db)
+    {
+        // ANAN-10E (HermesII) uses the standard 0x20 | (db & 0x1F) encoding.
+        var state = BaseState(attenDb: db);
+        var packet = BuildPacket(ControlFrame.CcRegister.Attenuator, ControlFrame.CcRegister.RxFreq, in state);
+
+        var dec = new Ep2Decoder();
+        var host = new HostCommandState();
+        dec.Decode(packet, host);
+
+        Assert.Equal(db, host.AttenuatorDb);
+    }
+
+    [Fact]
+    public void Decode_StartCommand_SetsRunning()
+    {
+        var packet = new byte[64];
+        ControlFrame.BuildStartStop(packet, start: true);
+
+        var dec = new Ep2Decoder();
+        var host = new HostCommandState();
+        var events = dec.Decode(packet, host);
+
+        Assert.Single(events);
+        Assert.Equal("Start", events[0].CommandKind);
+        Assert.True(host.Running);
+    }
+
+    [Fact]
+    public void Decode_StopCommand_ClearsRunning()
+    {
+        var dec = new Ep2Decoder();
+        var host = new HostCommandState { Running = true };
+
+        var startPkt = new byte[64];
+        ControlFrame.BuildStartStop(startPkt, start: true);
+        dec.Decode(startPkt, host);
+        Assert.True(host.Running);
+
+        var stopPkt = new byte[64];
+        ControlFrame.BuildStartStop(stopPkt, start: false);
+        var events = dec.Decode(stopPkt, host);
+
+        Assert.Equal("Stop", events[0].CommandKind);
+        Assert.False(host.Running);
+    }
+
+    [Fact]
+    public void Decode_StartWithWideband_StillStarts()
+    {
+        var packet = new byte[64];
+        ControlFrame.BuildStartStop(packet, start: true, includeWideband: true);
+
+        var dec = new Ep2Decoder();
+        var host = new HostCommandState();
+        var events = dec.Decode(packet, host);
+
+        Assert.Equal("Start", events[0].CommandKind);
+        Assert.True(host.Running);
+        Assert.Contains("wideband=1", events[0].Summary);
+    }
+
+    [Fact]
+    public void Decode_MoxBit_TracksAcrossKeyUpAndDown()
+    {
+        var dec = new Ep2Decoder();
+        var host = new HostCommandState();
+
+        var keyed = BuildPacket(ControlFrame.CcRegister.TxFreq, ControlFrame.CcRegister.RxFreq,
+            BaseState(mox: true));
+        dec.Decode(keyed, host);
+        Assert.True(host.Mox);
+
+        var unkeyed = BuildPacket(ControlFrame.CcRegister.TxFreq, ControlFrame.CcRegister.RxFreq,
+            BaseState(mox: false));
+        dec.Decode(unkeyed, host);
+        Assert.False(host.Mox);
+    }
+
+    [Fact]
+    public void Decode_UnrecognisedPacket_ReturnsEmpty()
+    {
+        var dec = new Ep2Decoder();
+        var host = new HostCommandState();
+
+        // Metis discovery-ish / unrelated header (0xEF 0xFE 0x02 …) is not an
+        // EP2 data frame nor a start/stop command.
+        var junk = new byte[64];
+        junk[0] = 0xEF; junk[1] = 0xFE; junk[2] = 0x02;
+
+        Assert.Empty(dec.Decode(junk, host));
+    }
+
+    [Fact]
+    public void Decode_DataFrame_EmitsOnePerUsbFrame()
+    {
+        var packet = BuildPacket(ControlFrame.CcRegister.Config, ControlFrame.CcRegister.DriveFilter,
+            BaseState(drive: 50));
+        var dec = new Ep2Decoder();
+        var host = new HostCommandState();
+        var events = dec.Decode(packet, host);
+
+        Assert.Equal(2, events.Count);
+        Assert.Equal("Config", events[0].CommandKind);
+        Assert.Equal("DriveFilter", events[1].CommandKind);
+        Assert.All(events, e => Assert.Equal(ProtocolVersion.P1, e.Protocol));
+    }
+}

--- a/tests/Zeus.VirtualRadio.Tests/Ep6EncoderRoundTripTests.cs
+++ b/tests/Zeus.VirtualRadio.Tests/Ep6EncoderRoundTripTests.cs
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Zeus.Protocol1;            // internal PacketParser, via InternalsVisibleTo
+using Zeus.VirtualRadio.P1;      // internal Ep6Encoder, via InternalsVisibleTo
+using Zeus.VirtualRadio.Rf;
+
+namespace Zeus.VirtualRadio.Tests;
+
+/// <summary>
+/// Anti-drift round-trip tests for <see cref="Ep6Encoder"/>: every packet it
+/// produces is fed back through the REAL <c>Zeus.Protocol1.PacketParser</c> — the
+/// decoder the emulator inverts — and the samples + FWD/REF telemetry + PTT echo
+/// are asserted to survive. Socketless: pure byte buffers, no UDP. If the EP6
+/// wire format ever changes in Zeus, these break.
+/// </summary>
+public class Ep6EncoderRoundTripTests
+{
+    private const int ComplexSamples = 126;          // PacketParser.ComplexSamplesPerPacket
+    private const double Int24Lsb = 1.0 / 8_388_608.0; // one int24 quantisation step
+    private const double Tol = 2 * Int24Lsb;           // round-trip tolerance (≈ 2.4e-7)
+
+    private static double[] MakeInterleavedIq()
+    {
+        // 126 complex samples → 252 interleaved doubles, all within [-1, +1].
+        var iq = new double[2 * ComplexSamples];
+        for (int n = 0; n < ComplexSamples; n++)
+        {
+            iq[2 * n] = 0.75 * Math.Sin(2 * Math.PI * n / 17.0);      // I
+            iq[2 * n + 1] = 0.60 * Math.Cos(2 * Math.PI * n / 23.0);  // Q
+        }
+        return iq;
+    }
+
+    [Fact]
+    public void Encode_RoundTripsThroughPacketParser_IqSurvives()
+    {
+        var enc = new Ep6Encoder();
+        var iq = MakeInterleavedIq();
+        var telemetry = new RfTelemetry(FwdAdc: 2000, RefAdc: 150,
+            FwdWatts: 50.0, RefWatts: 0.5, Swr: 1.1);
+
+        var packet = new byte[Ep6Encoder.Ep6PacketLength];
+        enc.Encode(packet, sequence: 0xDEADBEEF, iq, telemetry);
+
+        var outBuf = new double[2 * ComplexSamples];
+        bool ok = PacketParser.TryParsePacket(packet, outBuf, out uint seq, out int samples);
+
+        Assert.True(ok);
+        Assert.Equal(0xDEADBEEFu, seq);
+        Assert.Equal(ComplexSamples, samples);
+
+        for (int k = 0; k < 2 * ComplexSamples; k++)
+            Assert.True(Math.Abs(outBuf[k] - iq[k]) <= Tol,
+                $"sample {k}: encoded {iq[k]} but parsed {outBuf[k]}");
+    }
+
+    [Fact]
+    public void Encode_PlacesFwdRefTelemetry_WhereZeusReadsItBack()
+    {
+        var enc = new Ep6Encoder();
+        var iq = MakeInterleavedIq();
+        // RefAdc=150 (0x0096) keeps the C1[0]/C2[0] overload bit positions clear.
+        var telemetry = new RfTelemetry(FwdAdc: 3210, RefAdc: 150,
+            FwdWatts: 95.0, RefWatts: 0.4, Swr: 1.1);
+
+        var packet = new byte[Ep6Encoder.Ep6PacketLength];
+        enc.Encode(packet, sequence: 7, iq, telemetry);
+
+        var outBuf = new double[2 * ComplexSamples];
+        bool ok = PacketParser.TryParsePacket(packet, outBuf,
+            out _, out _,
+            out TelemetryReading tel0, out TelemetryReading tel1,
+            out byte overload);
+
+        Assert.True(ok);
+
+        // Frame 0 → FWD slot (C0 address 1 → 0x08, PTT echo bit set because keyed).
+        Assert.Equal(0x08, tel0.C0Address & 0x7E);
+        Assert.Equal(telemetry.FwdAdc, tel0.Ain1);   // Zeus reads FWD from Ain1 of 0x08
+
+        // Frame 1 → REF slot (C0 address 2 → 0x10).
+        Assert.Equal(0x10, tel1.C0Address & 0x7E);
+        Assert.Equal(telemetry.RefAdc, tel1.Ain0);   // Zeus reads REF from Ain0 of 0x10
+
+        // Clean telemetry bytes here must not look like an ADC overload.
+        Assert.Equal(0, overload);
+    }
+
+    [Fact]
+    public void Encode_WhileKeyed_EchoesHardwarePtt()
+    {
+        var enc = new Ep6Encoder();
+        var iq = MakeInterleavedIq();
+        var telemetry = new RfTelemetry(FwdAdc: 1000, RefAdc: 50,
+            FwdWatts: 25.0, RefWatts: 0.1, Swr: 1.05);
+
+        var packet = new byte[Ep6Encoder.Ep6PacketLength];
+        enc.Encode(packet, sequence: 1, iq, telemetry, pttEcho: true);
+
+        Assert.True(PacketParser.ExtractHardwarePtt(packet));
+    }
+
+    [Fact]
+    public void Encode_KeyedWithZeroDrive_StillEchoesHardwarePtt()
+    {
+        // Regression: C0[0] mirrors the firmware's debounced clean_PTT_in line,
+        // which is asserted whenever keyed regardless of drive amplitude. A
+        // keyed-with-zero-drive frame (drive slider at 0, or the transient between
+        // a MOX-on frame and the first nonzero-drive frame) yields an all-zero
+        // telemetry reading (FwdWatts == 0), yet the radio still echoes PTT. The
+        // echo must follow the decoded MOX flag, not a forward-watts threshold.
+        var enc = new Ep6Encoder();
+        var iq = MakeInterleavedIq();
+        var zeroDriveTelemetry = new RfTelemetry(FwdAdc: 0, RefAdc: 0,
+            FwdWatts: 0.0, RefWatts: 0.0, Swr: 1.0);
+
+        var packet = new byte[Ep6Encoder.Ep6PacketLength];
+        enc.Encode(packet, sequence: 1, iq, zeroDriveTelemetry, pttEcho: true);
+
+        Assert.True(PacketParser.ExtractHardwarePtt(packet));
+    }
+
+    [Fact]
+    public void Encode_NotKeyed_NoPttEchoAndZeroTelemetry()
+    {
+        var enc = new Ep6Encoder();
+        var iq = MakeInterleavedIq();
+        // Receive-only: the telemetry model emits an all-zero reading at rest.
+        var telemetry = new RfTelemetry(FwdAdc: 0, RefAdc: 0,
+            FwdWatts: 0.0, RefWatts: 0.0, Swr: 1.0);
+
+        var packet = new byte[Ep6Encoder.Ep6PacketLength];
+        enc.Encode(packet, sequence: 2, iq, telemetry, pttEcho: false);
+
+        Assert.False(PacketParser.ExtractHardwarePtt(packet));
+
+        var outBuf = new double[2 * ComplexSamples];
+        PacketParser.TryParsePacket(packet, outBuf, out _, out _,
+            out TelemetryReading tel0, out TelemetryReading tel1, out _);
+        Assert.Equal((ushort)0, tel0.Ain1); // FWD
+        Assert.Equal((ushort)0, tel1.Ain0); // REF
+    }
+
+    [Theory]
+    [InlineData(1.0)]
+    [InlineData(-1.0)]
+    [InlineData(2.5)]   // over-range positive → clamps to +full-scale
+    [InlineData(-2.5)]  // over-range negative → clamps to -full-scale
+    public void Encode_ClampsFullScale_WithoutOverflow(double level)
+    {
+        var enc = new Ep6Encoder();
+        var iq = new double[2 * ComplexSamples];
+        for (int k = 0; k < iq.Length; k++) iq[k] = level;
+
+        var telemetry = new RfTelemetry(0, 0, 0, 0, 1.0);
+        var packet = new byte[Ep6Encoder.Ep6PacketLength];
+        enc.Encode(packet, sequence: 3, iq, telemetry);
+
+        var outBuf = new double[2 * ComplexSamples];
+        Assert.True(PacketParser.TryParsePacket(packet, outBuf, out _, out _));
+
+        // Clamped full-scale lands within 1 LSB of ±1.0 (int24 max is 2^23-1).
+        double expected = level > 0 ? 1.0 : -1.0;
+        foreach (double v in outBuf)
+            Assert.True(Math.Abs(v - expected) <= Tol, $"value {v} not clamped near {expected}");
+    }
+
+    [Fact]
+    public void Encode_MicSamples_SurviveAsBigEndianInt16()
+    {
+        var enc = new Ep6Encoder();
+        var iq = MakeInterleavedIq();
+        var mic = new short[ComplexSamples];
+        for (int n = 0; n < ComplexSamples; n++) mic[n] = (short)(n * 37 - 2000);
+
+        var telemetry = new RfTelemetry(0, 0, 0, 0, 1.0);
+        var packet = new byte[Ep6Encoder.Ep6PacketLength];
+        enc.Encode(packet, sequence: 4, iq, telemetry, micSamples: mic);
+
+        var micOut = new short[ComplexSamples];
+        int n2 = PacketParser.ExtractMicSamples(packet, micOut);
+
+        Assert.Equal(ComplexSamples, n2);
+        for (int n = 0; n < ComplexSamples; n++) Assert.Equal(mic[n], micOut[n]);
+    }
+
+    [Fact]
+    public void Encode_EmptyMic_EmitsSilence()
+    {
+        var enc = new Ep6Encoder();
+        var iq = MakeInterleavedIq();
+        var packet = new byte[Ep6Encoder.Ep6PacketLength];
+        enc.Encode(packet, sequence: 5, iq, new RfTelemetry(0, 0, 0, 0, 1.0));
+
+        var micOut = new short[ComplexSamples];
+        PacketParser.ExtractMicSamples(packet, micOut);
+        Assert.All(micOut, s => Assert.Equal((short)0, s));
+    }
+
+    [Fact]
+    public void Encode_RejectsWrongPacketLength()
+    {
+        var enc = new Ep6Encoder();
+        var iq = MakeInterleavedIq();
+        Assert.Throws<ArgumentException>(() =>
+            enc.Encode(new byte[Ep6Encoder.Ep6PacketLength - 1], 0, iq, new RfTelemetry(0, 0, 0, 0, 1.0)));
+    }
+
+    [Fact]
+    public void Encode_RejectsShortIqBuffer()
+    {
+        var enc = new Ep6Encoder();
+        var shortIq = new double[2 * ComplexSamples - 1];
+        var packet = new byte[Ep6Encoder.Ep6PacketLength];
+        Assert.Throws<ArgumentException>(() =>
+            enc.Encode(packet, 0, shortIq, new RfTelemetry(0, 0, 0, 0, 1.0)));
+    }
+
+    [Fact]
+    public void Encode_IncrementingSequence_RoundTripsMonotonic()
+    {
+        var enc = new Ep6Encoder();
+        var iq = MakeInterleavedIq();
+        var telemetry = new RfTelemetry(0, 0, 0, 0, 1.0);
+        var packet = new byte[Ep6Encoder.Ep6PacketLength];
+        var outBuf = new double[2 * ComplexSamples];
+
+        for (uint s = 100; s < 110; s++)
+        {
+            enc.Encode(packet, s, iq, telemetry);
+            Assert.True(PacketParser.TryParsePacket(packet, outBuf, out uint seq, out _));
+            Assert.Equal(s, seq);
+        }
+    }
+}

--- a/tests/Zeus.VirtualRadio.Tests/P2CmdDecoderTests.cs
+++ b/tests/Zeus.VirtualRadio.Tests/P2CmdDecoderTests.cs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Buffers.Binary;
+using Zeus.Contracts;
+using Zeus.Protocol2;          // internal ComposeCmdRxBuffer / ComposeCmdTxBuffer, via InternalsVisibleTo
+using Zeus.VirtualRadio.P2;
+
+namespace Zeus.VirtualRadio.Tests;
+
+/// <summary>
+/// Anti-drift tests for <see cref="P2CmdDecoder"/>: the decoder is fed bytes
+/// produced by the REAL client composers
+/// (<see cref="Protocol2Client.ComposeCmdRxBuffer"/> /
+/// <see cref="Protocol2Client.ComposeCmdTxBuffer"/>) so a wire offset that
+/// moves in the client breaks the round-trip. Socketless.
+/// </summary>
+public class P2CmdDecoderTests
+{
+    private static P2CmdDecoder Decoder() => new(HpsdrBoardKind.HermesII);
+
+    [Fact]
+    public void DecodeCmdRx_Burst_DetectsByte1363Mux_AndNumAdc()
+    {
+        // The exact bytes the client emits for the HermesII PS time-mux burst.
+        byte[] p = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 1, numAdc: 1, sampleRateKhz: 192, psEnabled: true,
+            boardKind: HpsdrBoardKind.HermesII,
+            adcDitherEnabled: false, adcRandomEnabled: false,
+            rx2Enabled: false, g2eFeedbackBurst: true);
+
+        // Ground-truth: the client really does set byte 1363 = 0x02.
+        Assert.Equal((byte)0x02, p[1363]);
+
+        var state = new HostCommandState();
+        var events = Decoder().Decode(P2Wire.CmdRxPort, p, state);
+
+        Assert.NotEmpty(events);
+        Assert.Equal(ProtocolVersion.P2, events[0].Protocol);
+        Assert.True(state.PsArmedBurst);
+        Assert.Equal((byte)1, state.NumAdc);
+        Assert.Equal(192, state.SampleRateKhz);
+    }
+
+    [Fact]
+    public void DecodeCmdRx_Rest_NoMux_ReadsNegotiatedRate()
+    {
+        byte[] p = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 2, numAdc: 1, sampleRateKhz: 48, psEnabled: false,
+            boardKind: HpsdrBoardKind.HermesII);
+
+        Assert.Equal((byte)0x00, p[1363]);
+
+        var state = new HostCommandState();
+        Decoder().Decode(P2Wire.CmdRxPort, p, state);
+
+        Assert.False(state.PsArmedBurst);
+        Assert.Equal(48, state.SampleRateKhz);
+    }
+
+    [Fact]
+    public void DecodeCmdTx_ReadsByte59_TxStepAttenuator()
+    {
+        // HermesII is a single-ADC board, so the client takes the non-PS
+        // ComposeCmdTxBuffer branch (psEnabled=false) and writes
+        // p[57]=p[58]=p[59]=txStepAttnDb. Byte 59 is the TX-time ADC attenuator.
+        const byte seed = 31;
+        byte[] p = Protocol2Client.ComposeCmdTxBuffer(
+            seq: 3, sampleRateKhz: 192, txStepAttnDb: seed, paEnabled: true, psEnabled: false);
+
+        Assert.Equal(seed, p[59]);
+
+        var state = new HostCommandState();
+        Decoder().Decode(P2Wire.CmdTxPort, p, state);
+
+        Assert.Equal(seed, state.TxStepAttnDb);
+    }
+
+    [Fact]
+    public void DecodeCmdHighPriority_ReadsMoxAndDrive()
+    {
+        var p = new byte[P2Wire.BufLen];
+        BinaryPrimitives.WriteUInt32BigEndian(p.AsSpan(0, 4), 9);
+        p[P2Wire.HpRunMoxByte] = 0x03;       // run | PTT/MOX
+        p[P2Wire.HpDriveByte] = 200;         // drive level
+        // DDC0 RX NCO phase for 14.074 MHz.
+        uint rxPhase = (uint)(14_074_000L * P2Wire.HzToPhase);
+        BinaryPrimitives.WriteUInt32BigEndian(p.AsSpan(P2Wire.HpDdc0PhaseOffset, 4), rxPhase);
+
+        var state = new HostCommandState();
+        Decoder().Decode(P2Wire.CmdHighPriorityPort, p, state);
+
+        Assert.True(state.Running);
+        Assert.True(state.Mox);
+        Assert.Equal((byte)200, state.DriveByte);
+        Assert.InRange(state.RxFreqHz, 14_073_990L, 14_074_010L); // phase quantisation
+    }
+
+    [Fact]
+    public void DecodeCmdHighPriority_NotKeyed_MoxFalse()
+    {
+        var p = new byte[P2Wire.BufLen];
+        p[P2Wire.HpRunMoxByte] = 0x01; // run only, no MOX
+        p[P2Wire.HpDriveByte] = 0;
+
+        var state = new HostCommandState();
+        Decoder().Decode(P2Wire.CmdHighPriorityPort, p, state);
+
+        Assert.True(state.Running);
+        Assert.False(state.Mox);
+    }
+
+    [Fact]
+    public void DecodeCmdGeneral_MarksRunning()
+    {
+        var p = new byte[P2Wire.CmdSmallLength];
+        p[P2Wire.GeneralCmdByte] = P2Wire.GeneralConnect; // 0x00
+
+        var state = new HostCommandState();
+        var events = Decoder().Decode(P2Wire.CmdGeneralPort, p, state);
+
+        Assert.NotEmpty(events);
+        Assert.True(state.Running);
+    }
+
+    [Fact]
+    public void Decode_NoAutoArm_FreshStateLeavesPsBurstOff()
+    {
+        // A plain connect + rest CmdRx must NEVER leave PS armed.
+        var state = new HostCommandState();
+        var dec = Decoder();
+
+        var general = new byte[P2Wire.CmdSmallLength];
+        dec.Decode(P2Wire.CmdGeneralPort, general, state);
+
+        byte[] rest = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 1, numAdc: 1, sampleRateKhz: 48, psEnabled: false,
+            boardKind: HpsdrBoardKind.HermesII);
+        dec.Decode(P2Wire.CmdRxPort, rest, state);
+
+        Assert.False(state.PsArmedBurst);
+        Assert.False(state.Mox);
+    }
+}

--- a/tests/Zeus.VirtualRadio.Tests/P2DiscoveryReplyTests.cs
+++ b/tests/Zeus.VirtualRadio.Tests/P2DiscoveryReplyTests.cs
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Net;
+using System.Net.NetworkInformation;
+using Zeus.Contracts;
+using Zeus.Protocol2.Discovery;
+using Zeus.VirtualRadio.Discovery;
+using Zeus.VirtualRadio.P2;
+
+namespace Zeus.VirtualRadio.Tests;
+
+/// <summary>
+/// Anti-drift round-trip tests for the Protocol-2 discovery reply: the
+/// emulator's reply is fed straight through the REAL
+/// <see cref="ReplyParser"/> and must round-trip back to the same board /
+/// MAC / status. Socketless.
+/// </summary>
+public class P2DiscoveryReplyTests
+{
+    private static VirtualRadioProfile HermesII() =>
+        VirtualRadioProfile.Create(HpsdrBoardKind.HermesII, ProtocolVersion.P2);
+
+    [Fact]
+    public void Build_RoundTripsThroughReplyParser_AsHermesII()
+    {
+        var mac = DiscoveryResponder.DefaultMac;
+        Span<byte> buf = stackalloc byte[P2DiscoveryReply.ReplyLength];
+
+        int n = P2DiscoveryReply.Build(buf, HermesII(), mac, codeVersion: 73, numReceivers: 2, busy: false);
+
+        Assert.Equal(P2DiscoveryReply.ReplyLength, n);
+        Assert.True(ReplyParser.TryParse(buf[..n].ToArray(), IPAddress.Parse("192.168.1.50"), out var radio));
+        Assert.NotNull(radio);
+        Assert.Equal(HpsdrBoardKind.HermesII, radio!.Board);
+        Assert.Equal(mac, radio.Mac);
+        Assert.Equal((byte)73, radio.FirmwareVersion);
+        Assert.False(radio.Details.Busy);
+        Assert.Equal((byte)0x02, radio.Details.RawBoardId);
+        Assert.Equal((byte)2, radio.Details.NumReceivers);
+    }
+
+    [Fact]
+    public void Build_BusyFlag_IsReportedByParser()
+    {
+        Span<byte> buf = stackalloc byte[P2DiscoveryReply.ReplyLength];
+        P2DiscoveryReply.Build(buf, HermesII(), DiscoveryResponder.DefaultMac, 73, 2, busy: true);
+
+        Assert.True(ReplyParser.TryParse(buf.ToArray(), IPAddress.Loopback, out var radio));
+        Assert.True(radio!.Details.Busy);
+    }
+
+    [Fact]
+    public void Build_ClampsNumReceiversToAtLeastTwo()
+    {
+        Span<byte> buf = stackalloc byte[P2DiscoveryReply.ReplyLength];
+        P2DiscoveryReply.Build(buf, HermesII(), DiscoveryResponder.DefaultMac, 73, numReceivers: 0, busy: false);
+
+        ReplyParser.TryParse(buf.ToArray(), IPAddress.Loopback, out var radio);
+        Assert.True(radio!.Details.NumReceivers >= 2);
+    }
+
+    [Fact]
+    public void Build_PreservesMacBytes()
+    {
+        var mac = new PhysicalAddress(new byte[] { 0x02, 0x11, 0x22, 0x33, 0x44, 0x55 });
+        Span<byte> buf = stackalloc byte[P2DiscoveryReply.ReplyLength];
+        P2DiscoveryReply.Build(buf, HermesII(), mac, 73, 2, busy: false);
+
+        ReplyParser.TryParse(buf.ToArray(), IPAddress.Loopback, out var radio);
+        Assert.Equal(mac, radio!.Mac);
+    }
+
+    [Theory]
+    [InlineData(HpsdrBoardKind.Metis, 0x00)]
+    [InlineData(HpsdrBoardKind.Hermes, 0x01)]
+    [InlineData(HpsdrBoardKind.HermesII, 0x02)]
+    [InlineData(HpsdrBoardKind.HermesLite2, 0x06)]
+    [InlineData(HpsdrBoardKind.HermesC10, 0x14)]
+    public void BoardByte_RoundTripsThroughReplyParserMap(HpsdrBoardKind board, int expected)
+    {
+        Assert.Equal((byte)expected, P2DiscoveryReply.BoardByte(board));
+    }
+
+    [Fact]
+    public void IsDiscoveryProbe_DiscriminatesOnByte4()
+    {
+        // Discovery probe (RadioDiscoveryService): zero seq header + 0x02 at [4].
+        var probe = new byte[P2Wire.DiscoveryPacketLength];
+        probe[4] = 0x02;
+        Assert.True(P2DiscoveryReply.IsDiscoveryProbe(probe));
+
+        // CmdGeneral to the same port carries 0x00 there.
+        var general = new byte[P2Wire.CmdSmallLength];
+        general[4] = 0x00;
+        Assert.False(P2DiscoveryReply.IsDiscoveryProbe(general));
+    }
+
+    [Fact]
+    public void Build_ThrowsOnTooSmallBuffer()
+    {
+        Assert.Throws<ArgumentException>(() =>
+        {
+            byte[] tiny = new byte[10];
+            P2DiscoveryReply.Build(tiny, HermesII(), DiscoveryResponder.DefaultMac, 73, 2, false);
+        });
+    }
+}

--- a/tests/Zeus.VirtualRadio.Tests/P2HiPriStatusEncoderTests.cs
+++ b/tests/Zeus.VirtualRadio.Tests/P2HiPriStatusEncoderTests.cs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Zeus.Protocol2;          // public DecodeHiPriStatus
+using Zeus.VirtualRadio.P2;
+using Zeus.VirtualRadio.Rf;
+
+namespace Zeus.VirtualRadio.Tests;
+
+/// <summary>
+/// Anti-drift round-trip tests for <see cref="P2HiPriStatusEncoder"/>: the
+/// packet body (after the 4-byte sequence header the client strips) is fed
+/// through the REAL <see cref="Protocol2Client.DecodeHiPriStatus"/> and the
+/// FWD/REF/exciter/PTT/PLL/overload fields must survive. Socketless.
+/// </summary>
+public class P2HiPriStatusEncoderTests
+{
+    private static (P2TelemetryReading reading, byte[] packet) Encode(
+        RfTelemetry tel, bool ptt, bool pll, byte overload)
+    {
+        var enc = new P2HiPriStatusEncoder();
+        byte[] packet = enc.Build(sequence: 42, tel, ptt, pll, overload);
+        // The client strips the 4-byte BE seq header before decoding.
+        var body = packet.AsSpan(P2Wire.HiPriSeqHeaderBytes);
+        return (Protocol2Client.DecodeHiPriStatus(body), packet);
+    }
+
+    [Fact]
+    public void Build_KeyedTelemetry_RoundTripsFwdRevExciterPtt()
+    {
+        var tel = new RfTelemetry(FwdAdc: 2048, RefAdc: 96, FwdWatts: 9.5, RefWatts: 0.1, Swr: 1.1);
+        var (reading, _) = Encode(tel, ptt: true, pll: true, overload: 0x00);
+
+        Assert.Equal((ushort)2048, reading.FwdAdc);
+        Assert.Equal((ushort)96, reading.RevAdc);
+        Assert.Equal((ushort)2048, reading.ExciterAdc); // exciter mirrors FWD
+        Assert.True(reading.PttIn);
+        Assert.True(reading.PllLocked);
+        Assert.Equal((byte)0x00, reading.AdcOverloadBits);
+    }
+
+    [Fact]
+    public void Build_AtRest_FwdRevZero_NoPtt()
+    {
+        var tel = new RfTelemetry(0, 0, 0, 0, 1.0);
+        var (reading, _) = Encode(tel, ptt: false, pll: true, overload: 0x00);
+
+        Assert.Equal((ushort)0, reading.FwdAdc);
+        Assert.Equal((ushort)0, reading.RevAdc);
+        Assert.False(reading.PttIn);
+        Assert.True(reading.PllLocked);
+    }
+
+    [Fact]
+    public void Build_AdcOverloadBit_SurvivesDecode()
+    {
+        // The emulator asserts ADC overload when the host fails to seed byte 59
+        // while the single-ADC PS time-mux is armed.
+        var tel = new RfTelemetry(1000, 50, 1.0, 0.05, 1.05);
+        var (reading, _) = Encode(tel, ptt: true, pll: true, overload: 0x01);
+        Assert.Equal((byte)0x01, reading.AdcOverloadBits);
+    }
+
+    [Fact]
+    public void Build_PacketLength_MeetsClientMinimum()
+    {
+        var (_, packet) = Encode(new RfTelemetry(1, 2, 0, 0, 1.0), true, true, 0);
+        // 4-byte seq + at least 20-byte body = the client's HiPriStatusMinBytes.
+        Assert.True(packet.Length >= P2Wire.HiPriSeqHeaderBytes + P2Wire.HiPriStatusMinBody);
+    }
+}

--- a/tests/Zeus.VirtualRadio.Tests/P2RxDdcEncoderRoundTripTests.cs
+++ b/tests/Zeus.VirtualRadio.Tests/P2RxDdcEncoderRoundTripTests.cs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Zeus.Protocol2;          // internal DecodePsPairForTest, via InternalsVisibleTo
+using Zeus.VirtualRadio.P2;
+
+namespace Zeus.VirtualRadio.Tests;
+
+/// <summary>
+/// Anti-drift round-trip tests for <see cref="P2RxDdcEncoder"/>. The plain-RX
+/// path is decoded exactly as <c>Protocol2Client.HandleDdcPacket</c> does
+/// (int24-BE I/Q from byte 16, 1/2^23 scale); the PureSignal feedback path is
+/// fed pair-by-pair through the REAL
+/// <see cref="Protocol2Client.DecodePsPairForTest"/> — the canonical
+/// coupler→rx / reference→tx de-interleave the live client uses — so a swap or
+/// offset regression reds here. Socketless.
+/// </summary>
+public class P2RxDdcEncoderRoundTripTests
+{
+    private const double Int24Lsb = 1.0 / 8_388_608.0;
+    private const double Tol = 2 * Int24Lsb;
+
+    private static double[] MakeIq(int complex, double iScale, double qScale)
+    {
+        var iq = new double[2 * complex];
+        for (int n = 0; n < complex; n++)
+        {
+            iq[2 * n] = iScale * Math.Sin(2 * Math.PI * n / 19.0);
+            iq[2 * n + 1] = qScale * Math.Cos(2 * Math.PI * n / 29.0);
+        }
+        return iq;
+    }
+
+    [Fact]
+    public void EncodeRxIq_SamplesSurvive_AsInt24BigEndian()
+    {
+        var enc = new P2RxDdcEncoder();
+        var iq = MakeIq(P2RxDdcEncoder.RxSamplesPerPacket, 0.7, 0.5);
+
+        var packet = new byte[P2Wire.BufLen];
+        enc.EncodeRxIq(packet, sequence: 0xCAFEBABE, iq);
+
+        // Sequence at [0..3] BE.
+        Assert.Equal(0xCAu, packet[0]);
+        Assert.Equal(0xFEu, packet[1]);
+
+        // Decode exactly as Protocol2Client.HandleDdcPacket: 238 samples, int24
+        // BE I/Q from byte 16, scaled by 1/2^23.
+        const double scale = 1.0 / 8_388_608.0;
+        for (int s = 0; s < P2RxDdcEncoder.RxSamplesPerPacket; s++)
+        {
+            int off = 16 + s * 6;
+            int iRaw = SignExtend24((packet[off] << 16) | (packet[off + 1] << 8) | packet[off + 2]);
+            int qRaw = SignExtend24((packet[off + 3] << 16) | (packet[off + 4] << 8) | packet[off + 5]);
+            double iVal = iRaw * scale;
+            double qVal = qRaw * scale;
+            Assert.True(Math.Abs(iVal - iq[2 * s]) <= Tol, $"I[{s}] {iVal} != {iq[2 * s]}");
+            Assert.True(Math.Abs(qVal - iq[2 * s + 1]) <= Tol, $"Q[{s}] {qVal} != {iq[2 * s + 1]}");
+        }
+    }
+
+    [Fact]
+    public void EncodePsFeedback_RoundTripsThroughDecodePsPairForTest_CouplerIsRx_ReferenceIsTx()
+    {
+        var enc = new P2RxDdcEncoder();
+        // Distinct coupler / reference so a swap is unmistakable.
+        var coupler = MakeIq(P2RxDdcEncoder.PsPairsPerPacket, 0.40, 0.30);  // → rx
+        var reference = MakeIq(P2RxDdcEncoder.PsPairsPerPacket, 0.80, 0.60); // → tx
+
+        var packet = new byte[P2Wire.BufLen];
+        enc.EncodePsFeedback(packet, sequence: 7, coupler, reference);
+
+        // samplesPerFrame marker = 238 (the client reads this at [14..15] →
+        // 119 pairs).
+        int spf = (packet[14] << 8) | packet[15];
+        Assert.Equal(238, spf);
+
+        for (int i = 0; i < P2RxDdcEncoder.PsPairsPerPacket; i++)
+        {
+            int off = 16 + i * 12;
+            var (rxI, rxQ, txI, txQ) =
+                Protocol2Client.DecodePsPairForTest(new ReadOnlySpan<byte>(packet, off, 12));
+
+            Assert.True(Math.Abs(rxI - coupler[2 * i]) <= Tol, $"rxI[{i}]");
+            Assert.True(Math.Abs(rxQ - coupler[2 * i + 1]) <= Tol, $"rxQ[{i}]");
+            Assert.True(Math.Abs(txI - reference[2 * i]) <= Tol, $"txI[{i}]");
+            Assert.True(Math.Abs(txQ - reference[2 * i + 1]) <= Tol, $"txQ[{i}]");
+        }
+    }
+
+    [Theory]
+    [InlineData(2.5)]   // over-range → clamp to +full-scale
+    [InlineData(-2.5)]  // over-range → clamp to -full-scale
+    public void EncodeRxIq_ClampsFullScale(double level)
+    {
+        var enc = new P2RxDdcEncoder();
+        var iq = new double[2 * P2RxDdcEncoder.RxSamplesPerPacket];
+        for (int k = 0; k < iq.Length; k++) iq[k] = level;
+
+        var packet = new byte[P2Wire.BufLen];
+        enc.EncodeRxIq(packet, 1, iq);
+
+        const double scale = 1.0 / 8_388_608.0;
+        int off = 16;
+        int raw = SignExtend24((packet[off] << 16) | (packet[off + 1] << 8) | packet[off + 2]);
+        double v = raw * scale;
+        double expected = level > 0 ? 1.0 : -1.0;
+        Assert.True(Math.Abs(v - expected) <= Tol, $"value {v} not clamped near {expected}");
+    }
+
+    [Fact]
+    public void EncodeRxIq_RejectsWrongPacketLength()
+    {
+        var enc = new P2RxDdcEncoder();
+        var iq = MakeIq(P2RxDdcEncoder.RxSamplesPerPacket, 0.5, 0.5);
+        Assert.Throws<ArgumentException>(() =>
+            enc.EncodeRxIq(new byte[P2Wire.BufLen - 1], 0, iq));
+    }
+
+    [Fact]
+    public void EncodePsFeedback_RejectsShortBuffers()
+    {
+        var enc = new P2RxDdcEncoder();
+        var ok = MakeIq(P2RxDdcEncoder.PsPairsPerPacket, 0.5, 0.5);
+        var shortBuf = new double[2 * P2RxDdcEncoder.PsPairsPerPacket - 1];
+        var packet = new byte[P2Wire.BufLen];
+        Assert.Throws<ArgumentException>(() => enc.EncodePsFeedback(packet, 0, shortBuf, ok));
+        Assert.Throws<ArgumentException>(() => enc.EncodePsFeedback(packet, 0, ok, shortBuf));
+    }
+
+    private static int SignExtend24(int raw)
+    {
+        if ((raw & 0x800000) != 0) raw |= unchecked((int)0xFF000000);
+        return raw;
+    }
+}

--- a/tests/Zeus.VirtualRadio.Tests/RfTelemetryAndSyntheticIqTests.cs
+++ b/tests/Zeus.VirtualRadio.Tests/RfTelemetryAndSyntheticIqTests.cs
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using Zeus.Contracts;
+using Zeus.Server;          // public TxMetersService.ComputeMeters (Zeus's forward math)
+using Zeus.VirtualRadio;
+using Zeus.VirtualRadio.Rf; // internal RfTelemetryModel / SyntheticIqGenerator (needs InternalsVisibleTo)
+
+namespace Zeus.VirtualRadio.Tests;
+
+/// <summary>
+/// Phase-1 RF telemetry + synthetic-signal unit tests. All socketless / pure
+/// compute — the calibration-inversion suite is the anti-drift round trip: feed
+/// the ADC counts the emulator would put on the wire through Zeus's UNMODIFIED
+/// <see cref="TxMetersService.ComputeMeters"/> and assert it recovers the watts
+/// the emulator intended.
+/// </summary>
+public class RfTelemetryAndSyntheticIqTests
+{
+    // ANAN-10E impersonation: HermesII → RadioCalibration.Hermes
+    // (bridge 0.09 / ref 3.3 / offset 6 / 10 W rated). The model inverts onto
+    // the calibration's MaxWatts (10 W) so full drive reads the board's real
+    // rated output, not the 100 W PA-gain-bracket reference.
+    private static readonly RadioCalibration HermesIICal = RadioCalibration.Hermes;
+    private const double RatedWatts = 10.0;   // == HermesIICal.MaxWatts
+    private const long Band20mHz = 14_074_000;
+
+    private static RfTelemetryModel NewModel() =>
+        new(VirtualRadioProfile.Create(HpsdrBoardKind.HermesII, ProtocolVersion.P1));
+
+    // ---- RF telemetry / calibration inversion -----------------------------
+
+    [Fact]
+    public void Compute_NotKeyed_ReturnsZeroPower()
+    {
+        var model = NewModel();
+
+        // Even at full drive, an unkeyed radio reports nothing (FWD/REF are
+        // PTT-gated in the firmware).
+        var tel = model.Compute(driveByte: 255, Band20mHz, mox: false);
+
+        Assert.Equal(0, tel.FwdAdc);
+        Assert.Equal(0, tel.RefAdc);
+        Assert.Equal(0.0, tel.FwdWatts);
+        Assert.Equal(0.0, tel.RefWatts);
+        Assert.Equal(1.0, tel.Swr);
+    }
+
+    [Theory]
+    [InlineData((byte)1)]
+    [InlineData((byte)32)]
+    [InlineData((byte)64)]
+    [InlineData((byte)128)]
+    [InlineData((byte)200)]
+    [InlineData((byte)255)]
+    public void Compute_ForwardWatts_RoundTripsThroughZeusMeterMath(byte driveByte)
+    {
+        var model = NewModel();
+
+        var tel = model.Compute(driveByte, Band20mHz, mox: true);
+
+        // The curve the emulator intends: quadratic in drive byte.
+        double drive = driveByte / 255.0;
+        double targetWatts = RatedWatts * drive * drive;
+
+        // Feed the wire ADC counts through Zeus's OWN forward math.
+        var (fwdW, _, _) = TxMetersService.ComputeMeters(tel.FwdAdc, tel.RefAdc, HermesIICal);
+
+        // Round trip recovers the intended watts (loose at µW levels where the
+        // single-count ADC offset rounding dominates, tight at real power).
+        double tolerance = 0.02 * targetWatts + 0.01;
+        Assert.True(
+            Math.Abs(fwdW - targetWatts) <= tolerance,
+            $"drive={driveByte}: target={targetWatts:G6} W recovered={fwdW:G6} W (tol {tolerance:G3})");
+
+        // The model reports exactly what the client will render (same ADC, same
+        // calibration, same ComputeMeters).
+        Assert.Equal(fwdW, tel.FwdWatts, 9);
+        Assert.InRange(tel.FwdAdc, 0, 4095);
+        Assert.InRange(tel.RefAdc, 0, 4095);
+    }
+
+    [Fact]
+    public void Compute_FullDrive_ReadsRatedWatts()
+    {
+        var model = NewModel();
+
+        var tel = model.Compute(driveByte: 255, Band20mHz, mox: true);
+
+        // 100 % drive on the ANAN-10E lands on its ~10 W rated output.
+        Assert.Equal(RatedWatts, tel.FwdWatts, 1);
+    }
+
+    [Fact]
+    public void Compute_ForwardWatts_IsMonotoneInDriveByte()
+    {
+        var model = NewModel();
+
+        double previous = -1.0;
+        for (int d = 0; d <= 255; d += 5)
+        {
+            var tel = model.Compute((byte)d, Band20mHz, mox: true);
+            Assert.True(tel.FwdWatts >= previous,
+                $"watts must be monotone: drive={d} gave {tel.FwdWatts:G6} W after {previous:G6} W");
+            previous = tel.FwdWatts;
+        }
+    }
+
+    [Fact]
+    public void Compute_Swr_MatchesRequestedReflection()
+    {
+        var model = NewModel();
+
+        // Full drive (10 W, above the 2 W SWR floor) with a 2.0:1 mismatch.
+        var tel = model.Compute(driveByte: 255, Band20mHz, mox: true, swr: 2.0);
+
+        Assert.Equal(2.0, tel.Swr, 1);
+        Assert.True(tel.RefWatts > 0.0 && tel.RefWatts < tel.FwdWatts);
+    }
+
+    [Fact]
+    public void Compute_MatchedLoad_KeepsSwrNearUnity()
+    {
+        var model = NewModel();
+
+        var tel = model.Compute(driveByte: 255, Band20mHz, mox: true, swr: RfTelemetryModel.DefaultSwr);
+
+        // ~1.1:1 default, well below any trip threshold.
+        Assert.InRange(tel.Swr, 1.0, 1.3);
+    }
+
+    // ---- Synthetic IQ generator -------------------------------------------
+
+    private const double TwoPi = 2.0 * Math.PI;
+
+    private static VirtualRadioProfile SignalProfile(
+        IReadOnlyList<ToneSpec> tones, double noiseDbc, int rateKhz = 48) =>
+        VirtualRadioProfile.Create(HpsdrBoardKind.HermesII, ProtocolVersion.P1) with
+        {
+            SampleRateKhz = rateKhz,
+            Tones = tones,
+            NoiseFloorDbc = noiseDbc,
+        };
+
+    /// <summary>|Σ z[n]·e^{-j2π f n/fs}| / N — magnitude of the complex IQ at f.</summary>
+    private static double MagnitudeAt(ReadOnlySpan<double> iq, int complexN, double freqHz, double fs)
+    {
+        double re = 0.0, im = 0.0;
+        for (int n = 0; n < complexN; n++)
+        {
+            double i = iq[2 * n];
+            double q = iq[2 * n + 1];
+            double theta = TwoPi * freqHz * n / fs;
+            double c = Math.Cos(theta), s = Math.Sin(theta);
+            // z·e^{-jθ} = (i+jq)(cosθ − j sinθ)
+            re += i * c + q * s;
+            im += q * c - i * s;
+        }
+        return Math.Sqrt(re * re + im * im) / complexN;
+    }
+
+    [Fact]
+    public void Generate_PlacesToneAtExpectedBasebandOffset()
+    {
+        const long tuned = 14_074_000;
+        const long toneHz = tuned + 6_000;       // +6 kHz offset, inside 24 kHz Nyquist
+        const double fs = 48_000.0;
+        const int n = 4_800;
+
+        var gen = new SyntheticIqGenerator(
+            SignalProfile(new[] { new ToneSpec(toneHz, 0.0) }, noiseDbc: -110.0));
+
+        var iq = new double[2 * n];
+        gen.Generate(iq, n, tuned);
+
+        // Scan candidate offsets; the argmax must be the +6 kHz bin.
+        double bestMag = -1.0;
+        long bestOffset = long.MinValue;
+        for (long off = -20_000; off <= 20_000; off += 500)
+        {
+            double mag = MagnitudeAt(iq, n, off, fs);
+            if (mag > bestMag) { bestMag = mag; bestOffset = off; }
+        }
+
+        Assert.Equal(6_000, bestOffset);
+    }
+
+    [Fact]
+    public void Generate_RespectsNoiseFloor()
+    {
+        const double noiseDbc = -40.0;            // RMS 0.01 full-scale
+        const int n = 40_000;
+        double expectedRms = Math.Pow(10.0, noiseDbc / 20.0);
+
+        var gen = new SyntheticIqGenerator(
+            SignalProfile(Array.Empty<ToneSpec>(), noiseDbc));
+
+        var iq = new double[2 * n];
+        gen.Generate(iq, n, tunedHz: 14_074_000);
+
+        double power = 0.0;
+        for (int k = 0; k < n; k++)
+        {
+            double i = iq[2 * k];
+            double q = iq[2 * k + 1];
+            power += i * i + q * q;
+        }
+        double rms = Math.Sqrt(power / n);
+
+        Assert.InRange(rms, expectedRms * 0.85, expectedRms * 1.15);
+    }
+
+    [Fact]
+    public void Generate_ToneRisesWellAboveNoiseFloor()
+    {
+        const long tuned = 14_074_000;
+        const long toneHz = tuned + 3_000;
+        const double fs = 48_000.0;
+        const int n = 8_192;
+
+        var gen = new SyntheticIqGenerator(
+            SignalProfile(new[] { new ToneSpec(toneHz, 0.0) }, noiseDbc: -60.0));
+
+        var iq = new double[2 * n];
+        gen.Generate(iq, n, tuned);
+
+        double toneMag = MagnitudeAt(iq, n, 3_000, fs);
+        double offToneMag = MagnitudeAt(iq, n, -9_000, fs);
+
+        Assert.True(toneMag > offToneMag * 20.0,
+            $"tone {toneMag:G4} should dominate off-tone {offToneMag:G4}");
+    }
+
+    [Fact]
+    public void Generate_IsDeterministicAndPhaseContinuousAcrossCalls()
+    {
+        const long tuned = 14_074_000;
+        const int n = 1_024;
+        var tones = new[] { new ToneSpec(tuned + 5_000, -10.0) };
+
+        // One 2N call.
+        var whole = new double[4 * n];
+        new SyntheticIqGenerator(SignalProfile(tones, -90.0)).Generate(whole, 2 * n, tuned);
+
+        // Two N calls on a fresh generator: phase + noise stream persist, so the
+        // concatenation must be bit-identical (continuity + determinism).
+        var split = new double[4 * n];
+        var gen2 = new SyntheticIqGenerator(SignalProfile(tones, -90.0));
+        gen2.Generate(split.AsSpan(0, 2 * n), n, tuned);
+        gen2.Generate(split.AsSpan(2 * n, 2 * n), n, tuned);
+
+        Assert.Equal(whole, split);
+    }
+
+    [Fact]
+    public void Generate_ThrowsWhenBufferTooSmall()
+    {
+        var gen = new SyntheticIqGenerator(
+            SignalProfile(Array.Empty<ToneSpec>(), -110.0));
+
+        Assert.Throws<ArgumentException>(() => gen.Generate(new double[3], complexSamples: 4, tunedHz: 0));
+    }
+}

--- a/tests/Zeus.VirtualRadio.Tests/ScaffoldSanityTests.cs
+++ b/tests/Zeus.VirtualRadio.Tests/ScaffoldSanityTests.cs
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// See ATTRIBUTIONS.md at the repository root for the full provenance
+// statement and per-component attribution.
+
+using System.Net;
+using System.Net.Sockets;
+using Zeus.Contracts;
+using Zeus.Protocol1;
+using Zeus.Server;
+using Zeus.VirtualRadio;
+using Zeus.VirtualRadio.P1;
+
+namespace Zeus.VirtualRadio.Tests;
+
+/// <summary>
+/// Phase-0 scaffold sanity: the frozen shared types compile and the profile
+/// factory enforces board/protocol legality. The real wire round-trip and
+/// calibration-inversion tests land with the module bodies (Phase 1).
+/// </summary>
+public class ScaffoldSanityTests
+{
+    [Fact]
+    public void Create_AllowsLegalTriple()
+    {
+        var profile = VirtualRadioProfile.Create(HpsdrBoardKind.HermesII, ProtocolVersion.P1);
+        Assert.Equal(HpsdrBoardKind.HermesII, profile.Board);
+        Assert.Equal(ProtocolVersion.P1, profile.Protocol);
+    }
+
+    [Fact]
+    public void Create_RejectsIllegalTriple_Hl2OnP2()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            VirtualRadioProfile.Create(HpsdrBoardKind.HermesLite2, ProtocolVersion.P2));
+    }
+
+    [Fact]
+    public void BoardProtocolSupport_SeedMatchesPlan()
+    {
+        Assert.Equal(ProtocolSupport.P1, BoardProtocolSupport.For(HpsdrBoardKind.Metis));
+        Assert.Equal(ProtocolSupport.P1, BoardProtocolSupport.For(HpsdrBoardKind.HermesLite2));
+        Assert.Equal(ProtocolSupport.Both, BoardProtocolSupport.For(HpsdrBoardKind.HermesII));
+        Assert.True(BoardProtocolSupport.Supports(HpsdrBoardKind.Orion, ProtocolVersion.P2));
+    }
+}
+
+/// <summary>
+/// Gated loopback integration test for the live RX path. Spins the emulator
+/// in-process on <c>127.0.0.1:1024</c> and points the real Protocol-1 client at
+/// it over loopback. This is the ONE socket test in the suite and MUST stay
+/// gated behind the <c>ZEUS_VRADIO_LOOPBACK</c> env var (the repo rule: no real
+/// sockets in normal CI — a Windows CI host minidumps on real socket loops in
+/// unit tests). The implementer fills the body in Phase 1.
+/// </summary>
+public class Protocol1Emulator_LoopbackRx_IntegrationTest
+{
+    // ANAN-10E impersonation → HermesII → RadioCalibration.Hermes. Used to turn
+    // the FWD/REF ADC counts the client reads back into watts via Zeus's own
+    // forward math (TxMetersService.ComputeMeters) — the calibration round-trip.
+    private static readonly RadioCalibration Cal = RadioCalibration.Hermes;
+
+    // TxMetersService C0-echo address constants (the FWD/REF meter slot map).
+    private const byte C0AddrMask = 0x7E;
+    private const byte C0AddrAlexFwd = 0x08; // Ain1 = forward-power ADC
+    private const byte C0AddrAlexRef = 0x10; // Ain0 = reflected-power ADC
+
+    [SkippableFact]
+    public async Task LoopbackRx_DeliversFrames()
+    {
+        Skip.If(
+            string.IsNullOrEmpty(Environment.GetEnvironmentVariable("ZEUS_VRADIO_LOOPBACK")),
+            "Set ZEUS_VRADIO_LOOPBACK=1 to run the loopback RX integration test (binds a real UDP socket).");
+
+        int port = GetFreeUdpPort();
+        var endpoint = new IPEndPoint(IPAddress.Loopback, port);
+
+        // ANAN-10E on P1 with one S9 tone at 14.074 MHz and a quiet noise floor.
+        var profile = VirtualRadioProfile.Create(HpsdrBoardKind.HermesII, ProtocolVersion.P1) with
+        {
+            BindAddress = IPAddress.Loopback,
+            SampleRateKhz = 48,
+            TunedHz = 14_074_000,
+            Tones = new[] { new ToneSpec(14_074_000, -73) },
+            NoiseFloorDbc = -110,
+        };
+
+        var engine = new Protocol1Engine(profile, logger: null, port: port);
+        using var engineCts = new CancellationTokenSource();
+        Task engineTask = engine.RunAsync(engineCts.Token);
+
+        // Capture the FWD/REF ADC counts the client parses off the wire.
+        ushort fwdAdc = 0, refAdc = 0;
+
+        using var client = new Protocol1Client();
+        client.SetBoardKind(HpsdrBoardKind.HermesII);
+        client.TelemetryReceived += reading =>
+        {
+            switch (reading.C0Address & C0AddrMask)
+            {
+                case C0AddrAlexFwd: Volatile.Write(ref fwdAdc, reading.Ain1); break;
+                case C0AddrAlexRef: Volatile.Write(ref refAdc, reading.Ain0); break;
+            }
+        };
+
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+
+            await client.ConnectAsync(endpoint, cts.Token).ConfigureAwait(false);
+            client.SetVfoAHz(14_074_000);
+            await client.StartAsync(
+                new StreamConfig(HpsdrSampleRate.Rate48k, PreampOn: false, Atten: HpsdrAtten.Zero),
+                cts.Token).ConfigureAwait(false);
+
+            // --- RX: assert >=300 EP6 frames with <10% drop and non-garbage IQ.
+            int frameCount = 0;
+            double maxMag = 0;
+            await foreach (var frame in client.IqFrames.ReadAllAsync(cts.Token).ConfigureAwait(false))
+            {
+                Assert.Equal(48_000, frame.SampleRateHz);
+                Assert.Equal(PacketParser.ComplexSamplesPerPacket, frame.SampleCount);
+                var span = frame.InterleavedSamples.Span;
+                for (int s = 0; s < frame.SampleCount; s++)
+                {
+                    double i = span[2 * s], q = span[2 * s + 1];
+                    double mag = Math.Sqrt(i * i + q * q);
+                    if (mag > maxMag) maxMag = mag;
+                }
+                if (++frameCount >= 300) break;
+            }
+
+            long total = client.TotalFrames;
+            long dropped = client.DroppedFrames;
+            Assert.True(total >= 300, $"expected >=300 parsed frames, got {total}");
+            Assert.True(dropped * 10 < total, $"dropped {dropped}/{total} > 10%");
+            // The -73 dBc tone should be plainly above the -110 dBc floor: a tone
+            // amplitude near 10^(-73/20) ≈ 2.2e-4 full scale, far above noise.
+            Assert.True(maxMag > 5e-5, $"RX IQ looks like silence/garbage (maxMag={maxMag:E2})");
+
+            // --- TX path: drive the radio with a known drive byte + MOX and assert
+            // the engine decoded it AND telemetry reads back as forward power.
+            const byte testDrive = 192;
+            client.SetDriveByte(testDrive);
+            client.SetMox(true);
+
+            await WaitUntilAsync(
+                () => engine.DecodedMox && engine.DecodedDriveByte == testDrive,
+                cts.Token, TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+
+            Assert.True(engine.DecodedMox, "engine did not decode MOX");
+            Assert.Equal(testDrive, engine.DecodedDriveByte);
+
+            // Let a few keyed EP6 telemetry slots arrive, then read back watts.
+            await WaitUntilAsync(
+                () => Volatile.Read(ref fwdAdc) > Cal.AdcCalOffset + 10,
+                cts.Token, TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+
+            var (fwdWattsOn, _, _) = TxMetersService.ComputeMeters(
+                Volatile.Read(ref fwdAdc), Volatile.Read(ref refAdc), Cal);
+            Assert.True(fwdWattsOn > 0.0, $"expected fwd watts > 0 while keyed, got {fwdWattsOn:F3} W");
+
+            // --- Unkey: forward power must collapse back to ~0 W.
+            client.SetMox(false);
+            await WaitUntilAsync(
+                () => Volatile.Read(ref fwdAdc) <= Cal.AdcCalOffset + 2,
+                cts.Token, TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+
+            var (fwdWattsOff, _, _) = TxMetersService.ComputeMeters(
+                Volatile.Read(ref fwdAdc), Volatile.Read(ref refAdc), Cal);
+            Assert.True(fwdWattsOff < 0.01, $"expected ~0 fwd watts unkeyed, got {fwdWattsOff:F4} W");
+
+            Console.WriteLine(
+                $"[vradio-loopback] frames={total} dropped={dropped} ({(double)dropped / total * 100:F2}%) " +
+                $"maxIqMag={maxMag:E3} ep6Sent={engine.Snapshot().Ep6PacketsSent} " +
+                $"ep2Recv={engine.Snapshot().Ep2PacketsReceived} decodedDrive={engine.DecodedDriveByte} " +
+                $"fwdWattsKeyed={fwdWattsOn:F3} fwdWattsUnkeyed={fwdWattsOff:F4}");
+
+            await client.StopAsync(CancellationToken.None).ConfigureAwait(false);
+            await client.DisconnectAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+        finally
+        {
+            engineCts.Cancel();
+            try { await engineTask.ConfigureAwait(false); }
+            catch (OperationCanceledException) { }
+            catch (Exception) { /* shutdown best-effort */ }
+        }
+    }
+
+    /// <summary>Poll <paramref name="condition"/> until true or the timeout lapses.</summary>
+    private static async Task WaitUntilAsync(Func<bool> condition, CancellationToken ct, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (!condition())
+        {
+            if (DateTime.UtcNow >= deadline) return;
+            await Task.Delay(20, ct).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>Grab a currently-free loopback UDP port for the hermetic test.</summary>
+    private static int GetFreeUdpPort()
+    {
+        using var probe = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        probe.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        return ((IPEndPoint)probe.LocalEndPoint!).Port;
+    }
+}

--- a/tests/Zeus.VirtualRadio.Tests/Zeus.VirtualRadio.Tests.csproj
+++ b/tests/Zeus.VirtualRadio.Tests/Zeus.VirtualRadio.Tests.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\..\Zeus.VirtualRadio\Zeus.VirtualRadio.csproj" />
     <ProjectReference Include="..\..\Zeus.VirtualRadio.Host\Zeus.VirtualRadio.Host.csproj" />
     <ProjectReference Include="..\..\Zeus.Protocol1\Zeus.Protocol1.csproj" />
+    <ProjectReference Include="..\..\Zeus.Protocol2\Zeus.Protocol2.csproj" />
     <ProjectReference Include="..\..\Zeus.Server.Hosting\Zeus.Server.Hosting.csproj" />
     <ProjectReference Include="..\..\Zeus.Contracts\Zeus.Contracts.csproj" />
   </ItemGroup>

--- a/tests/Zeus.VirtualRadio.Tests/Zeus.VirtualRadio.Tests.csproj
+++ b/tests/Zeus.VirtualRadio.Tests/Zeus.VirtualRadio.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Zeus.VirtualRadio\Zeus.VirtualRadio.csproj" />
+    <ProjectReference Include="..\..\Zeus.VirtualRadio.Host\Zeus.VirtualRadio.Host.csproj" />
+    <ProjectReference Include="..\..\Zeus.Protocol1\Zeus.Protocol1.csproj" />
+    <ProjectReference Include="..\..\Zeus.Server.Hosting\Zeus.Server.Hosting.csproj" />
+    <ProjectReference Include="..\..\Zeus.Contracts\Zeus.Contracts.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Virtual HPSDR radio emulator — P1 + P2 engine (no PureSignal / no Zeus runtime change)

A standalone, cross-platform software radio that speaks the genuine HPSDR wire format over UDP, so Zeus connects to it as if it were hardware — closing the "bench-tested only on the G2, 28 other boards correct by hope" gap. New `Zeus.VirtualRadio` lib + `zeus-vradio` host + tests. Mirror of Zeus's one-way wire codecs; reuses Zeus constants via `InternalsVisibleTo`; round-trip tests against the real parsers are the anti-drift guarantee.

Contents:
- **P1 slice** — ANAN-10E / Protocol 1 RX→TX→telemetry (loopback test vs the real `Protocol1Client`: 300 frames / 0 drops, watts recovered through Zeus's own `TxMetersService`).
- **P2 engine** — discovery, DDC RX, TX-IQ ingest, hi-pri telemetry, PS-feedback path. Board-parameterized; other virtual boards build on it.

### Safe for the Zeus codebase
- **Additive.** The only edits to existing Zeus code are `InternalsVisibleTo` attributes (zero behavior change, zero new public surface).
- **Nothing in the Zeus runtime references the emulator**, and the release/installer workflows do not bundle `zeus-vradio`.
- CI green on all 5 platforms.

**No PureSignal here.** The gated ANAN-10E PS production change is reviewed separately in #1209. (#1210 stacks the G2E emulator coverage on this branch.)