### PR TITLE
fix: connect Protocol 3 through N9DSP sidecar

### DIFF
--- a/Zeus.Server.Hosting/Protocol3SidecarBridge.cs
+++ b/Zeus.Server.Hosting/Protocol3SidecarBridge.cs
@@ -1,0 +1,518 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus - OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+
+using System.Diagnostics;
+using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
+using System.Text.Json.Nodes;
+
+namespace Zeus.Server;
+
+public sealed record Protocol3SidecarSnapshot(
+    Uri DiagnosticsUrl,
+    string Status,
+    string DspEngine,
+    int RxExpectedStreams,
+    int RxActiveStreams,
+    int DspActiveChannels);
+
+public sealed class Protocol3SidecarBridge : IDisposable
+{
+    public const string HttpClientName = "Protocol3Sidecar";
+    private const string HostedSessionArmValue = "ENABLE_SIDECAR_P3_HOSTED_SESSION";
+
+    private readonly object _sync = new();
+    private readonly IHttpClientFactory _httpFactory;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<Protocol3SidecarBridge> _log;
+    private Process? _process;
+    private ProcessOutputTail? _processOutput;
+    private bool _ownsProcess;
+    private Uri? _diagnosticsUrl;
+    private Protocol3SidecarSnapshot? _lastSnapshot;
+
+    public Protocol3SidecarBridge(
+        IHttpClientFactory httpFactory,
+        IConfiguration configuration,
+        ILogger<Protocol3SidecarBridge> log)
+    {
+        _httpFactory = httpFactory;
+        _configuration = configuration;
+        _log = log;
+    }
+
+    public object Status
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return new
+                {
+                    configured = ExistingDiagnosticsUrl() is not null ||
+                        !string.IsNullOrWhiteSpace(Setting("Project", "ZEUS_PROTOCOL3_SIDECAR_PROJECT")),
+                    running = _process is { HasExited: false } || (_diagnosticsUrl is not null && !_ownsProcess),
+                    diagnosticsUrl = _diagnosticsUrl?.ToString(),
+                    last = _lastSnapshot,
+                    sidecarOutput = _processOutput?.Snapshot(),
+                };
+            }
+        }
+    }
+
+    public async Task<Protocol3SidecarSnapshot> ConnectAsync(
+        IPEndPoint radioEndpoint,
+        int p3Port,
+        int sampleRateHz,
+        int rxStreams,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(radioEndpoint);
+        if (p3Port is < 1 or > 65535) throw new ArgumentOutOfRangeException(nameof(p3Port));
+        if (sampleRateHz <= 0) throw new ArgumentOutOfRangeException(nameof(sampleRateHz));
+        if (rxStreams is < 1 or > 10) throw new ArgumentOutOfRangeException(nameof(rxStreams));
+
+        var existingUrl = ExistingDiagnosticsUrl();
+        if (existingUrl is not null)
+        {
+            var existing = await WaitForReadyAsync(existingUrl, rxStreams, TimeSpan.FromSeconds(10), ct)
+                .ConfigureAwait(false);
+            Remember(existing, ownsProcess: false, process: null);
+            return existing;
+        }
+
+        var project = FullPathSetting("Project", "ZEUS_PROTOCOL3_SIDECAR_PROJECT");
+        var n9dspLibrary = FullPathSetting("N9DspLibrary", "ZEUS_PROTOCOL3_N9DSP_LIBRARY");
+        if (string.IsNullOrWhiteSpace(project) || string.IsNullOrWhiteSpace(n9dspLibrary))
+        {
+            throw new InvalidOperationException(
+                "Protocol 3 sidecar is not configured. Set ZEUS_PROTOCOL3_SIDECAR_PROJECT to the private " +
+                "Zeus.Protocol3.Probe.csproj and ZEUS_PROTOCOL3_N9DSP_LIBRARY to the private n9dsp native library.");
+        }
+        if (!File.Exists(project))
+            throw new InvalidOperationException($"Protocol 3 sidecar project was not found: {project}");
+        if (!File.Exists(n9dspLibrary))
+            throw new InvalidOperationException($"N9DSP native library was not found: {n9dspLibrary}");
+
+        await DisconnectAsync(ct).ConfigureAwait(false);
+
+        var listenUrl = ListenUrl();
+        var diagnosticsUrl = DiagnosticsUrlForListen(listenUrl);
+        var psi = BuildStartInfo(project, n9dspLibrary, listenUrl, radioEndpoint.Address, p3Port, sampleRateHz, rxStreams);
+        var process = Process.Start(psi) ??
+            throw new InvalidOperationException("Protocol 3 sidecar process did not start.");
+        var output = ProcessOutputTail.Attach(process);
+        Remember(null, true, process, diagnosticsUrl, output);
+        _log.LogInformation(
+            "p3.sidecar.start pid={Pid} radio={Radio} p3Port={Port} diagnostics={Diagnostics}",
+            process.Id,
+            radioEndpoint.Address,
+            p3Port,
+            diagnosticsUrl);
+
+        try
+        {
+            var snapshot = await WaitForReadyAsync(diagnosticsUrl, rxStreams, TimeSpan.FromSeconds(15), ct)
+                .ConfigureAwait(false);
+            Remember(snapshot, true, process, diagnosticsUrl, output);
+            return snapshot;
+        }
+        catch
+        {
+            await DisconnectAsync(CancellationToken.None).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    public async Task DisconnectAsync(CancellationToken ct)
+    {
+        Process? process;
+        bool kill;
+        lock (_sync)
+        {
+            process = _process;
+            kill = _ownsProcess;
+            _process = null;
+            _processOutput = null;
+            _ownsProcess = false;
+            _diagnosticsUrl = null;
+            _lastSnapshot = null;
+        }
+
+        if (process is null || !kill) return;
+
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+                await process.WaitForExitAsync(ct).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _log.LogDebug(ex, "p3.sidecar.stop.error");
+        }
+        finally
+        {
+            process.Dispose();
+        }
+    }
+
+    public void Dispose()
+    {
+        try { DisconnectAsync(CancellationToken.None).GetAwaiter().GetResult(); }
+        catch { }
+    }
+
+    internal static Protocol3SidecarSnapshot ValidateDiagnosticsSnapshot(
+        JsonObject diagnostics,
+        Uri diagnosticsUrl,
+        int expectedRxStreams)
+    {
+        ArgumentNullException.ThrowIfNull(diagnostics);
+        ArgumentNullException.ThrowIfNull(diagnosticsUrl);
+        ValidateDiagnosticsUrl(diagnosticsUrl);
+
+        var protocol = RequiredString(diagnostics, "protocol");
+        if (!string.Equals(protocol, "p3", StringComparison.Ordinal))
+            throw new InvalidOperationException($"Protocol 3 sidecar diagnostics reported protocol '{protocol}', expected 'p3'.");
+
+        var p3 = RequiredObject(diagnostics, "p3");
+        var status = RequiredString(p3, "status");
+        if (!string.Equals(status, "ok", StringComparison.Ordinal) &&
+            !string.Equals(status, "degraded", StringComparison.Ordinal))
+            throw new InvalidOperationException(
+                $"Protocol 3 sidecar diagnostics status is '{status}', expected 'ok' or 'degraded'.");
+
+        var rxActive = RequiredInt(p3, "rxActiveStreams");
+        var rxExpected = p3.ContainsKey("rxExpectedStreams")
+            ? RequiredInt(p3, "rxExpectedStreams")
+            : rxActive;
+        if (rxExpected < expectedRxStreams || rxActive < expectedRxStreams)
+            throw new InvalidOperationException(
+                $"Protocol 3 sidecar reported {rxActive}/{rxExpected} RX streams; Zeus requires {expectedRxStreams}.");
+
+        var dsp = RequiredObject(p3, "dsp");
+        var engine = RequiredString(dsp, "engine");
+        if (!string.Equals(engine, "n9dsp", StringComparison.Ordinal))
+            throw new InvalidOperationException($"Protocol 3 sidecar DSP engine is '{engine}', expected 'n9dsp'.");
+
+        var dspChannels = dsp.ContainsKey("activeChannels")
+            ? RequiredInt(dsp, "activeChannels")
+            : rxActive;
+        if (dspChannels < expectedRxStreams)
+            throw new InvalidOperationException(
+                $"Protocol 3 sidecar N9DSP reports {dspChannels} active DSP channels; Zeus requires {expectedRxStreams}.");
+
+        return new Protocol3SidecarSnapshot(
+            diagnosticsUrl,
+            status,
+            engine,
+            rxExpected,
+            rxActive,
+            dspChannels);
+    }
+
+    private async Task<Protocol3SidecarSnapshot> WaitForReadyAsync(
+        Uri diagnosticsUrl,
+        int rxStreams,
+        TimeSpan timeout,
+        CancellationToken ct)
+    {
+        var deadline = DateTimeOffset.UtcNow + timeout;
+        Exception? lastError = null;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            ct.ThrowIfCancellationRequested();
+            try
+            {
+                var snapshot = await FetchSnapshotAsync(diagnosticsUrl, rxStreams, ct).ConfigureAwait(false);
+                _log.LogInformation(
+                    "p3.sidecar.ready diagnostics={Diagnostics} rx={RxActive}/{RxExpected} dsp={DspChannels}",
+                    diagnosticsUrl,
+                    snapshot.RxActiveStreams,
+                    snapshot.RxExpectedStreams,
+                    snapshot.DspActiveChannels);
+                return snapshot;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                lastError = ex;
+                if (HasOwnedProcessExited(out var exitCode, out var output))
+                {
+                    var details = string.IsNullOrWhiteSpace(output)
+                        ? string.Empty
+                        : $" Last sidecar output:{Environment.NewLine}{output}";
+                    throw new InvalidOperationException(
+                        $"Protocol 3 sidecar exited before diagnostics became ready (exit code {exitCode}).{details}",
+                        ex);
+                }
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(400), ct).ConfigureAwait(false);
+        }
+
+        throw new InvalidOperationException(
+            lastError is null
+                ? "Protocol 3 sidecar did not report ready diagnostics in time."
+                : $"Protocol 3 sidecar did not report ready diagnostics in time: {lastError.Message}",
+            lastError);
+    }
+
+    private async Task<Protocol3SidecarSnapshot> FetchSnapshotAsync(
+        Uri diagnosticsUrl,
+        int rxStreams,
+        CancellationToken ct)
+    {
+        ValidateDiagnosticsUrl(diagnosticsUrl);
+        var http = _httpFactory.CreateClient(HttpClientName);
+        using var response = await http.GetAsync(diagnosticsUrl, ct).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+            throw new InvalidOperationException(
+                $"Protocol 3 sidecar diagnostics returned HTTP {(int)response.StatusCode}.");
+
+        await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        var root = await JsonNode.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false) as JsonObject
+            ?? throw new InvalidOperationException("Protocol 3 sidecar diagnostics root is not an object.");
+        return ValidateDiagnosticsSnapshot(root, diagnosticsUrl, rxStreams);
+    }
+
+    private ProcessStartInfo BuildStartInfo(
+        string project,
+        string n9dspLibrary,
+        Uri listenUrl,
+        IPAddress radioIp,
+        int p3Port,
+        int sampleRateHz,
+        int rxStreams)
+    {
+        var dotnet = Setting("DotnetPath", "ZEUS_PROTOCOL3_SIDECAR_DOTNET");
+        if (string.IsNullOrWhiteSpace(dotnet)) dotnet = "dotnet";
+
+        var psi = new ProcessStartInfo(dotnet)
+        {
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            WorkingDirectory = Path.GetDirectoryName(project) ?? AppContext.BaseDirectory,
+        };
+        psi.ArgumentList.Add("run");
+        psi.ArgumentList.Add("--project");
+        psi.ArgumentList.Add(project);
+        if (BoolSetting("NoBuild", "ZEUS_PROTOCOL3_SIDECAR_NO_BUILD"))
+            psi.ArgumentList.Add("--no-build");
+        psi.ArgumentList.Add("--");
+        psi.ArgumentList.Add("--hosted-diagnostics-server");
+        psi.ArgumentList.Add("--allow-degraded-start");
+        psi.ArgumentList.Add("--listen");
+        psi.ArgumentList.Add(listenUrl.ToString());
+        psi.ArgumentList.Add("--host");
+        psi.ArgumentList.Add(radioIp.ToString());
+        psi.ArgumentList.Add("--port");
+        psi.ArgumentList.Add(p3Port.ToString(CultureInfo.InvariantCulture));
+        psi.ArgumentList.Add("--receive-ms");
+        psi.ArgumentList.Add("3000");
+        psi.ArgumentList.Add("--poll-ms");
+        psi.ArgumentList.Add("1000");
+        psi.ArgumentList.Add("--hosted-wait-ms");
+        psi.ArgumentList.Add("7000");
+        psi.ArgumentList.Add("--serve-ms");
+        psi.ArgumentList.Add("0");
+        psi.ArgumentList.Add("--freeze-ready-snapshot");
+        psi.ArgumentList.Add("--rx-count");
+        psi.ArgumentList.Add(rxStreams.ToString(CultureInfo.InvariantCulture));
+        psi.ArgumentList.Add("--rx-rate");
+        psi.ArgumentList.Add(sampleRateHz.ToString(CultureInfo.InvariantCulture));
+        psi.ArgumentList.Add("--n9dsp-library");
+        psi.ArgumentList.Add(n9dspLibrary);
+        psi.Environment["N9DSP_NATIVE_LIBRARY"] = n9dspLibrary;
+        psi.Environment["P3_ZEUS_HOSTED_RADIO_SESSION"] = HostedSessionArmValue;
+        return psi;
+    }
+
+    private Uri ListenUrl()
+    {
+        var configured = Setting("ListenUrl", "ZEUS_PROTOCOL3_SIDECAR_LISTEN");
+        if (!string.IsNullOrWhiteSpace(configured))
+        {
+            if (!Uri.TryCreate(configured, UriKind.Absolute, out var uri))
+                throw new InvalidOperationException($"Invalid Protocol 3 sidecar listen URL: {configured}");
+            ValidateLoopbackHttpBase(uri, "Protocol 3 sidecar listen URL");
+            return uri;
+        }
+
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return new Uri($"http://127.0.0.1:{port}/");
+    }
+
+    private Uri? ExistingDiagnosticsUrl()
+    {
+        var raw = Setting("DiagnosticsUrl", "ZEUS_PROTOCOL3_SIDECAR_DIAGNOSTICS_URL");
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+        if (!Uri.TryCreate(raw, UriKind.Absolute, out var uri))
+            throw new InvalidOperationException($"Invalid Protocol 3 sidecar diagnostics URL: {raw}");
+        ValidateDiagnosticsUrl(uri);
+        return uri;
+    }
+
+    private static Uri DiagnosticsUrlForListen(Uri listenUrl)
+    {
+        ValidateLoopbackHttpBase(listenUrl, "Protocol 3 sidecar listen URL");
+        return new UriBuilder(listenUrl)
+        {
+            Path = "/api/diagnostics/v2",
+            Query = string.Empty,
+            Fragment = string.Empty,
+        }.Uri;
+    }
+
+    private static void ValidateDiagnosticsUrl(Uri uri)
+    {
+        if (!uri.IsAbsoluteUri ||
+            !string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) ||
+            !uri.IsLoopback ||
+            !string.Equals(uri.AbsolutePath, "/api/diagnostics/v2", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                "Protocol 3 sidecar diagnostics URL must be loopback http://.../api/diagnostics/v2.");
+        }
+    }
+
+    private static void ValidateLoopbackHttpBase(Uri uri, string label)
+    {
+        if (!uri.IsAbsoluteUri ||
+            !string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) ||
+            !uri.IsLoopback ||
+            uri.Port is < 1 or > 65535)
+        {
+            throw new InvalidOperationException($"{label} must be loopback HTTP.");
+        }
+    }
+
+    private string? Setting(string key, string env)
+    {
+        var value = Environment.GetEnvironmentVariable(env);
+        if (!string.IsNullOrWhiteSpace(value)) return value.Trim();
+        value = _configuration[$"Zeus:Protocol3:Sidecar:{key}"];
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+
+    private string? FullPathSetting(string key, string env)
+    {
+        var value = Setting(key, env);
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        return Path.GetFullPath(Environment.ExpandEnvironmentVariables(value));
+    }
+
+    private bool BoolSetting(string key, string env)
+    {
+        var value = Setting(key, env);
+        return string.Equals(value, "1", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(value, "true", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(value, "yes", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private void Remember(
+        Protocol3SidecarSnapshot? snapshot,
+        bool ownsProcess,
+        Process? process,
+        Uri? diagnosticsUrl = null,
+        ProcessOutputTail? output = null)
+    {
+        lock (_sync)
+        {
+            _lastSnapshot = snapshot;
+            _ownsProcess = ownsProcess;
+            _process = process;
+            _processOutput = output;
+            _diagnosticsUrl = diagnosticsUrl ?? snapshot?.DiagnosticsUrl;
+        }
+    }
+
+    private bool HasOwnedProcessExited(out int? exitCode, out string output)
+    {
+        lock (_sync)
+        {
+            if (_ownsProcess && _process is { HasExited: true } process)
+            {
+                exitCode = process.ExitCode;
+                output = _processOutput?.Snapshot() ?? string.Empty;
+                return true;
+            }
+        }
+        exitCode = null;
+        output = string.Empty;
+        return false;
+    }
+
+    private static JsonObject RequiredObject(JsonObject parent, string property) =>
+        parent[property] as JsonObject ??
+        throw new InvalidOperationException($"Protocol 3 sidecar diagnostics missing object '{property}'.");
+
+    private static string RequiredString(JsonObject parent, string property) =>
+        parent[property]?.GetValue<string>() ??
+        throw new InvalidOperationException($"Protocol 3 sidecar diagnostics missing string '{property}'.");
+
+    private static int RequiredInt(JsonObject parent, string property)
+    {
+        var node = parent[property] ??
+            throw new InvalidOperationException($"Protocol 3 sidecar diagnostics missing number '{property}'.");
+        if (node is JsonValue value)
+        {
+            if (value.TryGetValue<int>(out var i)) return i;
+            if (value.TryGetValue<long>(out var l) && l <= int.MaxValue && l >= int.MinValue) return (int)l;
+            if (value.TryGetValue<uint>(out var u) && u <= int.MaxValue) return (int)u;
+            if (value.TryGetValue<ulong>(out var ul) && ul <= int.MaxValue) return (int)ul;
+        }
+        throw new InvalidOperationException($"Protocol 3 sidecar diagnostics property '{property}' is not an int.");
+    }
+
+    private sealed class ProcessOutputTail
+    {
+        private readonly object _sync = new();
+        private readonly Queue<string> _lines = new();
+        private readonly int _maxLines;
+
+        private ProcessOutputTail(int maxLines)
+        {
+            _maxLines = maxLines;
+        }
+
+        public static ProcessOutputTail Attach(Process process)
+        {
+            var tail = new ProcessOutputTail(80);
+            process.OutputDataReceived += (_, e) => tail.Append("stdout", e.Data);
+            process.ErrorDataReceived += (_, e) => tail.Append("stderr", e.Data);
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+            return tail;
+        }
+
+        public string Snapshot()
+        {
+            lock (_sync)
+                return string.Join(Environment.NewLine, _lines);
+        }
+
+        private void Append(string stream, string? line)
+        {
+            if (string.IsNullOrWhiteSpace(line)) return;
+            lock (_sync)
+            {
+                _lines.Enqueue($"{stream}: {line}");
+                while (_lines.Count > _maxLines) _lines.Dequeue();
+            }
+        }
+    }
+}

--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -209,6 +209,11 @@ public sealed class RadioService : IDisposable
     // supply a byte, in which case ConnectedBoardKind falls back to OrionMkII
     // for backward compat.
     private HpsdrBoardKind _p2BoardKind = HpsdrBoardKind.Unknown;
+    // True while Zeus is connected through the private N9DSP Protocol 3
+    // sidecar. The public host deliberately keeps only connection metadata;
+    // the sidecar owns all P3/N9DSP runtime code and binaries.
+    private bool _p3Active;
+    private int _p3MaxReceivers = Zeus.Contracts.WireContract.MaxReceivers;
     // Firmware / gateware version string for the live connection, captured at
     // connect time from the discovery reply (P1: code-version byte raw[9];
     // P2: raw[13] + beta). Diagnostics-only — surfaced by ConnectionProbe so a
@@ -846,7 +851,7 @@ public sealed class RadioService : IDisposable
     /// </summary>
     public bool IsConnected
     {
-        get { lock (_sync) return _activeClient is not null || _p2Active; }
+        get { lock (_sync) return _activeClient is not null || _p2Active || _p3Active; }
     }
 
     /// <summary>True while a Protocol-1 client owns the connection — i.e. the
@@ -866,6 +871,11 @@ public sealed class RadioService : IDisposable
     internal bool IsProtocol2Active
     {
         get { lock (_sync) return _p2Active; }
+    }
+
+    internal bool IsProtocol3Active
+    {
+        get { lock (_sync) return _p3Active; }
     }
 
     /// <summary>Cheap MOX accessor (no Receivers projection, unlike Snapshot).
@@ -4254,6 +4264,8 @@ public sealed class RadioService : IDisposable
             _p2Client = client;
             _p2Active = true;
             _p2BoardKind = boardKind;
+            _p3Active = false;
+            _p3MaxReceivers = Zeus.Contracts.WireContract.MaxReceivers;
             // Record the discovered firmware for the diagnostics snapshot.
             _connectedFirmware = firmware;
             _attOffsetDb = 0;
@@ -4334,6 +4346,72 @@ public sealed class RadioService : IDisposable
         P2Disconnected?.Invoke();
     }
 
+    public void MarkProtocol3Connected(
+        string endpoint,
+        int sampleRateHz,
+        int maxReceivers,
+        string? firmware = null)
+    {
+        Protocol2Client? previous;
+        lock (_sync)
+        {
+            previous = _p2Client;
+            _p2Client = null;
+            _p2Active = false;
+            _p2BoardKind = HpsdrBoardKind.Unknown;
+            _p3Active = true;
+            _p3MaxReceivers = Math.Clamp(maxReceivers, 1, Zeus.Contracts.WireContract.MaxReceivers);
+            _connectedFirmware = firmware;
+            _attOffsetDb = 0;
+            _adcOverloadLevel = 0;
+            _overloadSeenInWindow = false;
+            _lastTickMs = long.MinValue;
+            _lastOverloadMs = long.MinValue;
+            _lastAppliedEffectiveDb = -1;
+            _lastAdcOverloadBits = 0;
+            _lastAdc0MaxMagnitude = null;
+            _lastAdc1MaxMagnitude = null;
+            _adc0MaxMagnitudeAtOverload = 0;
+            _adc1MaxMagnitudeAtOverload = 0;
+            _lastAdcTelemetryUtc = null;
+        }
+        if (previous is not null) previous.TelemetryReceived -= OnP2Telemetry;
+        Mutate(s => s with
+        {
+            Status = ConnectionStatus.Connected,
+            Endpoint = endpoint,
+            SampleRate = sampleRateHz,
+            AttOffsetDb = 0,
+            AdcOverloadWarning = false,
+        });
+        RecomputePaAndPush();
+    }
+
+    public void MarkProtocol3Disconnected()
+    {
+        lock (_sync)
+        {
+            _p3Active = false;
+            _p3MaxReceivers = Zeus.Contracts.WireContract.MaxReceivers;
+            _connectedFirmware = null;
+            _attOffsetDb = 0;
+            _adcOverloadLevel = 0;
+            _overloadSeenInWindow = false;
+            _lastTickMs = long.MinValue;
+            _lastOverloadMs = long.MinValue;
+            _lastAppliedEffectiveDb = -1;
+        }
+        Mutate(s => s with
+        {
+            Status = ConnectionStatus.Disconnected,
+            Endpoint = null,
+            AttOffsetDb = 0,
+            AdcOverloadWarning = false,
+        });
+        _currentPsBoardKey = string.Empty;
+        _currentPsTxAttnDb = -1;
+    }
+
     // Resolves the board class for ALL board-specific behavior: PA settings,
     // drive-byte encoding, ATT behavior, filter switching. Normally returns
     // the board ID from discovery (P1) or infers OrionMkII for P2. When the
@@ -4372,6 +4450,10 @@ public sealed class RadioService : IDisposable
                     return _p2BoardKind != HpsdrBoardKind.Unknown
                         ? _p2BoardKind
                         : HpsdrBoardKind.OrionMkII;
+                }
+                if (_p3Active)
+                {
+                    return HpsdrBoardKind.OrionMkII;
                 }
                 return HpsdrBoardKind.Unknown;
             }
@@ -4418,6 +4500,8 @@ public sealed class RadioService : IDisposable
                 if (_p2Active)
                     return Zeus.Protocol2.Protocol2Client.MaxRxDdc
                          - Zeus.Protocol2.Protocol2Client.RxBaseDdc(ConnectedBoardKind);
+                if (_p3Active)
+                    return _p3MaxReceivers;
                 return Zeus.Contracts.WireContract.MaxReceivers;
             }
         }

--- a/Zeus.Server.Hosting/ZeusEndpoints.cs
+++ b/Zeus.Server.Hosting/ZeusEndpoints.cs
@@ -1512,6 +1512,75 @@ public static class ZeusEndpoints
             }
         });
 
+        app.MapPost("/api/connect/p3", async (
+            ConnectRequest req,
+            Protocol3PresenceProbe p3Presence,
+            Protocol3SidecarBridge sidecar,
+            RadioService radio,
+            HttpContext ctx) =>
+        {
+            const int p3RxStreams = Zeus.Contracts.WireContract.MaxReceivers;
+            const int p3RxRateHz = 1_536_000;
+
+            log.LogInformation("api.connect.p3 endpoint={Ep}", req.Endpoint);
+
+            if (!TryParseIpEndpoint(req.Endpoint, out var ipEndpoint))
+                return Results.BadRequest(new { error = $"Invalid endpoint '{req.Endpoint}'." });
+            if (radio.IsConnected)
+                return Results.Conflict(new { error = "Already connected. Disconnect first." });
+
+            var p3 = await p3Presence
+                .ProbeAsync(ipEndpoint.Address, TimeSpan.FromMilliseconds(700), ctx.RequestAborted)
+                .ConfigureAwait(false);
+            if (p3 is null)
+            {
+                return Results.Json(
+                    new { error = "Protocol 3 p3app was not detected on this radio.", protocol3Available = false },
+                    statusCode: StatusCodes.Status409Conflict);
+            }
+            if (p3.MaxRxStreams < p3RxStreams)
+            {
+                return Results.Json(
+                    new
+                    {
+                        error = $"Protocol 3 p3app reports only {p3.MaxRxStreams} RX streams; Zeus requires {p3RxStreams}.",
+                        maxRxStreams = p3.MaxRxStreams,
+                    },
+                    statusCode: StatusCodes.Status409Conflict);
+            }
+
+            try
+            {
+                var snapshot = await sidecar
+                    .ConnectAsync(ipEndpoint, p3.Port, p3RxRateHz, p3RxStreams, ctx.RequestAborted)
+                    .ConfigureAwait(false);
+                radio.MarkProtocol3Connected(
+                    req.Endpoint,
+                    p3RxRateHz,
+                    Math.Min(snapshot.RxActiveStreams, Zeus.Contracts.WireContract.MaxReceivers),
+                    p3.FirmwareVersion.ToString());
+                return Results.Ok(new
+                {
+                    protocol = "P3",
+                    endpoint = req.Endpoint,
+                    sampleRateHz = p3RxRateHz,
+                    maxReceivers = snapshot.RxActiveStreams,
+                    diagnosticsUrl = snapshot.DiagnosticsUrl.ToString(),
+                    dspEngine = snapshot.DspEngine,
+                });
+            }
+            catch (InvalidOperationException ex)
+            {
+                log.LogWarning(ex, "api.connect.p3 refused");
+                return Results.Json(new { error = ex.Message }, statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
+            catch (Exception ex)
+            {
+                log.LogError(ex, "api.connect.p3 failed");
+                return Results.Problem(ex.Message, statusCode: 500);
+            }
+        });
+
         app.MapPost("/api/disconnect/p2", async (DspPipelineService dsp, HttpContext ctx) =>
         {
             log.LogInformation("api.disconnect.p2");
@@ -1519,10 +1588,34 @@ public static class ZeusEndpoints
             return Results.Ok(new { status = "disconnected" });
         });
 
-        app.MapPost("/api/disconnect", async (RadioService r, HttpContext ctx) =>
+        app.MapPost("/api/disconnect/p3", async (
+            Protocol3SidecarBridge sidecar,
+            RadioService radio,
+            HttpContext ctx) =>
+        {
+            log.LogInformation("api.disconnect.p3");
+            await sidecar.DisconnectAsync(ctx.RequestAborted);
+            if (radio.IsProtocol3Active)
+                radio.MarkProtocol3Disconnected();
+            return Results.Ok(new { status = "disconnected" });
+        });
+
+        app.MapGet("/api/protocol3/sidecar", (Protocol3SidecarBridge sidecar) =>
+            Results.Ok(sidecar.Status));
+
+        app.MapPost("/api/disconnect", async (
+            RadioService r,
+            Protocol3SidecarBridge sidecar,
+            HttpContext ctx) =>
         {
             log.LogInformation("api.disconnect");
-            return await r.DisconnectAsync(ctx.RequestAborted);
+            if (r.IsProtocol3Active)
+            {
+                await sidecar.DisconnectAsync(ctx.RequestAborted);
+                r.MarkProtocol3Disconnected();
+                return Results.Ok(r.Snapshot());
+            }
+            return Results.Ok(await r.DisconnectAsync(ctx.RequestAborted));
         });
 
         app.MapPost("/api/vfo", (VfoSetRequest req, RadioService r) =>

--- a/Zeus.Server.Hosting/ZeusHost.cs
+++ b/Zeus.Server.Hosting/ZeusHost.cs
@@ -324,6 +324,12 @@ public static class ZeusHost
             Zeus.Protocol2.Discovery.IRadioDiscovery,
             Zeus.Protocol2.Discovery.RadioDiscoveryService>();
         builder.Services.AddSingleton<Protocol3PresenceProbe>();
+        builder.Services.AddHttpClient(Protocol3SidecarBridge.HttpClientName, c =>
+        {
+            c.Timeout = TimeSpan.FromSeconds(3);
+            c.DefaultRequestHeaders.UserAgent.ParseAdd("OpenHPSDR-Zeus");
+        });
+        builder.Services.AddSingleton<Protocol3SidecarBridge>();
         // TxIqRing is shared: TxAudioIngest writes modulated IQ into it, Protocol1Client
         // (constructed inside RadioService) reads from it for the EP2 payload.
         builder.Services.AddSingleton<Zeus.Protocol1.TxIqRing>();

--- a/tests/Zeus.Server.Tests/Protocol3SidecarBridgeTests.cs
+++ b/tests/Zeus.Server.Tests/Protocol3SidecarBridgeTests.cs
@@ -1,0 +1,88 @@
+using System.Text.Json.Nodes;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public sealed class Protocol3SidecarBridgeTests
+{
+    [Fact]
+    public void ValidateDiagnosticsSnapshot_AcceptsN9DspTenStreamSidecar()
+    {
+        var snapshot = Protocol3SidecarBridge.ValidateDiagnosticsSnapshot(
+            Diagnostics(streams: 10, engine: "n9dsp", status: "ok"),
+            new Uri("http://127.0.0.1:2074/api/diagnostics/v2"),
+            expectedRxStreams: 10);
+
+        Assert.Equal("ok", snapshot.Status);
+        Assert.Equal("n9dsp", snapshot.DspEngine);
+        Assert.Equal(10, snapshot.RxActiveStreams);
+        Assert.Equal(10, snapshot.RxExpectedStreams);
+        Assert.Equal(10, snapshot.DspActiveChannels);
+    }
+
+    [Fact]
+    public void ValidateDiagnosticsSnapshot_AcceptsDegradedN9DspTenStreamSidecar()
+    {
+        var snapshot = Protocol3SidecarBridge.ValidateDiagnosticsSnapshot(
+            Diagnostics(streams: 10, engine: "n9dsp", status: "degraded"),
+            new Uri("http://127.0.0.1:2074/api/diagnostics/v2"),
+            expectedRxStreams: 10);
+
+        Assert.Equal("degraded", snapshot.Status);
+        Assert.Equal("n9dsp", snapshot.DspEngine);
+        Assert.Equal(10, snapshot.RxActiveStreams);
+    }
+
+    [Fact]
+    public void ValidateDiagnosticsSnapshot_RejectsNonN9DspEngine()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            Protocol3SidecarBridge.ValidateDiagnosticsSnapshot(
+                Diagnostics(streams: 10, engine: "wdsp", status: "ok"),
+                new Uri("http://127.0.0.1:2074/api/diagnostics/v2"),
+                expectedRxStreams: 10));
+
+        Assert.Contains("expected 'n9dsp'", ex.Message);
+    }
+
+    [Fact]
+    public void ValidateDiagnosticsSnapshot_RejectsSixStreamSidecar()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            Protocol3SidecarBridge.ValidateDiagnosticsSnapshot(
+                Diagnostics(streams: 6, engine: "n9dsp", status: "ok"),
+                new Uri("http://127.0.0.1:2074/api/diagnostics/v2"),
+                expectedRxStreams: 10));
+
+        Assert.Contains("requires 10", ex.Message);
+    }
+
+    [Fact]
+    public void ValidateDiagnosticsSnapshot_RejectsNonLoopbackDiagnosticsUrl()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            Protocol3SidecarBridge.ValidateDiagnosticsSnapshot(
+                Diagnostics(streams: 10, engine: "n9dsp", status: "ok"),
+                new Uri("http://192.168.1.25:2074/api/diagnostics/v2"),
+                expectedRxStreams: 10));
+
+        Assert.Contains("loopback", ex.Message);
+    }
+
+    private static JsonObject Diagnostics(int streams, string engine, string status) => new()
+    {
+        ["protocol"] = "p3",
+        ["source"] = "radioSession",
+        ["p3"] = new JsonObject
+        {
+            ["status"] = status,
+            ["rxExpectedStreams"] = streams,
+            ["rxActiveStreams"] = streams,
+            ["dsp"] = new JsonObject
+            {
+                ["engine"] = engine,
+                ["activeChannels"] = streams,
+            },
+        },
+    };
+}

--- a/tests/Zeus.Server.Tests/RadioServiceUnifiedReceiverWriteTests.cs
+++ b/tests/Zeus.Server.Tests/RadioServiceUnifiedReceiverWriteTests.cs
@@ -91,6 +91,22 @@ public sealed class RadioServiceUnifiedReceiverWriteTests : IDisposable
     }
 
     [Fact]
+    public void Snapshot_Protocol3G2_AdvertisesTenReceivers()
+    {
+        using var radio = BuildRadio();
+
+        radio.MarkProtocol3Connected("127.0.0.1:1024", 1_536_000, WireContract.MaxReceivers);
+        radio.SetReceiver(9, enabled: true, vfoHz: 28_074_000);
+
+        var s = radio.Snapshot();
+        Assert.True(radio.IsConnected);
+        Assert.True(radio.IsProtocol3Active);
+        Assert.Equal(ConnectionStatus.Connected, s.Status);
+        Assert.Equal(WireContract.MaxReceivers, s.MaxReceivers);
+        Assert.Equal(WireContract.MaxReceivers, s.Receivers!.Where(r => r.Index < WireContract.MaxReceivers).Count());
+    }
+
+    [Fact]
     public void SetReceiver_Rx2_RoutesEnableVfoModeFilterAndAf()
     {
         using var radio = BuildRadio();

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -5571,6 +5571,22 @@ export function connectP2(
   );
 }
 
+export function connectP3(
+  req: ConnectRequest,
+  signal?: AbortSignal,
+): Promise<unknown> {
+  return jsonFetch(
+    '/api/connect/p3',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(req),
+      signal,
+    },
+    (raw) => raw,
+  );
+}
+
 // Take over a Busy radio: ask the server to send a protocol stop so the radio
 // drops its current owner, freeing it for an immediate connect. `endpoint` is
 // the discovered "ip:port"; `protocol` is 'P1' or 'P2'. Resolves once the
@@ -5603,6 +5619,14 @@ export function disconnect(signal?: AbortSignal): Promise<RadioStateDto> {
 export function disconnectP2(signal?: AbortSignal): Promise<unknown> {
   return jsonFetch(
     '/api/disconnect/p2',
+    { method: 'POST', signal },
+    (raw) => raw,
+  );
+}
+
+export function disconnectP3(signal?: AbortSignal): Promise<unknown> {
+  return jsonFetch(
+    '/api/disconnect/p3',
     { method: 'POST', signal },
     (raw) => raw,
   );

--- a/zeus-web/src/components/ConnectPanel.tsx
+++ b/zeus-web/src/components/ConnectPanel.tsx
@@ -47,8 +47,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   connect as apiConnect,
   connectP2 as apiConnectP2,
+  connectP3 as apiConnectP3,
   disconnect as apiDisconnect,
   disconnectP2 as apiDisconnectP2,
+  disconnectP3 as apiDisconnectP3,
   reclaimRadio,
   fetchRadios,
   fetchProtocol3Presence,
@@ -454,8 +456,7 @@ const MANUAL_BOARD_OPTIONS: ReadonlyArray<BoardKind> = [
 ];
 
 const PROTOCOL3_UNAVAILABLE_TITLE = 'Protocol 3 requires p3app running on the selected radio.';
-const PROTOCOL3_PREVIEW_TITLE =
-  'Protocol 3 p3app detected on this G2.';
+const PROTOCOL3_CONNECT_TITLE = 'Connect through Protocol 3 using the local N9DSP sidecar.';
 
 function hasProtocol3App(r: RadioInfoDto): boolean {
   return r.details?.protocol3Available === 'true';
@@ -688,14 +689,20 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
   // Busy-radio takeover flow. Caller owns the inflight/error state so both
   // entry points can wrap it (the takeover sends a reclaim first).
   const performConnect = useCallback(
-    async (r: RadioInfoDto, force = false) => {
+    async (r: RadioInfoDto, force = false, protocolOverride?: ProtocolChoice) => {
       const ep = endpointFor(r);
-      const protocol = r.details?.protocol ?? 'P1';
-      if (protocol === 'P3') {
-        throw new Error(PROTOCOL3_PREVIEW_TITLE);
-      }
+      const protocol = protocolOverride ?? (r.details?.protocol as ProtocolChoice | undefined) ?? 'P1';
+      const isP3 = protocol === 'P3';
       const isP2 = protocol === 'P2';
-      if (isP2) {
+      if (isP3) {
+        await apiConnectP3({
+          endpoint: ep,
+          sampleRate: 1_536_000,
+        });
+        const fresh = await fetchState();
+        applyState(fresh);
+        hydrateTxFromState(fresh);
+      } else if (isP2) {
         // Pass the discovered board byte (e.g. 0x01 = Hermes for Brick2).
         // Without this the server falls back to OrionMkII for every P2
         // connection — issue #171.
@@ -727,7 +734,7 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
         hydrateTxFromState(next);
       }
       setBoardId(r.boardId || null);
-      setConnectedProtocol(isP2 ? 'P2' : 'P1');
+      setConnectedProtocol(protocol);
       setLastConnectedEndpoint(ep || null);
       applyPostConnectEffects();
     },
@@ -735,12 +742,12 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
   );
 
   const handleConnect = useCallback(
-    async (r: RadioInfoDto) => {
+    async (r: RadioInfoDto, protocolOverride?: ProtocolChoice) => {
       if (inflightRef.current) return;
       setInflight(true);
       setError(null);
       try {
-        await performConnect(r);
+        await performConnect(r, false, protocolOverride);
       } catch (err) {
         setError(errorMessage(err));
       } finally {
@@ -758,10 +765,6 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
       if (inflightRef.current) return;
       const ep = endpointFor(r);
       const protocol = r.details?.protocol ?? 'P1';
-      if (protocol === 'P3') {
-        setError(PROTOCOL3_PREVIEW_TITLE);
-        return;
-      }
       const isP2 = protocol === 'P2';
       setInflight(true);
       setError(null);
@@ -796,12 +799,9 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
         setManualError('Port must be between 1 and 65535');
         return;
       }
-      if (protocol === 'P3') {
-        setManualError(PROTOCOL3_PREVIEW_TITLE);
-        return;
-      }
 
       const ep = `${ip}:${port}`;
+      const effectiveSampleRate: SampleRate = protocol === 'P3' ? 1_536_000 : sampleRate;
       setInflight(true);
       setManualError(null);
       try {
@@ -820,7 +820,12 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
           setManualError(`Board override: ${errorMessage(selErr)}`);
         }
 
-        if (protocol === 'P2') {
+        if (protocol === 'P3') {
+          await apiConnectP3({ endpoint: ep, sampleRate: effectiveSampleRate, force });
+          const fresh = await fetchState();
+          applyState(fresh);
+          hydrateTxFromState(fresh);
+        } else if (protocol === 'P2') {
           await apiConnectP2({ endpoint: ep, sampleRate, force });
           const fresh = await fetchState();
           applyState(fresh);
@@ -835,9 +840,9 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
         setLastConnectedEndpoint(ep);
         applyPostConnectEffects();
         if (manualSave || override) {
-          saveEndpoint({ label, ip, port, protocol, sampleRate, board });
+          saveEndpoint({ label, ip, port, protocol, sampleRate: effectiveSampleRate, board });
         }
-        setManualFormDefaults({ ip, port, protocol, sampleRate, board, label: '' });
+        setManualFormDefaults({ ip, port, protocol, sampleRate: effectiveSampleRate, board, label: '' });
       } catch (err) {
         // Busy radio (relay-chatter guard, P2 path): the server refuses a
         // second-master connect with a 409 { reclaimable: true }. Offer the
@@ -868,10 +873,6 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
   const handleManualForceConnect = useCallback(
     async (snap: NonNullable<typeof pendingManualTakeover>) => {
       if (inflightRef.current) return;
-      if (snap.protocol === 'P3') {
-        setManualError(PROTOCOL3_PREVIEW_TITLE);
-        return;
-      }
       const ep = `${snap.ip}:${snap.port}`;
       // Latch the ref directly (the effect that mirrors `inflight` only runs on
       // the next render) so the reclaim shows as inflight and a stray click
@@ -900,6 +901,7 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
     setInflight(true);
     setError(null);
     try {
+      try { await apiDisconnectP3(); } catch { /* may be P1/P2 */ }
       try { await apiDisconnect(); } catch { /* may be P2 */ }
       try { await apiDisconnectP2(); } catch { /* may have been P1 */ }
       const fresh = await fetchState();
@@ -1245,8 +1247,8 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
                           {showP3Chip && (
                             <span
                               className="chip"
-                              style={{ marginLeft: 6 }}
-                              title={PROTOCOL3_PREVIEW_TITLE}
+                              style={{ marginLeft: 6, opacity: 0.75 }}
+                              title={PROTOCOL3_CONNECT_TITLE}
                             >
                               <span className="v">P3</span>
                             </span>
@@ -1279,9 +1281,31 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
                           >
                             Take over
                           </button>
+                          {showP3Preview && (
+                            <button
+                              type="button"
+                              onClick={() => handleConnect(r, 'P3')}
+                              disabled={inflight}
+                              title={PROTOCOL3_CONNECT_TITLE}
+                              className="btn sm active"
+                            >
+                              P3
+                            </button>
+                          )}
                         </div>
                       ) : (
                         <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                          {showP3Preview && (
+                            <button
+                              type="button"
+                              onClick={() => handleConnect(r, 'P3')}
+                              disabled={inflight}
+                              title={PROTOCOL3_CONNECT_TITLE}
+                              className="btn sm active"
+                            >
+                              P3
+                            </button>
+                          )}
                           <button
                             type="button"
                             onClick={() => handleConnect(r)}
@@ -1521,7 +1545,7 @@ const fieldLabelStyle: React.CSSProperties = {
 
 function ManualMode(p: ManualModeProps) {
   const p3Disabled = !p.p3Available || p.p3Checking || p.inflight;
-  const canConnect = !p.inflight && p.protocol !== 'P3';
+  const canConnect = !p.inflight && (p.protocol !== 'P3' || (!p3Disabled && p.p3Available));
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
       <div
@@ -1599,7 +1623,7 @@ function ManualMode(p: ManualModeProps) {
                 p.p3Checking
                   ? 'Checking for p3app on this radio...'
                   : p.p3Available
-                    ? PROTOCOL3_PREVIEW_TITLE
+                    ? PROTOCOL3_CONNECT_TITLE
                     : PROTOCOL3_UNAVAILABLE_TITLE
               }
             >
@@ -1688,7 +1712,7 @@ function ManualMode(p: ManualModeProps) {
         type="button"
         onClick={p.onConnect}
         disabled={!canConnect}
-        title={p.protocol === 'P3' ? PROTOCOL3_PREVIEW_TITLE : undefined}
+        title={p.protocol === 'P3' ? PROTOCOL3_CONNECT_TITLE : undefined}
         className={`btn lg ${canConnect ? 'active' : ''}`}
         style={{ alignSelf: 'stretch' }}
       >
@@ -1718,7 +1742,6 @@ function ManualMode(p: ManualModeProps) {
           <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: 4 }}>
             {p.savedEndpoints.map((e) => {
               const isLast = e.id === p.lastConnectedId;
-              const p3Saved = e.protocol === 'P3';
               return (
                 <li
                   key={e.id}
@@ -1766,9 +1789,9 @@ function ManualMode(p: ManualModeProps) {
                     <button
                       type="button"
                       onClick={() => p.onReconnect(e)}
-                      disabled={p.inflight || p3Saved}
-                      className={`btn sm ${p.inflight || p3Saved ? '' : 'active'}`}
-                      title={p3Saved ? PROTOCOL3_PREVIEW_TITLE : undefined}
+                      disabled={p.inflight}
+                      className={`btn sm ${p.inflight ? '' : 'active'}`}
+                      title={e.protocol === 'P3' ? PROTOCOL3_CONNECT_TITLE : undefined}
                     >
                       Connect
                     </button>


### PR DESCRIPTION
## Summary
- add a GPL-side Protocol 3 sidecar bridge that launches or validates an external/private P3/N9DSP probe instead of vendoring proprietary code into Zeus
- wire `/api/connect/p3`, `/api/disconnect/p3`, and sidecar diagnostics so a G2 running p3app exposes 10 receivers through N9DSP
- enable the P3 protocol option in the connect UI while keeping it disabled unless p3app is detected on the radio

## Verification
- `dotnet test tests\Zeus.Server.Tests\Zeus.Server.Tests.csproj --filter "FullyQualifiedName~Protocol3SidecarBridgeTests|FullyQualifiedName~RadioServiceUnifiedReceiverWriteTests|FullyQualifiedName~Protocol3PresenceProbeTests" --nologo`
- `npm --prefix zeus-web run build`
- live smoke before final rebase: p3app presence reported 10 streams; `/api/connect/p3` returned protocol P3, DSP engine n9dsp, and maxReceivers 10; `/api/state` reported maxReceivers 10; `/api/disconnect/p3` shut down cleanly