### PR TITLE
fix(ps): G2E (HermesC10/Cyclone 10 LP) PureSignal — route external feedback tap + parity docs/instrumentation

### DIFF
--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -454,6 +454,21 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     private int _psBlockFill;
     private ulong _psBlockStartSeq;
 
+    // ---- HermesC10 (ANAN-G2E) PS wire instrumentation (issue #960) ----
+    // Read-only ~1 Hz diagnostic of the single-ADC time-mux PS feedback burst,
+    // gated on _boardKind == HermesC10 (see ShouldLogG2ePsWireDiag) so it is
+    // inert for every other board. It logs the byte-59 attenuation actually on
+    // the wire, the DDC0 feedback frame count on port 1035, and the peak coupler
+    // (rx_I[0]) and reference (rx_I[NR]) sample magnitudes from the de-interleaved
+    // pair — the numbers that make the next real-G2E bench (lb5va, #960) decisive
+    // on whether feedback is flowing and at what level. Pure logging: no wire
+    // write, no socket I/O, no hot-path allocation. Touched only from the RX
+    // thread inside HandlePsPairedPacket, so no synchronisation is needed.
+    private long _g2ePsDiagWindowStartMs;
+    private long _g2ePsDiagFramesInWindow;
+    private float _g2ePsDiagPeakCoupler;
+    private float _g2ePsDiagPeakReference;
+
     public Protocol2Client(ILogger<Protocol2Client> log)
     {
         _log = log;
@@ -1296,17 +1311,40 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
-    /// Arm or disarm PureSignal feedback streaming. When on:
-    ///   - <c>SendCmdRx</c> enables DDC0 alongside the user-visible DDC2 and
-    ///     synchronises DDC1→DDC0 (byte 1363 = 0x02) so the radio sends
-    ///     paired DDC0/DDC1 IQ on port 1035.
-    ///   - <c>SendCmdHighPriority</c> sets <c>ALEX_PS_BIT (0x00040000)</c>
-    ///     in alex0/alex1 and, during xmit, mirrors DDC0+DDC1 phase words
-    ///     to the TX DUC frequency.
-    ///   - The packet decoder switches to the paired format (6B DDC0 + 6B
-    ///     DDC1 per sample, repeating).
-    /// When off the radio reverts to the standard non-PS RX layout and any
-    /// in-flight paired packets are discarded by the decoder.
+    /// Arm or disarm PureSignal feedback streaming. The exact wire behaviour is
+    /// board-specific and routed through the per-board predicates — this summary
+    /// describes the two families the code actually composes.
+    ///
+    /// DUAL-ADC family (OrionMkII / Saturn / G2, <see cref="ReservesPsFeedbackDdcs"/>):
+    ///   - <c>SendCmdRx</c> enables the dedicated DDC0+DDC1 feedback pair
+    ///     alongside the user-visible RX on DDC2 and sets byte 1363 = 0x02 so the
+    ///     radio streams paired DDC0/DDC1 IQ on port 1035.
+    ///   - <c>SendCmdHighPriority</c> sets <c>ALEX_PS_BIT</c> and, during xmit,
+    ///     mirrors the DDC0/DDC1 phase words to the TX-DUC frequency
+    ///     (<see cref="ComposesPsFeedbackWire"/> is true).
+    ///
+    /// SINGLE-ADC time-mux family (ANAN-G2E / HermesC10 and ANAN-10E / HermesII,
+    /// <see cref="TimeMuxesPsFeedbackOnDdc0"/>): the HermesC10 gateware forms the
+    /// feedback pair INSIDE DDC0's packer, so the path is materially different
+    /// from Orion and this method does NOT compose the Orion layout for it:
+    ///   - <c>SendCmdRx</c> arms DDC0 ONLY — no DDC1 enable. The coupler
+    ///     (rx_I[0] = temp_ADC) is interleaved with the hardwired internal TX-DAC
+    ///     reference (rx_I[NR] = temp_DACD) coupler-first / reference-second by
+    ///     the Rx0 FIFO controller under byte 1363 = 0x02 (SyncRx[0][1];
+    ///     Hermes.v:717-720, Rx_specific_C&amp;C.v:181). The descriptor is armed
+    ///     only during a TX burst (via <c>PushTransmitEdge</c>) and DDC0 reverts
+    ///     to the operator's RX at rest.
+    ///   - There is explicitly NO <c>ALEX_PS_BIT</c> and NO DDC0/DDC1 phase
+    ///     mirror — that scheme is Orion-only and
+    ///     <see cref="ComposesPsFeedbackWire"/>(HermesC10) is false.
+    ///   - byte 59 (Angelia_atten_Tx0) is seeded to the protective floor while
+    ///     armed (<see cref="SeedsTxAdcProtection"/>) so the DAC reference + PA
+    ///     coupler cannot slam the single shared RX ADC at 0 dB on key-down.
+    ///
+    /// The packet decoder consumes the same coupler-first/reference-second paired
+    /// format (6B + 6B per sample) for both families. When off the radio reverts
+    /// to the standard non-PS RX layout, byte 59 is restored to the operator's
+    /// prior value, and any in-flight paired packets are discarded.
     /// </summary>
     public void SetPsFeedbackEnabled(bool on)
     {
@@ -2178,16 +2216,23 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
 
         if (psEnabled)
         {
-            // Zeus only composes the DDC0+DDC1 paired feedback layout (bit 1363
-            // sync) for boards where it reserves the front DDCs for feedback —
-            // the dual-ADC OrionMkII/Saturn/G2 family. On single-ADC Hermes-class
-            // radios (Hermes/0x01, HermesII/0x02, HermesC10/0x14) Zeus DISABLES
-            // PS (DDC0 is the operator's only RX), so leave the PS block alone.
-            // This is a Zeus software choice for the G2E, not a hardware limit —
-            // the G2E gateware can do Orion-style PS on DDC0 (byte 1363
-            // SyncRx[0]=0x02 interleave); see ReservesPsFeedbackDdcs. The same
-            // board set as the old `!= Hermes && != HermesII && != HermesC10`
-            // test (issue #960).
+            // This branch composes ONLY the dual-ADC Orion-style layout: the
+            // dedicated DDC0+DDC1 feedback pair (byte 1363 sync) alongside the
+            // user RX on DDC2, for boards where Zeus reserves the front DDCs for
+            // feedback — the OrionMkII/Saturn/G2 family (ReservesPsFeedbackDdcs).
+            //
+            // The single-ADC Hermes-class radios (Hermes/0x01, HermesII/0x02,
+            // HermesC10/0x14) do NOT take this branch — DDC0 is the operator's
+            // only RX, so the Orion pair layout does not apply. This is NOT "PS
+            // off" for the G2E/10E: as of v0.10.8 (#960) those boards perform
+            // Orion-style PS by TIME-MUXING the feedback pair onto DDC0 during a
+            // TX burst via the separate g2eFeedbackBurst descriptor above (byte
+            // 1363 = 0x02 coupler/reference interleave, DDC0-only), gated by
+            // TimeMuxesPsFeedbackOnDdc0 + txKeyed. Do NOT "restore" a disable
+            // here or add the reserve-DDC layout for the G2E — that would break
+            // the shipped single-ADC time-mux path and mis-route DDC0.
+            // ReservesPsFeedbackDdcs is the same board set as the old explicit
+            // `!= Hermes && != HermesII && != HermesC10` test (issue #960).
             if (ReservesPsFeedbackDdcs(boardKind))
             {
                 ddcEnable |= 0x01;
@@ -3683,6 +3728,14 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
             samplesPerPacket = 119;
         }
 
+        // HermesC10 (ANAN-G2E) PS wire instrumentation gate — computed once per
+        // packet (see field block near _psBlockStartSeq). When true we track the
+        // peak coupler/reference magnitudes in the decode loop below and emit a
+        // ~1 Hz diagnostic. Inert (false) for every other board — dual-ADC boards
+        // also reach this method but are excluded by ShouldLogG2ePsWireDiag.
+        bool g2eDiag = ShouldLogG2ePsWireDiag(
+            _boardKind, _psFeedbackEnabled, _moxOn || _tuneActive);
+
         for (int i = 0; i < samplesPerPacket; i++)
         {
             int off = 16 + i * 12;
@@ -3691,6 +3744,15 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
             // the live decode path so the regression guard is real.
             var (sampleRxI, sampleRxQ, sampleTxI, sampleTxQ) =
                 DecodePsPairForTest(new ReadOnlySpan<byte>(buf, off, 12));
+            if (g2eDiag)
+            {
+                // Peak |coupler| (rx_I[0]) and |reference| (rx_I[NR]) as a cheap
+                // max-of-|I|,|Q| — the level the next real-G2E bench needs to see.
+                float couplerMag = MathF.Max(MathF.Abs(sampleRxI), MathF.Abs(sampleRxQ));
+                float refMag = MathF.Max(MathF.Abs(sampleTxI), MathF.Abs(sampleTxQ));
+                if (couplerMag > _g2ePsDiagPeakCoupler) _g2ePsDiagPeakCoupler = couplerMag;
+                if (refMag > _g2ePsDiagPeakReference) _g2ePsDiagPeakReference = refMag;
+            }
             _psRxI[_psBlockFill] = sampleRxI;
             _psRxQ[_psBlockFill] = sampleRxQ;
             _psTxI[_psBlockFill] = sampleTxI;
@@ -3725,7 +3787,46 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
                 _psBlockFill = 0;
             }
         }
+
+        if (g2eDiag)
+        {
+            _g2ePsDiagFramesInWindow++;
+            long nowMs = Environment.TickCount64;
+            if (_g2ePsDiagWindowStartMs == 0) _g2ePsDiagWindowStartMs = nowMs;
+            if (nowMs - _g2ePsDiagWindowStartMs >= 1000)
+            {
+                // Mirrors the existing p1.tx.rate / p2.rxdiag 1 Hz cadence.
+                // arm=1 because byte 1363 = 0x02 is on the wire whenever this
+                // path runs; atten is the byte-59 (Angelia_atten_Tx0) value the
+                // host is actually sending; frames = DDC0 feedback packets on
+                // port 1035 in the window; peakFb/peakRef are the de-interleaved
+                // coupler/reference magnitudes (0..1). Read-only diagnostic.
+                _log.LogInformation(
+                    "p2.ps.g2e arm={Arm} atten={Atten} frames={Frames} peakFb={PeakFb:F4} peakRef={PeakRef:F4}",
+                    1, _txStepAttnDb, _g2ePsDiagFramesInWindow,
+                    _g2ePsDiagPeakCoupler, _g2ePsDiagPeakReference);
+                _g2ePsDiagWindowStartMs = nowMs;
+                _g2ePsDiagFramesInWindow = 0;
+                _g2ePsDiagPeakCoupler = 0f;
+                _g2ePsDiagPeakReference = 0f;
+            }
+        }
     }
+
+    /// <summary>
+    /// Gate for the read-only HermesC10 (ANAN-G2E) PS wire instrumentation
+    /// (<c>p2.ps.g2e</c>): emit ONLY on the ANAN-G2E, and only while PS feedback
+    /// is armed AND transmit is asserted (the single-ADC time-mux burst is the
+    /// only time DDC0 carries feedback). Deliberately excludes the sibling 10E
+    /// (<see cref="HpsdrBoardKind.HermesII"/>) — the diagnostic is scoped to the
+    /// G2E bench (#960, lb5va) — and every dual-ADC board (which also reaches the
+    /// paired-packet decoder via <see cref="ReservesPsFeedbackDdcs"/>), so it is
+    /// inert everywhere else. Pure predicate, no side effects — unit-testable
+    /// without sockets.
+    /// </summary>
+    internal static bool ShouldLogG2ePsWireDiag(
+        HpsdrBoardKind board, bool psFeedbackEnabled, bool txKeyed)
+        => board == HpsdrBoardKind.HermesC10 && psFeedbackEnabled && txKeyed;
 
     private static int SignExtend24(int raw)
     {

--- a/Zeus.Protocol2/Protocol2Client.cs
+++ b/Zeus.Protocol2/Protocol2Client.cs
@@ -2830,7 +2830,15 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         // 1296 ORs ALEX_RX_ANTENNA_BYPASS into alex0 only during xmit when
         // PS is armed and the operator selected the external path. Internal
         // coupler leaves this bit clear.
-        if (psWire && _psFeedbackExternal && xmit)
+        //
+        // G2E (#960 follow-up): on the full-Orion dual-ADC wire psWire owns this,
+        // but the single-ADC HermesC10 does time-mux PS with psWire=false — yet
+        // its ONE ADC can only see an EXTERNAL sampler tap through this relay.
+        // RoutesExternalPsFeedbackBypass adds ONLY the HermesC10 arm, so the 10E
+        // and every other board stay byte-identical. BENCH-GATED: needs a real
+        // G2E + external tap (the p2.ps.g2e log will show peakFb going non-zero).
+        if (RoutesExternalPsFeedbackBypass(_boardKind, _psFeedbackEnabled, _psFeedbackExternal)
+            && xmit)
         {
             alex0 |= AlexRxAntennaBypass;
         }
@@ -2916,6 +2924,34 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
     private const uint ALEX_BYPASS_HPF = 0x00001000;  // bit 12
 
     /// <summary>
+    /// Should the RX-aux BYPASS relay (alex0 bit 11, <see cref="AlexRxAntennaBypass"/>)
+    /// route an EXTERNAL PureSignal feedback tap into the RX ADC on this board?
+    ///
+    /// Two paths qualify:
+    ///  • The full-Orion dual-ADC PS wire (<see cref="ComposesPsFeedbackWire"/>):
+    ///    pihpsdr new_protocol.c:1284-1296 ORs the bit during xmit when PS is
+    ///    armed and the operator selected the external path.
+    ///  • The single-ADC HermesC10 / ANAN-G2E time-mux PS path (#960 follow-up):
+    ///    here <see cref="ComposesPsFeedbackWire"/> is <c>false</c>, but the board's
+    ///    ONE ADC can only see an external sampler tap (post-PA pad into the
+    ///    RXbypass / K36 jack — how the real G2E operator runs PS) through this
+    ///    same relay. Without the bit the external feedback never reaches the ADC
+    ///    and calcc can never converge — the observed "PS doesn't work on the G2E".
+    ///
+    /// Deliberately scoped to HermesC10: the 10E (HermesII) is the same class and
+    /// almost certainly needs the same routing, but is left byte-identical here
+    /// until a 10E owner can bench-confirm it. Every other board is unaffected.
+    /// The caller still ANDs the transmit-edge (xmit / MOX) condition.
+    /// </summary>
+    internal static bool RoutesExternalPsFeedbackBypass(
+        HpsdrBoardKind board, bool psEnabled, bool psExternal)
+    {
+        if (!psEnabled || !psExternal) return false;
+        if (ComposesPsFeedbackWire(psEnabled, board)) return true;
+        return board == HpsdrBoardKind.HermesC10 && G2ePsTimeMuxOnAir;
+    }
+
+    /// <summary>
     /// Compose the alex0 word the way <see cref="SendCmdHighPriority"/>
     /// does, exposed internal so wire-format tests can assert the
     /// PureSignal-related bits without standing up a socket. Mirrors the
@@ -2958,8 +2994,12 @@ public sealed class Protocol2Client : IDisposable, IAsyncDisposable
         uint alex0 = (alexCommon & ~ALEX_TX_ANTENNA_MASK) | EncodeTxAntennaBits(alex0AntWire)
                      | (moxOn ? ALEX_TX_RELAY : 0u);
         alex0 |= ComposeRxAuxBits(rxAuxInput, mkiiBpfRxSelect);
-        if (psEnabled && moxOn) alex0 |= AlexPsBit;
-        if (psEnabled && psExternal && moxOn) alex0 |= AlexRxAntennaBypass;
+        // PS bit is the full-Orion dual-ADC wire ONLY — single-ADC boards
+        // (HermesC10/G2E, HermesII/10E) never set ALEX_PS. Gate on the same
+        // predicate the live path uses so this helper mirrors the wire exactly.
+        if (ComposesPsFeedbackWire(psEnabled, board) && moxOn) alex0 |= AlexPsBit;
+        if (RoutesExternalPsFeedbackBypass(board, psEnabled, psExternal) && moxOn)
+            alex0 |= AlexRxAntennaBypass;
         return alex0;
     }
 

--- a/Zeus.VirtualRadio/P2/Protocol2Engine.cs
+++ b/Zeus.VirtualRadio/P2/Protocol2Engine.cs
@@ -77,10 +77,15 @@ public sealed class Protocol2Engine : IVirtualRadio
     // byte-59 (Angelia_atten_Tx0) protective seed was NOT pushed by the host, so
     // the TX-DAC reference + PA coupler hit the single RX ADC at < the protective
     // floor. This is the exact first-key-down ADC-overload condition a real
-    // G2E/10E would raise and that bench verification (#289) must confirm. The
-    // 10E host path seeds byte 59 to 31 dB (clears it); the G2E host path does
-    // NOT yet seed it (SeedsTxAdcProtection excludes HermesC10), so this latches
-    // on a G2E PS burst — the observable signature of the open byte-59 gap.
+    // G2E/10E would raise and that bench verification (#960) must confirm. As of
+    // v0.10.8 (#960) BOTH single-shared-ADC host paths seed byte 59 to the
+    // protective floor on arm — SeedsTxAdcProtection now covers the G2E
+    // (HermesC10) as well as the 10E (HermesII) — so in normal loopback the
+    // emulator floor (TxAdcProtectFloorDb = 1) is below the client-seeded 31 dB
+    // and this latch does NOT fire. It remains here as the observable signature
+    // of a MISSING byte-59 seed: it can only latch if some future edit stops
+    // seeding byte 59 (a PureSignal-hard-rule regression), which is exactly what
+    // the loopback test guards against.
     private volatile bool _psAdcOverloadLatched;
 
     // De-dup edge-trigger for CommandDecoded (steady re-sends of the same

--- a/tests/Zeus.Protocol2.Tests/PsWireFormatTests.cs
+++ b/tests/Zeus.Protocol2.Tests/PsWireFormatTests.cs
@@ -21,6 +21,7 @@
 // Both are GPL-2.0-or-later.
 
 using Xunit;
+using Zeus.Contracts;
 
 namespace Zeus.Protocol2.Tests;
 
@@ -337,5 +338,145 @@ public class PsWireFormatTests
         // Sample rate at bytes 14..15 BE — 192 = 0x00C0
         Assert.Equal((byte)0x00, p[14]);
         Assert.Equal((byte)0xC0, p[15]);
+    }
+
+    // ---- Golden full-buffer regression guards (issue #960) ----
+    // These pin the ENTIRE composed wire buffer (every non-zero byte, and by
+    // exhaustion every zero byte) for the HermesC10 (ANAN-G2E) single-ADC PS
+    // time-mux path, the shared 10E (HermesII) burst, and the dual-ADC family.
+    // They prove the G2E documentation + read-only instrumentation change made
+    // ZERO wire-byte change: if any compose byte drifts on any of these boards,
+    // exactly one of these fails.
+
+    // Collect the sparse (index -> value) map of all non-zero bytes. Comparing
+    // this against an explicit expected map pins the whole buffer: anything not
+    // listed MUST be zero, or the count/equality check fails.
+    private static SortedDictionary<int, byte> NonZeroBytes(byte[] p)
+    {
+        var map = new SortedDictionary<int, byte>();
+        for (int i = 0; i < p.Length; i++)
+            if (p[i] != 0) map[i] = p[i];
+        return map;
+    }
+
+    [Fact]
+    public void CmdRx_G2E_FeedbackBurst_GoldenBytes()
+    {
+        // ANAN-G2E (HermesC10) single-ADC time-mux PS feedback descriptor:
+        // DDC0 enable ONLY (no DDC1 — the TX-DAC reference is the hardwired
+        // rx_I[NR] receiver synced into Rx0), ADC0, 192 kHz / 24-bit, and
+        // byte 1363 = 0x02 arming the SyncRx[0][1] coupler/reference interleave.
+        var p = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 7, numAdc: 1, sampleRateKhz: 192, psEnabled: true,
+            boardKind: HpsdrBoardKind.HermesC10, g2eFeedbackBurst: true);
+
+        var expected = new SortedDictionary<int, byte>
+        {
+            [3] = 7,       // seq (BE)
+            [4] = 1,       // single ADC
+            [7] = 0x01,    // DDC0 enable only, NO DDC1
+            [19] = 0xC0,   // DDC0 192 kHz BE low (0x00C0)
+            [22] = 24,     // DDC0 24-bit
+            [1363] = 0x02, // SyncRx[0][1] coupler/reference interleave
+        };
+        Assert.Equal(expected, NonZeroBytes(p));
+    }
+
+    [Fact]
+    public void CmdRx_10E_FeedbackBurst_ByteIdenticalToG2E()
+    {
+        // The 10E (HermesII) burst is composed by the SAME g2eFeedbackBurst
+        // branch — it MUST be byte-for-byte identical to the G2E burst. This
+        // guards the shared branch: a G2E-scoped change must not perturb it.
+        var g2e = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 7, numAdc: 1, sampleRateKhz: 192, psEnabled: true,
+            boardKind: HpsdrBoardKind.HermesC10, g2eFeedbackBurst: true);
+        var tenE = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 7, numAdc: 1, sampleRateKhz: 192, psEnabled: true,
+            boardKind: HpsdrBoardKind.HermesII, g2eFeedbackBurst: true);
+
+        Assert.Equal(g2e, tenE);
+    }
+
+    [Fact]
+    public void CmdRx_DualAdc_PsArmed_GoldenBytes_Unaffected()
+    {
+        // Dual-ADC OrionMkII (G2/Saturn family) PS-armed compose: the dedicated
+        // DDC0+DDC1 feedback pair (0x05 enable = DDC0|DDC2) plus user RX on DDC2,
+        // byte 1363 = 0x02. Pinned to prove the bench radio's wire is untouched.
+        var p = Protocol2Client.ComposeCmdRxBuffer(
+            seq: 7, numAdc: 2, sampleRateKhz: 192, psEnabled: true,
+            boardKind: HpsdrBoardKind.OrionMkII);
+
+        var expected = new SortedDictionary<int, byte>
+        {
+            [3] = 7,       // seq (BE)
+            [4] = 2,       // dual ADC
+            [7] = 0x05,    // DDC0 (feedback) | DDC2 (user RX)
+            [19] = 0xC0,   // DDC0 192 kHz
+            [22] = 24,     // DDC0 24-bit
+            [23] = 2,      // DDC1 ADC = numAdc
+            [25] = 0xC0,   // DDC1 192 kHz
+            [28] = 24,     // DDC1 24-bit
+            [31] = 0xC0,   // DDC2 (user RX) 192 kHz
+            [34] = 24,     // DDC2 24-bit
+            [1363] = 0x02, // feedback pair sync
+        };
+        Assert.Equal(expected, NonZeroBytes(p));
+    }
+
+    [Fact]
+    public void CmdTx_G2E_PsArmed_Byte57Through59_TakeProtectiveFloor()
+    {
+        // On the G2E, ComposesPsFeedbackWire(HermesC10) is false, so SendCmdTx
+        // composes CmdTx with psEnabled=false while the byte-59 seed has driven
+        // txStepAttnDb to the protective floor (31). Bytes 57/58/59 all carry 31
+        // — the historical single-ADC shape with the protective attenuation.
+        var p = Protocol2Client.ComposeCmdTxBuffer(
+            seq: 7, sampleRateKhz: 48, txStepAttnDb: 31, paEnabled: true, psEnabled: false);
+
+        var expected = new SortedDictionary<int, byte>
+        {
+            [3] = 7,    // seq (BE)
+            [4] = 1,    // num_dac
+            [15] = 48,  // DAC sample rate 48 kHz BE low
+            [57] = 31,  // ADC step atten (historical shape)
+            [58] = 31,
+            [59] = 31,  // Angelia_atten_Tx0 protective floor
+        };
+        Assert.Equal(expected, NonZeroBytes(p));
+    }
+
+    // ---- HermesC10 PS wire-instrumentation gate (issue #960) ----
+    // The read-only p2.ps.g2e ~1 Hz diagnostic is gated by this pure predicate.
+    // Deterministic, socketless: proves the log fires ONLY on the ANAN-G2E while
+    // PS is armed AND keyed, and NEVER for the 10E or any dual-ADC board.
+
+    [Fact]
+    public void PsWireDiag_Emitted_OnlyFor_G2E_Armed_AndKeyed()
+    {
+        Assert.True(Protocol2Client.ShouldLogG2ePsWireDiag(
+            HpsdrBoardKind.HermesC10, psFeedbackEnabled: true, txKeyed: true));
+    }
+
+    [Theory]
+    [InlineData(false, true)]  // disarmed
+    [InlineData(true, false)]  // armed but not keyed (DDC0 is user RX at rest)
+    [InlineData(false, false)]
+    public void PsWireDiag_NotEmitted_ForG2E_WhenNotArmedAndKeyed(bool armed, bool keyed)
+    {
+        Assert.False(Protocol2Client.ShouldLogG2ePsWireDiag(
+            HpsdrBoardKind.HermesC10, psFeedbackEnabled: armed, txKeyed: keyed));
+    }
+
+    [Theory]
+    [InlineData(HpsdrBoardKind.HermesII)]   // sibling 10E — diagnostic is G2E-scoped
+    [InlineData(HpsdrBoardKind.OrionMkII)]  // dual-ADC — also reaches the paired decoder
+    [InlineData(HpsdrBoardKind.Orion)]
+    [InlineData(HpsdrBoardKind.Hermes)]
+    public void PsWireDiag_NeverEmitted_ForOtherBoards_EvenArmedAndKeyed(HpsdrBoardKind board)
+    {
+        Assert.False(Protocol2Client.ShouldLogG2ePsWireDiag(
+            board, psFeedbackEnabled: true, txKeyed: true));
     }
 }

--- a/tests/Zeus.Protocol2.Tests/PsWireFormatTests.cs
+++ b/tests/Zeus.Protocol2.Tests/PsWireFormatTests.cs
@@ -247,6 +247,79 @@ public class PsWireFormatTests
             "Bypass bit must not flip when PS isn't armed even if External is selected.");
     }
 
+    // ---- G2E (HermesC10) single-ADC external-feedback bypass routing ----
+    // The single-ADC G2E can only see an external sampler tap through the
+    // RX-aux BYPASS relay. psWire is false for HermesC10, so the historical
+    // gate never set the bit and calcc could never receive feedback. The fix
+    // routes it via RoutesExternalPsFeedbackBypass, scoped to HermesC10.
+
+    [Fact]
+    public void Alex0_G2e_BypassBit_SetWhenExternal_PsArmed_AndMox()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: 14_200_000,
+            moxOn: true,
+            psEnabled: true,
+            psExternal: true,
+            board: HpsdrBoardKind.HermesC10);
+
+        Assert.True((alex0 & Protocol2Client.AlexRxAntennaBypass) != 0,
+            "G2E external PS armed + MOX must route the tap via the BYPASS relay.");
+        // Parity: the single-ADC G2E must NOT assert ALEX_PS (that is the
+        // dual-ADC Orion wire only). A spurious PS bit here would diverge
+        // from the C10 gateware.
+        Assert.True((alex0 & Protocol2Client.AlexPsBit) == 0,
+            "G2E must never set ALEX_PS — it is not on the dual-ADC PS wire.");
+    }
+
+    [Fact]
+    public void Alex0_G2e_BypassBit_ClearWhenInternal()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: 14_200_000,
+            moxOn: true,
+            psEnabled: true,
+            psExternal: false,
+            board: HpsdrBoardKind.HermesC10);
+
+        Assert.True((alex0 & Protocol2Client.AlexRxAntennaBypass) == 0,
+            "G2E internal-coupler PS leaves the BYPASS relay clear.");
+    }
+
+    [Fact]
+    public void Alex0_G2e_BypassBit_ClearWhenMoxOff()
+    {
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: 14_200_000,
+            moxOn: false,
+            psEnabled: true,
+            psExternal: true,
+            board: HpsdrBoardKind.HermesC10);
+
+        Assert.True((alex0 & Protocol2Client.AlexRxAntennaBypass) == 0,
+            "G2E BYPASS relay must not flip outside xmit.");
+    }
+
+    [Fact]
+    public void Alex0_10e_BypassBit_StaysClear_ProvingG2eScoping()
+    {
+        // Other-board safety (KB2UKA hard constraint): the 10E (HermesII) is
+        // the same single-ADC class but is intentionally left byte-identical
+        // until a 10E owner can bench-confirm the routing. The fix must NOT
+        // change the 10E wire.
+        uint alex0 = Protocol2Client.ComposeAlex0ForTest(
+            rxFreqHz: 14_200_000,
+            moxOn: true,
+            psEnabled: true,
+            psExternal: true,
+            board: HpsdrBoardKind.HermesII);
+
+        Assert.True((alex0 & Protocol2Client.AlexRxAntennaBypass) == 0,
+            "10E BYPASS relay must stay clear — the fix is scoped to the G2E.");
+        Assert.True((alex0 & Protocol2Client.AlexPsBit) == 0,
+            "10E must never set ALEX_PS either (single-ADC board).");
+    }
+
     // ---- RxSpecific buffer parity between Internal and External ----
 
     [Fact]

--- a/tests/Zeus.VirtualRadio.Tests/Protocol2Emulator_LoopbackG2ePs_IntegrationTest.cs
+++ b/tests/Zeus.VirtualRadio.Tests/Protocol2Emulator_LoopbackG2ePs_IntegrationTest.cs
@@ -30,21 +30,19 @@ namespace Zeus.VirtualRadio.Tests;
 /// and the client decodes <see cref="PsFeedbackFrame"/>s. Unkeying returns DDC0
 /// to the user RX.
 ///
-/// THE G2E DELTA vs the 10E (the open, KB2UKA-gated item this test documents):
-/// the 10E host path seeds byte 59 (Angelia_atten_Tx0) to the protective floor
-/// (31 dB) on arm (<see cref="Protocol2Client.SeedsTxAdcProtection"/> is true for
-/// HermesII), so its loopback test asserts byte 59 >= 1. The G2E host path does
-/// NOT seed byte 59 — <c>SeedsTxAdcProtection(HermesC10)</c> is deliberately
-/// false (the G2E byte-59 seed is a separate, independently-gated pre-condition
-/// per the <see cref="Protocol2Client.G2ePsTimeMuxOnAir"/> doc, pre-condition A,
-/// and touching it is a PureSignal-hard-rule change requiring KB2UKA sign-off).
-/// So on the G2E byte 59 stays at the operator default (0) through the keyed
-/// burst, and the emulator — modelling the single-ADC hazard — raises
-/// first-key-down ADC overload in its hi-priority status. This test asserts BOTH:
-/// the feedback frames flow (the path is functionally complete) AND the overload
-/// latches (the byte-59 protective seed is still missing). That is exactly the
-/// "does the dark G2E PS path work, and what needs sign-off before real RF"
-/// answer, captured as a deterministic, hardware-free bench.
+/// THE G2E BYTE-59 SEED (v0.10.8, #960): the shipped client now seeds byte 59
+/// (Angelia_atten_Tx0) to the protective floor (31 dB) on arm for the G2E, just
+/// like the 10E — <see cref="Protocol2Client.SeedsTxAdcProtection"/> returns true
+/// for HermesC10 as well as HermesII. So through the keyed PS burst byte 59 is
+/// protective, the emulator's single-ADC overload model does NOT latch, and on
+/// disarm byte 59 restores to the operator's pre-arm value (0 here). This test
+/// therefore asserts: the feedback frames flow (the path is functionally
+/// complete) AND byte 59 is seeded protective AND NO ADC overload latches. It is
+/// a SELF-CONSISTENCY / regression bench — it proves the client and emulator
+/// agree on the digital wire, NOT that real-RF PS converges on a G2E. Real-G2E
+/// hardware validation (lb5va, #960) is still the open, KB2UKA-gated item; the
+/// byte-59 floor value itself (<see cref="Protocol2Client.PsTxAdcProtectFloorDb"/>)
+/// remains a burn-zone default that stays behind KB2UKA sign-off + bench.
 ///
 /// Gated behind <c>ZEUS_VRADIO_LOOPBACK</c> (it binds the well-known radio ports
 /// and uses real loopback sockets), so it never runs in the default socketless
@@ -79,7 +77,7 @@ public class Protocol2Emulator_LoopbackG2ePs_IntegrationTest
     }
 
     [SkippableFact]
-    public async Task ArmPs_KeyTx_DeliversFeedback_ButByte59Unseeded_RaisesAdcOverload()
+    public async Task ArmPs_KeyTx_DeliversFeedback_Byte59Seeded_NoAdcOverload()
     {
         Skip.IfNot(
             !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("ZEUS_VRADIO_LOOPBACK")),


### PR DESCRIPTION
## G2E (ANAN-G2E / HermesC10) PureSignal parity

**Goal:** get PureSignal working on the single-ADC ANAN-G2E (Thetis `HermesC10`, board `0x14`), whose FPGA is an Intel/Altera **Cyclone 10 LP `10CL040YF484`** (confirmed from the board's own P2 gateware `Hermes_Protocol_2_C10_v11.0.5`).

A deep three-way audit (C10 gateware ⟷ Thetis/pihpsdr ⟷ Zeus) found that Zeus's **digital PS wire is already at parity** — byte-1363 `SyncRx[0]=0x02` DDC0-only interleave, byte-59 TX-ADC protection seed, correctly **no** `ALEX_PS` bit and **no** DDC0/DDC1 phase mirror (that's the dual-ADC Orion wire, not the G2E). So the datapath was **not** restructured.

The real gap is the **feedback routing**, not the digital format.

### Root cause (the load-bearing fix — commit 2)
`ALEX_RX_ANTENNA_BYPASS` (alex0 **bit 11**) — the relay that connects the **RXbypass / K36 jack** to the RX front end — was gated on `ComposesPsFeedbackWire`, which is **`false` for the single-ADC HermesC10**. So on the G2E the bit was **never set**.

The one real G2E operator (lb5va, #960) runs PS from an **external sampler tap** — post a 500–600 W PA, ~50 dB pad, into the RXbypass jack. On a single-ADC board that tap can reach the ADC **only** through this relay. With the bit never set, the feedback never reaches the ADC → **calcc can never converge** → "PS doesn't work on the G2E."

**Fix:** new `RoutesExternalPsFeedbackBypass(board, psEnabled, psExternal)`. The existing full-Orion dual-ADC path is unchanged; a single **HermesC10** arm is added, gated by the existing `G2ePsTimeMuxOnAir` flag **plus** armed + external + xmit. byte-59 protection is untouched.

### Docs + instrumentation (commit 1)
- Corrected stale XML/comments that described the G2E as the Orion dual-ADC scheme (a future editor could otherwise "restore" the `Zeus DISABLES PS` disable and silently kill shipped G2E PS).
- Added a **read-only** ~1 Hz `p2.ps.g2e arm=.. atten=.. frames=.. peakFb=.. peakRef=..` log during a keyed PS burst — this is what makes the next bench decisive.

## Board scoping — other boards provably unaffected
- **Dual-ADC (G2/OrionMkII/Saturn family):** `RoutesExternalPsFeedbackBypass` reduces to the prior `psWire && external` — **byte-identical**.
- **10E (HermesII):** same single-ADC class and almost certainly needs the same routing, but **deliberately left byte-identical** here until a 10E owner can bench-confirm. Proven by a test.
- **All others:** predicate is `false` → unchanged.
- `PsEnabled` still initialises `false` on startup — untouched. No auto-arm. Operator must arm PS **and** select External.

## Tests / gates
- New tests: G2E external+armed+MOX **sets bit 11** and **never sets `ALEX_PS`**; G2E internal & mox-off stay clear; **10E stays byte-identical** (scoping proof).
- `dotnet build Zeus.slnx` clean · **308** Protocol2 tests · **112** VirtualRadio tests green.
- Also aligned the `ComposeAlex0ForTest` golden helper with the live per-board `ALEX_PS`/BYPASS gating (all existing golden tests unchanged — they use the dual-ADC default).

## ⚠️ Bench-gated — needs a real G2E + external tap (cannot be tested locally; G2 is the only bench)
This touches the PureSignal wire on a real HF amp. **Authorised by KB2UKA for the G2E; draft only — do not merge without a bench result.**

**Tester steps (external-tap G2E, e.g. lb5va):**
1. Arm PS, select **External** feedback source, key a carrier/two-tone.
2. Watch the `p2.ps.g2e` log: **`peakFb` should now go non-zero** (feedback reaching the ADC). Before this fix it was ~0.
3. Confirm calcc converges (PS corrects / feedback shows). Keep the external pad in place — byte-59 (31 dB) adds protection on top of it.

## Red-light items for your call
- The **byte-59 protective floor (31 dB, `PsTxAdcProtectFloorDb`)** is a shared 10E/G2E guess, not derived from a real G2E chain — burn-zone default, unchanged here, flagged.
- Extending the same bypass routing to the **10E** (once a 10E tester validates).
- Split-TX (TX on VFO B) PS-phase edge case (`D9`) is out of scope — single-VFO PS calibration is correct.
