### PR TITLE
feat(ft8): digital worked-before highlight + DXCC Country column

### DIFF
--- a/Zeus.Contracts/Ft8DecodeFrame.cs
+++ b/Zeus.Contracts/Ft8DecodeFrame.cs
@@ -17,12 +17,21 @@ using System.Text.Json.Serialization;
 namespace Zeus.Contracts;
 
 /// <summary>One decoded FT8/FT4 message line for the wire/UI.</summary>
+/// <remarks>
+/// <paramref name="WorkedBefore"/> and <paramref name="Country"/> are ADDITIVE
+/// enrichment attached server-side (see Ft8BroadcastService): the sender callsign
+/// has a prior FT8/FT4 QSO in the logbook, and its DXCC entity resolved from the
+/// callsign prefix (FT8 never transmits country). Both are optional with safe
+/// defaults so older clients and pre-enrichment JSON still deserialise.
+/// </remarks>
 public sealed record Ft8DecodeDto(
     float SnrDb,
     float DtSec,
     float FreqHz,
     int Score,
-    string Text);
+    string Text,
+    bool WorkedBefore = false,
+    string? Country = null);
 
 /// <summary>All decodes from one completed slot on one receiver.</summary>
 public sealed record Ft8DecodeBatchDto(

--- a/Zeus.Dsp.Ft8/CallsignCountryResolver.cs
+++ b/Zeus.Dsp.Ft8/CallsignCountryResolver.cs
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Zeus is distributed WITHOUT ANY WARRANTY; see the GNU General Public
+// License for details.
+
+namespace Zeus.Dsp.Ft8;
+
+/// <summary>
+/// Best-effort, pure-data resolver from an amateur callsign to an ABBREVIATED
+/// DXCC country/entity label. FT8/FT4 messages never transmit the country, so
+/// the FT8 workspace derives it from the callsign prefix here.
+///
+/// This is a SELF-CONTAINED FLOOR, not a full cty.dat: it covers roughly the
+/// ~90 most-active DXCC entities by longest-prefix match. There is no cty.dat
+/// in-tree (see zeus-web/src/dsp/ft8-qso-log.ts) and the only richer source
+/// (QRZ) is subscription-gated, rate-limited and blocking — unusable per
+/// decode. Unknown prefixes return <c>null</c> (the UI shows a blank cell).
+///
+/// Abbreviation format: a short 2–4 letter uppercase label, biased toward the
+/// familiar ITU/contest shorthand (USA, CAN, ENG, GER, JPN, AUS, …). It is a
+/// display hint, not an ADIF COUNTRY or DXCC number, and intentionally collapses
+/// some sub-entities to keep the table legible.
+///
+/// Pure and cross-platform: no I/O, no culture-sensitive operations, no statics
+/// that vary by platform — safe on macOS / Windows / Linux / arm64 / Pi.
+/// </summary>
+public static class CallsignCountryResolver
+{
+    // Portable / status suffixes that do NOT change the resolved entity for our
+    // purposes (e.g. K1ABC/P, G0XYZ/MM, DL1ABC/QRP). A bare single digit (region
+    // change, e.g. W1ABC/7) is handled separately in the splitter.
+    private static readonly HashSet<string> Suffixes = new(StringComparer.Ordinal)
+    {
+        "P", "M", "MM", "AM", "QRP", "R", "A", "LH", "B",
+    };
+
+    /// <summary>
+    /// Resolve an abbreviated country label from a callsign, or <c>null</c> when
+    /// the prefix is unknown or the input is not a plausible call. Never throws.
+    /// Handles compound calls: a slash-prefix wins (DL/K1ABC → Germany), a
+    /// slash-appended prefix wins (K1ABC/VE3 → Canada), and portable suffixes are
+    /// stripped (G0XYZ/P → England).
+    /// </summary>
+    public static string? Resolve(string? callsign)
+    {
+        if (string.IsNullOrWhiteSpace(callsign)) return null;
+
+        var prefix = LocationPrefixToken(callsign.Trim().ToUpperInvariant());
+        if (prefix.Length == 0) return null;
+
+        // Longest-prefix match: try the leading 4,3,2,1 characters in turn so a
+        // specific entry (GM = Scotland) beats the generic one (G = England).
+        int max = Math.Min(4, prefix.Length);
+        for (int len = max; len >= 1; len--)
+        {
+            if (Table.TryGetValue(prefix[..len], out var country))
+                return country;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Reduce a (possibly compound) call to the single token whose prefix names
+    /// the operating entity. Splits on '/', drops portable/status suffixes and
+    /// bare region digits, then — for a true PREFIX/CALL or CALL/PREFIX compound —
+    /// picks the shorter remaining token as the location indicator (DL in
+    /// DL/K1ABC, VE3 in K1ABC/VE3). Returns "" when nothing plausible remains.
+    /// </summary>
+    private static string LocationPrefixToken(string call)
+    {
+        if (!call.Contains('/'))
+            return IsCallChars(call) ? call : string.Empty;
+
+        var core = new List<string>();
+        foreach (var seg in call.Split('/', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (Suffixes.Contains(seg)) continue;         // /P, /MM, /QRP, …
+            if (IsAllDigits(seg)) continue;               // /7 region change
+            if (!IsCallChars(seg)) continue;              // junk
+            core.Add(seg);
+        }
+
+        if (core.Count == 0) return string.Empty;
+        if (core.Count == 1) return core[0];
+
+        // PREFIX/CALL or CALL/PREFIX: the location indicator is the shorter token
+        // (a bare prefix like DL/VE3/KH6 is shorter than the full home call). On a
+        // tie, keep the first — the leading slash-prefix form is the common one.
+        var shortest = core[0];
+        foreach (var seg in core)
+            if (seg.Length < shortest.Length) shortest = seg;
+        return shortest;
+    }
+
+    private static bool IsCallChars(string s)
+    {
+        foreach (var c in s)
+            if (!((c is >= 'A' and <= 'Z') || (c is >= '0' and <= '9')))
+                return false;
+        return s.Length > 0;
+    }
+
+    private static bool IsAllDigits(string s)
+    {
+        foreach (var c in s)
+            if (c is < '0' or > '9') return false;
+        return s.Length > 0;
+    }
+
+    // Prefix → abbreviated entity. Keys are 1–4 chars; longest-prefix wins, so a
+    // 2-char key (GM) overrides the generic 1-char key (G). Best-effort floor —
+    // extend as bench experience dictates. Ordinal lookup (keys are A–Z/0–9).
+    private static readonly Dictionary<string, string> Table = new(StringComparer.Ordinal)
+    {
+        // ---- North America ----
+        ["K"] = "USA", ["W"] = "USA", ["N"] = "USA",
+        ["AA"] = "USA", ["AB"] = "USA", ["AC"] = "USA", ["AD"] = "USA",
+        ["AE"] = "USA", ["AF"] = "USA", ["AG"] = "USA", ["AI"] = "USA",
+        ["AJ"] = "USA", ["AK"] = "USA", ["AL"] = "USA",
+        ["KH6"] = "HI", ["AH6"] = "HI", ["NH6"] = "HI", ["WH6"] = "HI",
+        ["KL7"] = "AK", ["AL7"] = "AK", ["NL7"] = "AK", ["WL7"] = "AK",
+        ["VE"] = "CAN", ["VA"] = "CAN", ["VO"] = "CAN", ["VY"] = "CAN", ["VB"] = "CAN",
+        ["XE"] = "MEX", ["XF"] = "MEX", ["4A"] = "MEX", ["6D"] = "MEX",
+
+        // ---- Caribbean / Central America (common DX) ----
+        ["KP4"] = "PR", ["KP2"] = "VI", ["CO"] = "CUB", ["CM"] = "CUB",
+        ["HI"] = "DOM", ["HH"] = "HTI", ["J3"] = "GRD", ["FG"] = "GLP",
+        ["TI"] = "CTR", ["TG"] = "GTM", ["YN"] = "NCA", ["HP"] = "PAN",
+
+        // ---- South America ----
+        ["PY"] = "BRA", ["PP"] = "BRA", ["PR"] = "BRA", ["PT"] = "BRA",
+        ["PU"] = "BRA", ["PV"] = "BRA", ["ZZ"] = "BRA",
+        ["LU"] = "ARG", ["LW"] = "ARG", ["L2"] = "ARG", ["AY"] = "ARG", ["AZ"] = "ARG",
+        ["CE"] = "CHL", ["CA"] = "CHL", ["XQ"] = "CHL", ["XR"] = "CHL",
+        ["HK"] = "COL", ["HJ"] = "COL", ["YV"] = "VEN", ["YY"] = "VEN",
+        ["OA"] = "PER", ["CX"] = "URU", ["CP"] = "BOL", ["HC"] = "ECU",
+        ["ZP"] = "PAR",
+
+        // ---- Western Europe ----
+        ["G"] = "ENG", ["M"] = "ENG", ["2E"] = "ENG",
+        ["GM"] = "SCO", ["MM"] = "SCO", ["2M"] = "SCO",
+        ["GW"] = "WAL", ["MW"] = "WAL", ["2W"] = "WAL",
+        ["GI"] = "NIR", ["MI"] = "NIR", ["2I"] = "NIR",
+        ["GD"] = "IOM", ["GU"] = "GSY", ["GJ"] = "JSY",
+        ["EI"] = "IRL", ["EJ"] = "IRL",
+        ["F"] = "FRA", ["DA"] = "GER", ["DB"] = "GER", ["DC"] = "GER",
+        ["DD"] = "GER", ["DF"] = "GER", ["DG"] = "GER", ["DH"] = "GER",
+        ["DJ"] = "GER", ["DK"] = "GER", ["DL"] = "GER", ["DM"] = "GER",
+        ["DO"] = "GER", ["DP"] = "GER", ["DR"] = "GER",
+        ["I"] = "ITA", ["EA"] = "ESP", ["EB"] = "ESP", ["EC"] = "ESP",
+        ["ED"] = "ESP", ["EE"] = "ESP", ["EF"] = "ESP", ["EG"] = "ESP", ["EH"] = "ESP",
+        ["CT"] = "POR", ["CR"] = "POR", ["CS"] = "POR",
+        ["PA"] = "NED", ["PB"] = "NED", ["PC"] = "NED", ["PD"] = "NED",
+        ["PE"] = "NED", ["PF"] = "NED", ["PG"] = "NED", ["PH"] = "NED", ["PI"] = "NED",
+        ["ON"] = "BEL", ["OO"] = "BEL", ["OP"] = "BEL", ["OQ"] = "BEL",
+        ["OR"] = "BEL", ["OS"] = "BEL", ["OT"] = "BEL",
+        ["LX"] = "LUX", ["HB9"] = "SUI", ["HB0"] = "LIE", ["HB"] = "SUI",
+        ["OE"] = "AUT", ["EA6"] = "BAL",
+
+        // ---- Northern Europe ----
+        ["OH"] = "FIN", ["OF"] = "FIN", ["OG"] = "FIN", ["OI"] = "FIN", ["OH0"] = "ALD",
+        ["SM"] = "SWE", ["SA"] = "SWE", ["SB"] = "SWE", ["SC"] = "SWE",
+        ["SD"] = "SWE", ["SE"] = "SWE", ["SF"] = "SWE", ["SG"] = "SWE",
+        ["SH"] = "SWE", ["SI"] = "SWE", ["SJ"] = "SWE", ["SK"] = "SWE",
+        ["SL"] = "SWE", ["7S"] = "SWE", ["8S"] = "SWE",
+        ["LA"] = "NOR", ["LB"] = "NOR", ["LC"] = "NOR", ["LD"] = "NOR",
+        ["LG"] = "NOR", ["LJ"] = "NOR", ["LN"] = "NOR",
+        ["OZ"] = "DEN", ["OU"] = "DEN", ["OV"] = "DEN", ["OW"] = "DEN", ["5P"] = "DEN", ["5Q"] = "DEN",
+        ["TF"] = "ISL",
+
+        // ---- Eastern Europe / Balkans / Baltics ----
+        ["SP"] = "POL", ["SN"] = "POL", ["SO"] = "POL", ["SQ"] = "POL", ["SR"] = "POL", ["3Z"] = "POL",
+        ["OK"] = "CZE", ["OL"] = "CZE", ["OM"] = "SVK",
+        ["HA"] = "HUN", ["HG"] = "HUN",
+        ["YO"] = "ROU", ["YP"] = "ROU", ["YQ"] = "ROU", ["YR"] = "ROU",
+        ["LZ"] = "BUL", ["YU"] = "SRB", ["YT"] = "SRB",
+        ["9A"] = "CRO", ["S5"] = "SVN", ["E7"] = "BIH",
+        ["Z3"] = "MKD", ["ZA"] = "ALB", ["Z6"] = "KOS",
+        ["SV"] = "GRE", ["SW"] = "GRE", ["SX"] = "GRE", ["SY"] = "GRE", ["SZ"] = "GRE", ["J4"] = "GRE",
+        ["YL"] = "LVA", ["LY"] = "LTU", ["ES"] = "EST",
+        ["UA"] = "RUS", ["UB"] = "RUS", ["UC"] = "RUS", ["UD"] = "RUS",
+        ["UE"] = "RUS", ["UF"] = "RUS", ["UG"] = "RUS", ["UH"] = "RUS", ["UI"] = "RUS",
+        ["R"] = "RUS",
+        ["UR"] = "UKR", ["US"] = "UKR", ["UT"] = "UKR", ["UU"] = "UKR",
+        ["UV"] = "UKR", ["UW"] = "UKR", ["UX"] = "UKR", ["UY"] = "UKR", ["UZ"] = "UKR", ["EM"] = "UKR", ["EO"] = "UKR",
+        ["EU"] = "BLR", ["EV"] = "BLR", ["EW"] = "BLR",
+        ["4L"] = "GEO", ["EK"] = "ARM", ["4J"] = "AZE", ["4K"] = "AZE",
+
+        // ---- Asia ----
+        ["JA"] = "JPN", ["JB"] = "JPN", ["JC"] = "JPN", ["JD"] = "JPN",
+        ["JE"] = "JPN", ["JF"] = "JPN", ["JG"] = "JPN", ["JH"] = "JPN",
+        ["JI"] = "JPN", ["JJ"] = "JPN", ["JK"] = "JPN", ["JL"] = "JPN",
+        ["JM"] = "JPN", ["JN"] = "JPN", ["JO"] = "JPN", ["JP"] = "JPN",
+        ["JQ"] = "JPN", ["JR"] = "JPN", ["JS"] = "JPN",
+        ["7J"] = "JPN", ["7K"] = "JPN", ["7L"] = "JPN", ["7M"] = "JPN", ["7N"] = "JPN",
+        ["8J"] = "JPN", ["8N"] = "JPN",
+        ["BA"] = "CHN", ["BD"] = "CHN", ["BG"] = "CHN", ["BH"] = "CHN",
+        ["BI"] = "CHN", ["BY"] = "CHN", ["BT"] = "CHN",
+        ["BV"] = "TWN", ["BU"] = "TWN", ["BW"] = "TWN", ["BX"] = "TWN",
+        ["HL"] = "KOR", ["DS"] = "KOR", ["DT"] = "KOR", ["6K"] = "KOR", ["6L"] = "KOR", ["6M"] = "KOR", ["6N"] = "KOR",
+        ["VU"] = "IND", ["AT"] = "IND", ["8T"] = "IND", ["VT"] = "IND",
+        ["HS"] = "THA", ["E2"] = "THA", ["9M"] = "MAL", ["9V"] = "SGP",
+        ["YB"] = "INA", ["YC"] = "INA", ["YD"] = "INA", ["YE"] = "INA", ["YF"] = "INA", ["YG"] = "INA", ["YH"] = "INA",
+        ["DU"] = "PHL", ["DV"] = "PHL", ["DW"] = "PHL", ["DX"] = "PHL", ["DY"] = "PHL", ["DZ"] = "PHL", ["4D"] = "PHL",
+        ["XV"] = "VTN", ["3W"] = "VTN", ["AP"] = "PAK", ["S2"] = "BAN",
+        ["4S"] = "SRI", ["A4"] = "OMA", ["A6"] = "UAE", ["A7"] = "QAT",
+        ["A9"] = "BHR", ["HZ"] = "SAU", ["7Z"] = "SAU", ["8Z"] = "SAU",
+        ["9K"] = "KWT", ["YK"] = "SYR", ["YI"] = "IRQ", ["EP"] = "IRN", ["EQ"] = "IRN",
+        ["4X"] = "ISR", ["4Z"] = "ISR", ["JY"] = "JOR", ["OD"] = "LBN",
+        ["TA"] = "TUR", ["TB"] = "TUR", ["TC"] = "TUR", ["YA"] = "AFG", ["UN"] = "KAZ", ["UP"] = "KAZ",
+
+        // ---- Oceania ----
+        ["VK"] = "AUS", ["AX"] = "AUS", ["VI"] = "AUS",
+        ["ZL"] = "NZL", ["ZM"] = "NZL", ["ZK"] = "NZL",
+        ["KH2"] = "GUM", ["FK"] = "NCL", ["FO"] = "FP", ["3D2"] = "FIJ",
+        ["DU1"] = "PHL", ["P2"] = "PNG", ["H4"] = "SOL", ["YJ"] = "VUT",
+        ["KH8"] = "SAM", ["5W"] = "SAM", ["A3"] = "TON",
+
+        // ---- Africa ----
+        ["ZS"] = "RSA", ["ZR"] = "RSA", ["ZT"] = "RSA", ["ZU"] = "RSA",
+        ["SU"] = "EGY", ["CN"] = "MAR", ["7X"] = "ALG", ["3V"] = "TUN",
+        ["5A"] = "LBY", ["EL"] = "LBR", ["5N"] = "NIG", ["5U"] = "NGR",
+        ["9G"] = "GHA", ["TR"] = "GAB", ["TY"] = "BEN", ["TU"] = "CIV",
+        ["5R"] = "MAD", ["5Z"] = "KEN", ["5H"] = "TAN", ["5X"] = "UGA",
+        ["9J"] = "ZAM", ["Z2"] = "ZIM", ["C9"] = "MOZ", ["V5"] = "NAM",
+        ["A2"] = "BOT", ["7P"] = "LES", ["3DA"] = "SWZ", ["D2"] = "AGL",
+        ["9Q"] = "DRC", ["TJ"] = "CAM", ["3C"] = "GEQ", ["6W"] = "SEN",
+        ["EA8"] = "CNR", ["EA9"] = "CEU", ["CT3"] = "MDR", ["D4"] = "CPV", ["FR"] = "REU",
+    };
+}

--- a/Zeus.Dsp.Ft8/CallsignCountryResolver.cs
+++ b/Zeus.Dsp.Ft8/CallsignCountryResolver.cs
@@ -70,6 +70,13 @@ public static class CallsignCountryResolver
     /// bare region digits, then — for a true PREFIX/CALL or CALL/PREFIX compound —
     /// picks the shorter remaining token as the location indicator (DL in
     /// DL/K1ABC, VE3 in K1ABC/VE3). Returns "" when nothing plausible remains.
+    ///
+    /// Suffix stripping is POSITION-AWARE: a status token (P/M/MM/AM/R/…) is only
+    /// dropped when it is a TRAILING segment. The first (leading) segment is always
+    /// kept as a candidate location prefix, because several status tokens double as
+    /// real CEPT prefixes (MM = Scotland, AM = Spain, R = Russia). This keeps the
+    /// standard visitor form MM/DL1ABC → Scotland while still stripping DL1ABC/MM
+    /// (maritime-mobile) → Germany.
     /// </summary>
     private static string LocationPrefixToken(string call)
     {
@@ -77,9 +84,13 @@ public static class CallsignCountryResolver
             return IsCallChars(call) ? call : string.Empty;
 
         var core = new List<string>();
-        foreach (var seg in call.Split('/', StringSplitOptions.RemoveEmptyEntries))
+        var segments = call.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        for (int i = 0; i < segments.Length; i++)
         {
-            if (Suffixes.Contains(seg)) continue;         // /P, /MM, /QRP, …
+            var seg = segments[i];
+            // Only a TRAILING segment may be a status suffix (/P, /MM, /QRP). The
+            // leading segment is never stripped, so MM/DL1ABC keeps MM (Scotland).
+            if (i > 0 && Suffixes.Contains(seg)) continue;
             if (IsAllDigits(seg)) continue;               // /7 region change
             if (!IsCallChars(seg)) continue;              // junk
             core.Add(seg);

--- a/Zeus.Dsp.Ft8/CallsignCountryResolver.cs
+++ b/Zeus.Dsp.Ft8/CallsignCountryResolver.cs
@@ -228,9 +228,9 @@ public static class CallsignCountryResolver
         // ---- Oceania ----
         ["VK"] = "AUS", ["AX"] = "AUS", ["VI"] = "AUS",
         ["ZL"] = "NZL", ["ZM"] = "NZL", ["ZK"] = "NZL",
-        ["KH2"] = "GUM", ["FK"] = "NCL", ["FO"] = "FP", ["3D2"] = "FIJ",
+        ["KH2"] = "GUM", ["FK"] = "NCL", ["FO"] = "FPO", ["3D2"] = "FIJ",
         ["DU1"] = "PHL", ["P2"] = "PNG", ["H4"] = "SOL", ["YJ"] = "VUT",
-        ["KH8"] = "SAM", ["5W"] = "SAM", ["A3"] = "TON",
+        ["KH8"] = "ASA", ["5W"] = "SAM", ["A3"] = "TON",
 
         // ---- Africa ----
         ["ZS"] = "RSA", ["ZR"] = "RSA", ["ZT"] = "RSA", ["ZU"] = "RSA",

--- a/Zeus.Server.Hosting/Ft8BroadcastService.cs
+++ b/Zeus.Server.Hosting/Ft8BroadcastService.cs
@@ -20,11 +20,25 @@ public sealed class Ft8BroadcastService : BackgroundService
 {
     private readonly Ft8Service _ft8;
     private readonly StreamingHub _hub;
+    private readonly LogService _log;
 
-    public Ft8BroadcastService(Ft8Service ft8, StreamingHub hub)
+    // Cached set of callsigns worked before on FT8/FT4 (the worked-before
+    // highlight source). Refreshed lazily on a short TTL rather than per decode:
+    // a logbook scan per slot (~10-30 decodes / 7.5-15 s) would be wasteful, and
+    // a TTL — unlike hooking a single create event — also picks up bulk ADIF
+    // imports uniformly. The staleness window (≤ TTL) is immaterial for a
+    // cosmetic highlight. Guarded by a lock because DecodesReady fires on the
+    // decoder thread.
+    private static readonly TimeSpan WorkedCacheTtl = TimeSpan.FromSeconds(30);
+    private readonly object _workedLock = new();
+    private IReadOnlySet<string> _workedCalls = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    private DateTime _workedLoadedUtc = DateTime.MinValue;
+
+    public Ft8BroadcastService(Ft8Service ft8, StreamingHub hub, LogService log)
     {
         _ft8 = ft8;
         _hub = hub;
+        _log = log;
         _ft8.DecodesReady += OnDecodes;
     }
 
@@ -32,9 +46,21 @@ public sealed class Ft8BroadcastService : BackgroundService
 
     private void OnDecodes(Ft8DecodeBatch batch)
     {
+        var worked = GetWorkedCalls();
+
         var decodes = new List<Ft8DecodeDto>(batch.Decodes.Count);
         foreach (var d in batch.Decodes)
-            decodes.Add(new Ft8DecodeDto(d.SnrDb, d.DtSec, d.FreqHz, d.Score, d.Text));
+        {
+            bool workedBefore = false;
+            string? country = null;
+            if (Ft8MessageParse.TryParseSender(d.Text, out var sender, out _))
+            {
+                workedBefore = worked.Contains(sender);
+                country = CallsignCountryResolver.Resolve(sender);
+            }
+            decodes.Add(new Ft8DecodeDto(
+                d.SnrDb, d.DtSec, d.FreqHz, d.Score, d.Text, workedBefore, country));
+        }
 
         var dto = new Ft8DecodeBatchDto(
             batch.Receiver,
@@ -43,6 +69,32 @@ public sealed class Ft8BroadcastService : BackgroundService
             decodes);
 
         _hub.BroadcastFt8Decode(Ft8DecodeFrame.Encode(dto));
+    }
+
+    /// <summary>
+    /// Return the cached worked-before set, refreshing it from the logbook when
+    /// the TTL has expired. A failed refresh keeps the last good set (a logbook
+    /// hiccup must never break the decode broadcast) and is swallowed — the
+    /// highlight just goes stale, never throws into the decode pipeline.
+    /// </summary>
+    private IReadOnlySet<string> GetWorkedCalls()
+    {
+        lock (_workedLock)
+        {
+            if (DateTime.UtcNow - _workedLoadedUtc >= WorkedCacheTtl)
+            {
+                try
+                {
+                    _workedCalls = _log.GetDigitalWorkedCallsignsAsync().GetAwaiter().GetResult();
+                }
+                catch
+                {
+                    // keep the previous set; just push the next retry out by the TTL
+                }
+                _workedLoadedUtc = DateTime.UtcNow;
+            }
+            return _workedCalls;
+        }
     }
 
     public override void Dispose()

--- a/Zeus.Server.Hosting/LogService.cs
+++ b/Zeus.Server.Hosting/LogService.cs
@@ -152,6 +152,34 @@ public sealed class LogService : IDisposable
         }, ct);
     }
 
+    /// <summary>
+    /// The set of callsigns ever worked on a DIGITAL voice-of-data mode (FT8 or
+    /// FT4 only), upper-cased. This is the authoritative "worked before" source
+    /// for the FT8 workspace highlight: a station counts as worked-before only if
+    /// a prior QSO was FT8/FT4 — NOT SSB/CW/AM/etc. Distinct from
+    /// <see cref="GetWorkedCallsignSummaryAsync"/>, which is all-modes. The
+    /// returned set uses case-insensitive comparison so callers can probe a raw
+    /// decoded sender directly. Reads through the shared LiteDB lease.
+    /// </summary>
+    public async Task<IReadOnlySet<string>> GetDigitalWorkedCallsignsAsync(CancellationToken ct = default)
+    {
+        return await Task.Run<IReadOnlySet<string>>(() =>
+        {
+            var docs = _logs.Query()
+                .Where(x => x.Mode == "FT8" || x.Mode == "FT4")
+                .ToList();
+
+            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var doc in docs)
+            {
+                var call = NormalizeCallsign(doc.Callsign);
+                if (call.Length > 0)
+                    set.Add(call);
+            }
+            return set;
+        }, ct);
+    }
+
     public async Task<LogEntry?> GetLogEntryAsync(string id, CancellationToken ct = default)
     {
         return await Task.Run(() =>

--- a/tests/Zeus.Contracts.Tests/Ft8DecodeFrameTests.cs
+++ b/tests/Zeus.Contracts.Tests/Ft8DecodeFrameTests.cs
@@ -3,6 +3,7 @@
 // Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
 // Copyright (C) 2025-2026 Brian Keating (EI6LF), Christian Suarez (N9WAR), and contributors.
 
+using System.Text;
 using Zeus.Contracts;
 using Xunit;
 
@@ -47,5 +48,59 @@ public class Ft8DecodeFrameTests
     {
         var bad = new byte[] { 0x01, 0x02, 0x03 };
         Assert.Throws<InvalidDataException>(() => Ft8DecodeFrame.Decode(bad));
+    }
+
+    [Fact]
+    public void RoundTrip_PreservesWorkedBeforeAndCountry()
+    {
+        var batch = new Ft8DecodeBatchDto(0, 1_700_000_000_000, "FT8",
+            new[]
+            {
+                new Ft8DecodeDto(-12f, 0.2f, 1234f, 18, "CQ DL1ABC JO31",
+                    WorkedBefore: true, Country: "GER"),
+                new Ft8DecodeDto(-5f, 0.0f, 900f, 22, "CQ N0XYZ"), // defaults
+            });
+
+        var back = Ft8DecodeFrame.Decode(Ft8DecodeFrame.Encode(batch));
+
+        Assert.True(back.Decodes[0].WorkedBefore);
+        Assert.Equal("GER", back.Decodes[0].Country);
+        Assert.False(back.Decodes[1].WorkedBefore);
+        Assert.Null(back.Decodes[1].Country);
+    }
+
+    [Fact]
+    public void Encode_EmitsCamelCaseEnrichmentFields()
+    {
+        var batch = new Ft8DecodeBatchDto(0, 1_700_000_000_000, "FT8",
+            new[] { new Ft8DecodeDto(-12f, 0.2f, 1234f, 18, "CQ DL1ABC JO31",
+                WorkedBefore: true, Country: "GER") });
+
+        var frame = Ft8DecodeFrame.Encode(batch);
+        var json = Encoding.UTF8.GetString(frame, 1, frame.Length - 1);
+
+        Assert.Contains("\"workedBefore\":true", json);
+        Assert.Contains("\"country\":\"GER\"", json);
+    }
+
+    [Fact]
+    public void Decode_OldShapeJsonWithoutEnrichment_DeserializesWithDefaults()
+    {
+        // A pre-feature server emits decodes with no workedBefore/country keys.
+        const string legacyJson =
+            "{\"receiver\":0,\"slotStartUnixMs\":1700000000000,\"protocol\":\"FT8\"," +
+            "\"decodes\":[{\"snrDb\":-12,\"dtSec\":0.2,\"freqHz\":1234,\"score\":18," +
+            "\"text\":\"CQ K1ABC FN42\"}]}";
+        var payload = Encoding.UTF8.GetBytes(legacyJson);
+        var frame = new byte[1 + payload.Length];
+        frame[0] = (byte)MsgType.Ft8Decode;
+        payload.CopyTo(frame, 1);
+
+        var back = Ft8DecodeFrame.Decode(frame);
+
+        Assert.Single(back.Decodes);
+        Assert.Equal("CQ K1ABC FN42", back.Decodes[0].Text);
+        Assert.False(back.Decodes[0].WorkedBefore);
+        Assert.Null(back.Decodes[0].Country);
     }
 }

--- a/tests/Zeus.Dsp.Ft8.Tests/CallsignCountryResolverTests.cs
+++ b/tests/Zeus.Dsp.Ft8.Tests/CallsignCountryResolverTests.cs
@@ -75,6 +75,27 @@ public sealed class CallsignCountryResolverTests
     }
 
     [Theory]
+    // A LEADING short segment that also doubles as a status suffix must be read as
+    // the location prefix, not stripped. MM = Scotland (CEPT visitor form), R =
+    // Russia. Regression guard: MM/DL1ABC used to resolve to GER (MM dropped).
+    [InlineData("MM/DL1ABC", "SCO")]    // Scotland visitor — NOT Germany
+    [InlineData("R/DL1ABC", "RUS")]     // leading R = Russia prefix, not stripped
+    public void Resolve_LeadingStatusLikePrefix_IsLocation(string call, string expected)
+    {
+        Assert.Equal(expected, CallsignCountryResolver.Resolve(call));
+    }
+
+    [Theory]
+    // The SAME tokens, when TRAILING, are still stripped as status suffixes so the
+    // home call resolves. This is the position-aware counterpart of the cases above.
+    [InlineData("DL1ABC/MM", "GER")]    // trailing MM (maritime mobile) → Germany
+    [InlineData("K1ABC/R", "USA")]      // trailing R stripped → USA
+    public void Resolve_TrailingStatusSuffix_IsStripped(string call, string expected)
+    {
+        Assert.Equal(expected, CallsignCountryResolver.Resolve(call));
+    }
+
+    [Theory]
     // Portable / status suffixes are stripped; the home call resolves.
     [InlineData("G0XYZ/P", "ENG")]
     [InlineData("DL1ABC/M", "GER")]

--- a/tests/Zeus.Dsp.Ft8.Tests/CallsignCountryResolverTests.cs
+++ b/tests/Zeus.Dsp.Ft8.Tests/CallsignCountryResolverTests.cs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Pins the offline DXCC-prefix country resolver used to fill the FT8 decode
+// table's Country column (FT8 never transmits country). Best-effort floor — the
+// table is intentionally a subset of cty.dat, so these cases assert the
+// documented behaviour (longest-prefix wins, compound/portable handling), not
+// exhaustive DXCC coverage.
+
+using Zeus.Dsp.Ft8;
+
+namespace Zeus.Dsp.Ft8.Tests;
+
+public sealed class CallsignCountryResolverTests
+{
+    [Theory]
+    [InlineData("K1ABC", "USA")]
+    [InlineData("W5XYZ", "USA")]
+    [InlineData("N9WAR", "USA")]
+    [InlineData("AA4ZZ", "USA")]
+    [InlineData("VE3ABC", "CAN")]
+    [InlineData("VA7XY", "CAN")]
+    [InlineData("G0XYZ", "ENG")]
+    [InlineData("M0ABC", "ENG")]
+    [InlineData("2E0AAA", "ENG")]
+    [InlineData("GM4XYZ", "SCO")]   // GM beats the generic G
+    [InlineData("GW1ABC", "WAL")]
+    [InlineData("GI4ABC", "NIR")]
+    [InlineData("DL1ABC", "GER")]
+    [InlineData("DJ0XYZ", "GER")]
+    [InlineData("JA1XYZ", "JPN")]
+    [InlineData("7K4AAA", "JPN")]
+    [InlineData("VK2ABC", "AUS")]
+    [InlineData("ZL1ABC", "NZL")]
+    [InlineData("I2ABC", "ITA")]
+    [InlineData("EA3XYZ", "ESP")]
+    [InlineData("F5ABC", "FRA")]
+    [InlineData("OH2ABC", "FIN")]
+    [InlineData("SM5ABC", "SWE")]
+    [InlineData("UA3ABC", "RUS")]
+    [InlineData("RK9AX", "RUS")]
+    [InlineData("UR5XYZ", "UKR")]
+    [InlineData("BA1ABC", "CHN")]
+    [InlineData("BV1XYZ", "TWN")]   // BV beats nothing generic; distinct from BA
+    [InlineData("HL2ABC", "KOR")]
+    [InlineData("PY2ABC", "BRA")]
+    [InlineData("LU1ABC", "ARG")]
+    public void Resolve_KnownPrefixes(string call, string expected)
+    {
+        Assert.Equal(expected, CallsignCountryResolver.Resolve(call));
+    }
+
+    [Fact]
+    public void Resolve_IsCaseInsensitive()
+    {
+        Assert.Equal("GER", CallsignCountryResolver.Resolve("dl1abc"));
+        Assert.Equal("USA", CallsignCountryResolver.Resolve("k1abc"));
+    }
+
+    [Theory]
+    // Slash-PREFIX form: the prefix segment names the entity.
+    [InlineData("DL/K1ABC", "GER")]
+    [InlineData("EA8/DL1ABC", "CNR")]   // Canary Is. — EA8 beats EA
+    [InlineData("OH/SM5ABC", "FIN")]
+    // Slash-appended prefix: the shorter prefix segment still wins.
+    [InlineData("K1ABC/VE3", "CAN")]
+    [InlineData("W1ABC/KH6", "HI")]     // Hawaii
+    public void Resolve_CompoundPrefixWins(string call, string expected)
+    {
+        Assert.Equal(expected, CallsignCountryResolver.Resolve(call));
+    }
+
+    [Theory]
+    // Portable / status suffixes are stripped; the home call resolves.
+    [InlineData("G0XYZ/P", "ENG")]
+    [InlineData("DL1ABC/M", "GER")]
+    [InlineData("GM4ABC/MM", "SCO")]
+    [InlineData("K1ABC/QRP", "USA")]
+    [InlineData("VK2ABC/R", "AUS")]
+    [InlineData("W1ABC/7", "USA")]      // bare region digit — still USA
+    public void Resolve_StripsPortableSuffixes(string call, string expected)
+    {
+        Assert.Equal(expected, CallsignCountryResolver.Resolve(call));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    [InlineData("CQ")]              // not a call
+    [InlineData("Q7ZZZ")]          // unallocated-ish prefix not in the floor table
+    [InlineData("1ABC")]           // leading digit, no entity letter
+    [InlineData("///")]            // only separators
+    public void Resolve_UnknownOrInvalid_ReturnsNull(string? call)
+    {
+        Assert.Null(CallsignCountryResolver.Resolve(call));
+    }
+}

--- a/tests/Zeus.Server.Tests/LogServiceDigitalWorkedTests.cs
+++ b/tests/Zeus.Server.Tests/LogServiceDigitalWorkedTests.cs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Brian Keating (EI6LF),
+//                         Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// Pins LogService.GetDigitalWorkedCallsignsAsync: the FT8 worked-before
+// highlight must count ONLY prior FT8/FT4 QSOs (KB2UKA standing order), never
+// SSB/CW/AM/etc. Runs against a throw-away LiteDB file through the normal shared
+// lease (no `new LiteDatabase`, no sockets).
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Zeus.Contracts;
+using Zeus.Server;
+
+namespace Zeus.Server.Tests;
+
+public sealed class LogServiceDigitalWorkedTests : IDisposable
+{
+    private readonly string _logDbPath =
+        Path.Combine(Path.GetTempPath(), $"zeus-log-digworked-{Guid.NewGuid():N}.db");
+
+    private LogService NewService() => new(NullLogger<LogService>.Instance, _logDbPath);
+
+    private static CreateLogEntryRequest Qso(string call, string mode) => new(
+        Callsign: call,
+        Name: null,
+        FrequencyMhz: 14.074,
+        Band: "20m",
+        Mode: mode,
+        RstSent: "-10",
+        RstRcvd: "-12",
+        Grid: null,
+        Country: null,
+        Dxcc: null,
+        CqZone: null,
+        ItuZone: null,
+        State: null,
+        Comment: null,
+        QsoDateTimeUtc: new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc));
+
+    [Fact]
+    public async Task GetDigitalWorked_IncludesFt8AndFt4_ExcludesPhoneAndCw()
+    {
+        using var svc = NewService();
+        await svc.CreateLogEntryAsync(Qso("K1FT8", "FT8"));
+        await svc.CreateLogEntryAsync(Qso("K4FT4", "FT4"));
+        await svc.CreateLogEntryAsync(Qso("W2SSB", "SSB"));
+        await svc.CreateLogEntryAsync(Qso("N3CW", "CW"));
+        await svc.CreateLogEntryAsync(Qso("K5AM", "AM"));
+
+        var worked = await svc.GetDigitalWorkedCallsignsAsync();
+
+        Assert.Contains("K1FT8", worked);
+        Assert.Contains("K4FT4", worked);
+        Assert.DoesNotContain("W2SSB", worked);
+        Assert.DoesNotContain("N3CW", worked);
+        Assert.DoesNotContain("K5AM", worked);
+    }
+
+    [Fact]
+    public async Task GetDigitalWorked_IncludesCallWorkedOnDigital_EvenIfAlsoWorkedOnPhone()
+    {
+        using var svc = NewService();
+        // Same operator, two QSOs: one SSB (must not, alone, count) and one FT8.
+        await svc.CreateLogEntryAsync(Qso("DL1ABC", "SSB"));
+        await svc.CreateLogEntryAsync(Qso("DL1ABC", "FT8"));
+
+        var worked = await svc.GetDigitalWorkedCallsignsAsync();
+
+        Assert.Contains("DL1ABC", worked);
+    }
+
+    [Fact]
+    public async Task GetDigitalWorked_PhoneOrCwOnlyCall_IsNotWorkedBefore()
+    {
+        using var svc = NewService();
+        await svc.CreateLogEntryAsync(Qso("VK2PHONE", "SSB"));
+        await svc.CreateLogEntryAsync(Qso("VK2PHONE", "CW"));
+
+        var worked = await svc.GetDigitalWorkedCallsignsAsync();
+
+        Assert.DoesNotContain("VK2PHONE", worked);
+    }
+
+    [Fact]
+    public async Task GetDigitalWorked_IsCaseInsensitiveForLookups()
+    {
+        using var svc = NewService();
+        await svc.CreateLogEntryAsync(Qso("rk9ax", "FT8")); // stored upper-cased
+
+        var worked = await svc.GetDigitalWorkedCallsignsAsync();
+
+        // The set normalises to upper and compares case-insensitively, so a raw
+        // decoded sender (any case) probes cleanly.
+        Assert.Contains("RK9AX", worked);
+        Assert.Contains("rk9ax", worked);
+    }
+
+    [Fact]
+    public async Task GetDigitalWorked_EmptyLogbook_ReturnsEmptySet()
+    {
+        using var svc = NewService();
+        var worked = await svc.GetDigitalWorkedCallsignsAsync();
+        Assert.Empty(worked);
+    }
+
+    public void Dispose()
+    {
+        try { File.Delete(_logDbPath); } catch { /* best-effort temp cleanup */ }
+    }
+}

--- a/zeus-web/src/layout/ft8/Ft8DecodeLegend.tsx
+++ b/zeus-web/src/layout/ft8/Ft8DecodeLegend.tsx
@@ -10,7 +10,7 @@ const LEGEND: ReadonlyArray<{ cls: string; label: string }> = [
   { cls: 'dw-legend__sw--cq', label: 'CQ' },
   { cls: 'dw-legend__sw--me', label: 'Calling you' },
   { cls: 'dw-legend__sw--new', label: 'New grid' },
-  { cls: 'dw-legend__sw--worked', label: 'Worked' },
+  { cls: 'dw-legend__sw--worked', label: 'Worked B4' },
   { cls: 'dw-legend__sw--tx', label: 'Your TX' },
 ];
 

--- a/zeus-web/src/layout/ft8/Ft8DecodeTable.test.ts
+++ b/zeus-web/src/layout/ft8/Ft8DecodeTable.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { classifyDecode } from './Ft8DecodeTable';
 import type { Ft8Row } from '../../state/ft8-store';
 
-function row(text: string): Ft8Row {
+function row(text: string, extra?: Partial<Ft8Row>): Ft8Row {
   return {
     id: 'x',
     receiver: 0,
@@ -14,6 +14,7 @@ function row(text: string): Ft8Row {
     freqHz: 1234,
     score: 20,
     text,
+    ...extra,
   };
 }
 
@@ -33,10 +34,12 @@ describe('classifyDecode', () => {
     expect(classifyDecode(row('RK9AX KB2UKA RR73'), 'KB2UKA')).toBe('normal');
   });
 
-  it('dims worked-before stations by caller', () => {
-    const worked = new Set(['RK9AX']);
-    expect(classifyDecode(row('GJ0KYZ RK9AX MO05'), undefined, worked)).toBe('worked');
-    expect(classifyDecode(row('GJ0KYZ DL2XYZ JO62'), undefined, worked)).toBe('normal');
+  it('flags worked-before from the authoritative server row flag', () => {
+    expect(classifyDecode(row('GJ0KYZ RK9AX MO05', { workedBefore: true }))).toBe('worked');
+    // Same message WITHOUT the flag is not worked — the old client-side
+    // workedCalls heuristic is gone.
+    expect(classifyDecode(row('GJ0KYZ RK9AX MO05', { workedBefore: false }))).toBe('normal');
+    expect(classifyDecode(row('GJ0KYZ RK9AX MO05'))).toBe('normal');
   });
 
   it('defaults to normal', () => {
@@ -46,23 +49,35 @@ describe('classifyDecode', () => {
   it('lights a new (unworked) grid on a directed decode', () => {
     const grids = new Set(['FN42']);
     // MO05 not yet worked → new; FN42 already worked → normal.
-    expect(classifyDecode(row('GJ0KYZ RK9AX MO05'), undefined, undefined, grids)).toBe('new');
-    expect(classifyDecode(row('GJ0KYZ RK9AX FN42'), undefined, undefined, grids)).toBe('normal');
+    expect(classifyDecode(row('GJ0KYZ RK9AX MO05'), undefined, grids)).toBe('new');
+    expect(classifyDecode(row('GJ0KYZ RK9AX FN42'), undefined, grids)).toBe('normal');
   });
 
   it('keeps CQ green even when its grid is new', () => {
     const grids = new Set<string>();
-    expect(classifyDecode(row('CQ RK9AX MO05'), undefined, undefined, grids)).toBe('cq');
+    expect(classifyDecode(row('CQ RK9AX MO05'), undefined, grids)).toBe('cq');
   });
 
   it('prefers worked-before over new-grid', () => {
-    const worked = new Set(['RK9AX']);
     const grids = new Set<string>();
-    expect(classifyDecode(row('GJ0KYZ RK9AX MO05'), undefined, worked, grids)).toBe('worked');
+    expect(classifyDecode(row('GJ0KYZ RK9AX MO05', { workedBefore: true }), undefined, grids)).toBe(
+      'worked',
+    );
+  });
+
+  it('prefers calling-me over worked-before', () => {
+    // I am being called AND the sender is worked-before → 'me' wins.
+    expect(
+      classifyDecode(row('KB2UKA RK9AX -12', { workedBefore: true }), 'KB2UKA'),
+    ).toBe('me');
+  });
+
+  it('keeps CQ above worked-before', () => {
+    expect(classifyDecode(row('CQ RK9AX MO05', { workedBefore: true }))).toBe('cq');
   });
 
   it('returns normal for a directed decode with no grid', () => {
     const grids = new Set<string>();
-    expect(classifyDecode(row('GJ0KYZ RK9AX -12'), undefined, undefined, grids)).toBe('normal');
+    expect(classifyDecode(row('GJ0KYZ RK9AX -12'), undefined, grids)).toBe('normal');
   });
 });

--- a/zeus-web/src/layout/ft8/Ft8DecodeTable.test.tsx
+++ b/zeus-web/src/layout/ft8/Ft8DecodeTable.test.tsx
@@ -10,7 +10,7 @@ import { act, render } from '../../components/meters/__tests__/harness';
 import { Ft8DecodeTable } from './Ft8DecodeTable';
 import { useFt8Store, type Ft8Row } from '../../state/ft8-store';
 
-function row(text: string, i: number): Ft8Row {
+function row(text: string, i: number, extra?: Partial<Ft8Row>): Ft8Row {
   return {
     id: `r${i}`,
     receiver: 0,
@@ -21,6 +21,7 @@ function row(text: string, i: number): Ft8Row {
     freqHz: 1000 + i,
     score: 0,
     text,
+    ...extra,
   };
 }
 
@@ -28,7 +29,7 @@ const ROWS: Ft8Row[] = [
   row('CQ K1ABC FN42', 0), // cq
   row('K7XYZ K9QQQ FN31', 1), // normal (neither CQ, me, nor worked)
   row('MYCALL K3ZZZ -05', 2), // me (directed at MYCALL)
-  row('K5AAA W1AW R-12', 3), // worked (sender W1AW is in the logbook)
+  row('K5AAA W1AW R-12', 3, { workedBefore: true }), // worked (server flag)
 ];
 
 function bodyRowCount(container: HTMLElement): number {
@@ -59,15 +60,42 @@ describe('Ft8DecodeTable filters', () => {
     unmount();
   });
 
-  it('Hide-worked-before drops rows whose sender is already logged', () => {
+  it('Hide-worked-before drops rows the server flagged worked', () => {
     const { container, unmount } = render(
       createElement(Ft8DecodeTable, {
         myCall: 'MYCALL',
         hideWorkedBefore: true,
-        workedCalls: new Set(['W1AW']),
       }),
     );
-    expect(bodyRowCount(container)).toBe(3); // the W1AW row is hidden
+    expect(bodyRowCount(container)).toBe(3); // the workedBefore W1AW row is hidden
+    unmount();
+  });
+
+  it('renders an abbreviated Country column to the right of Message', () => {
+    act(() => {
+      useFt8Store.setState({
+        rows: [row('CQ DL1ABC JO31', 0, { country: 'GER' })],
+      });
+    });
+    const { container, unmount } = render(createElement(Ft8DecodeTable, {}));
+    // Header has a Country column after Message.
+    const headers = Array.from(container.querySelectorAll('thead th')).map(
+      (th) => th.textContent,
+    );
+    expect(headers).toEqual(['UTC', 'dB', 'DT', 'Freq', 'Message', 'Country']);
+    // The decode row carries the resolved country in its country cell.
+    const countryCell = container.querySelector('tbody tr td.ft8-country');
+    expect(countryCell?.textContent).toBe('GER');
+    unmount();
+  });
+
+  it('leaves the Country cell blank when the decode has no country', () => {
+    act(() => {
+      useFt8Store.setState({ rows: [row('CQ N0XYZ', 0)] });
+    });
+    const { container, unmount } = render(createElement(Ft8DecodeTable, {}));
+    const countryCell = container.querySelector('tbody tr td.ft8-country');
+    expect(countryCell?.textContent).toBe('');
     unmount();
   });
 

--- a/zeus-web/src/layout/ft8/Ft8DecodeTable.tsx
+++ b/zeus-web/src/layout/ft8/Ft8DecodeTable.tsx
@@ -13,27 +13,31 @@ export type Ft8RowClass = 'cq' | 'me' | 'worked' | 'new' | 'normal';
 
 /**
  * Classify a decode for color-coding. `myCall` enables the directed-at-me
- * highlight; `workedCalls` (optional) dims stations already worked; `workedGrids`
- * (optional, 4-char upper-case) lights an otherwise-plain decode whose grid we
- * have NOT worked yet ('new'). CQ keeps its own green class even when its grid is
- * new — CQ is the louder signal in the table and the existing precedence is
- * relied on elsewhere.
+ * highlight; the worked-before highlight now comes from the AUTHORITATIVE
+ * server flag `row.workedBefore` (a prior FT8/FT4 QSO with the sender — full
+ * logbook history, digital modes only), replacing the old client-side
+ * all-modes/100-cap `workedCalls` heuristic. `workedGrids` (optional, 4-char
+ * upper-case) lights an otherwise-plain decode whose grid we have NOT worked
+ * yet ('new'). CQ keeps its own green class even when its grid is new — CQ is
+ * the louder signal in the table and the existing precedence is relied on
+ * elsewhere.
+ *
+ * Precedence: cq > me > worked > new > normal. 'me' (someone calling YOU)
+ * outranks worked-before; CQ outranks everything.
  */
 export function classifyDecode(
   row: Ft8Row,
   myCall?: string,
-  workedCalls?: ReadonlySet<string>,
   workedGrids?: ReadonlySet<string>,
 ): Ft8RowClass {
   const tokens = row.text.trim().split(/\s+/);
   const first = tokens[0]?.toUpperCase() ?? '';
-  const second = tokens[1]?.toUpperCase() ?? '';
   const me = myCall?.toUpperCase();
 
   // FT8 standard message: "<call-to> <call-from> <grid/report>".
   if (first === 'CQ') return 'cq';                  // a CQ row (even my own)
   if (me && first === me) return 'me';              // someone is calling ME
-  if (workedCalls && second && workedCalls.has(second)) return 'worked';
+  if (row.workedBefore === true) return 'worked';   // prior FT8/FT4 QSO (server)
   if (workedGrids) {
     const grid = parseFt8Message(row.text).grid;
     if (grid && !workedGrids.has(grid.toUpperCase())) return 'new';
@@ -57,7 +61,6 @@ const CLASS_CSS: Record<Ft8RowClass, string> = {
 
 export interface Ft8DecodeTableProps {
   myCall?: string;
-  workedCalls?: ReadonlySet<string>;
   workedGrids?: ReadonlySet<string>;
   onRowClick?: (row: Ft8Row) => void;
   /** FT8 Settings → Decode filters (client-side predicates over the live rows).
@@ -78,7 +81,6 @@ type FlowItem =
 
 export function Ft8DecodeTable({
   myCall,
-  workedCalls,
   workedGrids,
   onRowClick,
   showOnlyCq,
@@ -90,7 +92,7 @@ export function Ft8DecodeTable({
   const rows =
     showOnlyCq || hideWorkedBefore
       ? allRows.filter((r) => {
-          const cls = classifyDecode(r, myCall, workedCalls, workedGrids);
+          const cls = classifyDecode(r, myCall, workedGrids);
           if (showOnlyCq && cls !== 'cq' && cls !== 'me') return false;
           if (hideWorkedBefore && cls === 'worked') return false;
           return true;
@@ -104,7 +106,7 @@ export function Ft8DecodeTable({
       kind: 'rx',
       t: r.slotStartUnixMs,
       row: r,
-      cls: classifyDecode(r, myCall, workedCalls, workedGrids),
+      cls: classifyDecode(r, myCall, workedGrids),
     })),
     ...(txEchoes ?? []).map<FlowItem>((e) => ({ kind: 'tx', t: e.timeUtcMs, echo: e })),
   ].sort((a, b) => b.t - a.t);
@@ -126,6 +128,7 @@ export function Ft8DecodeTable({
           <th>DT</th>
           <th>Freq</th>
           <th>Message</th>
+          <th>Country</th>
         </tr>
       </thead>
       <tbody>
@@ -141,6 +144,7 @@ export function Ft8DecodeTable({
                 <td>
                   <span className="ft8-row__tx-badge">TX</span> {e.message}
                 </td>
+                <td className="ft8-country" />
               </tr>
             );
           }
@@ -157,6 +161,7 @@ export function Ft8DecodeTable({
               <td className="num">{r.dtSec.toFixed(1)}</td>
               <td className="num">{r.freqHz.toFixed(0)}</td>
               <td>{r.text}</td>
+              <td className="ft8-country">{r.country ?? ''}</td>
             </tr>
           );
         })}

--- a/zeus-web/src/layout/ft8/Ft8PopBody.tsx
+++ b/zeus-web/src/layout/ft8/Ft8PopBody.tsx
@@ -93,12 +93,12 @@ export function Ft8PopBody() {
   const loadPushConfig = useHamClockStore((s) => s.loadPushConfig);
   const pushDx = useHamClockStore((s) => s.pushDx);
 
-  // Worked-before / new-grid sets for decode-table highlighting, memoized from
-  // the logbook. NOTE: useLoggerStore.loadEntries caps at 100 entries (#1015).
-  const workedCalls = useMemo(
-    () => new Set(entries.map((e) => e.callsign.toUpperCase())),
-    [entries],
-  );
+  // New-grid set for decode-table highlighting, memoized from the logbook.
+  // Worked-before is no longer derived here — it is the authoritative server
+  // flag on each decode row (a prior FT8/FT4 QSO over the FULL logbook history),
+  // which replaces the old all-modes/100-cap client heuristic. NOTE:
+  // useLoggerStore.loadEntries caps at 100 entries (#1015), so the grid set is
+  // still a best-effort recent-history hint.
   const workedGrids = useMemo(
     () =>
       new Set(
@@ -343,7 +343,6 @@ export function Ft8PopBody() {
         <div className="dw-section__body dw-section__body--flush">
           <Ft8DecodeTable
             myCall={myCall || undefined}
-            workedCalls={workedCalls}
             workedGrids={workedGrids}
             onRowClick={onRowClick}
             showOnlyCq={settings.showOnlyCq}

--- a/zeus-web/src/state/ft8-store.ts
+++ b/zeus-web/src/state/ft8-store.ts
@@ -27,6 +27,12 @@ export interface Ft8DecodeDto {
   freqHz: number;
   score: number;
   text: string;
+  /** Server-side enrichment: the sender callsign has a prior FT8/FT4 QSO in the
+   *  logbook (digital worked-before — NOT SSB/CW). Absent on older servers. */
+  workedBefore?: boolean;
+  /** Server-side enrichment: abbreviated DXCC entity derived from the sender's
+   *  callsign prefix (FT8 never transmits country). null/absent when unknown. */
+  country?: string | null;
 }
 
 /** A completed slot's decodes for one receiver (the 0x38 payload). */

--- a/zeus-web/src/styles/ft8-theme.css
+++ b/zeus-web/src/styles/ft8-theme.css
@@ -282,8 +282,9 @@
 }
 .ft8-decode-table td.num { text-align: right; font-variant-numeric: tabular-nums; }
 /* Country column — abbreviated DXCC entity, sits to the RIGHT of Message
-   (symmetric to Freq on the LEFT). Dim + compact so it never competes with the
-   message text; the row colour class still tints it. */
+   (symmetric to Freq on the LEFT). Always rendered dim + compact (its own
+   --hud-text-dim colour wins over the row class) so it never competes with the
+   message text. */
 .ft8-decode-table td.ft8-country {
   color: var(--hud-text-dim);
   text-align: left;

--- a/zeus-web/src/styles/ft8-theme.css
+++ b/zeus-web/src/styles/ft8-theme.css
@@ -45,7 +45,7 @@
   /* Decode-row classes (color-coded message table). */
   --hud-cq:        var(--ok);            /* CQ calls — green */
   --hud-me:        var(--power);         /* directed at my call — amber */
-  --hud-worked:    var(--fg-2);          /* worked-before — muted */
+  --hud-worked:    var(--worked-b4);     /* worked-before (FT8/FT4) — magenta */
   --hud-new:       var(--accent-bright); /* new DXCC/grid — accent blue */
 
   color: var(--hud-text);
@@ -70,7 +70,9 @@
      fg-2 grey. */
   --hud-text:      var(--btn-active-text);
   --hud-text-dim:  color-mix(in srgb, var(--btn-active-text) 58%, transparent);
-  --hud-worked:    color-mix(in srgb, var(--btn-active-text) 42%, transparent);
+  /* worked-before keeps its magenta on the dark digital screen (the light-theme
+     --worked-b4 override in tokens.css runs a touch deeper for legibility);
+     it no longer collapses to a grey mix. */
 }
 /* Keep the drag-bar dark too so the title/gear read as part of the screen, not
    the silver chassis (the base header uses the global silver panel gradient in
@@ -279,10 +281,22 @@
   white-space: nowrap;
 }
 .ft8-decode-table td.num { text-align: right; font-variant-numeric: tabular-nums; }
+/* Country column — abbreviated DXCC entity, sits to the RIGHT of Message
+   (symmetric to Freq on the LEFT). Dim + compact so it never competes with the
+   message text; the row colour class still tints it. */
+.ft8-decode-table td.ft8-country {
+  color: var(--hud-text-dim);
+  text-align: left;
+  letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+}
 
 .ft8-row--cq     { color: var(--hud-cq); }
 .ft8-row--me     { color: var(--hud-me); background: var(--hud-cyan-soft); }
-.ft8-row--worked { color: var(--hud-worked); }
+.ft8-row--worked {
+  color: var(--hud-worked);
+  background: color-mix(in srgb, var(--hud-worked) 14%, transparent);
+}
 .ft8-row--new    { color: var(--hud-new); }
 
 /* Our own transmissions, echoed into the decode flow (WSJT-X yellow Tx line).

--- a/zeus-web/src/styles/tokens.css
+++ b/zeus-web/src/styles/tokens.css
@@ -56,6 +56,12 @@
   --chat-group-soft: rgba(176,124,255,0.16);
   --ok:            #2dd566;
   --ok-soft:       rgba(45,213,102,0.18);
+  /* Worked-before highlight for the FT8/FT4 decode table — a magenta-violet that
+     reads as "already in the log", distinct from CQ green / calling-me amber /
+     new-grid blue / TX red / dim grey. NOT --orange (reserved for the QRZ
+     button) and NOT a chat hue (--chat-group is a bluer violet). */
+  --worked-b4:     #d65ccf;
+  --worked-b4-soft: rgba(214,92,207,0.18);
   --green-soft:    #1aa84e;
   --amber:         #ffb13c;
   --amber-soft:    rgba(255,177,60,0.18);
@@ -319,6 +325,12 @@ html[data-fonts="geist"] { --font-sans: 'Inter', sans-serif; --font-mono: 'JetBr
    needles are unchanged (semantic). Warm lamp blooms become near-transparent
    in light mode because they were tuned for a black stage. */
 :root[data-theme="light"] {
+  /* Worked-before highlight: the FT8 decode table renders on the dark "lit
+     instrument" digital-window surface even in light theme, so keep a vivid
+     magenta-violet legible on dark. A touch deeper than the dark-theme value. */
+  --worked-b4:      #c845c0;
+  --worked-b4-soft: rgba(200,69,192,0.20);
+
   --immersive-bg:           var(--bg-0);
   --immersive-panel:        var(--bg-1);
   --immersive-panel-2:      var(--bg-1);


### PR DESCRIPTION
## FT8/FT4 logging improvements — worked-before highlight (digital-only) + Country column

Two operator-facing additions to the FT8/FT4 "Zeus Digital" decode table.

### 1. Worked-before highlight — FT8/FT4 only
When a decoded station's **sender callsign has a prior FT8 or FT4 QSO** in the logbook, its row is highlighted in a new color and the meaning is shown in the decode color key. "Worked before" means a prior **digital** QSO only — an SSB/AM/CW contact does **not** count (per KB2UKA).

- **Backend-authoritative.** The flag is computed server-side in `Ft8BroadcastService.OnDecodes()` (the single broadcast seam) from a 30s-TTL-cached set of FT8/FT4-worked calls (`LogService.GetDigitalWorkedCallsignsAsync`, `Mode IN {FT8,FT4}`). This replaces the old client heuristic, which keyed off **all modes** and only the **last 100** logbook entries (#1015). Now it's digital-only over the **full** history, with no per-decode DB hit or QRZ traffic.

### 2. Country column
An **abbreviated DXCC entity** is shown immediately to the **right of Message** (symmetric to the Freq number on the left). FT8 never transmits country, so it's derived from the callsign prefix by a new offline resolver (`CallsignCountryResolver`) — there is no cty.dat in-tree and QRZ is subscription-gated/rate-limited, unusable per-decode.

---

### 🚩 Needs your sign-off (KB2UKA) — red-light items
1. **New highlight color.** Added one token `--worked-b4` (magenta-violet — `#d65ccf` dark / `#c845c0` light) in `tokens.css`; `--hud-worked` repoints to it so the row + legend swatch recolor through existing plumbing. Picked to be distinct from CQ green / calling-you amber / new-grid blue / TX red / old grey, and deliberately **not** `--orange` (reserved for QRZ). **Eyeball the hue in dark + light** — easy to change.
2. **"Worked" legend entry recolored + relabeled → "Worked B4"** (was muted grey, any-mode). It now means digital worked-before. UX/visual call.
3. **Country abbreviations** are a **best-effort floor (~90 entities)** — short display-hint labels (USA/CAN/ENG/GER/JPN…), unknown prefixes render **blank**, compound/portable calls handled best-effort. Not an ADIF COUNTRY or DXCC number. Labels are yours to tune; extend the table as bench experience dictates.
4. **Additive `Ft8DecodeDto` fields** (`WorkedBefore`, `Country`) in `Zeus.Contracts` — wire-safe (old JSON still deserializes). Additive Contracts change, your approval.
5. **classifyDecode precedence:** `cq > me > worked > new`. "Calling you" still outranks worked-before; CQ stays loudest.

### Verified locally (worktree, rebased on current develop incl. v0.10.8)
- `dotnet build Zeus.slnx` ✅ 0 errors
- Backend tests ✅ — resolver **104**, contracts **111** (DTO round-trip + legacy JSON), LogService digital-worked **5**
- `npm run typecheck` ✅ · ft8 vitest **19** ✅ · `npm run build` ✅
- Guardrails: PureSignal untouched · LiteDB via the shared lease (no `new LiteDatabase`) · no real sockets in tests · colors via tokens (no raw hex; amber `#FFA028` untouched) · pure cross-platform resolver · no Claude/Anthropic in any commit.

### Built by the implement → adversarial-audit → fix swarm; then independently re-verified
The audit caught + fixed a real resolver bug (`MM/DL1ABC` CEPT-Scotland mis-resolved to Germany — leading status-token vs. prefix). I additionally fixed two misleading country labels (KH8≠5W, FO≠FP) and one stale CSS comment.

### Known follow-up (non-blocking)
- The worked-set refresh in `Ft8BroadcastService` does a sync logbook scan on the decode thread once per 30s TTL — bounded and infrequent, fine for a cosmetic highlight; could move off-thread if a very large logbook ever shows latency.

**Not bench-tested on hardware** — UI/logbook feature, no TX/PA/protocol path touched, so no G2 bench needed; worth an eyeball on the live decode table for color + country readability.
