### PR TITLE
feat(logbook): translucent 'On QRZ' highlight + footer key

### DIFF
--- a/zeus-web/src/components/design/LogbookLive.qrz.test.tsx
+++ b/zeus-web/src/components/design/LogbookLive.qrz.test.tsx
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Zeus — OpenHPSDR Protocol-1 / Protocol-2 client.
+// Copyright (C) 2025-2026 Douglas J. Cerrato (KB2UKA),
+//                         Christian Suarez (N9WAR), and contributors.
+//
+// "On QRZ" logbook indicator: any QSO already on QRZ.com — uploaded by Zeus or
+// imported as already-sent (ADIF APP_QRZLOG_LOGID) — gets a translucent green
+// row tint + the ✓ QRZ pill, with a footer legend. Both markers count
+// (qrzLogId OR qrzUploadedUtc).
+
+import { describe, expect, it, beforeEach } from 'vitest';
+import { createElement } from 'react';
+import { act, render } from '../meters/__tests__/harness';
+import { LogbookLive, isQrzPublished } from './LogbookLive';
+import { useLoggerStore } from '../../state/logger-store';
+import type { LogEntry } from '../../api/log';
+
+function entry(over: Partial<LogEntry> & Pick<LogEntry, 'id' | 'callsign'>): LogEntry {
+  return {
+    qsoDateTimeUtc: '2026-05-24T12:00:00Z',
+    name: null,
+    frequencyMhz: 14.074,
+    band: '20m',
+    mode: 'FT8',
+    rstSent: '-10',
+    rstRcvd: '-12',
+    grid: 'FN31',
+    country: null,
+    dxcc: null,
+    cqZone: null,
+    ituZone: null,
+    state: null,
+    comment: null,
+    createdUtc: '2026-05-24T12:00:05Z',
+    qrzLogId: null,
+    qrzUploadedUtc: null,
+    ...over,
+  };
+}
+
+describe('isQrzPublished', () => {
+  it('is true when uploaded by Zeus (qrzLogId set)', () => {
+    expect(isQrzPublished(entry({ id: '1', callsign: 'K1ABC', qrzLogId: 'ABC123' }))).toBe(true);
+  });
+  it('is true when only the upload timestamp is set (defensive)', () => {
+    expect(
+      isQrzPublished(entry({ id: '2', callsign: 'K2DEF', qrzUploadedUtc: '2026-05-24T12:01:00Z' })),
+    ).toBe(true);
+  });
+  it('is false for an un-uploaded QSO', () => {
+    expect(isQrzPublished(entry({ id: '3', callsign: 'K3GHI' }))).toBe(false);
+  });
+  it('treats an empty qrzLogId as not published', () => {
+    expect(isQrzPublished(entry({ id: '4', callsign: 'K4JKL', qrzLogId: '' }))).toBe(false);
+  });
+});
+
+describe('LogbookLive — On QRZ row highlight + legend', () => {
+  beforeEach(() => {
+    act(() => {
+      useLoggerStore.setState({
+        entries: [
+          entry({ id: 'pub', callsign: 'W1PUB', qrzLogId: 'QRZ-1' }),
+          entry({ id: 'unp', callsign: 'W2UNP' }),
+        ],
+        totalCount: 2,
+        loading: false,
+      });
+    });
+  });
+
+  it('tints only the QRZ-published row and shows its pill', () => {
+    const { container, unmount } = render(
+      createElement(LogbookLive, { searchText: '', hideQrzPublished: false }),
+    );
+    const tinted = container.querySelectorAll('.log-row--qrz');
+    expect(tinted.length).toBe(1);
+    // The tinted row is the published one and carries the ✓ QRZ pill.
+    expect(tinted[0]?.textContent).toContain('W1PUB');
+    expect(tinted[0]?.querySelector('.log-sync-pill')).not.toBeNull();
+    // The un-published row is neither tinted nor pilled.
+    const pills = container.querySelectorAll('.log-sync-pill');
+    expect(pills.length).toBe(1);
+    unmount();
+  });
+
+  it('renders the "On QRZ" footer legend key', () => {
+    const { container, unmount } = render(
+      createElement(LogbookLive, { searchText: '', hideQrzPublished: false }),
+    );
+    const legend = container.querySelector('.log-legend');
+    expect(legend).not.toBeNull();
+    expect(legend?.textContent).toContain('On QRZ');
+    expect(legend?.querySelector('.log-legend__sw')).not.toBeNull();
+    unmount();
+  });
+});

--- a/zeus-web/src/components/design/LogbookLive.tsx
+++ b/zeus-web/src/components/design/LogbookLive.tsx
@@ -69,6 +69,17 @@ function formatFrequencyMhz(freq: number | null | undefined): string | null {
   return typeof freq === 'number' && Number.isFinite(freq) ? freq.toFixed(3) : null;
 }
 
+/**
+ * Whether a QSO is already on QRZ.com — uploaded by Zeus (sets both fields via
+ * UpdateQrzUploadStatusAsync) OR imported from an ADIF that carried the QRZ
+ * log-id (APP_QRZLOG_LOGID → qrzLogId), i.e. sent to QRZ before. Either marker
+ * counts. Drives the translucent row highlight + the "✓ QRZ" pill, both keyed
+ * in the logbook footer legend.
+ */
+export function isQrzPublished(entry: LogEntry): boolean {
+  return Boolean(entry.qrzLogId || entry.qrzUploadedUtc);
+}
+
 function logRowTitle(entry: LogEntry): string {
   const frequency = formatFrequencyMhz(entry.frequencyMhz);
   return compactList([
@@ -201,7 +212,7 @@ export function LogbookLive({ searchText, hideQrzPublished }: LogbookLiveProps) 
           <button
             key={entry.id}
             type="button"
-            className={`log-row mono ${selectedIds.has(entry.id) ? 'selected' : ''}`}
+            className={`log-row mono ${selectedIds.has(entry.id) ? 'selected' : ''} ${isQrzPublished(entry) ? 'log-row--qrz' : ''}`}
             onClick={() => toggleSelected(entry.id)}
             title={logRowTitle(entry)}
           >
@@ -235,7 +246,7 @@ export function LogbookLive({ searchText, hideQrzPublished }: LogbookLiveProps) 
                 <span className="log-name-text">
                   {entry.name ?? '—'}
                 </span>
-                {entry.qrzLogId && (
+                {isQrzPublished(entry) && (
                   <span className="log-sync-pill">✓ QRZ</span>
                 )}
               </span>
@@ -245,6 +256,10 @@ export function LogbookLive({ searchText, hideQrzPublished }: LogbookLiveProps) 
         ))}
       </div>
       <div className="log-foot">
+        <span className="log-legend" title="Rows tinted green are already on QRZ.com — uploaded by Zeus or imported as already sent">
+          <span className="log-legend__sw" aria-hidden="true" />
+          <span className="log-legend__label">On QRZ</span>
+        </span>
         <span style={{ flex: 1 }} />
         <span className="label-xs">
           {filtersActive

--- a/zeus-web/src/styles/layout.css
+++ b/zeus-web/src/styles/layout.css
@@ -3364,6 +3364,11 @@
   border-bottom: 1px solid rgba(0,0,0,0.15);
   transition: background var(--dur-fast), color var(--dur-fast);
 }
+/* Already on QRZ.com (uploaded by Zeus or imported as already-sent) — a
+   translucent green wash so published QSOs read at a glance without fighting
+   the row text. Keyed in the footer legend. Placed before :hover/.selected so
+   interaction states still take over on the active row. */
+.log-row--qrz { background: color-mix(in srgb, var(--ok) 9%, transparent); }
 .log-row:hover { background: rgba(74, 158, 255, 0.12); color: var(--fg-0); }
 .log-row .t-call { color: var(--accent); font-weight: 700; }
 .log-row .t-mode { color: var(--fg-2); }
@@ -3397,7 +3402,7 @@
 .log-sync-pill {
   flex-shrink: 0;
   margin-left: auto;
-  color: var(--accent);
+  color: var(--ok); /* matches the "On QRZ" row tint + footer legend */
   font-size: 9px;
   font-weight: 800;
 }
@@ -3417,6 +3422,25 @@
   border-top: 1px solid rgba(0,0,0,0.4);
   background: linear-gradient(90deg, color-mix(in srgb, var(--panel-top) 60%, var(--panel-bot)), var(--panel-bot));
 }
+/* Footer key for the "On QRZ" row tint. */
+.log-legend {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 9px;
+  color: var(--fg-3);
+  white-space: nowrap;
+}
+.log-legend__sw {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  /* Same green wash as .log-row--qrz, opaque-blended over the panel so the
+     swatch is visible at legend size. */
+  background: color-mix(in srgb, var(--ok) 45%, var(--panel-bot));
+  border: 1px solid color-mix(in srgb, var(--ok) 60%, transparent);
+}
+.log-legend__label { letter-spacing: 0.02em; }
 
 /* ===== Memory ===== */
 .memgrid { padding: 6px; display: grid; grid-template-columns: repeat(2, 1fr); gap: 4px; overflow-y: auto; background: var(--bg-1); }


### PR DESCRIPTION
## Logbook — "On QRZ" indicator

Any QSO that's **already on QRZ.com** is now called out in the logbook view with a **translucent green row tint** and a **footer legend key**, so you can see at a glance which contacts are published.

"On QRZ" means either:
- **uploaded by Zeus** (sets `qrzLogId` + `qrzUploadedUtc`), or
- **sent to QRZ before** and brought in via ADIF import (the QRZ log-id field `APP_QRZLOG_LOGID` → `qrzLogId`).

Both markers count, via a shared `isQrzPublished()` helper.

### What changed (frontend only)
- `LogbookLive.tsx` — published rows get a `log-row--qrz` class; new **"On QRZ"** legend in the footer; the existing **✓ QRZ** pill now also keys off `isQrzPublished()`.
- `layout.css` — translucent green tint (`color-mix(--ok …)`, placed before `:hover`/`.selected` so interaction still wins); the ✓ QRZ pill recolored from blue to green to match the tint + key; legend swatch styles.
- Reuses data already on the wire (`qrzLogId` / `qrzUploadedUtc` are already on `LogEntry`) — **no backend, Contracts, or dependency change.**

### Decisions I made (change freely)
- **Green** (`--ok`) for the "published/confirmed" semantic — distinct from the blue hover/selected and blue call-sign. Recolored the existing ✓ QRZ pill to match so tint + pill + key are one color.
- Tint opacity ~9%; legend label "On QRZ"; legend lives at the left of the footer.
- The pre-existing hide-QRZ toggle + count still key on `qrzLogId` (identical in practice — the two fields are always set together; my `|| qrzUploadedUtc` is just defensive).

### Verified locally (worktree off current develop)
- `npm run typecheck` ✅ · new tests **6** ✅ (helper + render: tint on published only, pill count, legend) · existing logbook tests **10** ✅ (no regression) · `npm run build` ✅
- No PureSignal / sockets / raw hex (tokens only) / Claude refs.
