### PR TITLE
Gated ANAN-10E (HermesII) P2 PureSignal time-mux

### DIFF
--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -246,6 +246,12 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     // Default 0 matches the radio's power-on state and pihpsdr's untouched
     // baseline.
     private byte _txStepAttnDb;
+    // Operator's TX step-att value captured at the instant the single-ADC PS
+    // time-mux byte-59 protective seed (SeedsTxAdcProtection) overrode it, so the
+    // value is restored verbatim on PS disarm. null = no seed is currently
+    // active (the only state on every board except the 10E with its interlock
+    // lifted). See SetPsFeedbackEnabled / PsTxAdcProtectFloorDb.
+    private byte? _txAttnBeforePsSeed;
     // PA settings — pushed from RadioService when PaSettingsStore changes or
     // the VFO crosses a band edge. _paEnabled is the global toggle that lands
     // in CmdGeneral[58]; _driveByte is the pre-calibrated drive level for
@@ -1268,12 +1274,57 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         _psFeedbackEnabled = on;
         // Reset accumulator so we don't mix old samples with new on a re-arm.
         _psBlockFill = 0;
+
+        // Byte-59 TX-time ADC-overload protection seed (PureSignal hard rule).
+        // On a single-ADC time-mux board (ANAN-10E / HermesII, gated dark by
+        // Hermes10ePsTimeMuxOnAir) the TX-DAC reference + PA coupler land on the
+        // one RX ADC during a key-down; byte 59 (Angelia_atten_Tx0) is the
+        // gateware's TX-time attenuator for that ADC (Hermes.v:1483
+        // `atten0 = FPGA_PTT ? atten0_on_Tx : Attenuator0`,
+        // Tx_specific_C&C.v:182-183). Because ComposesPsFeedbackWire(HermesII) is
+        // deliberately false, ComposeCmdTxBuffer takes the non-PS branch and
+        // emits p[57]=p[58]=p[59]=_txStepAttnDb — so seeding _txStepAttnDb to the
+        // protective floor while armed pushes byte 59 protective, and restoring
+        // the operator's prior value on disarm returns the wire to normal. The
+        // seed/restore is the ONLY non-byte-identical effect, and it is reached
+        // only when SeedsTxAdcProtection is true (HermesII + flag): every other
+        // board, and HermesII with the flag false, take the historical path
+        // untouched. Gated on SeedsTxAdcProtection (NOT TimeMuxesPsFeedbackOnDdc0)
+        // so the G2E byte-59 seed stays its own separate, KB2UKA-gated
+        // pre-condition and the HermesC10 path is provably unchanged here.
+        bool seededTxAttn = false;
+        if (SeedsTxAdcProtection(_boardKind))
+        {
+            if (on)
+            {
+                _txAttnBeforePsSeed = _txStepAttnDb;
+                if (_txStepAttnDb != PsTxAdcProtectFloorDb)
+                {
+                    _txStepAttnDb = PsTxAdcProtectFloorDb;
+                    seededTxAttn = true;
+                }
+            }
+            else if (_txAttnBeforePsSeed is byte restore)
+            {
+                if (_txStepAttnDb != restore)
+                {
+                    _txStepAttnDb = restore;
+                    seededTxAttn = true;
+                }
+                _txAttnBeforePsSeed = null;
+            }
+        }
+
         if (_rxTask is not null)
         {
             // Re-emit RX-spec (DDC enables / sync bit) and HighPriority (PS
             // bit / DDC0/1 phase) so the radio honours the new state on the
             // very next sample window.
             SendCmdRx();
+            // Push the seeded/restored byte 59 — only when the seed actually
+            // moved the value, so non-10E (and flag-false) arms emit no extra
+            // CmdTx and stay byte-identical to today.
+            if (seededTxAttn) SendCmdTx();
             SendCmdHighPriority(run: true);
         }
     }
@@ -1812,6 +1863,71 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     internal static bool G2ePsTimeMuxOnAir;
 
     /// <summary>
+    /// Burn-zone interlock (PureSignal hard rule) for the ANAN-10E
+    /// (<see cref="HpsdrBoardKind.HermesII"/>) single-ADC time-multiplexed PS
+    /// feedback path — the sibling of <see cref="G2ePsTimeMuxOnAir"/>, scoped to
+    /// the 10E ONLY. It is held DARK (false) in production: while false the
+    /// HermesII wire/behaviour is byte-identical to the PS-disabled-on-single-ADC
+    /// path shipped today (RX audio survives, no feedback descriptor, no byte-59
+    /// seed). Flipped true ONLY by tests / the gated loopback emulator.
+    ///
+    /// Firmware ground truth (the 10E is byte-for-byte the same wire as the G2E,
+    /// differing only in the register name and the reference source):
+    ///   - <c>anan-10e_100b/P2-gateware/Hermes_v10.3/Rx_specific_C&amp;C.v:181</c>
+    ///     — command byte 1363 is the <c>Mux</c> register on the 10E
+    ///     (<c>1363: Mux &lt;= udp_rx_data;</c>); the old SyncRx read is commented
+    ///     out at :175-178. <c>Mux[1]</c> = the Rx1 PS select.
+    ///   - <c>Hermes.v:1080-1093</c> — <c>receiver2 receiver_inst1</c> (Rx1→DDC1)
+    ///     takes <c>in_data(Mux[1] ? temp_DACD : temp_ADC)</c>, slaving Rx1's
+    ///     input to the TX-DAC reference when <c>Mux[1]</c> is set; rate/freq
+    ///     slaved to Rx0.
+    ///   - <c>Hermes.v:684-687</c> — Rx0's single FIFO controller interleaves
+    ///     Sync-first (<c>rx_I[0]</c> = ADC coupler) then main
+    ///     (<c>rx_I[1]</c> = DAC reference) under <c>.Sync(Mux)</c> — the exact
+    ///     coupler-first / reference-second order the existing paired decoder
+    ///     (<see cref="DecodePsPairForTest"/>) consumes. Host enables DDC0 ONLY.
+    ///   - <c>Hermes.v:1483</c> <c>atten0 = FPGA_PTT ? atten0_on_Tx : Attenuator0</c>
+    ///     with <c>Tx_specific_C&amp;C.v:182-183</c> mapping byte 59 to
+    ///     <c>Angelia_atten_Tx0</c> — the TX-time ADC attenuator that protects the
+    ///     one RX ADC from the DAC feedback during a key-down (the byte-59 seed).
+    ///
+    /// Flipping this true autonomously is forbidden — see CLAUDE.md
+    /// "Hard Rules — PureSignal". The production flag flip and the final byte-59
+    /// seed value (<see cref="PsTxAdcProtectFloorDb"/>) require KB2UKA sign-off
+    /// plus 10E bench verification of first-key-down ADC overload.
+    /// </summary>
+    internal static bool Hermes10ePsTimeMuxOnAir;
+
+    /// <summary>
+    /// TX-time ADC-overload protection floor for the single-ADC time-mux PS
+    /// path (the byte-59 / <c>Angelia_atten_Tx0</c> seed). On a single-ADC board
+    /// the TX-DAC reference and PA coupler land on the one RX ADC during a TX
+    /// burst; byte 59 attenuates that ADC's TX-time input (gateware muxes it in
+    /// on <c>FPGA_PTT</c> — <c>Hermes.v:1483</c>, <c>Tx_specific_C&amp;C.v:182-183</c>).
+    /// 31 dB = the maximum (safest) attenuation, seeded so a fresh first key-down
+    /// with PS armed cannot slam the coupler into the ADC at 0 dB. The final
+    /// production value is bench-cal pending and KB2UKA-gated.
+    /// </summary>
+    internal const byte PsTxAdcProtectFloorDb = 31;
+
+    /// <summary>
+    /// True iff Zeus must seed the byte-59 (<c>Angelia_atten_Tx0</c>) TX-time ADC
+    /// attenuator to its protective floor (<see cref="PsTxAdcProtectFloorDb"/>)
+    /// while PS feedback is armed on this board — the single-ADC time-mux case
+    /// where the TX-DAC reference + PA coupler hit the one RX ADC on a TX burst.
+    ///
+    /// Scoped to the ANAN-10E (<see cref="HpsdrBoardKind.HermesII"/>) under the
+    /// <see cref="Hermes10ePsTimeMuxOnAir"/> interlock. The G2E (HermesC10)
+    /// byte-59 seed is a SEPARATE, independently-gated pre-condition (see the
+    /// <see cref="G2ePsTimeMuxOnAir"/> doc, pre-condition A) and is deliberately
+    /// NOT armed here — so the HermesC10 path stays byte-identical regardless of
+    /// this predicate. With the flag false this returns false for every board, so
+    /// no board is touched in production.
+    /// </summary>
+    internal static bool SeedsTxAdcProtection(HpsdrBoardKind board)
+        => board == HpsdrBoardKind.HermesII && Hermes10ePsTimeMuxOnAir;
+
+    /// <summary>
     /// True iff this board does Orion-style PureSignal on a SINGLE ADC by
     /// time-multiplexing DDC0 (issue #960) — the N1GP ANAN-G2E / HermesC10
     /// gateware. With command byte 1363 (SyncRx[0]) bit 1 (0x02) the Rx0 FIFO
@@ -1824,14 +1940,29 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     /// first slot -> rx, second slot -> tx), so the de-interleave is reused
     /// unchanged. Unlike the dual-ADC family (<see cref="ReservesPsFeedbackDdcs"/>)
     /// DDC0 is also the operator's only RX, so the feedback descriptor may be
-    /// armed ONLY during a TX burst and DDC0 reverts to user RX at rest. Gated by
-    /// <see cref="G2ePsTimeMuxOnAir"/> so the on-air path stays dark until the
-    /// byte-59 safety seed lands and the G2E is bench-verified. Hermes/HermesII
-    /// are deliberately excluded — their single-ADC mux is not gateware-verified
-    /// here and has no bench.
+    /// armed ONLY during a TX burst and DDC0 reverts to user RX at rest. Gated
+    /// per board by its own burn-zone interlock so the on-air path stays dark
+    /// until that board's byte-59 safety seed lands and it is bench-verified:
+    ///   - <see cref="HpsdrBoardKind.HermesC10"/> (ANAN-G2E) →
+    ///     <see cref="G2ePsTimeMuxOnAir"/>.
+    ///   - <see cref="HpsdrBoardKind.HermesII"/> (ANAN-10E) →
+    ///     <see cref="Hermes10ePsTimeMuxOnAir"/>. The 10E presents the identical
+    ///     coupler-first/reference-second interleave on DDC0 via command byte
+    ///     1363 — the <c>Mux</c> register on the 10E, where <c>Mux[1]</c> swings
+    ///     Rx1's input to <c>temp_DACD</c> (the TX-DAC reference) — so the same
+    ///     compose/decode machinery applies (anan-10e_100b/P2-gateware/
+    ///     Hermes_v10.3/Hermes.v:684-687, :1080-1093, Rx_specific_C&amp;C.v:181).
+    /// Plain <see cref="HpsdrBoardKind.Hermes"/> is deliberately excluded — its
+    /// single-ADC mux is not gateware-verified here and has no bench. Both flags
+    /// default false, so this is dark for every board in production.
     /// </summary>
     public static bool TimeMuxesPsFeedbackOnDdc0(HpsdrBoardKind board)
-        => G2ePsTimeMuxOnAir && board == HpsdrBoardKind.HermesC10;
+        => board switch
+        {
+            HpsdrBoardKind.HermesC10 => G2ePsTimeMuxOnAir,
+            HpsdrBoardKind.HermesII  => Hermes10ePsTimeMuxOnAir,
+            _                        => false,
+        };
 
     /// <summary>
     /// RX-thread dispatch decision (issue #960) — should an inbound DDC0 packet

--- a/tests/Zeus.Protocol2.Tests/PsFeedbackDdcRoutingTests.cs
+++ b/tests/Zeus.Protocol2.Tests/PsFeedbackDdcRoutingTests.cs
@@ -8,6 +8,7 @@
 // See ATTRIBUTIONS.md at the repository root for the full provenance
 // statement and per-component attribution.
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 using Zeus.Contracts;
 
@@ -464,5 +465,312 @@ public class PsFeedbackDdcRoutingTests
         Assert.True(rxQ > 0.49f && rxQ < 0.51f, $"coupler Q -> rx ~+0.5, got {rxQ}");
         Assert.True(txI < -0.99f, $"reference I should map to tx ~-1.0, got {txI}");
         Assert.True(txQ < -0.49f && txQ > -0.51f, $"reference Q -> tx ~-0.5, got {txQ}");
+    }
+
+    // -----------------------------------------------------------------------
+    // ANAN-10E (HermesII) single-ADC time-multiplexed PS feedback.
+    //
+    // The 10E PS feedback is byte-for-byte identical on the wire to the G2E
+    // (HermesC10) single-ADC time-mux path above — it differs only in the
+    // firmware register NAME (command byte 1363 is the `Mux` register on the
+    // 10E, where Mux[1] swings Rx1's input to temp_DACD) and the reference
+    // source, not in any byte Zeus emits/decodes. Firmware ground truth:
+    // anan-10e_100b/P2-gateware/Hermes_v10.3/Hermes.v:684-687, :1080-1093,
+    // :1483 and Rx_specific_C&C.v:181 / Tx_specific_C&C.v:182-183.
+    //
+    // SAFETY — the on-air path is held DARK by the burn-zone interlock
+    // Protocol2Client.Hermes10ePsTimeMuxOnAir (PureSignal hard rule), the
+    // sibling of G2ePsTimeMuxOnAir. With it false (production default) the
+    // HermesII wire/behaviour is byte-identical to PS-disabled-on-single-ADC:
+    // no feedback descriptor, no byte-59 seed, ComposesPsFeedbackWire false.
+    // It must not be flipped true until the byte-59 (Angelia_atten_Tx0)
+    // protective seed value is signed off by KB2UKA AND a real 10E
+    // bench-verifies first-key-down ADC overload.
+    //
+    // The flag is process-global. These tests live in THIS class (which is the
+    // only one that reads the time-mux flags) so they run sequentially with the
+    // dark-assertion tests above, and every mutation is restored in try/finally
+    // — no other test ever observes a lifted interlock. Pure routing logic is
+    // exercised by injecting timeMuxOnDdc0 explicitly (no static mutation).
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void TimeMuxesPsFeedbackOnDdc0_HermesII_TracksHermes10eFlag_AndIsDarkByDefault()
+    {
+        // Default (production): the 10E interlock is down, so the time-mux
+        // capability is false — byte-identical to PS-disabled.
+        Assert.False(Protocol2Client.Hermes10ePsTimeMuxOnAir);
+        Assert.False(Protocol2Client.TimeMuxesPsFeedbackOnDdc0(HpsdrBoardKind.HermesII));
+
+        bool savedG2e = Protocol2Client.G2ePsTimeMuxOnAir;
+        bool saved10e = Protocol2Client.Hermes10ePsTimeMuxOnAir;
+        try
+        {
+            // Lifting ONLY the 10E interlock turns the 10E capability on and
+            // leaves every other board exactly where it was: the G2E still
+            // tracks its OWN (still-down) flag, and Hermes / the dual-ADC
+            // family stay false.
+            Protocol2Client.Hermes10ePsTimeMuxOnAir = true;
+            Assert.True(Protocol2Client.TimeMuxesPsFeedbackOnDdc0(HpsdrBoardKind.HermesII));
+            Assert.False(Protocol2Client.TimeMuxesPsFeedbackOnDdc0(HpsdrBoardKind.HermesC10));
+            Assert.False(Protocol2Client.TimeMuxesPsFeedbackOnDdc0(HpsdrBoardKind.Hermes));
+            Assert.False(Protocol2Client.TimeMuxesPsFeedbackOnDdc0(HpsdrBoardKind.OrionMkII));
+        }
+        finally
+        {
+            Protocol2Client.G2ePsTimeMuxOnAir = savedG2e;
+            Protocol2Client.Hermes10ePsTimeMuxOnAir = saved10e;
+        }
+
+        Assert.False(Protocol2Client.Hermes10ePsTimeMuxOnAir); // restored
+    }
+
+    [Fact]
+    public void TimeMuxesPsFeedbackOnDdc0_G2E_StillTracksOwnFlag_IndependentOf10e()
+    {
+        // Regression lock: the G2E remains gated by G2ePsTimeMuxOnAir ALONE.
+        // Flipping the 10E flag must not affect the G2E (and vice-versa).
+        bool savedG2e = Protocol2Client.G2ePsTimeMuxOnAir;
+        bool saved10e = Protocol2Client.Hermes10ePsTimeMuxOnAir;
+        try
+        {
+            Protocol2Client.Hermes10ePsTimeMuxOnAir = true;
+            Protocol2Client.G2ePsTimeMuxOnAir = false;
+            Assert.False(Protocol2Client.TimeMuxesPsFeedbackOnDdc0(HpsdrBoardKind.HermesC10));
+
+            Protocol2Client.G2ePsTimeMuxOnAir = true;
+            Protocol2Client.Hermes10ePsTimeMuxOnAir = false;
+            Assert.True(Protocol2Client.TimeMuxesPsFeedbackOnDdc0(HpsdrBoardKind.HermesC10));
+            Assert.False(Protocol2Client.TimeMuxesPsFeedbackOnDdc0(HpsdrBoardKind.HermesII));
+        }
+        finally
+        {
+            Protocol2Client.G2ePsTimeMuxOnAir = savedG2e;
+            Protocol2Client.Hermes10ePsTimeMuxOnAir = saved10e;
+        }
+    }
+
+    [Fact]
+    public void Routes_Hermes10e_TimeMux_FalseAtRest_TrueInBurst()
+    {
+        // Core "feedback only during the burst, never at rest" property for the
+        // 10E. Injected timeMuxOnDdc0 (no static mutation) — pure routing logic.
+        Assert.False(Protocol2Client.RoutesDdc0ToPsFeedback(
+            psFeedbackEnabled: true, ddcIndex: 0, HpsdrBoardKind.HermesII,
+            txKeyed: false, timeMuxOnDdc0: true));   // at rest -> user RX
+        Assert.True(Protocol2Client.RoutesDdc0ToPsFeedback(
+            psFeedbackEnabled: true, ddcIndex: 0, HpsdrBoardKind.HermesII,
+            txKeyed: true, timeMuxOnDdc0: true));     // in burst -> feedback
+    }
+
+    [Fact]
+    public void Routes_Hermes10e_NeverEngagesWhenPsDisarmed()
+    {
+        // No auto-arm: even mid-burst with the capability on, an unarmed PS
+        // never routes DDC0 to feedback.
+        Assert.False(Protocol2Client.RoutesDdc0ToPsFeedback(
+            psFeedbackEnabled: false, ddcIndex: 0, HpsdrBoardKind.HermesII,
+            txKeyed: true, timeMuxOnDdc0: true));
+    }
+
+    [Fact]
+    public void Routes_Hermes10e_Production_DarkEvenInBurst()
+    {
+        // End-to-end production wiring: feeding the GATED capability
+        // (TimeMuxesPsFeedbackOnDdc0, dark) keeps the 10E on the user RX even
+        // mid-burst with PS armed — byte-identical to PS-disabled until the
+        // interlock lifts.
+        Assert.False(Protocol2Client.RoutesDdc0ToPsFeedback(
+            psFeedbackEnabled: true, ddcIndex: 0, HpsdrBoardKind.HermesII,
+            txKeyed: true,
+            timeMuxOnDdc0: Protocol2Client.TimeMuxesPsFeedbackOnDdc0(HpsdrBoardKind.HermesII)));
+    }
+
+    [Fact]
+    public void Compose_Hermes10e_FeedbackBurst_ByteExact()
+    {
+        // The 10E TX-burst feedback descriptor is byte-for-byte the G2E burst:
+        // DDC0 enable ONLY (no DDC1), ADC0, 192 kHz / 24-bit, byte 1363 = 0x02
+        // (Mux[1] = coupler/reference interleave). Same composer, board HermesII.
+        var p = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 9, numAdc: 1, sampleRateKhz: 192, psEnabled: true,
+            boardKind: HpsdrBoardKind.HermesII, g2eFeedbackBurst: true);
+
+        Assert.Equal((byte)1, p[4]);        // single ADC
+        Assert.Equal((byte)0x01, p[7]);     // DDC0 enable only, NO DDC1
+        Assert.Equal((byte)0x00, p[17]);    // DDC0 ADC0
+        Assert.Equal((byte)0x00, p[18]);    // DDC0 192 kHz BE high
+        Assert.Equal((byte)0xC0, p[19]);    // DDC0 192 kHz BE low
+        Assert.Equal((byte)24, p[22]);      // DDC0 24-bit
+        Assert.Equal((byte)0x02, p[1363]);  // Mux[1] interleave
+    }
+
+    [Fact]
+    public void Compose_Hermes10e_AtRest_PsArmed_NoFeedbackDescriptor()
+    {
+        // PS armed but NOT in a burst: the 10E descriptor stays plain user RX —
+        // DDC0 only, no sync byte. The "never at rest" compose-side guarantee.
+        var p = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 9, numAdc: 1, sampleRateKhz: 192, psEnabled: true,
+            boardKind: HpsdrBoardKind.HermesII, g2eFeedbackBurst: false);
+
+        Assert.Equal((byte)0x01, p[7]);     // only DDC0 enable (user RX)
+        Assert.Equal((byte)0x00, p[1363]);  // no interleave sync
+    }
+
+    [Theory]
+    [InlineData(HpsdrBoardKind.HermesC10)]
+    [InlineData(HpsdrBoardKind.Hermes)]
+    [InlineData(HpsdrBoardKind.HermesII)]
+    public void ComposesPsFeedbackWire_HermesII_StaysFalse_EvenWithFlagOn(HpsdrBoardKind board)
+    {
+        // The 10E PS engages via byte 1363 + byte 59 + the paired decode ONLY —
+        // never via the dual-ADC PS wire bytes (ALEX_PS, p[57]/p[58] PS shape).
+        // ComposesPsFeedbackWire stays false for every single-ADC board even
+        // with the 10E interlock lifted, so no PS-shaped bytes ever compose.
+        bool saved10e = Protocol2Client.Hermes10ePsTimeMuxOnAir;
+        try
+        {
+            Protocol2Client.Hermes10ePsTimeMuxOnAir = true;
+            Assert.False(Protocol2Client.ComposesPsFeedbackWire(
+                psFeedbackEnabled: true, board));
+        }
+        finally
+        {
+            Protocol2Client.Hermes10ePsTimeMuxOnAir = saved10e;
+        }
+    }
+
+    // ---- byte-59 (Angelia_atten_Tx0) TX-time ADC-overload protection seed ----
+
+    [Theory]
+    [InlineData(HpsdrBoardKind.HermesII)]
+    [InlineData(HpsdrBoardKind.HermesC10)]
+    [InlineData(HpsdrBoardKind.Hermes)]
+    [InlineData(HpsdrBoardKind.OrionMkII)]
+    public void SeedsTxAdcProtection_DarkInProduction_ForEveryBoard(HpsdrBoardKind board)
+    {
+        // With both interlocks down (production) NO board seeds byte 59 — so the
+        // CmdTx wire is byte-identical to today for every board.
+        Assert.False(Protocol2Client.SeedsTxAdcProtection(board));
+    }
+
+    [Fact]
+    public void SeedsTxAdcProtection_True_OnlyForHermesII_WhenFlagOn()
+    {
+        // With the 10E interlock lifted, ONLY the 10E seeds byte 59. The G2E
+        // byte-59 seed is a SEPARATE, independently-gated pre-condition and is
+        // deliberately NOT armed here, so the HermesC10 path is unchanged.
+        bool saved10e = Protocol2Client.Hermes10ePsTimeMuxOnAir;
+        bool savedG2e = Protocol2Client.G2ePsTimeMuxOnAir;
+        try
+        {
+            Protocol2Client.Hermes10ePsTimeMuxOnAir = true;
+            Protocol2Client.G2ePsTimeMuxOnAir = true; // even with G2E lifted too
+            Assert.True(Protocol2Client.SeedsTxAdcProtection(HpsdrBoardKind.HermesII));
+            Assert.False(Protocol2Client.SeedsTxAdcProtection(HpsdrBoardKind.HermesC10));
+            Assert.False(Protocol2Client.SeedsTxAdcProtection(HpsdrBoardKind.Hermes));
+            Assert.False(Protocol2Client.SeedsTxAdcProtection(HpsdrBoardKind.OrionMkII));
+        }
+        finally
+        {
+            Protocol2Client.Hermes10ePsTimeMuxOnAir = saved10e;
+            Protocol2Client.G2ePsTimeMuxOnAir = savedG2e;
+        }
+    }
+
+    [Fact]
+    public void Compose_Hermes10e_TxSpecific_NonPsShape_ProtectiveByte59Reaches_Wire()
+    {
+        // ComposesPsFeedbackWire(HermesII) is false, so ComposeCmdTxBuffer takes
+        // the non-PS branch: p[57]=p[58]=p[59]=txStepAttnDb. The seed sets
+        // txStepAttnDb to the protective floor (31), so byte 59 is protective on
+        // the wire — exactly what the gateware reads on FPGA_PTT (Hermes.v:1483).
+        bool gate = Protocol2Client.ComposesPsFeedbackWire(
+            psFeedbackEnabled: true, HpsdrBoardKind.HermesII);
+        Assert.False(gate);
+
+        var p = Protocol2Client.ComposeCmdTxBuffer(
+            seq: 1, sampleRateKhz: 192,
+            txStepAttnDb: Protocol2Client.PsTxAdcProtectFloorDb,
+            paEnabled: true, psEnabled: gate);
+        Assert.Equal(Protocol2Client.PsTxAdcProtectFloorDb, p[57]);
+        Assert.Equal(Protocol2Client.PsTxAdcProtectFloorDb, p[58]);
+        Assert.Equal(Protocol2Client.PsTxAdcProtectFloorDb, p[59]); // protective
+        Assert.True(p[59] >= 1, "byte 59 must clear the ADC-overload floor");
+    }
+
+    [Fact]
+    public void SetPsFeedbackEnabled_HermesII_FlagOff_DoesNotSeedByte59()
+    {
+        // Production (interlock down): arming PS on a 10E leaves the operator's
+        // TX step-att untouched — byte-identical to today, no seed.
+        using var p2 = new Protocol2Client(NullLogger<Protocol2Client>.Instance);
+        p2.SetBoardKind(HpsdrBoardKind.HermesII);
+        p2.SetTxAttenuationDb(3);
+        Assert.Equal((byte)3, p2.TxStepAttnDb);
+
+        p2.SetPsFeedbackEnabled(true);
+        Assert.Equal((byte)3, p2.TxStepAttnDb); // unchanged — no seed
+        p2.SetPsFeedbackEnabled(false);
+        Assert.Equal((byte)3, p2.TxStepAttnDb);
+    }
+
+    [Fact]
+    public void SetPsFeedbackEnabled_HermesII_FlagOn_SeedsByte59_RestoresOnDisarm()
+    {
+        // Interlock lifted: arming PS on a 10E seeds the byte-59 protective floor
+        // (31) so the TX-DAC feedback can't slam the only RX ADC at 0 dB on
+        // first key-down; disarm restores the operator's prior value verbatim.
+        bool saved10e = Protocol2Client.Hermes10ePsTimeMuxOnAir;
+        try
+        {
+            Protocol2Client.Hermes10ePsTimeMuxOnAir = true;
+            using var p2 = new Protocol2Client(NullLogger<Protocol2Client>.Instance);
+            p2.SetBoardKind(HpsdrBoardKind.HermesII);
+            p2.SetTxAttenuationDb(3);
+
+            p2.SetPsFeedbackEnabled(true);
+            Assert.Equal(Protocol2Client.PsTxAdcProtectFloorDb, p2.TxStepAttnDb); // 31
+
+            p2.SetPsFeedbackEnabled(false);
+            Assert.Equal((byte)3, p2.TxStepAttnDb); // restored
+        }
+        finally
+        {
+            Protocol2Client.Hermes10ePsTimeMuxOnAir = saved10e;
+        }
+    }
+
+    [Theory]
+    [InlineData(HpsdrBoardKind.HermesC10)]
+    [InlineData(HpsdrBoardKind.OrionMkII)]
+    [InlineData(HpsdrBoardKind.Hermes)]
+    public void SetPsFeedbackEnabled_NonHermesII_FlagOn_DoesNotSeedByte59(HpsdrBoardKind board)
+    {
+        // Zero-regression: with the 10E interlock lifted (AND the G2E one too),
+        // arming PS on any OTHER board never touches the TX step-att — the seed
+        // is HermesII-scoped. The G2E keeps its own separate, unimplemented
+        // byte-59 pre-condition; the dual-ADC family is unaffected.
+        bool saved10e = Protocol2Client.Hermes10ePsTimeMuxOnAir;
+        bool savedG2e = Protocol2Client.G2ePsTimeMuxOnAir;
+        try
+        {
+            Protocol2Client.Hermes10ePsTimeMuxOnAir = true;
+            Protocol2Client.G2ePsTimeMuxOnAir = true;
+            using var p2 = new Protocol2Client(NullLogger<Protocol2Client>.Instance);
+            p2.SetBoardKind(board);
+            p2.SetTxAttenuationDb(3);
+
+            p2.SetPsFeedbackEnabled(true);
+            Assert.Equal((byte)3, p2.TxStepAttnDb); // unchanged
+            p2.SetPsFeedbackEnabled(false);
+            Assert.Equal((byte)3, p2.TxStepAttnDb);
+        }
+        finally
+        {
+            Protocol2Client.Hermes10ePsTimeMuxOnAir = saved10e;
+            Protocol2Client.G2ePsTimeMuxOnAir = savedG2e;
+        }
     }
 }


### PR DESCRIPTION
## The actual 10E PureSignal production change (burn-zone)

Standalone from the virtual-radio tooling — this PR is **only** the Zeus production change: `Zeus.Protocol2/Protocol2Client.cs` + its unit tests. The emulator + the end-to-end PS proof live separately in #1208.

### What
The ANAN-10E hardware does PureSignal via single-ADC **time-mux** (Rx1 input `Mux[1] ? DAC : ADC`, CmdRx byte 1363=0x02, feeding the DAC reference back through the single RX ADC). Zeus had PS disabled for all single-ADC Hermes-class boards. This wires it for the 10E, mirroring the existing G2E/HermesC10 design.

### Gated DARK — safe by construction
- **New internal flag `Hermes10ePsTimeMuxOnAir`, DEFAULT FALSE, HermesII-scoped.** With it false (production), the wire is **byte-identical to today for every board** — the predicate switch is algebraically identical for all non-HermesII boards in both flag states.
- **byte-59 (`Angelia_atten_Tx0`) ADC-overload protection** seeded to 31 dB (max) on arm, restored on disarm.
- **`PsEnabled` startup-init untouched.** Zero change to the dual-ADC paired-DDC path, the HermesC10 branch, or any other board.

### Tests
`Zeus.Protocol2.Tests` **287/287** (PS routing 64/64, incl. the G2E dark assertions). +13 HermesII cases prove: flag-false → no PS wire; flag-true → byte 1363=0x02 + byte-59 seed; other boards unaffected with either flag.

### ⚠️ Not for real RF without KB2UKA sign-off
- The flag stays **dark**. Flipping it true in production + finalizing the byte-59 protective floor require **bench validation on a real 10E** (first-key-down ADC overload).
- Known bench-gated item (flag-true path only, unreachable in production): `SetTxAttenuationDb` doesn't refresh the pre-arm seed, so a mid-PS attenuation change could revert on disarm. Should be fixed before the flag ever goes on-air.

**Red-light:** PureSignal / burn-zone. KB2UKA-directed; draft pending bench sign-off.