### PR TITLE
fix(connect): remove duplicate P3 discover badge

### DIFF
--- a/zeus-web/src/components/ConnectPanel.tsx
+++ b/zeus-web/src/components/ConnectPanel.tsx
@@ -1281,31 +1281,9 @@ export function ConnectPanel({ compact = false }: ConnectPanelProps = {}) {
                           >
                             Take over
                           </button>
-                          {showP3Preview && (
-                            <button
-                              type="button"
-                              onClick={() => handleConnect(r, 'P3')}
-                              disabled={inflight}
-                              title={PROTOCOL3_CONNECT_TITLE}
-                              className="btn sm active"
-                            >
-                              P3
-                            </button>
-                          )}
                         </div>
                       ) : (
                         <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-                          {showP3Preview && (
-                            <button
-                              type="button"
-                              onClick={() => handleConnect(r, 'P3')}
-                              disabled={inflight}
-                              title={PROTOCOL3_CONNECT_TITLE}
-                              className="btn sm active"
-                            >
-                              P3
-                            </button>
-                          )}
                           <button
                             type="button"
                             onClick={() => handleConnect(r)}


### PR DESCRIPTION
## Summary
- remove the right-side P3 action buttons from discovered-radio rows
- keep the left-side P3 discovery chip so P3 availability is still visible
- leave the manual P3 connect path intact

## Verification
- npm --prefix zeus-web ci
- npm --prefix zeus-web run build

Tracking: zeus-w01n