### PR TITLE
fix(web): hydrate receiver protocol from state

### DIFF
--- a/Zeus.Contracts/Dtos.cs
+++ b/Zeus.Contracts/Dtos.cs
@@ -1271,6 +1271,11 @@ public sealed record StateDto(
     // reports 6; Protocol 3-capable G2 firmware can report the full 10.
     int MaxReceivers = WireContract.MaxReceivers,
 
+    // Active wire protocol for the current radio session. This is duplicated
+    // from RadioService runtime state so /api/state is self-contained after a
+    // browser reload; null when disconnected.
+    string? ConnectedProtocol = null,
+
     // ---- VFO lock (Thetis chkVFOLock) ----
     // Pure software guard: when true, operator dial tuning (panadapter click,
     // wheel, typed entry) is rejected so an accidental knob bump can't move the

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -876,7 +876,18 @@ public sealed class RadioService : IDisposable
         get { lock (_sync) return _mox; }
     }
 
-    public StateDto Snapshot() { lock (_sync) return _state with { Receivers = ProjectReceivers(_state), MaxReceivers = EffectiveMaxReceivers }; }
+    public StateDto Snapshot()
+    {
+        lock (_sync)
+        {
+            return _state with
+            {
+                Receivers = ProjectReceivers(_state),
+                MaxReceivers = EffectiveMaxReceivers,
+                ConnectedProtocol = ConnectedProtocolLocked(),
+            };
+        }
+    }
 
     /// <summary>Current operator preamp toggle. PreampOn isn't on the
     /// StateDto wire format, so DspPipelineService reads it directly when
@@ -4035,7 +4046,12 @@ public sealed class RadioService : IDisposable
             // fields on every mutation so StateChanged subscribers and the
             // SignalR broadcast always carry an up-to-date Receivers[] (wire
             // v2). Pure function of the flat fields — cheap (1–2 elements).
-            next = next with { Receivers = ProjectReceivers(next), MaxReceivers = EffectiveMaxReceivers };
+            next = next with
+            {
+                Receivers = ProjectReceivers(next),
+                MaxReceivers = EffectiveMaxReceivers,
+                ConnectedProtocol = ConnectedProtocolLocked(),
+            };
             _state = next;
         }
         _stateDirty = true;
@@ -4375,6 +4391,13 @@ public sealed class RadioService : IDisposable
             if (connected != HpsdrBoardKind.Unknown) return connected;
             return _preferredRadioStore?.Get() ?? HpsdrBoardKind.Unknown;
         }
+    }
+
+    private string? ConnectedProtocolLocked()
+    {
+        if (_p2Active) return "P2";
+        if (_activeClient is not null) return "P1";
+        return null;
     }
 
     // Board-aware count of user-visible receivers the connected radio can

--- a/zeus-web/src/api/client.test.ts
+++ b/zeus-web/src/api/client.test.ts
@@ -242,6 +242,7 @@ describe('normalizeState', () => {
     const s = normalizeState({
       wireVersion: 2,
       maxReceivers: 8,
+      connectedProtocol: 'P2',
       receivers: [
         { index: 0, enabled: true, adcSource: 0, vfoHz: 7_100_000, mode: 'LSB' },
         { index: 1, enabled: true, adcSource: 0, vfoHz: 7_150_000, mode: 'USB' },
@@ -250,6 +251,7 @@ describe('normalizeState', () => {
     });
     expect(s.wireVersion).toBe(2);
     expect(s.maxReceivers).toBe(8);
+    expect(s.connectedProtocol).toBe('P2');
     expect(s.receivers).toHaveLength(3);
     expect(s.receivers?.[2]).toMatchObject({ index: 2, enabled: true, adcSource: 1, mode: 'USB' });
   });
@@ -259,6 +261,7 @@ describe('normalizeState', () => {
     const s = normalizeState({});
     expect(s.receivers).toBeUndefined();
     expect(s.maxReceivers).toBeUndefined();
+    expect(s.connectedProtocol).toBeUndefined();
     expect(s.wireVersion).toBeUndefined();
   });
   it('reads zoomLevel from the server', () => {

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -451,6 +451,9 @@ export type RadioStateDto = {
   wireVersion?: number;
   // Active hardware DDC / receiver ceiling for this connection.
   maxReceivers?: number;
+  // Active backend wire protocol for the current connection. Present on v2+
+  // servers so reloads can recover protocol-gated Settings panels.
+  connectedProtocol?: 'P1' | 'P2' | null;
 };
 
 // Mirrors Zeus.Contracts.ReceiverDto — per-receiver (per-DDC) state. Index 0 is
@@ -2438,6 +2441,12 @@ function normalizeReceiver(raw: unknown, fallbackIndex: number): ReceiverDto {
   };
 }
 
+function normalizeConnectedProtocol(raw: unknown): 'P1' | 'P2' | null | undefined {
+  if (raw === undefined) return undefined;
+  if (raw === null) return null;
+  return raw === 'P1' || raw === 'P2' ? raw : null;
+}
+
 export function normalizeState(raw: unknown): RadioStateDto {
   const r = (raw ?? {}) as Record<string, unknown>;
   return {
@@ -2563,6 +2572,7 @@ export function normalizeState(raw: unknown): RadioStateDto {
       : undefined,
     wireVersion: typeof r.wireVersion === 'number' ? r.wireVersion : undefined,
     maxReceivers: typeof r.maxReceivers === 'number' ? r.maxReceivers : undefined,
+    connectedProtocol: normalizeConnectedProtocol(r.connectedProtocol),
   };
 }
 

--- a/zeus-web/src/state/connection-store.multiselect.test.ts
+++ b/zeus-web/src/state/connection-store.multiselect.test.ts
@@ -5,10 +5,17 @@
 // primary (always a member) whose values the controls display.
 
 import { beforeEach, describe, expect, it } from 'vitest';
+import type { RadioStateDto } from '../api/client';
 import { useConnectionStore } from './connection-store';
 
 function reset() {
-  useConnectionStore.setState({ focusedRxIndex: 0, selectedRxIndices: [0], rxFocus: 'A' });
+  useConnectionStore.setState({
+    status: 'Disconnected',
+    connectedProtocol: null,
+    focusedRxIndex: 0,
+    selectedRxIndices: [0],
+    rxFocus: 'A',
+  });
 }
 
 describe('connection-store multi-select', () => {
@@ -79,5 +86,25 @@ describe('connection-store multi-select', () => {
     expect(useConnectionStore.getState().rxFocus).toBe('B');
     useConnectionStore.getState().setFocusedRxIndex(0);
     expect(useConnectionStore.getState().rxFocus).toBe('A');
+  });
+
+  it('hydrates connectedProtocol from StateDto', () => {
+    const base = useConnectionStore.getState() as unknown as RadioStateDto;
+
+    useConnectionStore.getState().applyState({
+      ...base,
+      status: 'Connected',
+      connectedProtocol: 'P2',
+    });
+
+    expect(useConnectionStore.getState().connectedProtocol).toBe('P2');
+
+    useConnectionStore.getState().applyState({
+      ...base,
+      status: 'Disconnected',
+      connectedProtocol: null,
+    });
+
+    expect(useConnectionStore.getState().connectedProtocol).toBeNull();
   });
 });

--- a/zeus-web/src/state/connection-store.ts
+++ b/zeus-web/src/state/connection-store.ts
@@ -285,6 +285,12 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
         // adopts all other server fields) until the optimistic window expires.
         receivers: mergeReceivers(prev.receivers, s.receivers, trustVfo),
         maxReceivers: s.maxReceivers ?? prev.maxReceivers,
+        connectedProtocol:
+          s.connectedProtocol !== undefined
+            ? s.connectedProtocol
+            : s.status === 'Disconnected'
+            ? null
+            : prev.connectedProtocol,
         txVfo: s.txVfo,
         txReceiverIndex: s.txReceiverIndex ?? prev.txReceiverIndex,
         rxFocus: s.rx2Enabled ? prev.rxFocus : 'A',


### PR DESCRIPTION
## Summary
- Adds `connectedProtocol` to `/api/state` so state hydration carries the active P1/P2 session.
- Hydrates the frontend connection store from that field, preventing the Receivers settings panel from blanking when `connectedProtocol` was stale after reload/state-only startup.
- Covers protocol normalization and store hydration with focused tests.

## Notes
- This fixes the blank Receivers panel path. The separate backend/wire-contract question for exposing 10 DDCs on protocol/board `0x0A` is tracked as beads issue `zeus-uocw`.

## Tests
- `npm --prefix zeus-web run test -- client.test.ts connection-store.multiselect.test.ts ReceiversPanel.test.tsx`
- `npm --prefix zeus-web run build` after `git submodule update --init zeus-web/external/deepcw-engine`
- `dotnet build Zeus.Server.Hosting/Zeus.Server.Hosting.csproj -c Debug`
- `dotnet test tests/Zeus.Contracts.Tests/Zeus.Contracts.Tests.csproj -c Debug --no-build`
- `dotnet test tests/Zeus.Server.Tests/Zeus.Server.Tests.csproj -c Debug --no-build --filter FullyQualifiedName~RadioService` with isolated `ZEUS_PREFS_PATH`