### PR TITLE
fix: preserve Protocol 3 receiver state

### DIFF
--- a/Zeus.Server.Hosting/RadioService.cs
+++ b/Zeus.Server.Hosting/RadioService.cs
@@ -4478,6 +4478,7 @@ public sealed class RadioService : IDisposable
     private string? ConnectedProtocolLocked()
     {
         if (_p2Active) return "P2";
+        if (_p3Active) return "P3";
         if (_activeClient is not null) return "P1";
         return null;
     }

--- a/tests/Zeus.Server.Tests/RadioServiceUnifiedReceiverWriteTests.cs
+++ b/tests/Zeus.Server.Tests/RadioServiceUnifiedReceiverWriteTests.cs
@@ -102,6 +102,7 @@ public sealed class RadioServiceUnifiedReceiverWriteTests : IDisposable
         Assert.True(radio.IsConnected);
         Assert.True(radio.IsProtocol3Active);
         Assert.Equal(ConnectionStatus.Connected, s.Status);
+        Assert.Equal("P3", s.ConnectedProtocol);
         Assert.Equal(WireContract.MaxReceivers, s.MaxReceivers);
         Assert.Equal(WireContract.MaxReceivers, s.Receivers!.Where(r => r.Index < WireContract.MaxReceivers).Count());
     }

--- a/zeus-web/src/api/client.test.ts
+++ b/zeus-web/src/api/client.test.ts
@@ -255,6 +255,19 @@ describe('normalizeState', () => {
     expect(s.receivers).toHaveLength(3);
     expect(s.receivers?.[2]).toMatchObject({ index: 2, enabled: true, adcSource: 1, mode: 'USB' });
   });
+  it('preserves Protocol 3 in normalized state', () => {
+    const s = normalizeState({
+      wireVersion: 2,
+      maxReceivers: 10,
+      connectedProtocol: 'P3',
+      receivers: [
+        { index: 0, enabled: true, adcSource: 0, vfoHz: 7_100_000, mode: 'LSB' },
+      ],
+    });
+
+    expect(s.connectedProtocol).toBe('P3');
+    expect(s.maxReceivers).toBe(10);
+  });
   it('leaves receivers/maxReceivers undefined when a v1 server omits them', () => {
     // Undefined (not []/0) lets applyState keep the store's prior values rather
     // than collapsing the exposed-receiver control.

--- a/zeus-web/src/api/client.ts
+++ b/zeus-web/src/api/client.ts
@@ -453,7 +453,7 @@ export type RadioStateDto = {
   maxReceivers?: number;
   // Active backend wire protocol for the current connection. Present on v2+
   // servers so reloads can recover protocol-gated Settings panels.
-  connectedProtocol?: 'P1' | 'P2' | null;
+  connectedProtocol?: 'P1' | 'P2' | 'P3' | null;
 };
 
 // Mirrors Zeus.Contracts.ReceiverDto — per-receiver (per-DDC) state. Index 0 is
@@ -2441,10 +2441,10 @@ function normalizeReceiver(raw: unknown, fallbackIndex: number): ReceiverDto {
   };
 }
 
-function normalizeConnectedProtocol(raw: unknown): 'P1' | 'P2' | null | undefined {
+function normalizeConnectedProtocol(raw: unknown): 'P1' | 'P2' | 'P3' | null | undefined {
   if (raw === undefined) return undefined;
   if (raw === null) return null;
-  return raw === 'P1' || raw === 'P2' ? raw : null;
+  return raw === 'P1' || raw === 'P2' || raw === 'P3' ? raw : null;
 }
 
 export function normalizeState(raw: unknown): RadioStateDto {

--- a/zeus-web/src/state/connection-store.multiselect.test.ts
+++ b/zeus-web/src/state/connection-store.multiselect.test.ts
@@ -101,6 +101,14 @@ describe('connection-store multi-select', () => {
 
     useConnectionStore.getState().applyState({
       ...base,
+      status: 'Connected',
+      connectedProtocol: 'P3',
+    });
+
+    expect(useConnectionStore.getState().connectedProtocol).toBe('P3');
+
+    useConnectionStore.getState().applyState({
+      ...base,
       status: 'Disconnected',
       connectedProtocol: null,
     });


### PR DESCRIPTION
## Summary
- keep `/api/state` reporting `connectedProtocol: "P3"` while the Protocol 3 sidecar is active
- teach the frontend state normalizer/store to preserve P3 instead of coercing it to null
- add regressions for P3 state hydration so the Receivers settings panel keeps the 10-receiver ceiling after polling/reload

## Verification
- `dotnet test tests\Zeus.Server.Tests\Zeus.Server.Tests.csproj --filter "FullyQualifiedName~RadioServiceUnifiedReceiverWriteTests|FullyQualifiedName~Protocol3SidecarBridgeTests|FullyQualifiedName~Protocol3PresenceProbeTests" --nologo`
- `npm --prefix zeus-web exec vitest run src/api/client.test.ts src/components/ReceiversPanel.test.tsx src/state/connection-store.multiselect.test.ts`
- `npm --prefix zeus-web run build`